### PR TITLE
OAuth mux typed routing and provider probes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,63 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, initial-implementation]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
+  cache-first:
+    name: GloriousFlywheel cache-first check
+    runs-on: tinyland-nix
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect GloriousFlywheel action access
+        id: gf
+        shell: bash
+        env:
+          GF_ACTIONS_TOKEN: ${{ secrets.GF_ACTIONS_TOKEN || '' }}
+        run: |
+          if [ -n "${GF_ACTIONS_TOKEN:-}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::GF_ACTIONS_TOKEN is unset; skipping private GloriousFlywheel action checkout"
+          fi
+
+      - name: Checkout GloriousFlywheel action
+        if: steps.gf.outputs.enabled == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: tinyland-inc/GloriousFlywheel
+          ref: main
+          path: .gloriousflywheel
+          token: ${{ secrets.GF_ACTIONS_TOKEN }}
+          persist-credentials: false
+
+      - name: Run cache-first validation
+        if: steps.gf.outputs.enabled == 'true'
+        uses: ./.gloriousflywheel/.github/actions/nix-job
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN || '' }}
+        with:
+          attic-public-key: ${{ vars.ATTIC_PUBLIC_KEY || '' }}
+          push-cache: ${{ github.event_name == 'push' && 'true' || 'false' }}
+          command: |
+            set -euxo pipefail
+            test -n "${ATTIC_SERVER:-}"
+            test -n "${ATTIC_CACHE:-}"
+            test -n "${NIX_CONFIG:-}"
+            nix develop --command just check-local
+
+      - name: Record skipped cache-first validation
+        if: steps.gf.outputs.enabled != 'true'
+        shell: bash
+        run: |
+          echo "GloriousFlywheel cache-first validation skipped because GF_ACTIONS_TOKEN is unset." >> "$GITHUB_STEP_SUMMARY"
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -21,6 +73,12 @@ jobs:
 
       - name: Test
         run: zig build test
+
+      - name: Validate examples
+        run: |
+          for cfg in examples/*.config.json; do
+            OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate
+          done
 
       - name: Build release
         run: zig build -Doptimize=ReleaseSafe
@@ -37,6 +95,8 @@ jobs:
           - aarch64-linux-musl
           - x86_64-macos
           - aarch64-macos
+          - x86_64-windows
+          - aarch64-windows
     steps:
       - uses: actions/checkout@v4
 
@@ -49,13 +109,13 @@ jobs:
 
       - name: Check binary
         run: |
-          ls -lh zig-out/bin/oauth-mux
-          file zig-out/bin/oauth-mux
+          ls -lh zig-out/bin/oauth-mux*
+          file zig-out/bin/oauth-mux*
 
       - uses: actions/upload-artifact@v4
         with:
           name: oauth-mux-${{ matrix.target }}
-          path: zig-out/bin/oauth-mux
+          path: zig-out/bin/oauth-mux*
 
   nix:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
             OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate
           done
 
+      - name: Local E2E
+        run: ./scripts/e2e-local.sh
+
       - name: Build release
         run: zig build -Doptimize=ReleaseSafe
 

--- a/.github/workflows/release-proof.yml
+++ b/.github/workflows/release-proof.yml
@@ -1,0 +1,65 @@
+name: Release Proof
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version to stage and smoke-test"
+        required: false
+        default: "0.1.0"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  cache-first-release-proof:
+    name: GloriousFlywheel release proof
+    runs-on: tinyland-nix
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect GloriousFlywheel action access
+        id: gf
+        shell: bash
+        env:
+          GF_ACTIONS_TOKEN: ${{ secrets.GF_ACTIONS_TOKEN || '' }}
+        run: |
+          if [ -n "${GF_ACTIONS_TOKEN:-}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::GF_ACTIONS_TOKEN is unset; skipping private GloriousFlywheel action checkout"
+          fi
+
+      - name: Checkout GloriousFlywheel action
+        if: steps.gf.outputs.enabled == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: tinyland-inc/GloriousFlywheel
+          ref: main
+          path: .gloriousflywheel
+          token: ${{ secrets.GF_ACTIONS_TOKEN }}
+          persist-credentials: false
+
+      - name: Run cache-first release proof
+        if: steps.gf.outputs.enabled == 'true'
+        uses: ./.gloriousflywheel/.github/actions/nix-job
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN || '' }}
+        with:
+          attic-public-key: ${{ vars.ATTIC_PUBLIC_KEY || '' }}
+          push-cache: "false"
+          command: |
+            set -euxo pipefail
+            test -n "${ATTIC_SERVER:-}"
+            test -n "${ATTIC_CACHE:-}"
+            test -n "${NIX_CONFIG:-}"
+            nix develop --command just release-proof-local "${{ inputs.version }}"
+
+      - name: Record skipped release proof
+        if: steps.gf.outputs.enabled != 'true'
+        shell: bash
+        run: |
+          echo "GloriousFlywheel release proof skipped because GF_ACTIONS_TOKEN is unset." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,9 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
-      - name: Build release artifacts
+      - name: Build and smoke-test release artifacts
         run: |
-          nix develop --command ./scripts/release-local.sh "${GITHUB_REF_NAME#v}"
+          nix develop --command just release-proof-local "${GITHUB_REF_NAME#v}"
 
       - name: Upload release staging
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,4 +41,5 @@ jobs:
             v*/artifacts/*
             v*/npm-tarballs/*.tgz
             v*/homebrew/oauth-mux.rb
+            v*/handoff/*
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,45 +10,22 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - target: x86_64-linux-musl
-            artifact: oauth-mux-x86_64-linux
-          - target: aarch64-linux-musl
-            artifact: oauth-mux-aarch64-linux
-          - target: x86_64-macos
-            artifact: oauth-mux-x86_64-macos
-          - target: aarch64-macos
-            artifact: oauth-mux-aarch64-macos
-          - target: x86_64-windows
-            artifact: oauth-mux-x86_64-windows
-          - target: aarch64-windows
-            artifact: oauth-mux-aarch64-windows
     steps:
       - uses: actions/checkout@v4
 
-      - uses: mlugg/setup-zig@v2
+      - uses: cachix/install-nix-action@v30
         with:
-          version: 0.14.1
+          nix_path: nixpkgs=channel:nixos-unstable
 
-      - name: Build
-        run: zig build -Dtarget=${{ matrix.target }} -Doptimize=ReleaseSafe
-
-      - name: Package
+      - name: Build release artifacts
         run: |
-          cd zig-out/bin
-          binary=oauth-mux
-          if [ -f oauth-mux.exe ]; then
-            binary=oauth-mux.exe
-          fi
-          tar czf /tmp/${{ matrix.artifact }}.tar.gz "$binary"
-          sha256sum /tmp/${{ matrix.artifact }}.tar.gz > /tmp/${{ matrix.artifact }}.tar.gz.sha256
+          nix develop --command ./scripts/release-local.sh "${GITHUB_REF_NAME#v}"
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload release staging
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact }}
-          path: /tmp/${{ matrix.artifact }}.tar.gz*
+          name: oauth-mux-release-${{ github.ref_name }}
+          path: dist/out/
 
   release:
     needs: build
@@ -58,12 +35,10 @@ jobs:
         with:
           merge-multiple: true
 
-      - name: Generate checksums
-        run: cat *.sha256 > SHA256SUMS
-
       - uses: softprops/action-gh-release@v2
         with:
           files: |
-            *.tar.gz
-            SHA256SUMS
+            v*/artifacts/*
+            v*/npm-tarballs/*.tgz
+            v*/homebrew/oauth-mux.rb
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ jobs:
             artifact: oauth-mux-x86_64-macos
           - target: aarch64-macos
             artifact: oauth-mux-aarch64-macos
+          - target: x86_64-windows
+            artifact: oauth-mux-x86_64-windows
+          - target: aarch64-windows
+            artifact: oauth-mux-aarch64-windows
     steps:
       - uses: actions/checkout@v4
 
@@ -34,7 +38,11 @@ jobs:
       - name: Package
         run: |
           cd zig-out/bin
-          tar czf /tmp/${{ matrix.artifact }}.tar.gz oauth-mux
+          binary=oauth-mux
+          if [ -f oauth-mux.exe ]; then
+            binary=oauth-mux.exe
+          fi
+          tar czf /tmp/${{ matrix.artifact }}.tar.gz "$binary"
           sha256sum /tmp/${{ matrix.artifact }}.tar.gz > /tmp/${{ matrix.artifact }}.tar.gz.sha256
 
       - uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ bazel-*
 
 # Distribution artifacts
 dist/build/
+dist/out/
 *.tar.gz
 *.deb
 *.rpm

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ just release-local 0.1.0
 Outputs are written under `dist/out/v0.1.0/`:
 
 - `artifacts/` for binary tarballs and `SHA256SUMS`
+- `artifacts/install.sh` for checksum-verified `curl | sh` installs
 - `homebrew/oauth-mux.rb`
 - `npm/` package workspace
 - `npm-tarballs/`

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ just release
 ```
 
 `just check` enters the Nix dev shell and then runs `just check-local`, which
-runs Zig tests, builds the binary, and validates every example config.
+runs Zig tests, builds the binary, validates every example config, and runs the
+synthetic local E2E harness.
 
 ## Quick Checks
 
@@ -50,6 +51,16 @@ Probe a configured account:
 ```bash
 ./zig-out/bin/oauth-mux probe --provider codex --account max-1 --capability codex-mini --json
 ```
+
+Run the deterministic no-secret E2E harness:
+
+```bash
+just e2e
+```
+
+That harness creates a temporary provider config and proves env injection,
+command probes, route-scoped quota fallback, health persistence, and `exec`
+target injection without contacting live OAuth providers.
 
 ## Release Staging
 
@@ -85,3 +96,5 @@ Release attachments, npm publish order, Homebrew tap input, deb/rpm files, and
 full checksums.
 
 See `docs/release-runbook.md` for release and CI details.
+See `docs/spec/development-timeline-2026-04-27.md` for the current
+production-readiness timeline.

--- a/README.md
+++ b/README.md
@@ -67,4 +67,10 @@ Outputs are written under `dist/out/v0.1.0/`:
 - `npm-tarballs/`
 - `nfpm/` configs plus deb/rpm artifacts
 
+Build and smoke-test the same release tree:
+
+```bash
+just release-proof 0.1.0
+```
+
 See `docs/release-runbook.md` for release and CI details.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,70 @@
+# oauth-mux
+
+`oauth-mux` is a compiled OAuth fallback mux for AI harness subscriptions and
+connector auth. It selects among configured provider accounts, records typed
+credential liveness, and falls through without poisoning an entire account when
+only one route or capability is unavailable.
+
+The implementation is pure Zig with no external Zig dependencies.
+
+## Current Shape
+
+- Typed liveness model: `live`, `degraded`, `dead`.
+- Route-scoped health keys: `provider:account#capability`.
+- Provider definitions for credential parsing, env/config injection, failure
+  rules, and HTTP or command probes.
+- Built-in examples for Codex, Claude, GitHub, Linear, Vercel, Figma, FlakeHub,
+  and MCP HTTP resource-server probes.
+- Release graph for six targets:
+  - `x86_64-linux-musl`
+  - `aarch64-linux-musl`
+  - `x86_64-macos`
+  - `aarch64-macos`
+  - `x86_64-windows`
+  - `aarch64-windows`
+
+## Development
+
+Use `just` as the operator entrypoint:
+
+```bash
+just build
+just test
+just check
+just release
+```
+
+`just check` enters the Nix dev shell and then runs `just check-local`, which
+runs Zig tests, builds the binary, and validates every example config.
+
+## Quick Checks
+
+Validate an example:
+
+```bash
+OMUX_CONFIG=$PWD/examples/codex-max.config.json ./zig-out/bin/oauth-mux config validate
+```
+
+Probe a configured account:
+
+```bash
+./zig-out/bin/oauth-mux probe --provider codex --account max-1 --capability codex-mini --json
+```
+
+## Release Staging
+
+Build local release artifacts from one version:
+
+```bash
+just release-local 0.1.0
+```
+
+Outputs are written under `dist/out/v0.1.0/`:
+
+- `artifacts/` for binary tarballs and `SHA256SUMS`
+- `homebrew/oauth-mux.rb`
+- `npm/` package workspace
+- `npm-tarballs/`
+- `nfpm/` configs plus deb/rpm artifacts
+
+See `docs/release-runbook.md` for release and CI details.

--- a/README.md
+++ b/README.md
@@ -74,4 +74,14 @@ Build and smoke-test the same release tree:
 just release-proof 0.1.0
 ```
 
+Generate the non-publishing operator handoff for the staged tree:
+
+```bash
+just release-handoff 0.1.0
+```
+
+The handoff is written under `dist/out/v0.1.0/handoff/` and lists GitHub
+Release attachments, npm publish order, Homebrew tap input, deb/rpm files, and
+full checksums.
+
 See `docs/release-runbook.md` for release and CI details.

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
-# oauth-mux installer — detects OS/arch and downloads the right binary
+# oauth-mux installer - detects OS/arch, verifies checksums, installs the binary
 set -eu
 
-REPO="tinyland-inc/oauth-mux"
+REPO="${REPO:-tinyland-inc/oauth-mux}"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 VERSION="${VERSION:-latest}"
+OMUX_RELEASE_BASE_URL="${OMUX_RELEASE_BASE_URL:-}"
 
 main() {
     os=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -24,15 +25,28 @@ main() {
 
     if [ "$VERSION" = "latest" ]; then
         VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed 's/.*"v//' | sed 's/".*//')
+    else
+        VERSION=$(printf '%s' "$VERSION" | sed 's/^v//')
     fi
 
-    url="https://github.com/${REPO}/releases/download/v${VERSION}/oauth-mux-${target}.tar.gz"
+    archive="oauth-mux-${target}.tar.gz"
+    if [ -n "$OMUX_RELEASE_BASE_URL" ]; then
+        base_url="${OMUX_RELEASE_BASE_URL%/}"
+    else
+        base_url="https://github.com/${REPO}/releases/download/v${VERSION}"
+    fi
+    url="${base_url}/${archive}"
+    sums_url="${base_url}/SHA256SUMS"
+
     echo "downloading oauth-mux v${VERSION} for ${target}..."
 
     tmpdir=$(mktemp -d)
     trap 'rm -rf "$tmpdir"' EXIT
 
     curl -fsSL "$url" -o "$tmpdir/oauth-mux.tar.gz"
+    curl -fsSL "$sums_url" -o "$tmpdir/SHA256SUMS"
+    verify_checksum "$tmpdir/oauth-mux.tar.gz" "$tmpdir/SHA256SUMS" "$archive"
+
     tar xzf "$tmpdir/oauth-mux.tar.gz" -C "$tmpdir"
 
     mkdir -p "$INSTALL_DIR"
@@ -45,6 +59,28 @@ main() {
         echo ""
         echo "add to your PATH:"
         echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+    fi
+}
+
+verify_checksum() {
+    file="$1"
+    sums="$2"
+    archive="$3"
+
+    expected=$(awk -v archive="$archive" '$2 == archive { print $1; found = 1 } END { exit found ? 0 : 1 }' "$sums") || {
+        die "missing checksum for ${archive}"
+    }
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual=$(sha256sum "$file" | awk '{ print $1 }')
+    elif command -v shasum >/dev/null 2>&1; then
+        actual=$(shasum -a 256 "$file" | awk '{ print $1 }')
+    else
+        die "sha256sum or shasum is required to verify ${archive}"
+    fi
+
+    if [ "$actual" != "$expected" ]; then
+        die "checksum mismatch for ${archive}"
     fi
 }
 

--- a/dist/npm/bin/oauth-mux.js
+++ b/dist/npm/bin/oauth-mux.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+const binary = process.platform === "win32" ? "oauth-mux.exe" : "oauth-mux";
+const binPath = path.join(__dirname, binary);
+
+const result = spawnSync(binPath, process.argv.slice(2), { stdio: "inherit" });
+
+if (result.error) {
+  console.error(`oauth-mux: failed to launch ${binPath}: ${result.error.message}`);
+  process.exit(1);
+}
+
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+}
+
+process.exit(result.status ?? 1);

--- a/dist/npm/install.js
+++ b/dist/npm/install.js
@@ -9,6 +9,8 @@ const PLATFORM_MAP = {
   "darwin-x64": "@oauth-mux/darwin-x64",
   "linux-arm64": "@oauth-mux/linux-arm64",
   "linux-x64": "@oauth-mux/linux-x64",
+  "win32-arm64": "@oauth-mux/win32-arm64",
+  "win32-x64": "@oauth-mux/win32-x64",
 };
 
 const key = `${os.platform()}-${os.arch()}`;
@@ -21,8 +23,9 @@ if (!pkg) {
 
 try {
   const pkgDir = path.dirname(require.resolve(`${pkg}/package.json`));
-  const src = path.join(pkgDir, "bin", "oauth-mux");
-  const dest = path.join(__dirname, "bin", "oauth-mux");
+  const binary = os.platform() === "win32" ? "oauth-mux.exe" : "oauth-mux";
+  const src = path.join(pkgDir, "bin", binary);
+  const dest = path.join(__dirname, "bin", binary);
   fs.mkdirSync(path.dirname(dest), { recursive: true });
   fs.copyFileSync(src, dest);
   fs.chmodSync(dest, 0o755);

--- a/dist/npm/package.json
+++ b/dist/npm/package.json
@@ -4,8 +4,12 @@
   "description": "OAuth fallback muxing for AI harness subscriptions",
   "license": "MIT",
   "repository": "tinyland-inc/oauth-mux",
+  "files": [
+    "bin",
+    "install.js"
+  ],
   "bin": {
-    "oauth-mux": "bin/oauth-mux"
+    "oauth-mux": "bin/oauth-mux.js"
   },
   "scripts": {
     "postinstall": "node install.js"
@@ -14,6 +18,8 @@
     "@oauth-mux/darwin-arm64": "0.1.0",
     "@oauth-mux/darwin-x64": "0.1.0",
     "@oauth-mux/linux-arm64": "0.1.0",
-    "@oauth-mux/linux-x64": "0.1.0"
+    "@oauth-mux/linux-x64": "0.1.0",
+    "@oauth-mux/win32-arm64": "0.1.0",
+    "@oauth-mux/win32-x64": "0.1.0"
   }
 }

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -52,14 +52,14 @@ This runs `release-local` and then checks:
 
 Tags matching `v*` run `.github/workflows/release.yml`.
 
-The workflow calls:
+The workflow calls the same build-plus-smoke proof used locally:
 
 ```bash
-nix develop --command ./scripts/release-local.sh "${GITHUB_REF_NAME#v}"
+nix develop --command just release-proof-local "${GITHUB_REF_NAME#v}"
 ```
 
-It uploads the staged `dist/out/` tree, then attaches these files to the GitHub
-release:
+The release job only uploads the staged `dist/out/` tree after the smoke proof
+passes. It then attaches these files to the GitHub release:
 
 - `v*/artifacts/*`
 - `v*/npm-tarballs/*.tgz`
@@ -96,7 +96,7 @@ During known lab or runner outages, do not block release staging on a queued
 
 - local `just check`
 - local `nix flake check`
-- local `just release-local <version>`
+- local `just release-proof <version>`
 - hosted CI `test`, `nix`, and six cross-compile jobs
 
 Only claim GloriousFlywheel cache-first CI proof when the GF job actually runs

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -131,6 +131,8 @@ nix develop --command just release-proof-local <version>
 
 That workflow does not publish release artifacts. It proves that the staged
 release graph can attach to the same Nix/Attic substrate as normal CI.
+Because this workflow is introduced by the initial implementation PR, GitHub
+can dispatch it only after the workflow file exists on `main`.
 
 ## GloriousFlywheel Boundary
 
@@ -151,6 +153,10 @@ During known lab or runner outages, do not block release staging on a queued
 
 Only claim GloriousFlywheel cache-first CI proof when the GF job actually runs
 the private action and completes.
+
+Current PR evidence: run `25009779392`, job `73266579091`, completed the real
+private-action cache-first lane and ran `nix develop --command just check-local`
+on `tinyland-nix`. Cache push was intentionally disabled for the PR event.
 
 ## Before Marking A PR Ready
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -32,6 +32,20 @@ The Nix dev shell supplies Zig, Just, Node/npm, and nfpm, so `just release-local
 is the reproducible proof path. Running `scripts/release-local.sh` directly will
 still skip npm or deb/rpm output if those host tools are absent.
 
+Run the full build-plus-smoke proof:
+
+```bash
+just release-proof 0.1.0
+```
+
+This runs `release-local` and then checks:
+
+- required binary tarballs, debs, rpms, npm tarballs, and Homebrew formula
+- `SHA256SUMS` against the artifact directory
+- tarball payload names for Unix and Windows targets
+- rendered Homebrew formula placeholders and Ruby syntax when Ruby is present
+- local npm install of the matching platform package plus root shim
+
 ## Release Workflow
 
 Tags matching `v*` run `.github/workflows/release.yml`.
@@ -48,6 +62,19 @@ release:
 - `v*/artifacts/*`
 - `v*/npm-tarballs/*.tgz`
 - `v*/homebrew/oauth-mux.rb`
+
+## GloriousFlywheel Release Proof
+
+`.github/workflows/release-proof.yml` is a manual cache-first proof surface for
+the release path. It runs on `tinyland-nix`, checks out the private
+GloriousFlywheel action when `GF_ACTIONS_TOKEN` is available, and executes:
+
+```bash
+nix develop --command just release-proof-local <version>
+```
+
+That workflow does not publish release artifacts. It proves that the staged
+release graph can attach to the same Nix/Attic substrate as normal CI.
 
 ## GloriousFlywheel Boundary
 
@@ -72,7 +99,7 @@ the private action and completes.
 ## Before Marking A PR Ready
 
 - `just check` passes.
-- `just release-local <version>` produces all six binary tarballs and checksums.
+- `just release-proof <version>` produces and smoke-checks the release tree.
 - Hosted PR CI passes.
 - GF lane either passes or is explicitly deferred because of runner/token state.
 - Release notes mention any skipped GF proof.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -22,6 +22,7 @@ Expected output:
 - `artifacts/oauth-mux-x86_64-windows.tar.gz`
 - `artifacts/oauth-mux-aarch64-windows.tar.gz`
 - `artifacts/SHA256SUMS`
+- `artifacts/install.sh`
 - `homebrew/oauth-mux.rb`
 - `npm/` package workspace
 - `npm-tarballs/*.tgz`
@@ -45,6 +46,7 @@ This runs `release-local` and then checks:
 - tarball payload names for Unix and Windows targets
 - rendered Homebrew formula placeholders and Ruby syntax when Ruby is present
 - local npm install of the matching platform package plus root shim
+- local installer execution against the staged artifact directory
 
 ## Release Workflow
 
@@ -62,6 +64,10 @@ release:
 - `v*/artifacts/*`
 - `v*/npm-tarballs/*.tgz`
 - `v*/homebrew/oauth-mux.rb`
+
+The staged `install.sh` verifies the selected tarball against `SHA256SUMS`
+before installing. For local proof, `OMUX_RELEASE_BASE_URL=file://...` points it
+at the staged artifact directory instead of GitHub Releases.
 
 ## GloriousFlywheel Release Proof
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,78 @@
+# oauth-mux Release Runbook
+
+Updated: 2026-04-26
+
+## Local Release Proof
+
+Run the full local release staging path:
+
+```bash
+just release-local 0.1.0
+```
+
+This runs the single Zig release graph and stages artifacts under
+`dist/out/v0.1.0/`.
+
+Expected output:
+
+- `artifacts/oauth-mux-x86_64-linux.tar.gz`
+- `artifacts/oauth-mux-aarch64-linux.tar.gz`
+- `artifacts/oauth-mux-x86_64-macos.tar.gz`
+- `artifacts/oauth-mux-aarch64-macos.tar.gz`
+- `artifacts/oauth-mux-x86_64-windows.tar.gz`
+- `artifacts/oauth-mux-aarch64-windows.tar.gz`
+- `artifacts/SHA256SUMS`
+- `homebrew/oauth-mux.rb`
+- `npm/` package workspace
+- `npm-tarballs/*.tgz`
+- `nfpm/oauth-mux-{amd64,arm64}.yaml`
+- deb/rpm artifacts
+
+The Nix dev shell supplies Zig, Just, Node/npm, and nfpm, so `just release-local`
+is the reproducible proof path. Running `scripts/release-local.sh` directly will
+still skip npm or deb/rpm output if those host tools are absent.
+
+## Release Workflow
+
+Tags matching `v*` run `.github/workflows/release.yml`.
+
+The workflow calls:
+
+```bash
+nix develop --command ./scripts/release-local.sh "${GITHUB_REF_NAME#v}"
+```
+
+It uploads the staged `dist/out/` tree, then attaches these files to the GitHub
+release:
+
+- `v*/artifacts/*`
+- `v*/npm-tarballs/*.tgz`
+- `v*/homebrew/oauth-mux.rb`
+
+## GloriousFlywheel Boundary
+
+The normal CI workflow has a GloriousFlywheel cache-first lane on
+`tinyland-nix`. Because `GloriousFlywheel` is private, that lane needs
+`GF_ACTIONS_TOKEN` to check out the private composite action.
+
+If `GF_ACTIONS_TOKEN` is absent, CI records a token-gated skip instead of
+claiming a cache-first proof.
+
+During known lab or runner outages, do not block release staging on a queued
+`tinyland-nix` job alone. Use these signals together:
+
+- local `just check`
+- local `nix flake check`
+- local `just release-local <version>`
+- hosted CI `test`, `nix`, and six cross-compile jobs
+
+Only claim GloriousFlywheel cache-first CI proof when the GF job actually runs
+the private action and completes.
+
+## Before Marking A PR Ready
+
+- `just check` passes.
+- `just release-local <version>` produces all six binary tarballs and checksums.
+- Hosted PR CI passes.
+- GF lane either passes or is explicitly deferred because of runner/token state.
+- Release notes mention any skipped GF proof.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -47,6 +47,23 @@ This runs `release-local` and then checks:
 - rendered Homebrew formula placeholders and Ruby syntax when Ruby is present
 - local npm install of the matching platform package plus root shim
 - local installer execution against the staged artifact directory
+- non-publishing release handoff generation
+
+Generate only the handoff for an already staged tree:
+
+```bash
+just release-handoff 0.1.0
+```
+
+This validates the staged publication inputs and writes:
+
+- `dist/out/v0.1.0/handoff/release-handoff.md`
+- `dist/out/v0.1.0/handoff/publish-files.txt`
+- `dist/out/v0.1.0/handoff/SHA256SUMS.full`
+
+The handoff lists GitHub Release attachments, npm publish order, Homebrew tap
+input, deb/rpm files, and full checksums. It does not use registry credentials
+or publish anything.
 
 ## Release Workflow
 
@@ -59,11 +76,12 @@ nix develop --command just release-proof-local "${GITHUB_REF_NAME#v}"
 ```
 
 The release job only uploads the staged `dist/out/` tree after the smoke proof
-passes. It then attaches these files to the GitHub release:
+and handoff generation pass. It then attaches these files to the GitHub release:
 
 - `v*/artifacts/*`
 - `v*/npm-tarballs/*.tgz`
 - `v*/homebrew/oauth-mux.rb`
+- `v*/handoff/*`
 
 The staged `install.sh` verifies the selected tarball against `SHA256SUMS`
 before installing. For local proof, `OMUX_RELEASE_BASE_URL=file://...` points it

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,6 +1,38 @@
 # oauth-mux Release Runbook
 
-Updated: 2026-04-26
+Updated: 2026-04-27
+
+## Local Quality Gates
+
+Run the canonical repo check:
+
+```bash
+just check
+```
+
+This enters the Nix dev shell and runs:
+
+- Zig unit tests
+- binary build
+- every `examples/*.config.json` through `config validate`
+- synthetic local E2E via `scripts/e2e-local.sh`
+
+The E2E harness is intentionally no-secret and no-network. It creates a
+temporary provider definition, command probe, config, and state directory, then
+proves:
+
+- shell env injection for a selected account
+- command-transport capability probes
+- route-scoped quota fallback from `toy:a1#expensive` to `toy:a2#expensive`
+- unrelated route survival for `toy:a1#cheap`
+- persisted typed health evidence
+- `exec` target process env injection
+
+Run only that harness with:
+
+```bash
+just e2e
+```
 
 ## Local Release Proof
 

--- a/docs/spec/architecture-review-2026-04-25.md
+++ b/docs/spec/architecture-review-2026-04-25.md
@@ -88,6 +88,11 @@ Implemented:
   action, `just release` runs the single Zig release graph, and CI/release
   matrices include all six documented targets. See
   `docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md`.
+- Local release staging: `just release-local <version>` emits six binary
+  tarballs, checksums, a rendered Homebrew formula, npm package workspace and
+  tarballs, plus nfpm configs and deb/rpm artifacts through the Nix dev shell.
+- Root README and release runbook covering local validation, release staging,
+  GitHub release behavior, and the GloriousFlywheel runner/token boundary.
 
 ## Key Decisions
 
@@ -155,8 +160,9 @@ Decision record:
   timeout. Request body templating and richer header extraction are future work.
 - Health persistence is versioned and backward-compatible, but migration policy
   beyond the current evidence fields is not yet documented.
-- Release packaging templates exist for curl installer, npm, Homebrew, and
-  nfpm; checksum/artifact publication remains release-automation work.
+- Release packaging now has a local staging command. GitHub release publication
+  uses that command, but real npm/Homebrew/deb/rpm registry publication is still
+  future work.
 - GloriousFlywheel cache-first CI proves shared Nix/Attic substrate attachment,
   not universal remote execution or Bazel remote-cache behavior. `oauth-mux`
   remains Zig-only, so Bazel should stay out until there is a real target graph.
@@ -174,9 +180,8 @@ Decision record:
 
 1. Add provider-specific MCP examples only when the resource server URL and
    token audience are explicit.
-2. Turn the existing dist templates into a release automation path that emits
-   tarballs, checksums, npm platform packages, Homebrew formula updates, and
-   nfpm deb/rpm artifacts from one version input.
+2. Add registry publication handoffs for npm, Homebrew tap updates, and deb/rpm
+   repositories once artifact staging is accepted.
 3. Add a GloriousFlywheel-backed release proof job for the release artifact
    path once the one-version release recipe exists.
 4. Update TIN-491 and GitHub issue #197 with this checkpoint and the remaining
@@ -242,4 +247,8 @@ profile-level codex-max fallback -> selected max-3#codex-max with 200/use_this/l
 
 just release
 single Zig release graph builds all six documented targets
+
+just release-local 0.1.0
+emits six binary tarballs, SHA256SUMS, Homebrew formula, npm package workspace,
+npm tarballs, nfpm configs, and deb/rpm output
 ```

--- a/docs/spec/architecture-review-2026-04-25.md
+++ b/docs/spec/architecture-review-2026-04-25.md
@@ -101,6 +101,10 @@ Implemented:
   `handoff/publish-files.txt`, and `handoff/SHA256SUMS.full` with GitHub
   Release attachments, npm publish order, Homebrew tap input, deb/rpm files,
   and full checksums.
+- Deterministic local E2E proof: `just e2e` creates a temporary provider
+  definition, command probe, config, and state directory to prove env
+  injection, command probes, route-scoped quota fallback, health persistence,
+  and `exec` target injection without contacting live OAuth providers.
 - Manual GloriousFlywheel release proof: `.github/workflows/release-proof.yml`
   runs the same proof through the private cache-first `nix-job` action on
   `tinyland-nix` when runner capacity and `GF_ACTIONS_TOKEN` are available.
@@ -179,6 +183,10 @@ Decision record:
   handoff command. GitHub release publication uses that proof before attaching
   artifacts, but real npm/Homebrew/deb/rpm registry publication is still future
   work.
+- The deterministic E2E harness proves the mux core without live credentials,
+  but it is not a substitute for bounded live-provider QA. Codex, Claude,
+  GitHub, Linear, Figma, Vercel, FlakeHub, and MCP live probes still need
+  explicit secret scoping and call budgets.
 - GloriousFlywheel cache-first CI proves shared Nix/Attic substrate attachment,
   not universal remote execution or Bazel remote-cache behavior. `oauth-mux`
   remains Zig-only, so Bazel should stay out until there is a real target graph.
@@ -196,12 +204,14 @@ Decision record:
 
 1. Add provider-specific MCP examples only when the resource server URL and
    token audience are explicit.
-2. Turn the generated registry handoff into authenticated dry-run lanes for npm,
+2. Add a bounded live-provider QA lane that consumes real calls only when
+   explicitly triggered with scoped secrets.
+3. Turn the generated registry handoff into authenticated dry-run lanes for npm,
    Homebrew tap updates, and deb/rpm repositories.
-3. Promote the manual GloriousFlywheel release proof into a required
+4. Promote the manual GloriousFlywheel release proof into a required
    pre-publication self-hosted gate once runner capacity is stable enough for
    release blocking.
-4. Update TIN-491 and GitHub issue #197 with this checkpoint and the remaining
+5. Update TIN-491 and GitHub issue #197 with this checkpoint and the remaining
    provider-verification work.
 
 ## Validation

--- a/docs/spec/architecture-review-2026-04-25.md
+++ b/docs/spec/architecture-review-2026-04-25.md
@@ -91,6 +91,12 @@ Implemented:
 - Local release staging: `just release-local <version>` emits six binary
   tarballs, checksums, a rendered Homebrew formula, npm package workspace and
   tarballs, plus nfpm configs and deb/rpm artifacts through the Nix dev shell.
+- Local release proof: `just release-proof <version>` stages the release and
+  smoke-checks required artifacts, checksums, archive payloads, Homebrew
+  rendering, and local npm installation.
+- Manual GloriousFlywheel release proof: `.github/workflows/release-proof.yml`
+  runs the same proof through the private cache-first `nix-job` action on
+  `tinyland-nix` when runner capacity and `GF_ACTIONS_TOKEN` are available.
 - Root README and release runbook covering local validation, release staging,
   GitHub release behavior, and the GloriousFlywheel runner/token boundary.
 
@@ -182,8 +188,8 @@ Decision record:
    token audience are explicit.
 2. Add registry publication handoffs for npm, Homebrew tap updates, and deb/rpm
    repositories once artifact staging is accepted.
-3. Add a GloriousFlywheel-backed release proof job for the release artifact
-   path once the one-version release recipe exists.
+3. Promote the manual GloriousFlywheel release proof into a required pre-tag
+   publication gate once runner capacity is stable enough for release blocking.
 4. Update TIN-491 and GitHub issue #197 with this checkpoint and the remaining
    provider-verification work.
 
@@ -251,4 +257,8 @@ single Zig release graph builds all six documented targets
 just release-local 0.1.0
 emits six binary tarballs, SHA256SUMS, Homebrew formula, npm package workspace,
 npm tarballs, nfpm configs, and deb/rpm output
+
+just release-proof 0.1.0
+stages the release and verifies required artifacts, checksums, archive payloads,
+Homebrew rendering, and local npm installation
 ```

--- a/docs/spec/architecture-review-2026-04-25.md
+++ b/docs/spec/architecture-review-2026-04-25.md
@@ -1,0 +1,245 @@
+# OAuth Mux Architecture Review
+
+Updated: 2026-04-26
+
+Issue context: Linear `TIN-491`, GitHub `tinyland-inc/lab#197`.
+
+## Current Checkpoint
+
+This checkpoint turns `oauth-mux` from a simple account switcher into a typed,
+schema-driven OAuth routing core.
+
+Implemented:
+
+- Versioned typed health persistence for account and route liveness.
+- Distinct auth, operability, and availability states:
+  `live`, `degraded`, and `dead`.
+- Account health keys and route health keys:
+  `provider:account` and `provider:account#capability`.
+- Provider-level fallback for provider-wide degradation.
+- Capability-aware selection via profile entries and `--capability`.
+- Declarative provider definitions for token parsing, env/config injection,
+  refresh endpoints, failure classification, and capability probes.
+- Semantic `config validate` for provider definitions, profile references,
+  secrets, direct env mappings, failure rules, and probe definitions.
+- Std-only probe execution module that classifies HTTP and command probe
+  results and records them into typed health state.
+- Operator-facing `probe` command for account validation and capability probes
+  without launching a target command.
+- Codex Max example config and operator plan for three subscription accounts.
+- `init --codex-max` for generating the three-account scaffold directly.
+- Persisted last-probe evidence fields: source, observed time, retry-after,
+  hint class, and mux decision.
+- Live validation of three isolated Codex Max stores, each logged in through
+  Codex CLI with its own `CODEX_HOME`.
+- Live command-probe validation for both semantic Codex route labels:
+  `codex-mini` and `codex-max`.
+- Induced route-failure pipeline coverage: a degraded `codex-max` route falls
+  through to the next account while the same account remains eligible for
+  `codex-mini`.
+- Provider authoring checklist for schema-only OAuth harness support, including
+  HTTP-vs-command probe admission rules and the current Codex direct-HTTP
+  research finding.
+- Probe privacy validation in `config validate`: capability probe URLs and
+  command argv entries may not embed token material.
+- Failure-rule coverage validation in `config validate`: probed schema
+  providers must define failure rules, and each failure rule must include a
+  concrete matcher rather than acting as a catch-all classifier.
+- Fixture redaction validation in `zig build test`: files under
+  `test/fixtures` are scanned for common OAuth token, bearer header, cookie,
+  and API-key markers.
+- Explicit Codex direct-HTTP probe decision record: no direct Codex HTTP probe
+  is admitted until an official/provider-owned source documents endpoint
+  semantics, token audience, typed failure classes, reset behavior, and quota
+  impact.
+- `just check` now enters `nix develop` once and runs both `zig build test` and
+  `zig build` inside that shell, avoiding duplicate Nix wrapper startup.
+- Provider probe admission matrix for Codex, Claude, Anthropic API, MCP,
+  GitHub, Linear, Figma, Vercel, and FlakeHub.
+- Built-in GitHub `identity` capability probe using the documented
+  `GET /user` endpoint, with GitHub-specific 403 rate-limit vs degraded
+  classification and an env-backed example config.
+- Narrow HTTP probe body support for GraphQL identity checks, plus built-in
+  Linear `identity` capability probing `viewer` through the documented GraphQL
+  endpoint.
+- Built-in Vercel `identity` capability probe using the documented `GET /v2/user`
+  endpoint, with a scoped env-backed example config.
+- Built-in Figma REST OAuth `identity` capability probe using the documented
+  `GET /v1/me` endpoint.
+- Generic custom-token-header probe auth (`auth = token_header`) plus Figma
+  PAT `identity-pat` support using `X-Figma-Token`. Plan access tokens are not
+  mapped to `/v1/me` because Figma excludes that endpoint for plan tokens.
+- URL-template expansion for non-secret resource identifiers in probe URLs,
+  plus Figma plan-token `file-metadata-plan` support using
+  `GET /v1/files/{{OMUX_FIGMA_PLAN_FILE_KEY}}/meta`.
+- Built-in Claude Code `auth-status` command probe using the documented
+  `claude auth status --json` command under the selected `CLAUDE_CONFIG_DIR`.
+- Built-in FlakeHub / Determinate `status` command probe using
+  `determinate-nixd status`; direct HTTP remains unadmitted.
+- Built-in MCP HTTP `resource-metadata` and `resource` probe templates for
+  RFC 9728 protected resource metadata and audience-bound bearer resource
+  checks.
+- Release entrypoint alignment: `just release` now aliases the full release
+  build, Windows targets are included in `release-all`, and `just check`
+  validates every example config after build.
+- GloriousFlywheel substrate integration plan and first CI lace-up:
+  `just check` now delegates to devshell-local `just check-local`, CI has a
+  `tinyland-nix` cache-first lane through the GloriousFlywheel `nix-job`
+  action, `just release` runs the single Zig release graph, and CI/release
+  matrices include all six documented targets. See
+  `docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md`.
+
+## Key Decisions
+
+### Route Health Does Not Poison Account Health
+
+Quota exhaustion for `codex:max-1#codex-max` must not mark
+`codex:max-1` unusable for every route. Account-level auth failures still
+dominate every route on that account.
+
+### Provider Definitions Stay Data-First
+
+New AI harness support should usually be added as config data:
+
+- credential JSON paths
+- refresh endpoints
+- config directory or env injection shape
+- failure classification rules
+- optional capability probe plans
+
+Compiled adapters remain reserved for behavior that cannot be represented
+safely with small data structures.
+
+### Probe Plans Are Not Secrets
+
+Provider definitions may describe how to probe a capability. The access token is
+injected only at execution time, never persisted in the provider schema, health
+state, or logs.
+
+Command probes follow the same rule: the provider definition stores argv only,
+and the pipeline supplies account-scoped env such as `CODEX_HOME` at execution
+time.
+
+### Codex Max Needs Capability Routes
+
+Three Codex Max accounts are not just three login stores. The mux must know
+whether a specific model/task route is unavailable, quota exhausted, temporarily
+rate-limited, or auth-dead.
+
+### Codex Uses Command Probes First
+
+The first verified Codex route probes use `codex exec --json` rather than a
+direct OAuth resource endpoint. That matches the subscription-backed ChatGPT
+surface actually exposed by Codex CLI 0.125.0 on this workstation and lets the
+mux distinguish a live route from plan/model incompatibility by parsing JSONL
+events.
+
+### Direct Codex HTTP Probes Are Unadmitted
+
+As of 2026-04-26, no official Codex subscription-account HTTP health endpoint
+has been found with documented method, request shape, token audience, response
+schema, typed failure classes, retry/reset semantics, and quota impact. Treat
+direct Codex HTTP probing as blocked until that admission gate is satisfied.
+
+Decision record:
+`docs/spec/codex-direct-http-probe-decision-2026-04-26.md`.
+
+## Current Risks
+
+- Direct Codex HTTP probing is intentionally unadmitted pending official
+  endpoint documentation. MCP probes are now resource-server templates; live
+  use still requires an explicit resource metadata URL or resource probe URL.
+- Probe execution is intentionally minimal: HTTP method, URL, bearer auth,
+  explicit custom token headers, success range, retry-after, one hint header,
+  one optional response-body hint, or argv plus account env and an explicit
+  timeout. Request body templating and richer header extraction are future work.
+- Health persistence is versioned and backward-compatible, but migration policy
+  beyond the current evidence fields is not yet documented.
+- Release packaging templates exist for curl installer, npm, Homebrew, and
+  nfpm; checksum/artifact publication remains release-automation work.
+- GloriousFlywheel cache-first CI proves shared Nix/Attic substrate attachment,
+  not universal remote execution or Bazel remote-cache behavior. `oauth-mux`
+  remains Zig-only, so Bazel should stay out until there is a real target graph.
+- `GloriousFlywheel` is a private repo, so the cache-first CI lane requires
+  `GF_ACTIONS_TOKEN` to check out the composite action locally. Without that
+  secret, CI records the skipped proof instead of claiming substrate execution.
+- The live Codex route probes intentionally spend small subscription calls and
+  should remain explicit operator actions or bounded fallback checks, not a
+  background polling loop.
+- Canonical `just check` passes through one Nix shell entry. Direct
+  `zig build test` / `zig build` remains faster for tight local iteration, but
+  `just check` is still the operator-facing validation command.
+
+## Next Arc
+
+1. Add provider-specific MCP examples only when the resource server URL and
+   token audience are explicit.
+2. Turn the existing dist templates into a release automation path that emits
+   tarballs, checksums, npm platform packages, Homebrew formula updates, and
+   nfpm deb/rpm artifacts from one version input.
+3. Add a GloriousFlywheel-backed release proof job for the release artifact
+   path once the one-version release recipe exists.
+4. Update TIN-491 and GitHub issue #197 with this checkpoint and the remaining
+   provider-verification work.
+
+## Validation
+
+Latest validation at this checkpoint:
+
+```text
+zig build test
+passed
+
+zig build
+passed
+
+OMUX_CONFIG=$PWD/examples/codex-max.config.json ./zig-out/bin/oauth-mux config validate
+config: valid
+
+OMUX_CONFIG=$PWD/examples/github.config.json ./zig-out/bin/oauth-mux config validate
+config: valid
+
+OMUX_CONFIG=$PWD/examples/linear.config.json ./zig-out/bin/oauth-mux config validate
+config: valid
+
+OMUX_CONFIG=$PWD/examples/vercel.config.json ./zig-out/bin/oauth-mux config validate
+config: valid
+
+OMUX_CONFIG=$PWD/examples/figma.config.json ./zig-out/bin/oauth-mux config validate
+config: valid
+
+OMUX_CONFIG=$PWD/examples/figma-pat.config.json ./zig-out/bin/oauth-mux config validate
+config: valid
+
+OMUX_CONFIG=$PWD/examples/figma-plan.config.json ./zig-out/bin/oauth-mux config validate
+config: valid
+
+OMUX_CONFIG=$PWD/examples/claude.config.json ./zig-out/bin/oauth-mux config validate
+config: valid
+
+OMUX_CONFIG=$PWD/examples/flakehub.config.json ./zig-out/bin/oauth-mux config validate
+config: valid
+
+OMUX_CONFIG=$PWD/examples/mcp-http.config.json ./zig-out/bin/oauth-mux config validate
+config: valid
+
+just check
+validates every examples/*.config.json and prints all checks passed
+
+just codex-max-login-status-all
+max-1 -> Logged in using ChatGPT
+max-2 -> Logged in using ChatGPT
+max-3 -> Logged in using ChatGPT
+
+just codex-max-probe-all
+codex-mini: max-1, max-2, max-3 -> 200/use_this/live/available
+
+just codex-max-probe-all codex-max
+current review refresh:
+max-1#codex-max -> degraded/unknown_4xx/status 400
+max-2#codex-max -> degraded/unknown_4xx/status 400
+profile-level codex-max fallback -> selected max-3#codex-max with 200/use_this/live/available
+
+just release
+single Zig release graph builds all six documented targets
+```

--- a/docs/spec/architecture-review-2026-04-25.md
+++ b/docs/spec/architecture-review-2026-04-25.md
@@ -98,6 +98,8 @@ Implemented:
 - Manual GloriousFlywheel release proof: `.github/workflows/release-proof.yml`
   runs the same proof through the private cache-first `nix-job` action on
   `tinyland-nix` when runner capacity and `GF_ACTIONS_TOKEN` are available.
+- Tag release publication now runs the same Nix-backed release proof before
+  uploading staged artifacts to GitHub Releases.
 - Root README and release runbook covering local validation, release staging,
   GitHub release behavior, and the GloriousFlywheel runner/token boundary.
 
@@ -167,9 +169,9 @@ Decision record:
   timeout. Request body templating and richer header extraction are future work.
 - Health persistence is versioned and backward-compatible, but migration policy
   beyond the current evidence fields is not yet documented.
-- Release packaging now has a local staging command. GitHub release publication
-  uses that command, but real npm/Homebrew/deb/rpm registry publication is still
-  future work.
+- Release packaging now has a local staging and smoke-proof command. GitHub
+  release publication uses that proof before attaching artifacts, but real
+  npm/Homebrew/deb/rpm registry publication is still future work.
 - GloriousFlywheel cache-first CI proves shared Nix/Attic substrate attachment,
   not universal remote execution or Bazel remote-cache behavior. `oauth-mux`
   remains Zig-only, so Bazel should stay out until there is a real target graph.
@@ -189,8 +191,9 @@ Decision record:
    token audience are explicit.
 2. Add registry publication handoffs for npm, Homebrew tap updates, and deb/rpm
    repositories once artifact staging is accepted.
-3. Promote the manual GloriousFlywheel release proof into a required pre-tag
-   publication gate once runner capacity is stable enough for release blocking.
+3. Promote the manual GloriousFlywheel release proof into a required
+   pre-publication self-hosted gate once runner capacity is stable enough for
+   release blocking.
 4. Update TIN-491 and GitHub issue #197 with this checkpoint and the remaining
    provider-verification work.
 

--- a/docs/spec/architecture-review-2026-04-25.md
+++ b/docs/spec/architecture-review-2026-04-25.md
@@ -94,7 +94,13 @@ Implemented:
   artifacts through the Nix dev shell.
 - Local release proof: `just release-proof <version>` stages the release and
   smoke-checks required artifacts, checksums, archive payloads, Homebrew
-  rendering, local npm installation, and local installer execution.
+  rendering, local npm installation, local installer execution, and
+  non-publishing release handoff generation.
+- Release handoff proof: `just release-handoff <version>` validates an already
+  staged tree and writes `handoff/release-handoff.md`,
+  `handoff/publish-files.txt`, and `handoff/SHA256SUMS.full` with GitHub
+  Release attachments, npm publish order, Homebrew tap input, deb/rpm files,
+  and full checksums.
 - Manual GloriousFlywheel release proof: `.github/workflows/release-proof.yml`
   runs the same proof through the private cache-first `nix-job` action on
   `tinyland-nix` when runner capacity and `GF_ACTIONS_TOKEN` are available.
@@ -169,9 +175,10 @@ Decision record:
   timeout. Request body templating and richer header extraction are future work.
 - Health persistence is versioned and backward-compatible, but migration policy
   beyond the current evidence fields is not yet documented.
-- Release packaging now has a local staging and smoke-proof command. GitHub
-  release publication uses that proof before attaching artifacts, but real
-  npm/Homebrew/deb/rpm registry publication is still future work.
+- Release packaging now has a local staging, smoke-proof, and non-publishing
+  handoff command. GitHub release publication uses that proof before attaching
+  artifacts, but real npm/Homebrew/deb/rpm registry publication is still future
+  work.
 - GloriousFlywheel cache-first CI proves shared Nix/Attic substrate attachment,
   not universal remote execution or Bazel remote-cache behavior. `oauth-mux`
   remains Zig-only, so Bazel should stay out until there is a real target graph.
@@ -189,8 +196,8 @@ Decision record:
 
 1. Add provider-specific MCP examples only when the resource server URL and
    token audience are explicit.
-2. Add registry publication handoffs for npm, Homebrew tap updates, and deb/rpm
-   repositories once artifact staging is accepted.
+2. Turn the generated registry handoff into authenticated dry-run lanes for npm,
+   Homebrew tap updates, and deb/rpm repositories.
 3. Promote the manual GloriousFlywheel release proof into a required
    pre-publication self-hosted gate once runner capacity is stable enough for
    release blocking.

--- a/docs/spec/architecture-review-2026-04-25.md
+++ b/docs/spec/architecture-review-2026-04-25.md
@@ -90,10 +90,11 @@ Implemented:
   `docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md`.
 - Local release staging: `just release-local <version>` emits six binary
   tarballs, checksums, a rendered Homebrew formula, npm package workspace and
-  tarballs, plus nfpm configs and deb/rpm artifacts through the Nix dev shell.
+  tarballs, a checksum-verifying curl installer, plus nfpm configs and deb/rpm
+  artifacts through the Nix dev shell.
 - Local release proof: `just release-proof <version>` stages the release and
   smoke-checks required artifacts, checksums, archive payloads, Homebrew
-  rendering, and local npm installation.
+  rendering, local npm installation, and local installer execution.
 - Manual GloriousFlywheel release proof: `.github/workflows/release-proof.yml`
   runs the same proof through the private cache-first `nix-job` action on
   `tinyland-nix` when runner capacity and `GF_ACTIONS_TOKEN` are available.
@@ -260,5 +261,5 @@ npm tarballs, nfpm configs, and deb/rpm output
 
 just release-proof 0.1.0
 stages the release and verifies required artifacts, checksums, archive payloads,
-Homebrew rendering, and local npm installation
+Homebrew rendering, local npm installation, and installer execution
 ```

--- a/docs/spec/architecture-review-2026-04-25.md
+++ b/docs/spec/architecture-review-2026-04-25.md
@@ -191,8 +191,11 @@ Decision record:
   not universal remote execution or Bazel remote-cache behavior. `oauth-mux`
   remains Zig-only, so Bazel should stay out until there is a real target graph.
 - `GloriousFlywheel` is a private repo, so the cache-first CI lane requires
-  `GF_ACTIONS_TOKEN` to check out the composite action locally. Without that
-  secret, CI records the skipped proof instead of claiming substrate execution.
+  `GF_ACTIONS_TOKEN` to check out the composite action locally. This is now
+  configured for `oauth-mux`; PR run `25009779392`, job `73266579091`, checked
+  out the private action and ran `nix develop --command just check-local` on
+  `tinyland-nix`. Without that secret, CI records the skipped proof instead of
+  claiming substrate execution.
 - The live Codex route probes intentionally spend small subscription calls and
   should remain explicit operator actions or bounded fallback checks, not a
   background polling loop.

--- a/docs/spec/codex-direct-http-probe-decision-2026-04-26.md
+++ b/docs/spec/codex-direct-http-probe-decision-2026-04-26.md
@@ -1,0 +1,87 @@
+# Codex Direct HTTP Probe Decision
+
+Updated: 2026-04-26
+
+Issue context: Linear `TIN-491`, GitHub `tinyland-inc/lab#197`.
+
+## Decision
+
+Do not add a direct Codex HTTP status or route-probe endpoint yet.
+
+Codex subscription-backed routes remain command-probe-first through
+`codex exec --json` under the selected account's `CODEX_HOME`. The mux may
+classify those JSONL results into typed route liveness, but it must not assume
+that a ChatGPT subscription OAuth token is a general OpenAI API bearer token or
+that an undocumented Codex resource endpoint is safe to call.
+
+## Evidence
+
+Official OpenAI Codex docs currently cover Codex CLI usage, authentication
+through ChatGPT or API key, and the command-line interface. They do not document
+a subscription-backed HTTP endpoint whose method, request shape, response
+schema, retry semantics, and quota impact are stable enough for `oauth-mux` to
+use as a direct health probe.
+
+Local CLI evidence from this workstation:
+
+```text
+codex --version -> codex-cli 0.125.0
+codex login --help -> login status, --with-api-key, --device-auth
+codex debug --help -> models, app-server, prompt-input
+codex exec --help -> --json, --ephemeral, --ignore-user-config; auth still uses CODEX_HOME
+```
+
+Live mux evidence already exists for the command transport:
+
+```text
+just codex-max-login-status-all
+max-1 -> Logged in using ChatGPT
+max-2 -> Logged in using ChatGPT
+max-3 -> Logged in using ChatGPT
+
+just codex-max-probe-all
+codex-mini: max-1, max-2, max-3 -> 200/use_this/live/available
+
+just codex-max-probe-all codex-max
+codex-max: max-1, max-2, max-3 -> 200/use_this/live/available
+```
+
+OpenAI's MCP and connector docs are relevant to provider authoring, but they
+describe passing application-managed OAuth access tokens to MCP connectors. That
+does not establish a Codex subscription-account health endpoint.
+
+Sources:
+
+- <https://developers.openai.com/codex/cli>
+- <https://developers.openai.com/codex/cli/reference>
+- <https://developers.openai.com/codex/auth>
+- <https://developers.openai.com/api/docs/guides/tools-connectors-mcp>
+
+## Admission Gate
+
+Revisit a direct Codex HTTP probe only when an official or provider-owned source
+documents all of the following:
+
+- endpoint and method
+- required request body, headers, and token audience
+- whether subscription-backed Codex accepts the token directly
+- success response schema
+- status, header, and body mappings for revoked auth, inactive subscription,
+  insufficient tier, scope failure, short rate limit, quota exhaustion, and
+  provider outage
+- retry-after or reset-window semantics
+- evidence that probing does not spend meaningful user quota
+- redaction requirements for fixtures, logs, health state, and issue comments
+
+Until those facts are pinned, a direct HTTP probe is considered unadmitted.
+
+## Implications
+
+- Built-in Codex route probes stay command-based.
+- `CODEX_HOME` remains the account boundary for Codex subscription stores.
+- The mux must never export ChatGPT subscription OAuth tokens as generic API
+  keys unless OpenAI documents that exact behavior.
+- Schema-defined HTTP probes remain valid for other providers when their
+  endpoint semantics pass the admission gate.
+- Unsupported model, tier mismatch, quota exhaustion, rate limit, and revoked
+  auth remain typed liveness outcomes, not generic circuit-breaker penalties.

--- a/docs/spec/codex-max-operator-plan-2026-04-25.md
+++ b/docs/spec/codex-max-operator-plan-2026-04-25.md
@@ -1,0 +1,259 @@
+# Codex Max Operator Plan
+
+Updated: 2026-04-26
+
+This note narrows the next `oauth-mux` arc to three Codex Max accounts.
+
+## Current Evidence
+
+Official OpenAI help currently describes Codex as available with ChatGPT Plus,
+Pro, Business, and Enterprise/Edu plans, with Codex CLI and IDE sign-in through
+ChatGPT. The help surface still mentions the GPT-5.1-Codex family, but the
+installed Codex CLI 0.125.0 catalog on this workstation exposes
+`gpt-5.3-codex` and `gpt-5.3-codex-spark`. Treat `codex-max` and
+`codex-mini` as oauth-mux route labels, not fixed OpenAI model IDs.
+
+Local structure-only inspection of this workstation's Codex cache confirms the
+credential shape expected by `oauth-mux`:
+
+```text
+auth_mode
+tokens.id_token
+tokens.access_token
+tokens.refresh_token
+tokens.account_id
+last_refresh
+```
+
+No token values were printed or copied.
+
+Live non-secret Codex evidence captured on 2026-04-25:
+
+```text
+codex login status -> Logged in using ChatGPT
+codex debug models -> gpt-5.3-codex, gpt-5.3-codex-spark
+codex exec -m gpt-5.3-codex-spark -> turn.completed with usage
+codex exec -m gpt-5.1-codex-max -> status 400 unsupported model for ChatGPT account
+```
+
+Redacted JSONL cassettes for these two `codex exec --json` outcomes live under:
+
+```text
+test/fixtures/cassettes/codex/
+```
+
+Live three-account evidence captured on 2026-04-26:
+
+```text
+just codex-max-login-status-all
+max-1 -> Logged in using ChatGPT
+max-2 -> Logged in using ChatGPT
+max-3 -> Logged in using ChatGPT
+
+just codex-max-probe-all
+codex-mini: max-1, max-2, max-3 -> 200/use_this/live/available
+
+just codex-max-probe-all codex-max
+codex-max: max-1, max-2, max-3 -> 200/use_this/live/available
+```
+
+Only login status, auth store paths, and mux probe classifications were
+inspected. Token contents were not read or printed.
+
+Sources:
+
+- <https://help.openai.com/en/articles/11369540-codex-in-chatgpt>
+- <https://help.openai.com/en/articles/11381614>
+
+## Account Layout
+
+Use one `CODEX_HOME` per account. The example config uses:
+
+```text
+~/.local/share/oauth-mux/codex/max-1/auth.json
+~/.local/share/oauth-mux/codex/max-2/auth.json
+~/.local/share/oauth-mux/codex/max-3/auth.json
+```
+
+The config file lives at:
+
+```text
+examples/codex-max.config.json
+```
+
+It can also be generated as the active user config:
+
+```bash
+oauth-mux init --codex-max
+```
+
+Each account is represented twice:
+
+- `config_dir`: the directory exported to Codex as `CODEX_HOME`
+- `secret.path`: the `auth.json` read by `oauth-mux` for validation and future
+  refresh/probe work
+
+This duplication is intentional for now. It keeps the runtime explicit and
+avoids guessing that every config-dir-backed provider stores credentials at the
+same relative path.
+
+## Store Bootstrap
+
+The three Codex Max stores are intentionally not created or populated by
+`oauth-mux`; each store must be logged in through Codex so refresh/session state
+belongs to that isolated `CODEX_HOME`.
+
+On this workstation, the three isolated stores now exist and are logged in:
+
+```text
+~/.local/share/oauth-mux/codex/max-1/auth.json
+~/.local/share/oauth-mux/codex/max-2/auth.json
+~/.local/share/oauth-mux/codex/max-3/auth.json
+```
+
+Create the isolation directories:
+
+```bash
+just codex-max-bootstrap-dirs
+```
+
+Then login each subscription account separately:
+
+```bash
+just codex-max-login max-1
+just codex-max-login max-2
+just codex-max-login max-3
+```
+
+Do not copy `~/.codex/auth.json` into these stores unless the goal is
+deliberately to duplicate the same account. For the three-plan mux, each login
+should produce its own `auth.json` in its own store.
+
+For device-code login instead of browser redirect, use:
+
+```bash
+just codex-max-login-device max-1
+```
+
+Check store login status without probing model routes:
+
+```bash
+just codex-max-login-status-all
+```
+
+## Route Profiles
+
+Two profile lanes are defined with stable route labels:
+
+```text
+codex-max  -> codex:max-1#codex-max, max-2, max-3
+codex-mini -> codex:max-1#codex-mini, max-2, max-3
+```
+
+Route health is stored independently from account health. A quota-exhausted
+`codex:max-1#codex-max` route should not make `codex:max-1` unusable for
+`codex-mini`.
+
+## Operator Commands
+
+Validate the example schema:
+
+```bash
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux config validate
+```
+
+Equivalent repo helper:
+
+```bash
+just codex-max-validate
+```
+
+Check selection, credential parse/expiry state, and the built-in max route
+command probe:
+
+```bash
+OMUX_CONFIG=$PWD/examples/codex-max.config.json \
+  oauth-mux probe --profile codex-max --capability codex-max
+```
+
+Force a specific account:
+
+```bash
+OMUX_CONFIG=$PWD/examples/codex-max.config.json \
+  oauth-mux probe --provider codex --account max-2 --capability codex-max --json
+```
+
+Safer first-pass matrix probe, using the cheaper `codex-mini` route and a
+temporary health store:
+
+```bash
+just codex-max-probe-all
+```
+
+Probe one account and route:
+
+```bash
+just codex-max-probe max-2 codex-max
+```
+
+The JSON output includes redacted last-probe evidence:
+
+```json
+{
+  "last_probe": {
+    "source": "credential_validation",
+    "observed_at": 1770000000,
+    "retry_after_s": null,
+    "hint_class": "none",
+    "decision": "use_this"
+  }
+}
+```
+
+Run Codex through the mux:
+
+```bash
+OMUX_CONFIG=$PWD/examples/codex-max.config.json \
+  oauth-mux exec --profile codex-max -- codex
+```
+
+## Probe Status
+
+The built-in Codex provider now has command-transport probes for the semantic
+route labels:
+
+```text
+codex-max  -> codex exec --json --ephemeral --ignore-rules -m gpt-5.3-codex
+codex-mini -> codex exec --json --ephemeral --ignore-rules -m gpt-5.3-codex-spark
+```
+
+These probes run with the selected account's `CODEX_HOME`, parse Codex JSONL,
+and classify `turn.completed` as success. Codex JSONL errors are fed through
+provider failure rules, so unsupported model or plan-tier messages become
+`degraded.tier_insufficient` instead of a generic circuit-breaker penalty.
+The built-in Codex probes use a 120 second timeout; custom probes default to 30
+seconds unless `timeout_ms` is set explicitly.
+
+As of the 2026-04-26 live sweep, both built-in Codex route labels have been
+verified against all three isolated Max stores.
+
+The command probes intentionally burn a tiny Codex call. Use them for explicit
+operator `probe` runs and capability-aware fallback decisions, not as a tight
+background polling loop.
+
+Do not add a direct Codex HTTP probe endpoint until all of the following are
+verified:
+
+- endpoint and method
+- required request body, if any
+- whether subscription-backed Codex accepts the token directly
+- which status/header/body fields distinguish rate limit, quota exhaustion,
+  inactive subscription, and revoked auth
+- whether probing consumes meaningful user quota
+
+This is now an explicit architecture decision rather than an open next step.
+See:
+
+```text
+docs/spec/codex-direct-http-probe-decision-2026-04-26.md
+```

--- a/docs/spec/development-timeline-2026-04-27.md
+++ b/docs/spec/development-timeline-2026-04-27.md
@@ -1,0 +1,103 @@
+# oauth-mux Development Timeline
+
+Updated: 2026-04-27
+
+Issue context: Linear `TIN-491`, GitHub `tinyland-inc/lab#197`.
+
+## Current Stage
+
+`oauth-mux` is in internal alpha: the core mux, typed liveness model, provider
+schema, Codex Max operator flow, release staging, and no-secret E2E proof are
+implemented. It is ready for controlled operator use and PR review, but not yet
+for public unattended production use.
+
+The remaining production gap is no longer the core selection model. The gap is
+operational hardening: live-provider QA, authenticated package publication dry
+runs, documented rollback, and real GloriousFlywheel private-action proof once
+`GF_ACTIONS_TOKEN` is configured.
+
+## Completed Arc
+
+1. Research and formal model.
+   OAuth/MCP governance notes, provider admission rules, liveness algebra, and
+   route-scoped fallback semantics are documented.
+
+2. Core mux implementation.
+   The Zig pipeline handles provider resolution, account selection, secret
+   reads, token parsing, typed health, env/config injection, and exec handoff.
+
+3. Provider schema and probes.
+   Built-ins now cover Codex, Claude, GitHub, Linear, Vercel, Figma, FlakeHub,
+   and MCP HTTP resource-server probes. New providers can usually be added as
+   JSON provider definitions rather than compiled code.
+
+4. Codex Max operator path.
+   Three isolated `CODEX_HOME` accounts are modeled as named accounts with
+   separate capability routes for `codex-mini` and `codex-max`.
+
+5. Release substrate.
+   `just release-proof <version>` stages six targets, verifies checksums,
+   tests the npm shim and curl installer locally, and writes the registry
+   handoff without using publication credentials.
+
+6. Deterministic E2E.
+   `just e2e` creates a temporary provider and proves config validation, env
+   injection, command probes, route-scoped quota fallback, persisted health,
+   and `exec` injection without live credentials or network calls.
+
+## Current Gates
+
+- `just check`
+  Runs unit tests, build, example config validation, and no-secret E2E.
+
+- Hosted PR CI
+  Runs direct Zig build/test, example validation, no-secret E2E, release build,
+  and all six cross-compiles.
+
+- `just release-proof <version>`
+  Runs local release staging, artifact smoke checks, installer proof, npm shim
+  proof, and handoff generation.
+
+- GloriousFlywheel cache-first lane
+  Present but token-gated. A green skip is useful diagnostic evidence, not a
+  cache-first proof. Count it only when the private action checks out and runs.
+
+## Production Readiness
+
+Ready now:
+
+- internal operator experimentation;
+- local three-account Codex Max setup and explicit probe runs;
+- schema-only provider authoring against no-secret fixtures;
+- draft release artifact review;
+- PR review with hosted CI evidence.
+
+Not ready yet:
+
+- unattended automatic live-provider probing;
+- public npm/Homebrew/deb/rpm publication;
+- required self-hosted release gate;
+- background daemon token refresh as an operational dependency;
+- documented rollback for each registry lane;
+- formal security review of secret backends and generated config dirs.
+
+## Next Arc
+
+1. Add a live-provider QA workflow that is manual-only, secret-scoped, and
+   budget-aware. It should run `codex-mini` first, then higher-cost routes only
+   when explicitly requested.
+
+2. Convert the release handoff into authenticated dry-run lanes:
+   npm provenance dry run, Homebrew formula audit in the tap, and deb/rpm
+   repository staging checks.
+
+3. Configure `GF_ACTIONS_TOKEN` or otherwise expose the private
+   GloriousFlywheel action so cache-first CI can prove the same E2E gate on
+   `tinyland-nix`.
+
+4. Add a small canary script for the three real Codex Max accounts that reports
+   liveness and route decisions without changing auth state or leaking tokens.
+
+5. Decide the daemon boundary: keep it optional until token refresh semantics
+   and provider-specific refresh safety are proven for each OAuth-backed
+   harness.

--- a/docs/spec/development-timeline-2026-04-27.md
+++ b/docs/spec/development-timeline-2026-04-27.md
@@ -13,8 +13,8 @@ for public unattended production use.
 
 The remaining production gap is no longer the core selection model. The gap is
 operational hardening: live-provider QA, authenticated package publication dry
-runs, documented rollback, and real GloriousFlywheel private-action proof once
-`GF_ACTIONS_TOKEN` is configured.
+runs, documented rollback, and post-merge GloriousFlywheel release-proof
+execution before public tags.
 
 ## Completed Arc
 
@@ -59,8 +59,10 @@ runs, documented rollback, and real GloriousFlywheel private-action proof once
   proof, and handoff generation.
 
 - GloriousFlywheel cache-first lane
-  Present but token-gated. A green skip is useful diagnostic evidence, not a
-  cache-first proof. Count it only when the private action checks out and runs.
+  Proven on PR run `25009779392`, job `73266579091`: the private
+  `GloriousFlywheel` action checked out, `nix-job` ran on `tinyland-nix`, and
+  `nix develop --command just check-local` passed. Cache push is intentionally
+  disabled on PR events.
 
 ## Production Readiness
 
@@ -91,9 +93,9 @@ Not ready yet:
    npm provenance dry run, Homebrew formula audit in the tap, and deb/rpm
    repository staging checks.
 
-3. Configure `GF_ACTIONS_TOKEN` or otherwise expose the private
-   GloriousFlywheel action so cache-first CI can prove the same E2E gate on
-   `tinyland-nix`.
+3. After merge, run the manual GloriousFlywheel release-proof workflow from
+   `main` before publishing tags. GitHub cannot dispatch PR-local workflow
+   files until they exist on the default branch.
 
 4. Add a small canary script for the three real Codex Max accounts that reports
    liveness and route decisions without changing auth state or leaking tokens.

--- a/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
+++ b/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
@@ -91,14 +91,19 @@ input:
 
 `just release-proof <version>` runs the same staging command and then validates
 the artifact tree, checksums, archive payloads, Homebrew rendering, local npm
-install path, and local installer path. `.github/workflows/release-proof.yml`
-exposes this as a manual GloriousFlywheel proof on `tinyland-nix` through the
-private `nix-job` action. It is intentionally manual while runner capacity is
-expected to be noisy.
+install path, local installer path, and non-publishing release handoff
+generation. The handoff captures GitHub Release attachments, npm publish order,
+Homebrew tap input, deb/rpm files, and full checksums under
+`dist/out/v<version>/handoff/`.
+
+`.github/workflows/release-proof.yml` exposes this as a manual GloriousFlywheel
+proof on `tinyland-nix` through the private `nix-job` action. It is
+intentionally manual while runner capacity is expected to be noisy.
 
 The tag release workflow also runs `just release-proof-local` before uploading
 the staged artifact tree, so GitHub Release publication is gated by the same
-artifact smoke checks even when the manual self-hosted proof is deferred.
+artifact smoke and handoff checks even when the manual self-hosted proof is
+deferred.
 
 `just release` runs the single Zig release graph (`zig build release`) rather
 than entering the Nix devshell once per target. Per-target Just recipes remain
@@ -106,11 +111,13 @@ available for focused iteration.
 
 ## Next Integration Gates
 
-1. Promote the manual GloriousFlywheel release proof into a required
+1. Turn the generated release handoff into authenticated dry-run lanes for npm,
+   Homebrew tap updates, and deb/rpm repository publication.
+2. Promote the manual GloriousFlywheel release proof into a required
    pre-publication self-hosted gate once `tinyland-nix` capacity is stable
    enough to block releases on it.
-2. Keep Bazel out until there is a real target graph or downstream adoption
+3. Keep Bazel out until there is a real target graph or downstream adoption
    reason; if added later, copy the GloriousFlywheel shape:
    `cache-contract-strict` before any cache-backed Bazel command.
-3. Add a scheduled or manual live-provider QA workflow only after secret
+4. Add a scheduled or manual live-provider QA workflow only after secret
    scoping is explicit; route probes spend real subscription calls.

--- a/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
+++ b/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
@@ -61,6 +61,12 @@ When `GF_ACTIONS_TOKEN` and the Attic settings are present, this proves that
 `oauth-mux` can build and test on the shared GloriousFlywheel Nix runner
 substrate with Attic cache attachment.
 
+Current evidence: PR run `25009779392`, job `73266579091`, checked out
+`tinyland-inc/GloriousFlywheel`, ran the private `nix-job` action on
+`tinyland-nix`, executed `nix develop --command just check-local`, and passed
+the deterministic no-secret E2E gate. Cache push was intentionally skipped
+because PR events set `push-cache` to `false`.
+
 It does not yet prove:
 
 - cache-first CI execution when the private action checkout token is absent;
@@ -103,7 +109,9 @@ Homebrew tap input, deb/rpm files, and full checksums under
 
 `.github/workflows/release-proof.yml` exposes this as a manual GloriousFlywheel
 proof on `tinyland-nix` through the private `nix-job` action. It is
-intentionally manual while runner capacity is expected to be noisy.
+intentionally manual while runner capacity is expected to be noisy. GitHub can
+dispatch it only after the workflow file exists on `main`; run it after this PR
+lands and before publishing tags.
 
 The tag release workflow also runs `just release-proof-local` before uploading
 the staged artifact tree, so GitHub Release publication is gated by the same

--- a/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
+++ b/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
@@ -96,15 +96,19 @@ exposes this as a manual GloriousFlywheel proof on `tinyland-nix` through the
 private `nix-job` action. It is intentionally manual while runner capacity is
 expected to be noisy.
 
+The tag release workflow also runs `just release-proof-local` before uploading
+the staged artifact tree, so GitHub Release publication is gated by the same
+artifact smoke checks even when the manual self-hosted proof is deferred.
+
 `just release` runs the single Zig release graph (`zig build release`) rather
 than entering the Nix devshell once per target. Per-target Just recipes remain
 available for focused iteration.
 
 ## Next Integration Gates
 
-1. Promote the manual GloriousFlywheel release proof into a required pre-tag
-   publication gate once `tinyland-nix` capacity is stable enough to block
-   releases on it.
+1. Promote the manual GloriousFlywheel release proof into a required
+   pre-publication self-hosted gate once `tinyland-nix` capacity is stable
+   enough to block releases on it.
 2. Keep Bazel out until there is a real target graph or downstream adoption
    reason; if added later, copy the GloriousFlywheel shape:
    `cache-contract-strict` before any cache-backed Bazel command.

--- a/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
+++ b/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
@@ -1,0 +1,101 @@
+# GloriousFlywheel Substrate Integration
+
+Updated: 2026-04-26
+
+This records how `oauth-mux` attaches to the house remote runner and cache
+substrate without importing unrelated build-system weight.
+
+## Source Contract
+
+The read-only source for this pass was sibling repo `../GloriousFlywheel`.
+Its current contract is:
+
+- use capability-shaped runner labels such as `tinyland-nix`, not
+  project-specific runner labels;
+- attach local and CI work to the same Nix/devshell substrate where possible;
+- treat Attic and Bazel remote cache as acceleration layers, not publication
+  authority;
+- be explicit when a path proves cache-backed execution rather than full remote
+  execution or universal remote builder offload;
+- for Bazel repos, verify the strict cache contract before invoking Bazel.
+
+`oauth-mux` is Zig-only today. It has no Bazel target graph, so the first
+integration point is the Nix/Attic runner path, not a Bazel wrapper.
+
+## Applied Shape
+
+`just check` remains the operator entrypoint. It now enters the Nix devshell
+and delegates the validation body to `just check-local`.
+
+`just check-local` is the devshell-local validation body:
+
+1. `zig build test`
+2. `zig build`
+3. validate every `examples/*.config.json`
+
+This split gives local operators and remote CI the same test body while letting
+GloriousFlywheel jobs enter the devshell once and run the local check directly.
+
+The CI workflow now has a cache-first lane:
+
+- runner: `tinyland-nix`
+- action source: private checkout of
+  `tinyland-inc/GloriousFlywheel/.github/actions/nix-job`
+- required runtime evidence: `ATTIC_SERVER`, `ATTIC_CACHE`, and `NIX_CONFIG`
+- command: `nix develop --command just check-local`
+
+Because `GloriousFlywheel` is private, `oauth-mux` does not reference the
+cross-repo composite action directly. The workflow checks out the substrate repo
+into `.gloriousflywheel` with `GF_ACTIONS_TOKEN` and then uses the local
+composite action path. If `GF_ACTIONS_TOKEN` is not configured, the job records
+that the cache-first proof was skipped rather than failing before any useful
+diagnostics can run.
+
+The existing GitHub-hosted lane remains as a portability check. It still builds
+and tests with Zig directly, and now validates all example configs too.
+
+## What This Proves
+
+When `GF_ACTIONS_TOKEN` and the Attic settings are present, this proves that
+`oauth-mux` can build and test on the shared GloriousFlywheel Nix runner
+substrate with Attic cache attachment.
+
+It does not yet prove:
+
+- cache-first CI execution when the private action checkout token is absent;
+- full remote execution for every local developer action;
+- Bazel remote-cache behavior, because this repo has no Bazel targets;
+- package publication to npm, Homebrew, deb, rpm, or GitHub Releases;
+- live OAuth provider route health, except when explicit operator probe jobs
+  are run with real credentials.
+
+## Release Tie-In
+
+CI and release target matrices now match the repo contract:
+
+- `x86_64-linux-musl`
+- `aarch64-linux-musl`
+- `x86_64-macos`
+- `aarch64-macos`
+- `x86_64-windows`
+- `aarch64-windows`
+
+This is still artifact-build plumbing. The next release arc is to generate
+tarballs, checksums, npm platform packages, Homebrew formula updates, and
+nfpm deb/rpm packages from one version input.
+
+`just release` runs the single Zig release graph (`zig build release`) rather
+than entering the Nix devshell once per target. Per-target Just recipes remain
+available for focused iteration.
+
+## Next Integration Gates
+
+1. Add a `release-local` recipe that emits all release archives and checksums
+   from one version input.
+2. Add a GloriousFlywheel-backed release proof job that runs on `tinyland-nix`
+   before tag publication.
+3. Keep Bazel out until there is a real target graph or downstream adoption
+   reason; if added later, copy the GloriousFlywheel shape:
+   `cache-contract-strict` before any cache-backed Bazel command.
+4. Add a scheduled or manual live-provider QA workflow only after secret
+   scoping is explicit; route probes spend real subscription calls.

--- a/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
+++ b/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
@@ -32,6 +32,7 @@ and delegates the validation body to `just check-local`.
 1. `zig build test`
 2. `zig build`
 3. validate every `examples/*.config.json`
+4. `scripts/e2e-local.sh`
 
 This split gives local operators and remote CI the same test body while letting
 GloriousFlywheel jobs enter the devshell once and run the local check directly.
@@ -68,6 +69,10 @@ It does not yet prove:
 - package publication to npm, Homebrew, deb, rpm, or GitHub Releases;
 - live OAuth provider route health, except when explicit operator probe jobs
   are run with real credentials.
+
+It does prove the deterministic no-secret mux E2E path: env injection, command
+probe classification, route-scoped fallback, persisted health evidence, and
+`exec` target env injection.
 
 ## Release Tie-In
 

--- a/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
+++ b/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
@@ -88,14 +88,21 @@ input:
 - npm package workspace and npm tarballs
 - nfpm configs and deb/rpm artifacts
 
+`just release-proof <version>` runs the same staging command and then validates
+the artifact tree, checksums, archive payloads, Homebrew rendering, and local npm
+install path. `.github/workflows/release-proof.yml` exposes this as a manual
+GloriousFlywheel proof on `tinyland-nix` through the private `nix-job` action.
+It is intentionally manual while runner capacity is expected to be noisy.
+
 `just release` runs the single Zig release graph (`zig build release`) rather
 than entering the Nix devshell once per target. Per-target Just recipes remain
 available for focused iteration.
 
 ## Next Integration Gates
 
-1. Add a GloriousFlywheel-backed release proof job that runs on `tinyland-nix`
-   before tag publication.
+1. Promote the manual GloriousFlywheel release proof into a required pre-tag
+   publication gate once `tinyland-nix` capacity is stable enough to block
+   releases on it.
 2. Keep Bazel out until there is a real target graph or downstream adoption
    reason; if added later, copy the GloriousFlywheel shape:
    `cache-contract-strict` before any cache-backed Bazel command.

--- a/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
+++ b/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
@@ -84,15 +84,17 @@ CI and release target matrices now match the repo contract:
 input:
 
 - binary tarballs and `SHA256SUMS`
+- checksum-verifying `install.sh` for `curl | sh`
 - rendered Homebrew formula
 - npm package workspace and npm tarballs
 - nfpm configs and deb/rpm artifacts
 
 `just release-proof <version>` runs the same staging command and then validates
-the artifact tree, checksums, archive payloads, Homebrew rendering, and local npm
-install path. `.github/workflows/release-proof.yml` exposes this as a manual
-GloriousFlywheel proof on `tinyland-nix` through the private `nix-job` action.
-It is intentionally manual while runner capacity is expected to be noisy.
+the artifact tree, checksums, archive payloads, Homebrew rendering, local npm
+install path, and local installer path. `.github/workflows/release-proof.yml`
+exposes this as a manual GloriousFlywheel proof on `tinyland-nix` through the
+private `nix-job` action. It is intentionally manual while runner capacity is
+expected to be noisy.
 
 `just release` runs the single Zig release graph (`zig build release`) rather
 than entering the Nix devshell once per target. Per-target Just recipes remain

--- a/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
+++ b/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
@@ -80,9 +80,13 @@ CI and release target matrices now match the repo contract:
 - `x86_64-windows`
 - `aarch64-windows`
 
-This is still artifact-build plumbing. The next release arc is to generate
-tarballs, checksums, npm platform packages, Homebrew formula updates, and
-nfpm deb/rpm packages from one version input.
+`just release-local <version>` now stages release artifacts from one version
+input:
+
+- binary tarballs and `SHA256SUMS`
+- rendered Homebrew formula
+- npm package workspace and npm tarballs
+- nfpm configs and deb/rpm artifacts
 
 `just release` runs the single Zig release graph (`zig build release`) rather
 than entering the Nix devshell once per target. Per-target Just recipes remain
@@ -90,12 +94,10 @@ available for focused iteration.
 
 ## Next Integration Gates
 
-1. Add a `release-local` recipe that emits all release archives and checksums
-   from one version input.
-2. Add a GloriousFlywheel-backed release proof job that runs on `tinyland-nix`
+1. Add a GloriousFlywheel-backed release proof job that runs on `tinyland-nix`
    before tag publication.
-3. Keep Bazel out until there is a real target graph or downstream adoption
+2. Keep Bazel out until there is a real target graph or downstream adoption
    reason; if added later, copy the GloriousFlywheel shape:
    `cache-contract-strict` before any cache-backed Bazel command.
-4. Add a scheduled or manual live-provider QA workflow only after secret
+3. Add a scheduled or manual live-provider QA workflow only after secret
    scoping is explicit; route probes spend real subscription calls.

--- a/docs/spec/oauth-mux-formal-model.md
+++ b/docs/spec/oauth-mux-formal-model.md
@@ -312,9 +312,9 @@ Provider support is data first:
   "failure_rules": [
     { "status": 401, "class": { "dead": "token_revoked" } },
     { "status": 403, "class": { "degraded": "tier_insufficient" } },
-    { "status": 429, "retry_after_lt": 3601, "class": "rate_limited" },
-    { "status": 429, "retry_after_gte": 3601, "class": "quota_exhausted" },
-    { "status_min": 500, "status_max": 599, "class": "provider_degraded" }
+    { "status": 429, "retry_after_lt": 3601, "class": { "rate_limited": {} } },
+    { "status": 429, "retry_after_gte": 3601, "class": { "quota_exhausted": {} } },
+    { "status_min": 500, "status_max": 599, "class": { "provider_degraded": {} } }
   ]
 }
 ```

--- a/docs/spec/oauth-mux-formal-model.md
+++ b/docs/spec/oauth-mux-formal-model.md
@@ -1,0 +1,391 @@
+# OAuth Mux Formal Model
+
+Updated: 2026-04-25
+
+This document defines the working model for `oauth-mux`: a small compiled
+credential mux for AI harnesses that can select, validate, refresh, and inject
+the right OAuth-backed account without leaking secrets or collapsing separate
+accounts into one global login.
+
+## Goals
+
+- Support multiple accounts per provider, starting with Codex / OpenAI
+  subscription accounts.
+- Keep secrets backend-agnostic: keychain, SOPS, age, env, file, command, and
+  stdin are storage details, not provider logic.
+- Prefer config-directory isolation for tools that already own refresh and
+  login state, such as Codex through `CODEX_HOME`.
+- Classify failures with typed state rather than one generic health penalty.
+- Let new provider support be mostly declarative, with compiled adapters only
+  for provider-specific behavior that cannot be described safely in JSON.
+- Keep the implementation pure Zig and `std`-only.
+
+## Standards Baseline
+
+The implementation should track the current OAuth and MCP substrate instead of
+copying one vendor's local auth cache shape.
+
+- OAuth governance: IETF OAuth Working Group. The WG is active in the IETF
+  Security Area, with public work on the datatracker, `oauth@ietf.org`, and
+  the IETF OAuth Zulip stream.
+- OAuth framework: OAuth 2.1 while it remains a draft, with OAuth 2.0
+  compatibility where providers require it. The MCP 2025-11-25 authorization
+  spec references `draft-ietf-oauth-v2-1-13`; the IETF OAuth WG document list
+  currently shows `draft-ietf-oauth-v2-1-15` as active.
+- OAuth security: RFC 9700, PKCE S256, strict redirect handling, no implicit
+  flow, no resource-owner-password flow.
+- Discovery: RFC 8414 authorization server metadata and OpenID Connect
+  discovery where the MCP spec requires fallback.
+- Device login: RFC 8628 where a provider supports headless login.
+- Dynamic registration: RFC 7591 where available.
+- Protected resources: RFC 9728 for MCP protected resource metadata.
+- Audience binding: RFC 8707 resource indicators for MCP.
+- Sender-constrained tokens: RFC 9449 DPoP where a provider advertises it.
+
+MCP HTTP authorization is treated as an OAuth profile. MCP stdio authorization
+is treated as environment or config injection because the MCP spec explicitly
+keeps stdio credentials outside the HTTP authorization flow.
+
+Primary references:
+
+- IETF OAuth WG: <https://datatracker.ietf.org/wg/oauth/about/>
+- OAuth WG document list: <https://datatracker.ietf.org/wg/oauth/>
+- OAuth 2.1 draft: <https://datatracker.ietf.org/doc/draft-ietf-oauth-v2-1/>
+- RFC 9700, OAuth 2.0 Security BCP: <https://www.rfc-editor.org/rfc/rfc9700>
+- RFC 8414, authorization server metadata: <https://www.rfc-editor.org/rfc/rfc8414>
+- RFC 8628, device authorization grant: <https://www.rfc-editor.org/rfc/rfc8628>
+- RFC 9449, DPoP: <https://www.rfc-editor.org/rfc/rfc9449>
+- RFC 9728, protected resource metadata: <https://www.rfc-editor.org/rfc/rfc9728>
+- MCP authorization 2025-11-25:
+  <https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization>
+
+## Agent Harness Observations
+
+Codex, Claude Code, and MCP expose three distinct auth surfaces, so the mux
+must not collapse them into one credential model:
+
+- Codex uses ChatGPT subscription access for local CLI and IDE use. OpenAI's
+  current help docs say Codex is included with Plus, Pro, Business,
+  Enterprise/Edu, and currently Free/Go for a limited period; usage limits
+  depend on plan and task shape. The docs also distinguish subscription-backed
+  Codex use from API-key use and tell existing API-key users to log out and
+  sign back in to switch to subscription access.
+- Claude Code supports browser login for Claude.ai Pro/Max and organization
+  accounts, plus Console/API-key and cloud-provider auth. Official Claude Code
+  docs say local credentials can live in macOS Keychain and that custom API key
+  helpers may refresh on a TTL or after HTTP 401.
+- MCP HTTP authorization is an OAuth profile. Its spec says auth is optional,
+  HTTP transports should follow the MCP authorization spec, stdio transports
+  should use environment credentials instead, and clients must handle protected
+  resource metadata plus resource indicators. This is why `oauth-mux` models
+  HTTP MCP as route/capability liveness but stdio MCP as injection.
+
+Vendor references:
+
+- OpenAI Codex with ChatGPT plan:
+  <https://help.openai.com/en/articles/11369540-codex-in-chatgpt>
+- OpenAI Codex CLI sign-in:
+  <https://help.openai.com/en/articles/11381614>
+- Claude Code authentication:
+  <https://docs.anthropic.com/en/docs/claude-code/getting-started>,
+  <https://docs.anthropic.com/en/docs/claude-code/team>
+
+## Account Identity
+
+An account is not a token. An account is a stable local reference to a provider
+identity and its isolation boundary:
+
+```text
+provider:account
+codex:max-1
+codex:max-2
+codex:max-3
+claude:personal
+linear:work
+figma:design
+```
+
+The mux never needs to print or persist the token value to prove selection. It
+can expose non-secret breadcrumbs:
+
+```text
+OMUX_ACTIVE_PROVIDER=codex
+OMUX_ACTIVE_ACCOUNT=max-2
+OMUX_ACTIVE_PROFILE=research
+```
+
+For Codex, the account boundary should be a `CODEX_HOME` directory or keyring
+namespace. Raw ChatGPT OAuth access tokens should not be exported as shell env.
+
+Route-level health uses a suffix on the account key:
+
+```text
+provider:account
+provider:account#capability
+codex:max-1
+codex:max-1#codex-max
+mcp:figma#tools/design-context
+```
+
+Account state dominates route state. If `codex:max-1` is dead, every route on
+that account is unusable. If only `codex:max-1#codex-max` is quota
+exhausted, the same account can still be selected for another capability.
+Profiles may also include the route suffix directly:
+
+```json
+{
+  "profiles": {
+    "codex-max": {
+      "providers": [
+        "codex:max-1#codex-max",
+        "codex:max-2#codex-max",
+        "codex:max-3#codex-max"
+      ]
+    }
+  }
+}
+```
+
+The CLI may pass an equivalent route selector with `--capability <name>` for
+profiles that list only `provider:account`. The selected route is exposed as
+`OMUX_ACTIVE_CAPABILITY`.
+
+## Pipeline Algebra
+
+The core pipeline remains a monadic `try` chain:
+
+```text
+Config
+  -> Resolve Provider
+  -> Select Account
+  -> Read Secret
+  -> Parse Credential
+  -> Refresh If Needed
+  -> Probe Capability
+  -> Classify Liveness
+  -> Inject Env / Config Dir
+  -> Exec
+```
+
+Each stage either returns an updated context or a typed error. Provider-specific
+code is limited to parsing, refresh construction, injection shape, and probe
+classification.
+
+## Liveness Algebra
+
+The first split is credential liveness:
+
+```zig
+CredentialLiveness =
+    live(Availability)
+  | degraded(DegradedReason)
+  | dead(DeadReason)
+```
+
+This is necessary but not sufficient. The mux also needs capability scope:
+
+```zig
+RouteState = {
+    provider: ProviderRef,
+    account: AccountRef,
+    capability: CapabilityRef,
+    proof: CredentialProof,
+    liveness: CredentialLiveness,
+    evidence: HealthEvidence,
+}
+```
+
+A credential may be live for one capability and unusable for another. Examples:
+
+- Codex ChatGPT login is present, but a specific model route rejects the
+  subscription.
+- Figma MCP auth is valid, but the tool schema is rejected by a client.
+- Linear MCP OAuth is valid, but a tool call needs additional scopes.
+
+## Availability Semantics
+
+Availability describes capacity, not identity:
+
+```zig
+Availability =
+    available
+  | rate_limited(retry_after_s, window)
+  | quota_exhausted(window_resets_at)
+  | cooldown(until, reason)
+```
+
+Routing rules:
+
+- `available`: use the account.
+- `rate_limited`: skip it now, but allow it after the short retry window.
+- `quota_exhausted`: skip it until the long quota window resets.
+- `cooldown`: skip it until the explicit local cooldown expires.
+
+Do not punish long-window quota exhaustion the same way as bad credentials.
+Quota exhaustion is expected capacity state, not account corruption.
+
+## Operability Semantics
+
+Degraded state means the credential can authenticate but is not currently a
+usable route for the requested work:
+
+```zig
+DegradedReason =
+    tier_insufficient
+  | subscription_paused
+  | provider_degraded
+  | scope_insufficient
+  | schema_invalid
+  | terms_required
+  | step_up_required
+  | pending_verification
+  | unknown_4xx
+```
+
+Route-level `scope_insufficient`, `schema_invalid`, `terms_required`,
+`step_up_required`, and `pending_verification` keep MCP step-up, client schema
+failures, and account action requirements out of the generic auth-failure path.
+
+## Dead Semantics
+
+Dead state means automatic retry is unsafe or useless:
+
+```zig
+DeadReason =
+    token_revoked
+  | account_deleted
+  | auth_permanently_failed
+```
+
+Dead credentials require user action: login again, rotate the secret, or remove
+the account.
+
+## Provider Definition Schema
+
+Provider support is data first:
+
+```json
+{
+  "name": "codex",
+  "auth": {
+    "token_endpoint": "https://auth0.openai.com/oauth/token",
+    "pkce": true,
+    "grant_types": ["authorization_code", "refresh_token"]
+  },
+  "credential": {
+    "access_token_path": "tokens.access_token",
+    "refresh_token_path": "tokens.refresh_token",
+    "expires_in_path": "tokens.expires_in",
+    "api_key_path": "OPENAI_API_KEY"
+  },
+  "injection": {
+    "config_dir_env": "CODEX_HOME",
+    "credential_filename": "auth.json"
+  },
+  "detection": {
+    "binary_names": ["codex"],
+    "env_markers": ["CODEX_HOME"]
+  },
+  "capabilities": [
+    {
+      "name": "chat:max",
+      "aliases": ["codex-max"],
+      "probe": {
+        "transport": "command",
+        "auth": "none",
+        "command": [
+          "codex",
+          "exec",
+          "--json",
+          "--ephemeral",
+          "--ignore-rules",
+          "-m",
+          "gpt-5.3-codex",
+          "Reply exactly: OMUX_CODEX_MAX_PROBE"
+        ],
+        "timeout_ms": 120000,
+        "success_status_min": 200,
+        "success_status_max": 299
+      }
+    }
+  ],
+  "failure_rules": [
+    { "status": 401, "class": { "dead": "token_revoked" } },
+    { "status": 403, "class": { "degraded": "tier_insufficient" } },
+    { "status": 429, "retry_after_lt": 3601, "class": "rate_limited" },
+    { "status": 429, "retry_after_gte": 3601, "class": "quota_exhausted" },
+    { "status_min": 500, "status_max": 599, "class": "provider_degraded" }
+  ]
+}
+```
+
+The compiled adapter may add provider probes, but the common shape should be
+declarative enough for new OAuth-backed tools to be added without editing the
+selection core. Capability probes are plans, not secrets: token material or
+account-scoped env such as `CODEX_HOME` is added only when the probe executes.
+HTTP probes use `method`, `url`, bearer auth, and optional hint headers.
+Command probes use argv plus inherited environment overlays, must have a
+positive `timeout_ms`, and are classified from stdout/stderr cassettes when the
+provider supplies a parser. Failure rules are intentionally small: exact status
+or status range, optional `retry_after` threshold, optional case-insensitive
+hint substring, and a typed liveness class. This keeps provider extension
+friendly without introducing regex engines or plugin code.
+
+## Health Evidence
+
+Every liveness transition should be backed by redacted evidence:
+
+```text
+provider
+account
+capability
+observed_at
+source = parse | refresh | identity_probe | route_probe | mcp_initialize
+http_status
+retry_after_s
+www_authenticate_class
+body_class
+decision
+```
+
+Never persist access tokens, refresh tokens, ID tokens, full authorization
+headers, cookies, or raw provider responses that can contain secrets.
+
+## Codex First Target
+
+For three Codex Max accounts, the initial config should model three isolated
+account stores:
+
+```json
+{
+  "providers": {
+    "codex": {
+      "kind": "codex",
+      "accounts": {
+        "max-1": {
+          "priority": 30,
+          "secret": { "backend": "file", "path": "~/.config/oauth-mux/codex/max-1/auth.json" },
+          "config_dir": "~/.config/oauth-mux/codex/max-1"
+        },
+        "max-2": {
+          "priority": 20,
+          "secret": { "backend": "file", "path": "~/.config/oauth-mux/codex/max-2/auth.json" },
+          "config_dir": "~/.config/oauth-mux/codex/max-2"
+        },
+        "max-3": {
+          "priority": 10,
+          "secret": { "backend": "file", "path": "~/.config/oauth-mux/codex/max-3/auth.json" },
+          "config_dir": "~/.config/oauth-mux/codex/max-3"
+        }
+      }
+    }
+  }
+}
+```
+
+The first robust mux behavior should prove:
+
+- plan 1 short rate limit skips to plan 2 and re-enters after retry;
+- plan 2 quota exhaustion skips until reset;
+- plan 3 auth failure becomes dead and requires login;
+- no selection proof prints token material.

--- a/docs/spec/provider-authoring-checklist-2026-04-26.md
+++ b/docs/spec/provider-authoring-checklist-2026-04-26.md
@@ -1,0 +1,300 @@
+# Provider Authoring Checklist
+
+Updated: 2026-04-26
+
+This checklist defines the acceptance bar for adding a new OAuth-backed AI
+harness to `oauth-mux` without changing the selection core. The goal is a
+schema-first provider shape that lets an operator add support for a new tool in
+one deliberate pass: identity boundary, credential parser, secret backend,
+injection shape, probes, failure rules, and privacy constraints.
+
+Issue context: Linear `TIN-491`, GitHub `tinyland-inc/lab#197`.
+
+## Current Research Finding
+
+For Codex subscription accounts, keep command probes as the primary live route
+probe. As of 2026-04-26:
+
+- OpenAI's current Codex CLI docs describe local CLI use, ChatGPT/API-key
+  sign-in, and plan inclusion, but do not document a subscription-account HTTP
+  status endpoint suitable for direct probing.
+- The installed Codex CLI 0.125.0 exposes `login status`, `debug models`, and
+  `exec`, but no direct auth-health endpoint.
+- `oauth-mux` has verified three isolated Codex stores through `CODEX_HOME` and
+  live `codex exec --json` command probes for `codex-mini` and `codex-max`.
+
+Do not add a direct Codex HTTP probe until the endpoint, method, request body,
+auth semantics, status/header/body classes, and quota impact are all verified
+from an official or provider-owned source.
+
+Decision record:
+`docs/spec/codex-direct-http-probe-decision-2026-04-26.md`.
+
+Provider admission matrix:
+`docs/spec/provider-probe-admission-matrix-2026-04-26.md`.
+
+## Standards Baseline
+
+Provider definitions must be consistent with the current OAuth and MCP floor:
+
+- OAuth 2.1 draft-ietf-oauth-v2-1-15 for the framework baseline while OAuth
+  2.1 remains an Internet-Draft.
+- RFC 9700 for OAuth security BCP.
+- RFC 8414 for authorization server metadata.
+- RFC 7591 for dynamic client registration when a provider supports it.
+- RFC 9728 for protected resource metadata, especially MCP HTTP servers.
+- RFC 8707 resource indicators for audience-bound MCP access tokens.
+- RFC 9449 DPoP only when the provider advertises sender-constrained tokens.
+- MCP authorization 2025-11-25 for HTTP MCP authorization behavior.
+
+For MCP specifically:
+
+- HTTP transports are OAuth resource-server surfaces and should follow the MCP
+  authorization profile.
+- Stdio transports should get credentials from environment/config injection,
+  not the HTTP authorization flow.
+- Runtime `insufficient_scope`, step-up, or pending-verification conditions are
+  degraded route states, not dead credentials.
+
+## Authoring Steps
+
+1. Name the provider identity.
+
+Use a short stable provider name and an account name that describes the local
+identity boundary, not the token value.
+
+```text
+provider:account
+provider:account#capability
+codex:max-1#codex-max
+figma:design#tools/get-design-context
+```
+
+The account boundary must be explicit: config directory, keychain namespace,
+SOPS path, env var, command output, or another secret backend. Do not rely on a
+provider's global default auth path unless the tool is intentionally
+single-account.
+
+2. Choose the secret backend.
+
+Allowed backends map to `src/types.zig` and `src/config.zig`:
+
+```text
+file
+env
+keychain
+sops
+age
+command
+stdin
+```
+
+The backend stores or returns raw secret material. It does not define provider
+logic. Provider logic belongs in `provider_definitions` or a compiled adapter
+only when data is insufficient.
+
+3. Parse the credential shape.
+
+Fill `credential` paths for the provider's local JSON or command output:
+
+```json
+{
+  "credential": {
+    "access_token_path": "tokens.access_token",
+    "refresh_token_path": "tokens.refresh_token",
+    "expires_at_path": "expires_at",
+    "api_key_path": "api_key"
+  }
+}
+```
+
+Only structure may be documented. Do not copy token values into fixtures,
+docs, logs, issues, or commits.
+
+4. Define the injection shape.
+
+Use config-directory injection when the harness owns refresh/session behavior:
+
+```json
+{
+  "injection": {
+    "config_dir_env": "CODEX_HOME",
+    "credential_filename": "auth.json"
+  }
+}
+```
+
+Use direct env injection only when the target harness expects a bearer token or
+API key in an environment variable:
+
+```json
+{
+  "injection": {
+    "direct_env": [["GH_TOKEN", "access_token"]]
+  }
+}
+```
+
+Never export a ChatGPT subscription OAuth token as a generic API key unless the
+provider documents that exact behavior.
+
+5. Define capability routes.
+
+Model separate task/model/tool lanes as capabilities:
+
+```json
+{
+  "capabilities": [
+    {
+      "name": "codex-max",
+      "aliases": ["max", "gpt-5.3-codex"],
+      "probe": {
+        "transport": "command",
+        "auth": "none",
+        "timeout_ms": 120000,
+        "command": [
+          "codex",
+          "exec",
+          "--json",
+          "--ephemeral",
+          "--ignore-rules",
+          "-m",
+          "gpt-5.3-codex",
+          "Reply exactly: OMUX_CODEX_MAX_PROBE"
+        ]
+      }
+    }
+  ]
+}
+```
+
+Capability state must not poison the account globally. A failed
+`provider:account#expensive-route` may skip that route while
+`provider:account#cheap-route` remains selectable.
+
+6. Select the probe transport.
+
+Use `http` only when all probe facts are known:
+
+- endpoint and method
+- required body and headers
+- auth scheme
+- success status range
+- retry-after or reset signal
+- status/body/header mappings for revoked auth, insufficient tier, quota,
+  rate limit, scope, step-up, and provider outage
+- confirmation that the probe does not spend meaningful user quota
+
+Use `command` when the harness already owns OAuth refresh/session semantics or
+when no safe public HTTP probe is documented. Command probes must be bounded by
+`timeout_ms`, must not log secrets, and should have cassettes for success and
+typed failure cases.
+
+`config validate` rejects probe URLs or command argv entries that embed obvious
+token material such as bearer authorization headers, access tokens, refresh
+tokens, ID tokens, or token-template placeholders. The mux injects credentials
+at execution time; provider schemas describe only how to run the probe.
+
+7. Map failures into liveness.
+
+Every provider should define the smallest useful `failure_rules` set:
+
+```json
+[
+  { "status": 401, "class": { "dead": "token_revoked" } },
+  { "status": 403, "class": { "degraded": "scope_insufficient" } },
+  { "status": 429, "retry_after_lt": 3601, "class": "rate_limited" },
+  { "status": 429, "retry_after_gte": 3601, "class": "quota_exhausted" },
+  { "status_min": 500, "status_max": 599, "class": "provider_degraded" }
+]
+```
+
+`config validate` requires schema-defined providers with capability probes to
+include failure rules. It also rejects catch-all failure rules: every rule must
+include at least one matcher such as `status`, `status_min`, `status_max`,
+`retry_after_gte`, `retry_after_lt`, or `hint_contains`. Empty
+`hint_contains` values are invalid.
+
+Routing semantics:
+
+- `dead`: user action required; do not automatically retry.
+- `degraded`: try the next account for this route; retry only after a long
+  window or explicit step-up.
+- `rate_limited`: skip briefly or wait and retry after the short window.
+- `quota_exhausted`: skip until the quota window resets.
+- `provider_degraded`: try the next provider, not only the next account.
+
+8. Add proof fixtures and tests.
+
+At minimum, add redacted fixtures or synthetic tests for:
+
+- credential parse success
+- missing secret or parse failure
+- route success
+- route-level rate limit
+- route-level quota exhaustion
+- route-level degraded state
+- account-level dead credential
+- provider-level outage
+- JSON/status output that omits token material
+
+For command probes, store cassettes under `test/fixtures/cassettes/<provider>/`
+with all secrets removed.
+
+`zig build test` walks `test/fixtures` and rejects common OAuth/API secret
+markers, including access tokens, refresh tokens, ID tokens, bearer
+authorization material, cookies, OpenAI-style `sk-` keys, and session-token
+prefixes. This is intentionally a high-signal guard, not a substitute for
+operator review before committing a new cassette.
+
+9. Validate the operator surface.
+
+Before merging a provider definition:
+
+```bash
+just check
+OMUX_CONFIG=/path/to/config.json oauth-mux config validate
+oauth-mux probe --provider <provider> --account <account> --capability <capability> --json
+```
+
+For live subscription probes, record only:
+
+- account label
+- capability label
+- mux decision
+- liveness state
+- availability or degraded/dead reason
+- redacted status or hint class
+
+Do not record access tokens, refresh tokens, ID tokens, cookies, authorization
+headers, raw provider responses, or full credential JSON.
+
+## Acceptance Gate
+
+A new schema-only provider is acceptable when:
+
+- `config validate` catches broken provider/account/profile/probe references.
+- The provider can be selected through `exec`, `env`, and `probe`.
+- Account-level failures dominate route state.
+- Route-level failures do not poison unrelated capabilities.
+- At least one positive and one negative probe path are covered by tests or
+  redacted cassettes.
+- The docs identify the official provider/OAuth/MCP source used for each
+  auth, refresh, and probe decision.
+
+Compiled adapter code is justified only when the provider requires behavior the
+schema cannot safely express, such as a non-JSON credential format, a custom
+command-output parser, DPoP signing, or provider-specific refresh behavior.
+
+## References
+
+- OpenAI Codex CLI: https://developers.openai.com/codex/cli
+- OpenAI MCP and Connectors: https://developers.openai.com/api/docs/guides/tools-connectors-mcp
+- MCP authorization 2025-11-25: https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
+- OAuth 2.1 draft 15: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-15
+- RFC 9700 OAuth Security BCP: https://www.rfc-editor.org/rfc/rfc9700.html
+- RFC 8414 Authorization Server Metadata: https://www.rfc-editor.org/rfc/rfc8414.html
+- RFC 7591 Dynamic Client Registration: https://www.rfc-editor.org/rfc/rfc7591
+- RFC 9728 Protected Resource Metadata: https://www.rfc-editor.org/rfc/rfc9728
+- RFC 8707 Resource Indicators: https://www.rfc-editor.org/rfc/rfc8707
+- RFC 9449 DPoP: https://www.rfc-editor.org/rfc/rfc9449

--- a/docs/spec/provider-authoring-checklist-2026-04-26.md
+++ b/docs/spec/provider-authoring-checklist-2026-04-26.md
@@ -203,9 +203,9 @@ Every provider should define the smallest useful `failure_rules` set:
 [
   { "status": 401, "class": { "dead": "token_revoked" } },
   { "status": 403, "class": { "degraded": "scope_insufficient" } },
-  { "status": 429, "retry_after_lt": 3601, "class": "rate_limited" },
-  { "status": 429, "retry_after_gte": 3601, "class": "quota_exhausted" },
-  { "status_min": 500, "status_max": 599, "class": "provider_degraded" }
+  { "status": 429, "retry_after_lt": 3601, "class": { "rate_limited": {} } },
+  { "status": 429, "retry_after_gte": 3601, "class": { "quota_exhausted": {} } },
+  { "status_min": 500, "status_max": 599, "class": { "provider_degraded": {} } }
 ]
 ```
 
@@ -214,6 +214,12 @@ include failure rules. It also rejects catch-all failure rules: every rule must
 include at least one matcher such as `status`, `status_min`, `status_max`,
 `retry_after_gte`, `retry_after_lt`, or `hint_contains`. Empty
 `hint_contains` values are invalid.
+
+Failure classes use Zig tagged-union JSON shape: payload variants use
+`{ "dead": "token_revoked" }` or `{ "degraded": "scope_insufficient" }`;
+no-payload variants use `{ "rate_limited": {} }`,
+`{ "quota_exhausted": {} }`, `{ "provider_degraded": {} }`,
+`{ "success": {} }`, or `{ "failure": {} }`.
 
 Routing semantics:
 

--- a/docs/spec/provider-probe-admission-matrix-2026-04-26.md
+++ b/docs/spec/provider-probe-admission-matrix-2026-04-26.md
@@ -1,0 +1,107 @@
+# Provider Probe Admission Matrix
+
+Updated: 2026-04-26
+
+Issue context: Linear `TIN-491`, GitHub `tinyland-inc/lab#197`.
+
+This matrix converts provider research into an implementation gate for
+`oauth-mux` provider definitions. "Admitted" means a provider has a documented
+low-impact endpoint or command shape that can be modeled as a typed probe after
+failure rules and redaction tests are added. It does not mean the provider is
+implemented yet.
+
+## Status Vocabulary
+
+- `admitted_http`: provider-owned docs expose a low-impact HTTP identity or
+  metadata endpoint suitable for schema-defined probing.
+- `admitted_command`: provider-owned docs expose a CLI/status command or local
+  session boundary that is safer than direct HTTP probing.
+- `mcp_profile`: probe behavior is governed by the MCP HTTP authorization
+  profile and must be discovered per resource server.
+- `unadmitted`: do not probe directly until provider-owned docs pin endpoint,
+  auth semantics, failure classes, reset behavior, and quota impact.
+
+## Matrix
+
+| Provider | Current Admission | Probe Shape | Required Classification |
+| --- | --- | --- | --- |
+| Codex / OpenAI subscription | `admitted_command`; direct HTTP `unadmitted` | `codex exec --json` under selected `CODEX_HOME` | JSONL success, unsupported model/tier, quota/rate, revoked auth |
+| Claude Code subscription | `admitted_command`; built-in `auth-status` probe | `claude auth status --json` under selected `CLAUDE_CONFIG_DIR`; no prompt/model call | logged in, logged out, keychain/session missing; tier/rate/quota still require future route probes |
+| Anthropic API key | `admitted_http`; not subscription equivalent | `GET https://api.anthropic.com/v1/models` with `x-api-key` and `anthropic-version`; avoid message probes that spend tokens | 200 live, 401 dead, 403/scope or workspace issue, 429 rate/quota, 5xx provider degraded |
+| MCP HTTP server | `mcp_profile`; built-in `resource-metadata` and `resource` probe templates | `GET {{OMUX_MCP_RESOURCE_METADATA_URL}}` without auth for RFC 9728 metadata; `GET {{OMUX_MCP_RESOURCE_PROBE_URL}}` with resource-bound bearer token for server probe | 401 invalid/expired token, 403 insufficient_scope or step-up, malformed metadata/schema, provider degraded |
+| MCP stdio server | `admitted_command` / injection | Environment or config injection; MCP HTTP OAuth flow does not apply | missing secret, malformed env/config, child-process failure |
+| GitHub | `admitted_http`; built-in `identity` probe | `GET https://api.github.com/user` with bearer token | 200 live, 401 dead, 403 forbidden/rate-limited, rate-limit headers |
+| Linear | `admitted_http`; built-in `identity` probe | `POST https://api.linear.app/graphql` with `query { viewer { id name email } }` and OAuth bearer token | 200 plus GraphQL errors, 401 dead, 403/scope, 429/rate, 5xx degraded |
+| Figma REST | `admitted_http`; built-in OAuth `identity`, PAT `identity-pat`, and plan-token `file-metadata-plan` probes | `GET https://api.figma.com/v1/me` with OAuth bearer token and `current_user:read`; PATs use `X-Figma-Token`; plan access tokens use `GET /v1/files/{{OMUX_FIGMA_PLAN_FILE_KEY}}/meta` with `file_metadata:read` | 200 live, 401 dead, 403 scope/tier, 404 resource not allowed/found, 429/rate, 5xx degraded |
+| Figma Remote MCP | `mcp_profile` | Treat as MCP HTTP resource, not as Figma REST | MCP metadata, scope challenge, tool/schema errors |
+| Vercel | `admitted_http`; built-in `identity` probe | `GET https://api.vercel.com/v2/user`; token metadata endpoint and semantic `softBlock` body checks are later optional refinements | 200 live, 401 dead, 403 forbidden/team/scope, 429/rate, 5xx degraded |
+| FlakeHub / Determinate | `admitted_command`; built-in `status` probe; direct HTTP `unadmitted` | `determinate-nixd status`; `fh status` remains an equivalent future CLI path when installed | logged in, logged out, local daemon/auth failure; generated token expiry remains future typed parsing |
+
+## Implementation Notes
+
+1. Admitted HTTP probes must still pass the provider authoring checklist:
+   explicit method, URL, auth scheme, success range, failure rules, redacted
+   cassettes, and no token material in config.
+2. Identity endpoints are preferred over work endpoints. Do not validate a
+   provider by sending a model prompt, creating an issue, reading a design file,
+   or triggering a build unless no lower-impact probe exists and the operator
+   explicitly opts in.
+3. GraphQL probes need semantic success checks. A 200 response with an `errors`
+   array is not automatically live.
+4. MCP HTTP probes must be audience-bound. A token minted for one MCP resource
+   server must not be replayed to another server.
+5. Subscription tools that own refresh/session state should remain command-first
+   until the provider documents direct resource-server semantics.
+6. Custom token-header probes are explicit. Use `auth = token_header` with a
+   non-`Authorization` header name such as `X-Figma-Token`; use `auth = bearer`
+   for OAuth Authorization headers.
+7. URL templates are for non-secret resource identifiers only. Placeholder
+   names must be env-var shaped (`A_Z0_9_`); runtime values must be URL-safe
+   unreserved characters.
+
+## Provider Source Links
+
+- Codex CLI/auth:
+  <https://developers.openai.com/codex/cli>,
+  <https://developers.openai.com/codex/cli/reference>,
+  <https://developers.openai.com/codex/auth>
+- OpenAI MCP connectors:
+  <https://developers.openai.com/api/docs/guides/tools-connectors-mcp>
+- Claude Code setup/IAM:
+  <https://docs.anthropic.com/en/docs/claude-code/getting-started>,
+  <https://docs.anthropic.com/en/docs/claude-code/team>,
+  <https://docs.anthropic.com/en/docs/claude-code/settings>
+- Anthropic API auth:
+  <https://docs.anthropic.com/en/api/getting-started>,
+  <https://docs.anthropic.com/en/api/models-list>
+- MCP authorization:
+  <https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization>
+- GitHub REST auth/user:
+  <https://docs.github.com/v3/auth>,
+  <https://docs.github.com/rest/users/users>
+- Linear API/OAuth:
+  <https://linear.app/developers/graphql>,
+  <https://linear.app/developers/oauth-2-0-authentication>
+- Figma REST API/OAuth/users:
+  <https://developers.figma.com/docs/rest-api/>,
+  <https://developers.figma.com/docs/rest-api/authentication/>,
+  <https://developers.figma.com/docs/rest-api/users-endpoints/>
+- Vercel REST API/tokens:
+  <https://docs.vercel.com/docs/rest-api/reference/endpoints/user/get-the-user>,
+  <https://vercel.com/docs/sign-in-with-vercel/tokens>
+- FlakeHub/Determinate auth:
+  <https://docs.determinate.systems/flakehub/concepts/authentication/>,
+  <https://docs.determinate.systems/flakehub/cli/>
+
+## Standards Source Links
+
+- IETF OAuth 2.1 draft-ietf-oauth-v2-1-15:
+  <https://datatracker.ietf.org/doc/draft-ietf-oauth-v2-1/>
+- RFC 9700, OAuth 2.0 Security BCP:
+  <https://www.rfc-editor.org/rfc/rfc9700>
+- RFC 8414, OAuth authorization server metadata:
+  <https://www.rfc-editor.org/rfc/rfc8414>
+- RFC 8707, OAuth resource indicators:
+  <https://www.rfc-editor.org/rfc/rfc8707>
+- RFC 9728, OAuth protected resource metadata:
+  <https://www.rfc-editor.org/rfc/rfc9728>

--- a/examples/claude.config.json
+++ b/examples/claude.config.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "defaults": {
+    "provider": "claude",
+    "strategy": "health-weighted",
+    "shell": "fish"
+  },
+  "providers": {
+    "claude": {
+      "kind": "claude",
+      "accounts": {
+        "work": {
+          "priority": 10,
+          "config_dir": "~/.claude",
+          "secret": {
+            "backend": "file",
+            "path": "~/.claude/.credentials.json"
+          },
+          "tags": ["oauth", "claude"]
+        }
+      }
+    }
+  },
+  "profiles": {
+    "claude": {
+      "providers": ["claude:work#auth-status"],
+      "strategy": "health-weighted",
+      "affinity_ttl_minutes": 20
+    }
+  },
+  "strategies": {
+    "health-weighted": {
+      "kind": "health-weighted",
+      "rate_limit_penalty": -10,
+      "failure_penalty": -20,
+      "success_bonus": 1
+    }
+  }
+}

--- a/examples/codex-max.config.json
+++ b/examples/codex-max.config.json
@@ -1,0 +1,71 @@
+{
+  "version": 1,
+  "defaults": {
+    "provider": "codex",
+    "strategy": "health-weighted",
+    "shell": "fish"
+  },
+  "providers": {
+    "codex": {
+      "kind": "codex",
+      "config_dir_env": "CODEX_HOME",
+      "accounts": {
+        "max-1": {
+          "priority": 30,
+          "config_dir": "~/.local/share/oauth-mux/codex/max-1",
+          "secret": {
+            "backend": "file",
+            "path": "~/.local/share/oauth-mux/codex/max-1/auth.json"
+          },
+          "tags": ["subscription", "codex-max"]
+        },
+        "max-2": {
+          "priority": 20,
+          "config_dir": "~/.local/share/oauth-mux/codex/max-2",
+          "secret": {
+            "backend": "file",
+            "path": "~/.local/share/oauth-mux/codex/max-2/auth.json"
+          },
+          "tags": ["subscription", "codex-max"]
+        },
+        "max-3": {
+          "priority": 10,
+          "config_dir": "~/.local/share/oauth-mux/codex/max-3",
+          "secret": {
+            "backend": "file",
+            "path": "~/.local/share/oauth-mux/codex/max-3/auth.json"
+          },
+          "tags": ["subscription", "codex-max"]
+        }
+      }
+    }
+  },
+  "profiles": {
+    "codex-max": {
+      "providers": [
+        "codex:max-1#codex-max",
+        "codex:max-2#codex-max",
+        "codex:max-3#codex-max"
+      ],
+      "strategy": "health-weighted",
+      "affinity_ttl_minutes": 20
+    },
+    "codex-mini": {
+      "providers": [
+        "codex:max-1#codex-mini",
+        "codex:max-2#codex-mini",
+        "codex:max-3#codex-mini"
+      ],
+      "strategy": "health-weighted",
+      "affinity_ttl_minutes": 20
+    }
+  },
+  "strategies": {
+    "health-weighted": {
+      "kind": "health-weighted",
+      "rate_limit_penalty": -10,
+      "failure_penalty": -20,
+      "success_bonus": 1
+    }
+  }
+}

--- a/examples/figma-pat.config.json
+++ b/examples/figma-pat.config.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "defaults": {
+    "provider": "figma-pat",
+    "strategy": "health-weighted",
+    "shell": "fish"
+  },
+  "providers": {
+    "figma-pat": {
+      "kind": "figma",
+      "accounts": {
+        "work": {
+          "priority": 10,
+          "secret": {
+            "backend": "env",
+            "variable": "OMUX_FIGMA_PAT"
+          },
+          "tags": ["pat", "figma"]
+        }
+      }
+    }
+  },
+  "profiles": {
+    "figma-pat": {
+      "providers": ["figma-pat:work#identity-pat"],
+      "strategy": "health-weighted",
+      "affinity_ttl_minutes": 20
+    }
+  },
+  "strategies": {
+    "health-weighted": {
+      "kind": "health-weighted",
+      "rate_limit_penalty": -10,
+      "failure_penalty": -20,
+      "success_bonus": 1
+    }
+  }
+}

--- a/examples/figma-plan.config.json
+++ b/examples/figma-plan.config.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "defaults": {
+    "provider": "figma-plan",
+    "strategy": "health-weighted",
+    "shell": "fish"
+  },
+  "providers": {
+    "figma-plan": {
+      "kind": "figma",
+      "accounts": {
+        "work": {
+          "priority": 10,
+          "secret": {
+            "backend": "env",
+            "variable": "OMUX_FIGMA_PLAN_TOKEN"
+          },
+          "tags": ["plan-token", "figma"]
+        }
+      }
+    }
+  },
+  "profiles": {
+    "figma-plan": {
+      "providers": ["figma-plan:work#file-metadata-plan"],
+      "strategy": "health-weighted",
+      "affinity_ttl_minutes": 20
+    }
+  },
+  "strategies": {
+    "health-weighted": {
+      "kind": "health-weighted",
+      "rate_limit_penalty": -10,
+      "failure_penalty": -20,
+      "success_bonus": 1
+    }
+  }
+}

--- a/examples/figma.config.json
+++ b/examples/figma.config.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "defaults": {
+    "provider": "figma",
+    "strategy": "health-weighted",
+    "shell": "fish"
+  },
+  "providers": {
+    "figma": {
+      "kind": "figma",
+      "accounts": {
+        "work": {
+          "priority": 10,
+          "secret": {
+            "backend": "env",
+            "variable": "OMUX_FIGMA_WORK_TOKEN"
+          },
+          "tags": ["oauth", "figma"]
+        }
+      }
+    }
+  },
+  "profiles": {
+    "figma": {
+      "providers": ["figma:work#identity"],
+      "strategy": "health-weighted",
+      "affinity_ttl_minutes": 20
+    }
+  },
+  "strategies": {
+    "health-weighted": {
+      "kind": "health-weighted",
+      "rate_limit_penalty": -10,
+      "failure_penalty": -20,
+      "success_bonus": 1
+    }
+  }
+}

--- a/examples/flakehub.config.json
+++ b/examples/flakehub.config.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "defaults": {
+    "provider": "flakehub",
+    "strategy": "health-weighted",
+    "shell": "fish"
+  },
+  "providers": {
+    "flakehub": {
+      "kind": "flakehub",
+      "accounts": {
+        "work": {
+          "priority": 10,
+          "secret": {
+            "backend": "env",
+            "variable": "OMUX_FLAKEHUB_TOKEN"
+          },
+          "tags": ["api-key", "flakehub", "determinate"]
+        }
+      }
+    }
+  },
+  "profiles": {
+    "flakehub": {
+      "providers": ["flakehub:work#status"],
+      "strategy": "health-weighted",
+      "affinity_ttl_minutes": 20
+    }
+  },
+  "strategies": {
+    "health-weighted": {
+      "kind": "health-weighted",
+      "rate_limit_penalty": -10,
+      "failure_penalty": -20,
+      "success_bonus": 1
+    }
+  }
+}

--- a/examples/github.config.json
+++ b/examples/github.config.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "defaults": {
+    "provider": "github",
+    "strategy": "health-weighted",
+    "shell": "fish"
+  },
+  "providers": {
+    "github": {
+      "kind": "github",
+      "accounts": {
+        "work": {
+          "priority": 10,
+          "secret": {
+            "backend": "env",
+            "variable": "OMUX_GITHUB_WORK_TOKEN"
+          },
+          "tags": ["oauth", "github"]
+        }
+      }
+    }
+  },
+  "profiles": {
+    "github": {
+      "providers": ["github:work#identity"],
+      "strategy": "health-weighted",
+      "affinity_ttl_minutes": 20
+    }
+  },
+  "strategies": {
+    "health-weighted": {
+      "kind": "health-weighted",
+      "rate_limit_penalty": -10,
+      "failure_penalty": -20,
+      "success_bonus": 1
+    }
+  }
+}

--- a/examples/linear.config.json
+++ b/examples/linear.config.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "defaults": {
+    "provider": "linear",
+    "strategy": "health-weighted",
+    "shell": "fish"
+  },
+  "providers": {
+    "linear": {
+      "kind": "linear",
+      "accounts": {
+        "work": {
+          "priority": 10,
+          "secret": {
+            "backend": "env",
+            "variable": "OMUX_LINEAR_WORK_TOKEN"
+          },
+          "tags": ["oauth", "linear"]
+        }
+      }
+    }
+  },
+  "profiles": {
+    "linear": {
+      "providers": ["linear:work#identity"],
+      "strategy": "health-weighted",
+      "affinity_ttl_minutes": 20
+    }
+  },
+  "strategies": {
+    "health-weighted": {
+      "kind": "health-weighted",
+      "rate_limit_penalty": -10,
+      "failure_penalty": -20,
+      "success_bonus": 1
+    }
+  }
+}

--- a/examples/mcp-http.config.json
+++ b/examples/mcp-http.config.json
@@ -1,0 +1,43 @@
+{
+  "version": 1,
+  "defaults": {
+    "provider": "mcp",
+    "strategy": "health-weighted",
+    "shell": "fish"
+  },
+  "providers": {
+    "mcp": {
+      "kind": "mcp",
+      "accounts": {
+        "figma": {
+          "priority": 10,
+          "secret": {
+            "backend": "env",
+            "variable": "OMUX_MCP_FIGMA_TOKEN"
+          },
+          "tags": ["oauth", "mcp", "figma"]
+        }
+      }
+    }
+  },
+  "profiles": {
+    "mcp-resource": {
+      "providers": ["mcp:figma#resource"],
+      "strategy": "health-weighted",
+      "affinity_ttl_minutes": 20
+    },
+    "mcp-metadata": {
+      "providers": ["mcp:figma#resource-metadata"],
+      "strategy": "health-weighted",
+      "affinity_ttl_minutes": 20
+    }
+  },
+  "strategies": {
+    "health-weighted": {
+      "kind": "health-weighted",
+      "rate_limit_penalty": -10,
+      "failure_penalty": -20,
+      "success_bonus": 1
+    }
+  }
+}

--- a/examples/vercel.config.json
+++ b/examples/vercel.config.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "defaults": {
+    "provider": "vercel",
+    "strategy": "health-weighted",
+    "shell": "fish"
+  },
+  "providers": {
+    "vercel": {
+      "kind": "vercel",
+      "accounts": {
+        "work": {
+          "priority": 10,
+          "secret": {
+            "backend": "env",
+            "variable": "OMUX_VERCEL_WORK_TOKEN"
+          },
+          "tags": ["oauth", "vercel"]
+        }
+      }
+    }
+  },
+  "profiles": {
+    "vercel": {
+      "providers": ["vercel:work#identity"],
+      "strategy": "health-weighted",
+      "affinity_ttl_minutes": 20
+    }
+  },
+  "strategies": {
+    "health-weighted": {
+      "kind": "health-weighted",
+      "rate_limit_penalty": -10,
+      "failure_penalty": -20,
+      "success_bonus": 1
+    }
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
         };
 
         devShells.default = pkgs.mkShell {
-          packages = [ zig pkgs.just ];
+          packages = [ zig pkgs.just pkgs.nodejs pkgs.nfpm ];
 
           shellHook = ''
             echo "oauth-mux dev shell — zig $(zig version)"

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
         };
 
         devShells.default = pkgs.mkShell {
-          packages = [ zig ];
+          packages = [ zig pkgs.just ];
 
           shellHook = ''
             echo "oauth-mux dev shell — zig $(zig version)"

--- a/justfile
+++ b/justfile
@@ -140,8 +140,15 @@ check:
     nix develop --command just check-local
 
 check-local:
-    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done'
+    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh'
     @echo "all checks passed"
+
+e2e:
+    nix develop --command just e2e-local
+
+e2e-local:
+    zig build
+    ./scripts/e2e-local.sh
 
 # ── Config ──
 

--- a/justfile
+++ b/justfile
@@ -91,6 +91,9 @@ release-all:
     {{zig}} build release
     @echo "all release builds complete"
 
+release-local VERSION="0.1.0":
+    nix develop --command ./scripts/release-local.sh {{VERSION}}
+
 release-linux-amd64:
     {{zig}} build -Dtarget=x86_64-linux-musl -Doptimize=ReleaseSafe
 

--- a/justfile
+++ b/justfile
@@ -94,6 +94,16 @@ release-all:
 release-local VERSION="0.1.0":
     nix develop --command ./scripts/release-local.sh {{VERSION}}
 
+release-smoke VERSION="0.1.0":
+    nix develop --command ./scripts/release-smoke.sh {{VERSION}}
+
+release-proof VERSION="0.1.0":
+    nix develop --command just release-proof-local {{VERSION}}
+
+release-proof-local VERSION="0.1.0":
+    ./scripts/release-local.sh {{VERSION}}
+    ./scripts/release-smoke.sh {{VERSION}}
+
 release-linux-amd64:
     {{zig}} build -Dtarget=x86_64-linux-musl -Doptimize=ReleaseSafe
 

--- a/justfile
+++ b/justfile
@@ -97,12 +97,16 @@ release-local VERSION="0.1.0":
 release-smoke VERSION="0.1.0":
     nix develop --command ./scripts/release-smoke.sh {{VERSION}}
 
+release-handoff VERSION="0.1.0":
+    nix develop --command ./scripts/release-handoff.sh {{VERSION}}
+
 release-proof VERSION="0.1.0":
     nix develop --command just release-proof-local {{VERSION}}
 
 release-proof-local VERSION="0.1.0":
     ./scripts/release-local.sh {{VERSION}}
     ./scripts/release-smoke.sh {{VERSION}}
+    ./scripts/release-handoff.sh {{VERSION}}
 
 release-linux-amd64:
     {{zig}} build -Dtarget=x86_64-linux-musl -Doptimize=ReleaseSafe

--- a/justfile
+++ b/justfile
@@ -35,9 +35,60 @@ status: build
 health: build
     ./zig-out/bin/oauth-mux health
 
+probe *ARGS: build
+    ./zig-out/bin/oauth-mux probe {{ARGS}}
+
+# ── Codex Max operator helpers ──
+
+codex_max_config := "examples/codex-max.config.json"
+codex_max_state := "/tmp/oauth-mux-codex-max-health"
+
+codex-max-bootstrap-dirs:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for account in max-1 max-2 max-3; do
+      dir="$HOME/.local/share/oauth-mux/codex/${account}"
+      mkdir -p "$dir"
+      echo "$dir"
+    done
+
+codex-max-validate: build
+    OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux config validate
+
+codex-max-login ACCOUNT: codex-max-bootstrap-dirs
+    CODEX_HOME=$HOME/.local/share/oauth-mux/codex/{{ACCOUNT}} codex login
+
+codex-max-login-device ACCOUNT: codex-max-bootstrap-dirs
+    CODEX_HOME=$HOME/.local/share/oauth-mux/codex/{{ACCOUNT}} codex login --device-auth
+
+codex-max-login-status ACCOUNT:
+    CODEX_HOME=$HOME/.local/share/oauth-mux/codex/{{ACCOUNT}} codex login status
+
+codex-max-login-status-all:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for account in max-1 max-2 max-3; do
+      echo "=== ${account} ==="
+      CODEX_HOME="$HOME/.local/share/oauth-mux/codex/${account}" codex login status || true
+    done
+
+codex-max-probe ACCOUNT CAPABILITY="codex-mini": build
+    OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux probe --provider codex --account {{ACCOUNT}} --capability {{CAPABILITY}} --json
+
+codex-max-probe-all CAPABILITY="codex-mini": build
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for account in max-1 max-2 max-3; do
+      echo "=== ${account} {{CAPABILITY}} ==="
+      OMUX_CONFIG="$PWD/{{codex_max_config}}" OMUX_STATE_DIR="{{codex_max_state}}" ./zig-out/bin/oauth-mux probe --provider codex --account "${account}" --capability "{{CAPABILITY}}" --json
+    done
+
 # ── Cross-compilation ──
 
-release-all: release-linux-amd64 release-linux-arm64 release-macos-amd64 release-macos-arm64
+release: release-all
+
+release-all:
+    {{zig}} build release
     @echo "all release builds complete"
 
 release-linux-amd64:
@@ -52,6 +103,12 @@ release-macos-amd64:
 release-macos-arm64:
     {{zig}} build -Dtarget=aarch64-macos -Doptimize=ReleaseSafe
 
+release-windows-amd64:
+    {{zig}} build -Dtarget=x86_64-windows -Doptimize=ReleaseSafe
+
+release-windows-arm64:
+    {{zig}} build -Dtarget=aarch64-windows -Doptimize=ReleaseSafe
+
 # ── Nix ──
 
 nix-build:
@@ -62,7 +119,11 @@ nix-check:
 
 # ── Validation ──
 
-check: test build
+check:
+    nix develop --command just check-local
+
+check-local:
+    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done'
     @echo "all checks passed"
 
 # ── Config ──

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+bin="${OMUX_BIN:-$repo_root/zig-out/bin/oauth-mux}"
+
+if [ ! -x "$bin" ]; then
+  printf 'missing oauth-mux binary: %s\n' "$bin" >&2
+  printf 'run `zig build` or `just e2e` first\n' >&2
+  exit 1
+fi
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/oauth-mux-e2e.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+config="$tmp/config.json"
+state_dir="$tmp/state"
+exec_out="$tmp/exec.out"
+probe_cmd="$tmp/probe-harness.sh"
+
+mkdir -p "$state_dir" "$tmp/a1-home" "$tmp/a2-home"
+
+cat >"$probe_cmd" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+
+capability="${1:-}"
+
+case "${capability}:${OMUX_ACTIVE_ACCOUNT:-}" in
+  expensive:a1)
+    printf '%s\n' 'quota_exhausted: simulated monthly route limit'
+    exit 1
+    ;;
+  cheap:a1|cheap:a2|expensive:a2)
+    printf 'ok provider=%s account=%s capability=%s\n' \
+      "${OMUX_ACTIVE_PROVIDER:-}" \
+      "${OMUX_ACTIVE_ACCOUNT:-}" \
+      "${OMUX_ACTIVE_CAPABILITY:-}"
+    exit 0
+    ;;
+  *)
+    printf 'unexpected probe route: capability=%s account=%s\n' \
+      "${capability}" \
+      "${OMUX_ACTIVE_ACCOUNT:-}" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod 0755 "$probe_cmd"
+
+cat >"$config" <<EOF
+{
+  "version": 1,
+  "defaults": {
+    "provider": "toy",
+    "strategy": "health-weighted",
+    "shell": "bash"
+  },
+  "provider_definitions": {
+    "toy": {
+      "name": "toy",
+      "display_name": "Toy E2E Harness",
+      "credential": {
+        "access_token_path": "access_token"
+      },
+      "injection": {
+        "config_dir_env": "TOY_HOME",
+        "credential_filename": "auth.json",
+        "direct_env": [
+          ["TOY_TOKEN", "access_token"]
+        ]
+      },
+      "capabilities": [
+        {
+          "name": "cheap",
+          "probe": {
+            "transport": "command",
+            "auth": "none",
+            "timeout_ms": 5000,
+            "command": ["$probe_cmd", "cheap"]
+          }
+        },
+        {
+          "name": "expensive",
+          "probe": {
+            "transport": "command",
+            "auth": "none",
+            "timeout_ms": 5000,
+            "command": ["$probe_cmd", "expensive"]
+          }
+        }
+      ],
+      "failure_rules": [
+        {
+          "status": 400,
+          "hint_contains": "quota_exhausted",
+          "class": {
+            "quota_exhausted": {}
+          }
+        },
+        {
+          "status": 400,
+          "class": {
+            "degraded": "unknown_4xx"
+          }
+        }
+      ]
+    }
+  },
+  "providers": {
+    "toy": {
+      "kind": "toy",
+      "config_dir_env": "TOY_HOME",
+      "accounts": {
+        "a1": {
+          "priority": 20,
+          "config_dir": "$tmp/a1-home",
+          "secret": {
+            "backend": "env",
+            "variable": "OMUX_E2E_A1_AUTH"
+          }
+        },
+        "a2": {
+          "priority": 10,
+          "config_dir": "$tmp/a2-home",
+          "secret": {
+            "backend": "env",
+            "variable": "OMUX_E2E_A2_AUTH"
+          }
+        }
+      }
+    }
+  },
+  "profiles": {
+    "cheap": {
+      "providers": [
+        "toy:a1#cheap",
+        "toy:a2#cheap"
+      ],
+      "strategy": "health-weighted"
+    },
+    "expensive": {
+      "providers": [
+        "toy:a1#expensive",
+        "toy:a2#expensive"
+      ],
+      "strategy": "health-weighted"
+    }
+  },
+  "strategies": {
+    "health-weighted": {
+      "kind": "health-weighted",
+      "rate_limit_penalty": -10,
+      "failure_penalty": -20,
+      "success_bonus": 1
+    }
+  }
+}
+EOF
+
+auth_a1='{"access_token":"omux-e2e-a1"}'
+auth_a2='{"access_token":"omux-e2e-a2"}'
+
+omux() {
+  OMUX_CONFIG="$config" \
+    OMUX_STATE_DIR="$state_dir" \
+    OMUX_E2E_A1_AUTH="$auth_a1" \
+    OMUX_E2E_A2_AUTH="$auth_a2" \
+    "$bin" "$@"
+}
+
+expect_contains() {
+  haystack="$1"
+  needle="$2"
+  label="$3"
+
+  case "$haystack" in
+    *"$needle"*) ;;
+    *)
+      printf 'e2e assertion failed: %s\n' "$label" >&2
+      printf 'expected to find: %s\n' "$needle" >&2
+      printf 'output was:\n%s\n' "$haystack" >&2
+      exit 1
+      ;;
+  esac
+}
+
+printf 'e2e: validate generated config\n'
+omux config validate >/dev/null
+
+printf 'e2e: cheap route selects first healthy account\n'
+cheap_env="$(omux env --profile cheap --capability cheap --shell bash)"
+expect_contains "$cheap_env" "export TOY_TOKEN='omux-e2e-a1'" "cheap env injects account a1 token"
+expect_contains "$cheap_env" "export TOY_HOME='$tmp/a1-home'" "cheap env injects account a1 config dir"
+expect_contains "$cheap_env" "export OMUX_ACTIVE_ACCOUNT='a1'" "cheap env marks active account a1"
+
+printf 'e2e: expensive route falls back after route-scoped quota exhaustion\n'
+expensive_probe="$(omux probe --profile expensive --capability expensive --json)"
+expect_contains "$expensive_probe" '"account":"a2"' "expensive probe falls back to account a2"
+expect_contains "$expensive_probe" '"probe_executed":true' "expensive probe executes capability probe"
+expect_contains "$expensive_probe" '"health_key":"toy:a2#expensive"' "expensive probe records selected route health"
+
+health_json="$(omux health --json)"
+expect_contains "$health_json" '"key":"toy:a1#expensive"' "health includes failed route key"
+expect_contains "$health_json" '"availability":"quota_exhausted"' "health records quota exhausted route availability"
+expect_contains "$health_json" '"decision":"try_next_account"' "health records fallback decision"
+
+printf 'e2e: route health does not poison unrelated capability\n'
+cheap_after_quota="$(omux env --profile cheap --capability cheap --shell bash)"
+expect_contains "$cheap_after_quota" "export OMUX_ACTIVE_ACCOUNT='a1'" "cheap route still uses a1 after expensive quota"
+
+printf 'e2e: env command skips known exhausted route\n'
+expensive_env="$(omux env --profile expensive --capability expensive --shell bash)"
+expect_contains "$expensive_env" "export TOY_TOKEN='omux-e2e-a2'" "expensive env uses fallback account a2"
+expect_contains "$expensive_env" "export OMUX_ACTIVE_ACCOUNT='a2'" "expensive env marks active account a2"
+
+printf 'e2e: exec injects selected account into target process\n'
+OMUX_E2E_EXEC_OUT="$exec_out" omux exec --profile cheap --capability cheap -- sh -c 'printf "%s:%s" "$OMUX_ACTIVE_ACCOUNT" "$TOY_TOKEN" > "$OMUX_E2E_EXEC_OUT"'
+exec_result="$(cat "$exec_out")"
+expect_contains "$exec_result" 'a1:omux-e2e-a1' "exec target receives selected account env"
+
+printf 'e2e-local passed\n'

--- a/scripts/release-handoff.sh
+++ b/scripts/release-handoff.sh
@@ -131,7 +131,8 @@ publish after \`just release-proof ${version}\` has passed.
 
 - Local proof: \`just release-proof ${version}\`
 - Hosted tag proof: \`.github/workflows/release.yml\`
-- Optional self-hosted proof: \`gh workflow run release-proof.yml -f version=${version}\`
+- Optional self-hosted proof after the workflow exists on \`main\`:
+  \`gh workflow run release-proof.yml -f version=${version}\`
 
 During runner or lab outages, treat a queued self-hosted proof as deferred
 evidence. Do not claim GloriousFlywheel cache-first proof unless the

--- a/scripts/release-handoff.sh
+++ b/scripts/release-handoff.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+version="${1:-${VERSION:-0.1.0}}"
+version="${version#v}"
+
+out_dir="$repo_root/dist/out/v${version}"
+artifacts_dir="$out_dir/artifacts"
+npm_tgz_dir="$out_dir/npm-tarballs"
+homebrew_formula="$out_dir/homebrew/oauth-mux.rb"
+handoff_dir="$out_dir/handoff"
+handoff_file="$handoff_dir/release-handoff.md"
+publish_files="$handoff_dir/publish-files.txt"
+full_checksums="$handoff_dir/SHA256SUMS.full"
+
+binary_tarballs=(
+  "oauth-mux-x86_64-linux.tar.gz"
+  "oauth-mux-aarch64-linux.tar.gz"
+  "oauth-mux-x86_64-macos.tar.gz"
+  "oauth-mux-aarch64-macos.tar.gz"
+  "oauth-mux-x86_64-windows.tar.gz"
+  "oauth-mux-aarch64-windows.tar.gz"
+)
+
+system_packages=(
+  "oauth-mux_${version}_amd64.deb"
+  "oauth-mux_${version}_arm64.deb"
+  "oauth-mux-${version}-1.x86_64.rpm"
+  "oauth-mux-${version}-1.aarch64.rpm"
+)
+
+npm_platform_tarballs=(
+  "oauth-mux-darwin-arm64-${version}.tgz"
+  "oauth-mux-darwin-x64-${version}.tgz"
+  "oauth-mux-linux-arm64-${version}.tgz"
+  "oauth-mux-linux-x64-${version}.tgz"
+  "oauth-mux-win32-arm64-${version}.tgz"
+  "oauth-mux-win32-x64-${version}.tgz"
+)
+
+npm_root_tarball="oauth-mux-${version}.tgz"
+
+hash_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{ print $1 }'
+  else
+    shasum -a 256 "$1" | awk '{ print $1 }'
+  fi
+}
+
+require_file() {
+  if [ ! -f "$1" ]; then
+    printf 'missing release handoff input: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+relative_to_out() {
+  printf '%s\n' "${1#"$out_dir"/}"
+}
+
+table_row() {
+  local path="$1"
+  local rel
+  rel="$(relative_to_out "$path")"
+  printf '| `%s` | `%s` |\n' "$rel" "$(hash_file "$path")" >>"$handoff_file"
+}
+
+if [ ! -d "$out_dir" ]; then
+  printf 'release output does not exist: %s\n' "$out_dir" >&2
+  printf 'run: just release-local %s\n' "$version" >&2
+  exit 1
+fi
+
+require_file "$artifacts_dir/SHA256SUMS"
+require_file "$artifacts_dir/install.sh"
+require_file "$homebrew_formula"
+require_file "$out_dir/nfpm/oauth-mux-amd64.yaml"
+require_file "$out_dir/nfpm/oauth-mux-arm64.yaml"
+
+for artifact in "${binary_tarballs[@]}" "${system_packages[@]}"; do
+  require_file "$artifacts_dir/$artifact"
+done
+
+for tarball in "${npm_platform_tarballs[@]}" "$npm_root_tarball"; do
+  require_file "$npm_tgz_dir/$tarball"
+done
+
+actual_npm_count="$(find "$npm_tgz_dir" -maxdepth 1 -type f -name '*.tgz' | wc -l | tr -d ' ')"
+expected_npm_count="$((${#npm_platform_tarballs[@]} + 1))"
+if [ "$actual_npm_count" != "$expected_npm_count" ]; then
+  printf 'expected %s npm tarballs, found %s in %s\n' "$expected_npm_count" "$actual_npm_count" "$npm_tgz_dir" >&2
+  exit 1
+fi
+
+mkdir -p "$handoff_dir"
+
+: >"$publish_files"
+for artifact in "${binary_tarballs[@]}" "${system_packages[@]}" "SHA256SUMS" "install.sh"; do
+  printf '%s\n' "artifacts/$artifact" >>"$publish_files"
+done
+for tarball in "${npm_platform_tarballs[@]}" "$npm_root_tarball"; do
+  printf '%s\n' "npm-tarballs/$tarball" >>"$publish_files"
+done
+printf '%s\n' "homebrew/oauth-mux.rb" >>"$publish_files"
+
+: >"$full_checksums"
+while read -r rel; do
+  path="$out_dir/$rel"
+  require_file "$path"
+  printf '%s  %s\n' "$(hash_file "$path")" "$rel" >>"$full_checksums"
+done <"$publish_files"
+
+generated_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+git_commit="$(git rev-parse --short HEAD 2>/dev/null || printf 'unknown')"
+
+cat >"$handoff_file" <<EOF
+# oauth-mux v${version} Release Handoff
+
+Generated: ${generated_at}
+Source commit: ${git_commit}
+Release tree: \`dist/out/v${version}\`
+
+This handoff is non-publishing. It proves and lists the files an operator would
+publish after \`just release-proof ${version}\` has passed.
+
+## Required Proofs
+
+- Local proof: \`just release-proof ${version}\`
+- Hosted tag proof: \`.github/workflows/release.yml\`
+- Optional self-hosted proof: \`gh workflow run release-proof.yml -f version=${version}\`
+
+During runner or lab outages, treat a queued self-hosted proof as deferred
+evidence. Do not claim GloriousFlywheel cache-first proof unless the
+\`tinyland-nix\` job actually checks out the private action and runs.
+
+## GitHub Release Attachments
+
+Attach these files from \`dist/out/v${version}\`:
+
+| File | SHA256 |
+| --- | --- |
+EOF
+
+for artifact in "${binary_tarballs[@]}" "${system_packages[@]}" "install.sh" "SHA256SUMS"; do
+  table_row "$artifacts_dir/$artifact"
+done
+
+cat >>"$handoff_file" <<EOF
+
+## npm Publish Order
+
+Publish platform packages first, then the root shim:
+
+\`\`\`bash
+EOF
+
+for tarball in "${npm_platform_tarballs[@]}"; do
+  printf 'npm publish dist/out/v%s/npm-tarballs/%s --access public --provenance\n' "$version" "$tarball" >>"$handoff_file"
+done
+printf 'npm publish dist/out/v%s/npm-tarballs/%s --provenance\n' "$version" "$npm_root_tarball" >>"$handoff_file"
+
+cat >>"$handoff_file" <<EOF
+\`\`\`
+
+## Homebrew Tap
+
+Copy the rendered formula into the tap and review the four platform checksums:
+
+\`\`\`bash
+cp dist/out/v${version}/homebrew/oauth-mux.rb <tap-checkout>/Formula/oauth-mux.rb
+git -C <tap-checkout> diff -- Formula/oauth-mux.rb
+\`\`\`
+
+Formula file:
+
+| File | SHA256 |
+| --- | --- |
+EOF
+
+table_row "$homebrew_formula"
+
+cat >>"$handoff_file" <<EOF
+
+## deb/rpm Handoff
+
+Publish these files to the package repository or attach them to the GitHub
+release until a repository is selected:
+
+| File | SHA256 |
+| --- | --- |
+EOF
+
+for artifact in "${system_packages[@]}"; do
+  table_row "$artifacts_dir/$artifact"
+done
+
+cat >>"$handoff_file" <<EOF
+
+## npm Tarballs
+
+| File | SHA256 |
+| --- | --- |
+EOF
+
+for tarball in "${npm_platform_tarballs[@]}" "$npm_root_tarball"; do
+  table_row "$npm_tgz_dir/$tarball"
+done
+
+cat >>"$handoff_file" <<EOF
+
+## Generated Files
+
+- \`handoff/release-handoff.md\`: this operator handoff
+- \`handoff/publish-files.txt\`: relative file list for publishing scripts
+- \`handoff/SHA256SUMS.full\`: checksums for GitHub, npm, Homebrew, deb, and rpm handoff files
+
+## Boundary
+
+This step does not use npm, Homebrew, package-repository, or GitHub release
+write credentials. Publication should remain manual until each registry lane has
+its own authenticated dry run and rollback runbook.
+EOF
+
+printf 'release handoff written:\n'
+printf '  %s\n' "$handoff_file"
+printf '  %s\n' "$publish_files"
+printf '  %s\n' "$full_checksums"

--- a/scripts/release-local.sh
+++ b/scripts/release-local.sh
@@ -26,6 +26,15 @@ hash_file() {
   fi
 }
 
+write_artifact_checksums() {
+  : >"$artifacts_dir/SHA256SUMS"
+  for artifact in "$artifacts_dir"/*; do
+    [ -f "$artifact" ] || continue
+    [ "$(basename "$artifact")" = "SHA256SUMS" ] && continue
+    printf '%s  %s\n' "$(hash_file "$artifact")" "$(basename "$artifact")" >>"$artifacts_dir/SHA256SUMS"
+  done
+}
+
 package_binary() {
   local build_dir="$1"
   local artifact="$2"
@@ -75,10 +84,7 @@ package_binary "x86_64-windows" "oauth-mux-x86_64-windows" "@oauth-mux/win32-x64
 package_binary "aarch64-windows" "oauth-mux-aarch64-windows" "@oauth-mux/win32-arm64" "win32" "arm64" "oauth-mux.exe"
 
 printf 'writing SHA256SUMS...\n'
-: >"$artifacts_dir/SHA256SUMS"
-for archive in "$artifacts_dir"/*.tar.gz; do
-  printf '%s  %s\n' "$(hash_file "$archive")" "$(basename "$archive")" >>"$artifacts_dir/SHA256SUMS"
-done
+write_artifact_checksums
 
 sha_linux_x64="$(hash_file "$artifacts_dir/oauth-mux-x86_64-linux.tar.gz")"
 sha_linux_arm64="$(hash_file "$artifacts_dir/oauth-mux-aarch64-linux.tar.gz")"
@@ -141,15 +147,14 @@ if command -v nfpm >/dev/null 2>&1; then
     nfpm package -f "$nfpm_dir/oauth-mux-${arch}.yaml" -p deb -t "$artifacts_dir" >/dev/null
     nfpm package -f "$nfpm_dir/oauth-mux-${arch}.yaml" -p rpm -t "$artifacts_dir" >/dev/null
   done
-  : >"$artifacts_dir/SHA256SUMS"
-  for artifact in "$artifacts_dir"/*; do
-    [ -f "$artifact" ] || continue
-    [ "$(basename "$artifact")" = "SHA256SUMS" ] && continue
-    printf '%s  %s\n' "$(hash_file "$artifact")" "$(basename "$artifact")" >>"$artifacts_dir/SHA256SUMS"
-  done
 else
   printf 'warning: nfpm not found; deb/rpm artifacts skipped, configs written to %s\n' "$nfpm_dir" >&2
 fi
+
+printf 'staging curl installer...\n'
+cp dist/install.sh "$artifacts_dir/install.sh"
+chmod 0755 "$artifacts_dir/install.sh"
+write_artifact_checksums
 
 printf '\nrelease output: %s\n' "$out_dir"
 printf 'artifacts:      %s\n' "$artifacts_dir"

--- a/scripts/release-local.sh
+++ b/scripts/release-local.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+version="${1:-${VERSION:-0.1.0}}"
+version="${version#v}"
+
+out_dir="$repo_root/dist/out/v${version}"
+artifacts_dir="$out_dir/artifacts"
+npm_dir="$out_dir/npm"
+npm_tgz_dir="$out_dir/npm-tarballs"
+homebrew_dir="$out_dir/homebrew"
+nfpm_dir="$out_dir/nfpm"
+work_dir="$out_dir/work"
+
+rm -rf "$out_dir"
+mkdir -p "$artifacts_dir" "$npm_dir" "$npm_tgz_dir" "$homebrew_dir" "$nfpm_dir" "$work_dir"
+
+hash_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{ print $1 }'
+  else
+    shasum -a 256 "$1" | awk '{ print $1 }'
+  fi
+}
+
+package_binary() {
+  local build_dir="$1"
+  local artifact="$2"
+  local npm_pkg="$3"
+  local npm_os="$4"
+  local npm_cpu="$5"
+  local binary_name="$6"
+  local src="zig-out/${build_dir}/${binary_name}"
+
+  if [ ! -f "$src" ]; then
+    printf 'missing release binary: %s\n' "$src" >&2
+    exit 1
+  fi
+
+  local stage="$work_dir/${artifact}"
+  mkdir -p "$stage"
+  cp "$src" "$stage/${binary_name}"
+  chmod 0755 "$stage/${binary_name}"
+  tar -czf "$artifacts_dir/${artifact}.tar.gz" -C "$stage" "$binary_name"
+
+  local pkg_dir="$npm_dir/@oauth-mux/${npm_pkg#@oauth-mux/}"
+  mkdir -p "$pkg_dir/bin"
+  cp "$src" "$pkg_dir/bin/${binary_name}"
+  chmod 0755 "$pkg_dir/bin/${binary_name}"
+  cat >"$pkg_dir/package.json" <<EOF
+{
+  "name": "${npm_pkg}",
+  "version": "${version}",
+  "description": "Platform binary for oauth-mux",
+  "license": "MIT",
+  "repository": "tinyland-inc/oauth-mux",
+  "os": ["${npm_os}"],
+  "cpu": ["${npm_cpu}"],
+  "files": ["bin"]
+}
+EOF
+}
+
+printf 'building release binaries...\n'
+zig build release
+
+package_binary "x86_64-linux" "oauth-mux-x86_64-linux" "@oauth-mux/linux-x64" "linux" "x64" "oauth-mux"
+package_binary "aarch64-linux" "oauth-mux-aarch64-linux" "@oauth-mux/linux-arm64" "linux" "arm64" "oauth-mux"
+package_binary "x86_64-macos" "oauth-mux-x86_64-macos" "@oauth-mux/darwin-x64" "darwin" "x64" "oauth-mux"
+package_binary "aarch64-macos" "oauth-mux-aarch64-macos" "@oauth-mux/darwin-arm64" "darwin" "arm64" "oauth-mux"
+package_binary "x86_64-windows" "oauth-mux-x86_64-windows" "@oauth-mux/win32-x64" "win32" "x64" "oauth-mux.exe"
+package_binary "aarch64-windows" "oauth-mux-aarch64-windows" "@oauth-mux/win32-arm64" "win32" "arm64" "oauth-mux.exe"
+
+printf 'writing SHA256SUMS...\n'
+: >"$artifacts_dir/SHA256SUMS"
+for archive in "$artifacts_dir"/*.tar.gz; do
+  printf '%s  %s\n' "$(hash_file "$archive")" "$(basename "$archive")" >>"$artifacts_dir/SHA256SUMS"
+done
+
+sha_linux_x64="$(hash_file "$artifacts_dir/oauth-mux-x86_64-linux.tar.gz")"
+sha_linux_arm64="$(hash_file "$artifacts_dir/oauth-mux-aarch64-linux.tar.gz")"
+sha_macos_x64="$(hash_file "$artifacts_dir/oauth-mux-x86_64-macos.tar.gz")"
+sha_macos_arm64="$(hash_file "$artifacts_dir/oauth-mux-aarch64-macos.tar.gz")"
+
+printf 'rendering Homebrew formula...\n'
+sed \
+  -e "s|\${VERSION}|${version}|g" \
+  -e "s|\${SHA_LINUX_X64}|${sha_linux_x64}|g" \
+  -e "s|\${SHA_LINUX_ARM64}|${sha_linux_arm64}|g" \
+  -e "s|\${SHA_MACOS_X64}|${sha_macos_x64}|g" \
+  -e "s|\${SHA_MACOS_ARM64}|${sha_macos_arm64}|g" \
+  dist/homebrew/oauth-mux.rb >"$homebrew_dir/oauth-mux.rb"
+
+printf 'rendering npm package workspace...\n'
+root_pkg_dir="$npm_dir/oauth-mux"
+mkdir -p "$root_pkg_dir/bin"
+sed "s|0.1.0|${version}|g" dist/npm/package.json >"$root_pkg_dir/package.json"
+cp dist/npm/install.js "$root_pkg_dir/install.js"
+cp dist/npm/bin/oauth-mux.js "$root_pkg_dir/bin/oauth-mux.js"
+chmod 0755 "$root_pkg_dir/bin/oauth-mux.js"
+
+if command -v npm >/dev/null 2>&1; then
+  printf 'packing npm tarballs...\n'
+  for pkg_json in "$npm_dir"/@oauth-mux/*/package.json; do
+    npm pack "$(dirname "$pkg_json")" --pack-destination "$npm_tgz_dir" >/dev/null
+  done
+  npm pack "$root_pkg_dir" --pack-destination "$npm_tgz_dir" >/dev/null
+else
+  printf 'warning: npm not found; package directories rendered but npm tarballs skipped\n' >&2
+fi
+
+write_nfpm_config() {
+  local arch="$1"
+  local src="$2"
+  local config="$nfpm_dir/oauth-mux-${arch}.yaml"
+  cat >"$config" <<EOF
+name: oauth-mux
+arch: "${arch}"
+version: "${version}"
+maintainer: "Jess Sullivan <jess@sulliwood.org>"
+description: "OAuth fallback muxing for AI harness subscriptions"
+homepage: "https://github.com/tinyland-inc/oauth-mux"
+license: MIT
+contents:
+  - src: ${src}
+    dst: /usr/bin/oauth-mux
+    file_info:
+      mode: 0755
+EOF
+}
+
+write_nfpm_config "amd64" "$repo_root/zig-out/x86_64-linux/oauth-mux"
+write_nfpm_config "arm64" "$repo_root/zig-out/aarch64-linux/oauth-mux"
+
+if command -v nfpm >/dev/null 2>&1; then
+  printf 'building nfpm deb/rpm packages...\n'
+  for arch in amd64 arm64; do
+    nfpm package -f "$nfpm_dir/oauth-mux-${arch}.yaml" -p deb -t "$artifacts_dir" >/dev/null
+    nfpm package -f "$nfpm_dir/oauth-mux-${arch}.yaml" -p rpm -t "$artifacts_dir" >/dev/null
+  done
+  : >"$artifacts_dir/SHA256SUMS"
+  for artifact in "$artifacts_dir"/*; do
+    [ -f "$artifact" ] || continue
+    [ "$(basename "$artifact")" = "SHA256SUMS" ] && continue
+    printf '%s  %s\n' "$(hash_file "$artifact")" "$(basename "$artifact")" >>"$artifacts_dir/SHA256SUMS"
+  done
+else
+  printf 'warning: nfpm not found; deb/rpm artifacts skipped, configs written to %s\n' "$nfpm_dir" >&2
+fi
+
+printf '\nrelease output: %s\n' "$out_dir"
+printf 'artifacts:      %s\n' "$artifacts_dir"
+printf 'npm workspace:  %s\n' "$npm_dir"
+printf 'npm tarballs:   %s\n' "$npm_tgz_dir"
+printf 'homebrew:       %s\n' "$homebrew_dir/oauth-mux.rb"

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -23,6 +23,7 @@ required_artifacts=(
   "oauth-mux_0.1.0_arm64.deb"
   "oauth-mux-0.1.0-1.x86_64.rpm"
   "oauth-mux-0.1.0-1.aarch64.rpm"
+  "install.sh"
 )
 
 required_npm_tarballs=(
@@ -128,6 +129,7 @@ esac
 if [ -n "${platform_tgz:-}" ]; then
   tmp="$(mktemp -d)"
   trap 'rm -rf "$tmp"' EXIT
+
   export npm_config_cache="$tmp/npm-cache"
   export npm_config_update_notifier=false
   npm install \
@@ -138,6 +140,14 @@ if [ -n "${platform_tgz:-}" ]; then
     --no-audit \
     --no-fund >/dev/null
   "$tmp/app/node_modules/.bin/oauth-mux" version | grep -qx "oauth-mux ${version}"
+
+  printf 'checking curl installer...\n'
+  install_dir="$tmp/install-bin"
+  VERSION="$version" \
+    OMUX_RELEASE_BASE_URL="file://$artifacts_dir" \
+    INSTALL_DIR="$install_dir" \
+    sh "$artifacts_dir/install.sh" >/dev/null
+  "$install_dir/oauth-mux" version | grep -qx "oauth-mux ${version}"
 fi
 
 printf 'release smoke passed for v%s\n' "$version"

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+version="${1:-${VERSION:-0.1.0}}"
+version="${version#v}"
+
+out_dir="$repo_root/dist/out/v${version}"
+artifacts_dir="$out_dir/artifacts"
+npm_tgz_dir="$out_dir/npm-tarballs"
+homebrew_formula="$out_dir/homebrew/oauth-mux.rb"
+
+required_artifacts=(
+  "oauth-mux-x86_64-linux.tar.gz"
+  "oauth-mux-aarch64-linux.tar.gz"
+  "oauth-mux-x86_64-macos.tar.gz"
+  "oauth-mux-aarch64-macos.tar.gz"
+  "oauth-mux-x86_64-windows.tar.gz"
+  "oauth-mux-aarch64-windows.tar.gz"
+  "oauth-mux_0.1.0_amd64.deb"
+  "oauth-mux_0.1.0_arm64.deb"
+  "oauth-mux-0.1.0-1.x86_64.rpm"
+  "oauth-mux-0.1.0-1.aarch64.rpm"
+)
+
+required_npm_tarballs=(
+  "oauth-mux-0.1.0.tgz"
+  "oauth-mux-darwin-arm64-0.1.0.tgz"
+  "oauth-mux-darwin-x64-0.1.0.tgz"
+  "oauth-mux-linux-arm64-0.1.0.tgz"
+  "oauth-mux-linux-x64-0.1.0.tgz"
+  "oauth-mux-win32-arm64-0.1.0.tgz"
+  "oauth-mux-win32-x64-0.1.0.tgz"
+)
+
+hash_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{ print $1 }'
+  else
+    shasum -a 256 "$1" | awk '{ print $1 }'
+  fi
+}
+
+require_file() {
+  if [ ! -f "$1" ]; then
+    printf 'missing required release file: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'missing required command for release smoke: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+printf 'checking release tree: %s\n' "$out_dir"
+if [ ! -d "$out_dir" ]; then
+  printf 'release output does not exist: %s\n' "$out_dir" >&2
+  exit 1
+fi
+
+for artifact in "${required_artifacts[@]}"; do
+  artifact="${artifact/0.1.0/${version}}"
+  require_file "$artifacts_dir/$artifact"
+done
+
+require_file "$artifacts_dir/SHA256SUMS"
+require_file "$homebrew_formula"
+
+printf 'checking checksums...\n'
+while read -r expected filename; do
+  [ -n "${expected:-}" ] || continue
+  require_file "$artifacts_dir/$filename"
+  actual="$(hash_file "$artifacts_dir/$filename")"
+  if [ "$actual" != "$expected" ]; then
+    printf 'checksum mismatch for %s: expected %s got %s\n' "$filename" "$expected" "$actual" >&2
+    exit 1
+  fi
+done <"$artifacts_dir/SHA256SUMS"
+
+printf 'checking archive contents...\n'
+for archive in \
+  oauth-mux-x86_64-linux.tar.gz \
+  oauth-mux-aarch64-linux.tar.gz \
+  oauth-mux-x86_64-macos.tar.gz \
+  oauth-mux-aarch64-macos.tar.gz; do
+  tar -tzf "$artifacts_dir/$archive" | grep -qx 'oauth-mux'
+done
+for archive in \
+  oauth-mux-x86_64-windows.tar.gz \
+  oauth-mux-aarch64-windows.tar.gz; do
+  tar -tzf "$artifacts_dir/$archive" | grep -qx 'oauth-mux.exe'
+done
+
+printf 'checking Homebrew formula...\n'
+if grep -q '\${' "$homebrew_formula"; then
+  printf 'unrendered placeholder remains in %s\n' "$homebrew_formula" >&2
+  exit 1
+fi
+if command -v ruby >/dev/null 2>&1; then
+  ruby -c "$homebrew_formula" >/dev/null
+fi
+
+printf 'checking npm tarballs...\n'
+require_command npm
+for tarball in "${required_npm_tarballs[@]}"; do
+  tarball="${tarball/0.1.0/${version}}"
+  require_file "$npm_tgz_dir/$tarball"
+done
+
+os="$(uname -s)"
+arch="$(uname -m)"
+case "$os:$arch" in
+  Darwin:arm64|Darwin:aarch64) platform_tgz="oauth-mux-darwin-arm64-${version}.tgz" ;;
+  Darwin:x86_64|Darwin:amd64) platform_tgz="oauth-mux-darwin-x64-${version}.tgz" ;;
+  Linux:arm64|Linux:aarch64) platform_tgz="oauth-mux-linux-arm64-${version}.tgz" ;;
+  Linux:x86_64|Linux:amd64) platform_tgz="oauth-mux-linux-x64-${version}.tgz" ;;
+  *)
+    printf 'skipping local npm install smoke for unsupported host platform: %s/%s\n' "$os" "$arch"
+    platform_tgz=""
+    ;;
+esac
+
+if [ -n "${platform_tgz:-}" ]; then
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  export npm_config_cache="$tmp/npm-cache"
+  export npm_config_update_notifier=false
+  npm install \
+    --prefix "$tmp/app" \
+    "$npm_tgz_dir/$platform_tgz" \
+    "$npm_tgz_dir/oauth-mux-${version}.tgz" \
+    --ignore-scripts=false \
+    --no-audit \
+    --no-fund >/dev/null
+  "$tmp/app/node_modules/.bin/oauth-mux" version | grep -qx "oauth-mux ${version}"
+fi
+
+printf 'release smoke passed for v%s\n' "$version"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -6,6 +6,7 @@ pub const version = "0.1.0";
 pub const Command = union(enum) {
     exec: ExecArgs,
     env: EnvArgs,
+    probe: ProbeArgs,
     status: StatusArgs,
     health: HealthArgs,
     config_validate,
@@ -21,6 +22,7 @@ pub const Command = union(enum) {
     pub const ExecArgs = struct {
         profile: ?[]const u8 = null,
         provider: ?[]const u8 = null,
+        capability: ?[]const u8 = null,
         strategy: ?[]const u8 = null,
         target_argv: []const []const u8 = &.{},
     };
@@ -28,7 +30,16 @@ pub const Command = union(enum) {
     pub const EnvArgs = struct {
         profile: ?[]const u8 = null,
         provider: ?[]const u8 = null,
+        capability: ?[]const u8 = null,
         shell: ?[]const u8 = null,
+    };
+
+    pub const ProbeArgs = struct {
+        profile: ?[]const u8 = null,
+        provider: ?[]const u8 = null,
+        account: ?[]const u8 = null,
+        capability: ?[]const u8 = null,
+        json: bool = false,
     };
 
     pub const StatusArgs = struct {
@@ -37,12 +48,14 @@ pub const Command = union(enum) {
     };
 
     pub const HealthArgs = struct {
+        json: bool = false,
         provider: ?[]const u8 = null,
         reset: ?[]const u8 = null,
     };
 
     pub const InitArgs = struct {
         interactive: bool = false,
+        codex_max: bool = false,
     };
 
     pub const CompletionsArgs = struct {
@@ -58,6 +71,7 @@ pub fn parse(args: []const []const u8) Command {
 
     if (eql(cmd, "exec")) return parseExec(rest);
     if (eql(cmd, "env")) return parseEnv(rest);
+    if (eql(cmd, "probe")) return parseProbe(rest);
     if (eql(cmd, "status")) return parseStatus(rest);
     if (eql(cmd, "health")) return parseHealth(rest);
     if (eql(cmd, "config")) return parseConfig(rest);
@@ -96,6 +110,9 @@ fn parseExec(args: []const []const u8) Command {
         } else if (eql(args[i], "--provider")) {
             i += 1;
             if (i < args.len) result.provider = args[i];
+        } else if (eql(args[i], "--capability")) {
+            i += 1;
+            if (i < args.len) result.capability = args[i];
         } else if (eql(args[i], "--strategy")) {
             i += 1;
             if (i < args.len) result.strategy = args[i];
@@ -114,12 +131,38 @@ fn parseEnv(args: []const []const u8) Command {
         } else if (eql(args[i], "--provider")) {
             i += 1;
             if (i < args.len) result.provider = args[i];
+        } else if (eql(args[i], "--capability")) {
+            i += 1;
+            if (i < args.len) result.capability = args[i];
         } else if (eql(args[i], "--shell")) {
             i += 1;
             if (i < args.len) result.shell = args[i];
         }
     }
     return .{ .env = result };
+}
+
+fn parseProbe(args: []const []const u8) Command {
+    var result = Command.ProbeArgs{};
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        if (eql(args[i], "--profile") or eql(args[i], "-p")) {
+            i += 1;
+            if (i < args.len) result.profile = args[i];
+        } else if (eql(args[i], "--provider")) {
+            i += 1;
+            if (i < args.len) result.provider = args[i];
+        } else if (eql(args[i], "--account")) {
+            i += 1;
+            if (i < args.len) result.account = args[i];
+        } else if (eql(args[i], "--capability")) {
+            i += 1;
+            if (i < args.len) result.capability = args[i];
+        } else if (eql(args[i], "--json")) {
+            result.json = true;
+        }
+    }
+    return .{ .probe = result };
 }
 
 fn parseStatus(args: []const []const u8) Command {
@@ -134,7 +177,9 @@ fn parseHealth(args: []const []const u8) Command {
     var result = Command.HealthArgs{};
     var i: usize = 0;
     while (i < args.len) : (i += 1) {
-        if (eql(args[i], "--reset")) {
+        if (eql(args[i], "--json")) {
+            result.json = true;
+        } else if (eql(args[i], "--reset")) {
             i += 1;
             if (i < args.len) result.reset = args[i];
         } else if (eql(args[i], "--provider")) {
@@ -156,6 +201,7 @@ fn parseInit(args: []const []const u8) Command {
     var result = Command.InitArgs{};
     for (args) |arg| {
         if (eql(arg, "--interactive") or eql(arg, "-i")) result.interactive = true;
+        if (eql(arg, "--codex-max")) result.codex_max = true;
     }
     return .{ .init = result };
 }
@@ -171,17 +217,20 @@ pub fn printUsage(writer: anytype) !void {
         \\Usage: oauth-mux <command> [options]
         \\
         \\Commands:
-        \\  exec [--profile <name>] [--provider <name>] -- <cmd> [args...]
+        \\  exec [--profile <name>] [--provider <name>] [--capability <name>] -- <cmd> [args...]
         \\      Execute a command with muxed OAuth credentials injected.
         \\
-        \\  env [--profile <name>] [--shell fish|zsh|bash|ksh]
+        \\  env [--profile <name>] [--provider <name>] [--capability <name>] [--shell fish|zsh|bash|ksh]
         \\      Print shell export statements for eval.
+        \\
+        \\  probe [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
+        \\      Validate a selected account and run its capability probe when configured.
         \\
         \\  status [--json] [--provider <name>]
         \\      Show active accounts, health scores, and circuit states.
         \\
-        \\  health [--reset <account>] [--provider <name>]
-        \\      Show or reset health tracking data.
+        \\  health [--json] [--reset <account>] [--provider <name>]
+        \\      Show or reset redacted health and liveness tracking data.
         \\
         \\  config validate    Validate the configuration file.
         \\  config path        Print the config file path.
@@ -190,7 +239,7 @@ pub fn printUsage(writer: anytype) !void {
         \\  daemon stop        Stop the daemon.
         \\  daemon status      Show daemon status.
         \\
-        \\  init [--interactive]
+        \\  init [--interactive] [--codex-max]
         \\      Generate a starter config file.
         \\
         \\  completions <shell> Generate shell completions (fish|zsh|bash).
@@ -213,11 +262,12 @@ pub fn printUsage(writer: anytype) !void {
 }
 
 test "parse exec with profile and target" {
-    const args = [_][]const u8{ "exec", "--profile", "work", "--", "claude", "chat" };
+    const args = [_][]const u8{ "exec", "--profile", "work", "--capability", "codex-max", "--", "claude", "chat" };
     const cmd = parse(&args);
     switch (cmd) {
         .exec => |exec| {
             try std.testing.expectEqualStrings("work", exec.profile.?);
+            try std.testing.expectEqualStrings("codex-max", exec.capability.?);
             try std.testing.expectEqual(@as(usize, 2), exec.target_argv.len);
             try std.testing.expectEqualStrings("claude", exec.target_argv[0]);
             try std.testing.expectEqualStrings("chat", exec.target_argv[1]);
@@ -227,10 +277,13 @@ test "parse exec with profile and target" {
 }
 
 test "parse env with shell" {
-    const args = [_][]const u8{ "env", "--shell", "fish" };
+    const args = [_][]const u8{ "env", "--shell", "fish", "--capability", "tools/design-context" };
     const cmd = parse(&args);
     switch (cmd) {
-        .env => |env_args| try std.testing.expectEqualStrings("fish", env_args.shell.?),
+        .env => |env_args| {
+            try std.testing.expectEqualStrings("fish", env_args.shell.?);
+            try std.testing.expectEqualStrings("tools/design-context", env_args.capability.?);
+        },
         else => return error.Unexpected,
     }
 }
@@ -244,22 +297,62 @@ test "parse status json" {
     }
 }
 
+test "parse probe with account capability and json" {
+    const args = [_][]const u8{ "probe", "--provider", "codex", "--account", "max-2", "--capability", "codex-max", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .probe => |probe| {
+            try std.testing.expectEqualStrings("codex", probe.provider.?);
+            try std.testing.expectEqualStrings("max-2", probe.account.?);
+            try std.testing.expectEqualStrings("codex-max", probe.capability.?);
+            try std.testing.expect(probe.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse init codex max" {
+    const args = [_][]const u8{ "init", "--codex-max" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .init => |init| try std.testing.expect(init.codex_max),
+        else => return error.Unexpected,
+    }
+}
+
+test "parse health json provider" {
+    const args = [_][]const u8{ "health", "--json", "--provider", "codex" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .health => |health| {
+            try std.testing.expect(health.json);
+            try std.testing.expectEqualStrings("codex", health.provider.?);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
     if (eql(shell_name, "fish")) {
         try writer.writeAll(
             \\complete -c oauth-mux -f
             \\complete -c oauth-mux -n __fish_use_subcommand -a exec -d 'Execute with muxed credentials'
             \\complete -c oauth-mux -n __fish_use_subcommand -a env -d 'Print shell exports'
+            \\complete -c oauth-mux -n __fish_use_subcommand -a probe -d 'Probe account liveness'
             \\complete -c oauth-mux -n __fish_use_subcommand -a status -d 'Show status'
             \\complete -c oauth-mux -n __fish_use_subcommand -a health -d 'Show health data'
             \\complete -c oauth-mux -n __fish_use_subcommand -a config -d 'Config operations'
             \\complete -c oauth-mux -n __fish_use_subcommand -a init -d 'Generate config'
             \\complete -c oauth-mux -n __fish_use_subcommand -a version -d 'Print version'
             \\complete -c oauth-mux -n __fish_use_subcommand -a completions -d 'Generate completions'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env' -l profile -s p -d 'Profile name' -r
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env' -l provider -d 'Provider name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe' -l profile -s p -d 'Profile name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe' -l provider -d 'Provider name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from probe' -l account -d 'Account name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe' -l capability -d 'Route capability' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from probe' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from env' -l shell -d 'Shell type' -r -a 'fish zsh bash ksh'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from status' -l json -d 'JSON output'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
             \\
         );
@@ -271,6 +364,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\  commands=(
             \\    'exec:Execute with muxed credentials'
             \\    'env:Print shell exports'
+            \\    'probe:Probe account liveness'
             \\    'status:Show status'
             \\    'health:Show health data'
             \\    'config:Config operations'
@@ -287,7 +381,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
         try writer.writeAll(
             \\_oauth_mux_completions() {
             \\  local cur="${COMP_WORDS[COMP_CWORD]}"
-            \\  COMPREPLY=($(compgen -W "exec env status health config init version completions" -- "$cur"))
+            \\  COMPREPLY=($(compgen -W "exec env probe status health config init version completions" -- "$cur"))
             \\}
             \\complete -F _oauth_mux_completions oauth-mux
             \\

--- a/src/config.zig
+++ b/src/config.zig
@@ -1,10 +1,12 @@
 const std = @import("std");
 const types = @import("types.zig");
 const paths = @import("paths.zig");
+const provider_schema = @import("provider_schema.zig");
 
 pub const Config = struct {
     version: u32 = 1,
     defaults: Defaults = .{},
+    provider_definitions: std.json.ArrayHashMap(provider_schema.ProviderDefinition) = .{},
     providers: std.json.ArrayHashMap(ProviderConfig) = .{},
     profiles: std.json.ArrayHashMap(ProfileConfig) = .{},
     strategies: std.json.ArrayHashMap(StrategyConfig) = .{},
@@ -89,6 +91,70 @@ pub fn loadFromBytes(allocator: std.mem.Allocator, bytes: []const u8) !std.json.
     });
 }
 
+pub fn validate(cfg: Config, writer: anytype) !void {
+    var ok = true;
+
+    if (cfg.defaults.provider) |provider_name| {
+        if (cfg.providers.map.get(provider_name) == null) {
+            try writer.print("config error: defaults.provider references unknown provider '{s}'\n", .{provider_name});
+            ok = false;
+        }
+    }
+
+    if (cfg.defaults.strategy) |strategy_name| {
+        if (cfg.strategies.map.get(strategy_name) == null) {
+            try writer.print("config error: defaults.strategy references unknown strategy '{s}'\n", .{strategy_name});
+            ok = false;
+        }
+    }
+
+    var def_it = cfg.provider_definitions.map.iterator();
+    while (def_it.next()) |entry| {
+        try validateProviderDefinition(entry.key_ptr.*, entry.value_ptr.*, writer, &ok);
+    }
+
+    var provider_it = cfg.providers.map.iterator();
+    while (provider_it.next()) |entry| {
+        const provider_name = entry.key_ptr.*;
+        const prov = entry.value_ptr.*;
+        try validateProviderConfig(cfg, provider_name, prov, writer, &ok);
+    }
+
+    var profile_it = cfg.profiles.map.iterator();
+    while (profile_it.next()) |entry| {
+        const profile_name = entry.key_ptr.*;
+        const profile = entry.value_ptr.*;
+
+        if (profile.strategy) |strategy_name| {
+            if (cfg.strategies.map.get(strategy_name) == null) {
+                try writer.print("config error: profiles.{s}.strategy references unknown strategy '{s}'\n", .{ profile_name, strategy_name });
+                ok = false;
+            }
+        }
+
+        for (profile.providers) |spec| {
+            const ref = splitProviderAccount(spec) orelse {
+                try writer.print("config error: profiles.{s}.providers entry '{s}' must be provider:account[#capability]\n", .{ profile_name, spec });
+                ok = false;
+                continue;
+            };
+
+            const prov = cfg.providers.map.get(ref.provider) orelse {
+                try writer.print("config error: profiles.{s}.providers references unknown provider '{s}'\n", .{ profile_name, ref.provider });
+                ok = false;
+                continue;
+            };
+
+            if (prov.accounts.map.get(ref.account) == null) {
+                try writer.print("config error: profiles.{s}.providers references unknown account '{s}:{s}'\n", .{ profile_name, ref.provider, ref.account });
+                ok = false;
+            }
+        }
+    }
+
+    if (!ok) return error.ConfigValidationError;
+}
+
 pub fn resolveSecretBackend(secret: SecretConfig) !types.SecretBackend {
     const map = std.StaticStringMap(enum { keychain, sops, age, env, file, command, stdin }).initComptime(.{
         .{ "keychain", .keychain },
@@ -126,6 +192,366 @@ pub fn resolveSecretBackend(secret: SecretConfig) !types.SecretBackend {
         } },
         .stdin => .stdin,
     };
+}
+
+pub fn resolveProviderDefinition(cfg: Config, provider_name: []const u8) provider_schema.ProviderDefinition {
+    if (cfg.provider_definitions.map.get(provider_name)) |def| return def;
+
+    if (cfg.providers.map.get(provider_name)) |prov_cfg| {
+        if (cfg.provider_definitions.map.get(prov_cfg.kind)) |def| return def;
+        if (provider_schema.findBuiltin(prov_cfg.kind)) |def| return def;
+    }
+
+    if (provider_schema.findBuiltin(provider_name)) |def| return def;
+    return provider_schema.generic_def;
+}
+
+pub fn resolveProviderKind(cfg: Config, provider_name: []const u8) ?types.ProviderKind {
+    if (cfg.providers.map.get(provider_name)) |prov_cfg| {
+        return types.ProviderKind.fromString(prov_cfg.kind);
+    }
+    return types.ProviderKind.fromString(provider_name);
+}
+
+fn validateProviderConfig(cfg: Config, provider_name: []const u8, prov: ProviderConfig, writer: anytype, ok: *bool) !void {
+    if (provider_name.len == 0) {
+        try writer.writeAll("config error: provider name must not be empty\n");
+        ok.* = false;
+    }
+
+    if (prov.kind.len == 0) {
+        try writer.print("config error: providers.{s}.kind must not be empty\n", .{provider_name});
+        ok.* = false;
+    }
+
+    if (!hasProviderDefinition(cfg, provider_name, prov.kind)) {
+        try writer.print("config error: providers.{s}.kind '{s}' has no built-in or provider_definitions entry\n", .{ provider_name, prov.kind });
+        ok.* = false;
+    }
+
+    var account_it = prov.accounts.map.iterator();
+    while (account_it.next()) |entry| {
+        const account_name = entry.key_ptr.*;
+        const account = entry.value_ptr.*;
+
+        if (account_name.len == 0) {
+            try writer.print("config error: providers.{s}.accounts contains an empty account name\n", .{provider_name});
+            ok.* = false;
+        }
+
+        validateSecretConfig(provider_name, account_name, account.secret, writer, ok) catch |e| switch (e) {
+            error.ConfigValidationError => {},
+            else => return e,
+        };
+    }
+}
+
+fn validateProviderDefinition(def_key: []const u8, def: provider_schema.ProviderDefinition, writer: anytype, ok: *bool) !void {
+    if (def.name.len == 0) {
+        try writer.print("config error: provider_definitions.{s}.name must not be empty\n", .{def_key});
+        ok.* = false;
+    }
+
+    if (def.credential.access_token_path.len == 0) {
+        try writer.print("config error: provider_definitions.{s}.credential.access_token_path must not be empty\n", .{def_key});
+        ok.* = false;
+    }
+
+    if (def.credential.refresh_token_path.len == 0) {
+        try writer.print("config error: provider_definitions.{s}.credential.refresh_token_path must not be empty\n", .{def_key});
+        ok.* = false;
+    }
+
+    if (def.injection.credential_filename.len == 0) {
+        try writer.print("config error: provider_definitions.{s}.injection.credential_filename must not be empty\n", .{def_key});
+        ok.* = false;
+    }
+
+    if (def.injection.direct_env) |direct_env| {
+        for (direct_env) |mapping| {
+            if (mapping[0].len == 0) {
+                try writer.print("config error: provider_definitions.{s}.injection.direct_env contains an empty env var name\n", .{def_key});
+                ok.* = false;
+            }
+            if (!isSupportedTokenField(mapping[1])) {
+                try writer.print("config error: provider_definitions.{s}.injection.direct_env maps {s} to unsupported token field '{s}'\n", .{ def_key, mapping[0], mapping[1] });
+                ok.* = false;
+            }
+        }
+    }
+
+    var has_capability_probe = false;
+    for (def.capabilities, 0..) |capability, idx| {
+        if (capability.name.len == 0) {
+            try writer.print("config error: provider_definitions.{s}.capabilities[{d}].name must not be empty\n", .{ def_key, idx });
+            ok.* = false;
+        }
+        if (capability.probe) |probe| {
+            has_capability_probe = true;
+            try validateProbeDefinition(def_key, idx, probe, writer, ok);
+            if (probe.timeout_ms == 0) {
+                try writer.print("config error: provider_definitions.{s}.capabilities[{d}].probe.timeout_ms must be greater than zero\n", .{ def_key, idx });
+                ok.* = false;
+            }
+            if (probe.success_status_min > probe.success_status_max) {
+                try writer.print("config error: provider_definitions.{s}.capabilities[{d}].probe success status range is invalid\n", .{ def_key, idx });
+                ok.* = false;
+            }
+        }
+    }
+
+    if (has_capability_probe and def.failure_rules.len == 0) {
+        try writer.print("config error: provider_definitions.{s} must define failure_rules when capabilities include probes\n", .{def_key});
+        ok.* = false;
+    }
+
+    for (def.failure_rules, 0..) |rule, idx| {
+        try validateFailureRule(def_key, idx, rule, writer, ok);
+    }
+}
+
+fn validateFailureRule(
+    def_key: []const u8,
+    rule_idx: usize,
+    rule: provider_schema.FailureRule,
+    writer: anytype,
+    ok: *bool,
+) !void {
+    if (!failureRuleHasMatcher(rule)) {
+        try writer.print("config error: provider_definitions.{s}.failure_rules[{d}] must include at least one matcher\n", .{ def_key, rule_idx });
+        ok.* = false;
+    }
+
+    if (rule.hint_contains) |hint| {
+        if (hint.len == 0) {
+            try writer.print("config error: provider_definitions.{s}.failure_rules[{d}].hint_contains must not be empty\n", .{ def_key, rule_idx });
+            ok.* = false;
+        }
+    }
+
+    if (rule.status_min) |min| {
+        if (rule.status_max) |max| {
+            if (min > max) {
+                try writer.print("config error: provider_definitions.{s}.failure_rules[{d}] has status_min greater than status_max\n", .{ def_key, rule_idx });
+                ok.* = false;
+            }
+        }
+    }
+
+    if (rule.retry_after_gte) |min_wait| {
+        if (rule.retry_after_lt) |max_wait| {
+            if (min_wait >= max_wait) {
+                try writer.print("config error: provider_definitions.{s}.failure_rules[{d}] retry_after_gte must be less than retry_after_lt\n", .{ def_key, rule_idx });
+                ok.* = false;
+            }
+        }
+    }
+}
+
+fn failureRuleHasMatcher(rule: provider_schema.FailureRule) bool {
+    return rule.status != null or
+        rule.status_min != null or
+        rule.status_max != null or
+        rule.retry_after_gte != null or
+        rule.retry_after_lt != null or
+        rule.hint_contains != null;
+}
+
+fn validateProbeDefinition(
+    def_key: []const u8,
+    capability_idx: usize,
+    probe: provider_schema.ProbeDefinition,
+    writer: anytype,
+    ok: *bool,
+) !void {
+    switch (probe.transport) {
+        .http => {
+            if (!isSupportedProbeMethod(probe.method)) {
+                try writer.print("config error: provider_definitions.{s}.capabilities[{d}].probe.method '{s}' is unsupported\n", .{ def_key, capability_idx, probe.method });
+                ok.* = false;
+            }
+            if (probe.url.len == 0) {
+                try writer.print("config error: provider_definitions.{s}.capabilities[{d}].probe.url must not be empty\n", .{ def_key, capability_idx });
+                ok.* = false;
+            }
+            if (containsSecretLikeProbeMaterial(probe.url)) {
+                try writer.print("config error: provider_definitions.{s}.capabilities[{d}].probe.url must not contain token material\n", .{ def_key, capability_idx });
+                ok.* = false;
+            }
+            if (!isValidUrlTemplate(probe.url)) {
+                try writer.print("config error: provider_definitions.{s}.capabilities[{d}].probe.url contains an invalid template placeholder\n", .{ def_key, capability_idx });
+                ok.* = false;
+            }
+            if (probe.auth == .token_header) {
+                if (probe.auth_header) |header| {
+                    if (!isSafeTokenHeaderName(header)) {
+                        try writer.print("config error: provider_definitions.{s}.capabilities[{d}].probe.auth_header must be a non-Authorization HTTP header name without control characters\n", .{ def_key, capability_idx });
+                        ok.* = false;
+                    }
+                } else {
+                    try writer.print("config error: provider_definitions.{s}.capabilities[{d}].probe.auth_header is required when auth is token_header\n", .{ def_key, capability_idx });
+                    ok.* = false;
+                }
+            } else if (probe.auth_header != null) {
+                try writer.print("config error: provider_definitions.{s}.capabilities[{d}].probe.auth_header requires auth token_header\n", .{ def_key, capability_idx });
+                ok.* = false;
+            }
+            if (probe.body) |body| {
+                if (!std.mem.eql(u8, probe.method, "POST")) {
+                    try writer.print("config error: provider_definitions.{s}.capabilities[{d}].probe.body requires method POST\n", .{ def_key, capability_idx });
+                    ok.* = false;
+                }
+                if (body.len == 0) {
+                    try writer.print("config error: provider_definitions.{s}.capabilities[{d}].probe.body must not be empty\n", .{ def_key, capability_idx });
+                    ok.* = false;
+                }
+                if (containsSecretLikeProbeMaterial(body)) {
+                    try writer.print("config error: provider_definitions.{s}.capabilities[{d}].probe.body must not contain token material\n", .{ def_key, capability_idx });
+                    ok.* = false;
+                }
+            }
+            if (probe.content_type) |content_type| {
+                if (content_type.len == 0) {
+                    try writer.print("config error: provider_definitions.{s}.capabilities[{d}].probe.content_type must not be empty\n", .{ def_key, capability_idx });
+                    ok.* = false;
+                }
+            }
+        },
+        .command => {
+            if (probe.command == null or probe.command.?.len == 0) {
+                try writer.print("config error: provider_definitions.{s}.capabilities[{d}].probe.command must not be empty\n", .{ def_key, capability_idx });
+                ok.* = false;
+            }
+            if (probe.command) |command| {
+                for (command, 0..) |arg, arg_idx| {
+                    if (containsSecretLikeProbeMaterial(arg)) {
+                        try writer.print("config error: provider_definitions.{s}.capabilities[{d}].probe.command[{d}] must not contain token material\n", .{ def_key, capability_idx, arg_idx });
+                        ok.* = false;
+                    }
+                }
+            }
+        },
+    }
+}
+
+fn containsSecretLikeProbeMaterial(value: []const u8) bool {
+    const needles = [_][]const u8{
+        "access_token=",
+        "refresh_token=",
+        "id_token=",
+        "authorization=",
+        "authorization:",
+        "bearer ",
+        "bearer%20",
+        "\"access_token\"",
+        "\"refresh_token\"",
+        "\"id_token\"",
+        "{{access_token}}",
+        "{{refresh_token}}",
+        "{{id_token}}",
+    };
+
+    for (needles) |needle| {
+        if (indexOfIgnoreCase(value, needle) != null) return true;
+    }
+
+    return false;
+}
+
+fn indexOfIgnoreCase(haystack: []const u8, needle: []const u8) ?usize {
+    if (needle.len == 0) return 0;
+    if (needle.len > haystack.len) return null;
+
+    var i: usize = 0;
+    while (i + needle.len <= haystack.len) : (i += 1) {
+        if (std.ascii.eqlIgnoreCase(haystack[i .. i + needle.len], needle)) return i;
+    }
+
+    return null;
+}
+
+fn validateSecretConfig(provider_name: []const u8, account_name: []const u8, secret: SecretConfig, writer: anytype, ok: *bool) !void {
+    _ = resolveSecretBackend(secret) catch {
+        try writer.print("config error: providers.{s}.accounts.{s}.secret is incomplete for backend '{s}'\n", .{ provider_name, account_name, secret.backend });
+        ok.* = false;
+        return error.ConfigValidationError;
+    };
+
+    if (std.mem.eql(u8, secret.backend, "command")) {
+        if (secret.command == null or secret.command.?.len == 0) {
+            try writer.print("config error: providers.{s}.accounts.{s}.secret.command must not be empty\n", .{ provider_name, account_name });
+            ok.* = false;
+        }
+    }
+}
+
+fn hasProviderDefinition(cfg: Config, provider_name: []const u8, provider_kind: []const u8) bool {
+    if (cfg.provider_definitions.map.get(provider_name) != null) return true;
+    if (cfg.provider_definitions.map.get(provider_kind) != null) return true;
+    return provider_schema.findBuiltin(provider_kind) != null or provider_schema.findBuiltin(provider_name) != null;
+}
+
+const ProviderAccountRef = struct {
+    provider: []const u8,
+    account: []const u8,
+    capability: ?[]const u8 = null,
+};
+
+fn splitProviderAccount(spec: []const u8) ?ProviderAccountRef {
+    const idx = std.mem.indexOf(u8, spec, ":") orelse return null;
+    if (idx == 0 or idx + 1 >= spec.len) return null;
+
+    const rest = spec[idx + 1 ..];
+    if (std.mem.indexOf(u8, rest, "#")) |hash| {
+        if (hash == 0 or hash + 1 >= rest.len) return null;
+        return .{
+            .provider = spec[0..idx],
+            .account = rest[0..hash],
+            .capability = rest[hash + 1 ..],
+        };
+    }
+
+    return .{ .provider = spec[0..idx], .account = rest };
+}
+
+fn isSupportedTokenField(field: []const u8) bool {
+    return std.mem.eql(u8, field, "access_token") or
+        std.mem.eql(u8, field, "refresh_token");
+}
+
+fn isSupportedProbeMethod(method: []const u8) bool {
+    return std.mem.eql(u8, method, "GET") or
+        std.mem.eql(u8, method, "POST") or
+        std.mem.eql(u8, method, "HEAD");
+}
+
+fn isValidUrlTemplate(template: []const u8) bool {
+    var offset: usize = 0;
+    while (std.mem.indexOfPos(u8, template, offset, "{{")) |start| {
+        const name_start = start + 2;
+        const end = std.mem.indexOfPos(u8, template, name_start, "}}") orelse return false;
+        if (!isSafeUrlTemplateName(template[name_start..end])) return false;
+        offset = end + 2;
+    }
+    return std.mem.indexOfPos(u8, template, offset, "}}") == null;
+}
+
+fn isSafeUrlTemplateName(name: []const u8) bool {
+    if (name.len == 0) return false;
+    for (name) |c| {
+        if (std.ascii.isAlphanumeric(c) or c == '_') continue;
+        return false;
+    }
+    return true;
+}
+
+fn isSafeTokenHeaderName(header: []const u8) bool {
+    if (header.len == 0) return false;
+    if (std.ascii.eqlIgnoreCase(header, "authorization")) return false;
+    for (header) |c| {
+        if (c <= 32 or c == 127 or c == ':') return false;
+    }
+    return true;
 }
 
 test "loadFromBytes minimal config" {
@@ -166,6 +592,798 @@ test "loadFromBytes minimal config" {
     try std.testing.expectEqual(@as(i32, 10), work.priority);
     try std.testing.expectEqualStrings("env", work.secret.backend);
     try std.testing.expectEqualStrings("CLAUDE_TOKEN", work.secret.variable.?);
+}
+
+test "loadFromBytes provider definition override" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "display_name": "Toy CLI",
+        \\      "credential": {
+        \\        "access_token_path": "tokens.access",
+        \\        "refresh_token_path": "tokens.refresh"
+        \\      },
+        \\      "injection": {
+        \\        "direct_env": [["TOY_TOKEN", "access_token"]]
+        \\      },
+        \\      "capabilities": [
+        \\        {
+        \\          "name": "chat:max",
+        \\          "aliases": ["codex-max"],
+        \\          "probe": {
+        \\            "method": "POST",
+        \\            "url": "https://example.invalid/v1/probe",
+        \\            "hint_header": "www-authenticate"
+        \\          }
+        \\        }
+        \\      ],
+        \\      "failure_rules": [
+        \\        {
+        \\          "status": 403,
+        \\          "hint_contains": "scope",
+        \\          "class": { "degraded": "scope_insufficient" }
+        \\        }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    const def = resolveProviderDefinition(parsed.value, "toy");
+    try std.testing.expectEqualStrings("Toy CLI", def.display_name);
+    try std.testing.expectEqualStrings("tokens.access", def.credential.access_token_path);
+    try std.testing.expectEqual(@as(usize, 1), def.capabilities.len);
+    const plan = provider_schema.probePlanForCapability(def, "codex-max").?;
+    try std.testing.expectEqualStrings("chat:max", plan.capability);
+    try std.testing.expectEqualStrings("POST", plan.method);
+    try std.testing.expectEqual(@as(usize, 1), def.failure_rules.len);
+    const classified = provider_schema.classifyHttp(def, 403, null, "missing scope");
+    switch (classified) {
+        .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.scope_insufficient, reason),
+        else => return error.TestUnexpectedResult,
+    }
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try validate(parsed.value, out.writer());
+    try std.testing.expectEqual(@as(usize, 0), out.items.len);
+}
+
+test "validate rejects unknown provider kind without definition" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "has no built-in or provider_definitions entry") != null);
+}
+
+test "validate rejects unknown profile account" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": {
+        \\          "secret": { "backend": "env", "variable": "CODEX_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "research": { "providers": ["codex:max-2"] }
+        \\  },
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "unknown account 'codex:max-2'") != null);
+}
+
+test "validate accepts capability profile route" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": {
+        \\          "secret": { "backend": "env", "variable": "CODEX_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "research": { "providers": ["codex:max-1#codex-max"] }
+        \\  },
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try validate(parsed.value, out.writer());
+    try std.testing.expectEqual(@as(usize, 0), out.items.len);
+}
+
+test "validate rejects unsupported direct env token field" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "injection": {
+        \\        "direct_env": [["TOY_EXPIRES", "expires_at"]]
+        \\      }
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "unsupported token field 'expires_at'") != null);
+}
+
+test "validate rejects unsupported capability probe method" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "capabilities": [
+        \\        {
+        \\          "name": "chat:max",
+        \\          "probe": {
+        \\            "method": "TRACE",
+        \\            "url": "https://example.invalid/v1/probe"
+        \\          }
+        \\        }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "probe.method 'TRACE' is unsupported") != null);
+}
+
+test "validate rejects empty command capability probe" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "capabilities": [
+        \\        {
+        \\          "name": "chat:max",
+        \\          "probe": {
+        \\            "transport": "command",
+        \\            "command": []
+        \\          }
+        \\        }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "probe.command must not be empty") != null);
+}
+
+test "validate rejects zero capability probe timeout" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "capabilities": [
+        \\        {
+        \\          "name": "chat:max",
+        \\          "probe": {
+        \\            "method": "GET",
+        \\            "url": "https://example.invalid/v1/probe",
+        \\            "timeout_ms": 0
+        \\          }
+        \\        }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "probe.timeout_ms must be greater than zero") != null);
+}
+
+test "validate rejects token material in http probe url" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "capabilities": [
+        \\        {
+        \\          "name": "chat:max",
+        \\          "probe": {
+        \\            "method": "GET",
+        \\            "url": "https://example.invalid/v1/probe?access_token=secret"
+        \\          }
+        \\        }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "probe.url must not contain token material") != null);
+}
+
+test "validate rejects malformed url template placeholder" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "capabilities": [
+        \\        {
+        \\          "name": "identity",
+        \\          "probe": {
+        \\            "method": "GET",
+        \\            "url": "https://example.invalid/v1/files/{{BAD-NAME}}/meta"
+        \\          }
+        \\        }
+        \\      ],
+        \\      "failure_rules": [
+        \\        { "status": 403, "class": { "degraded": "scope_insufficient" } }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "probe.url contains an invalid template placeholder") != null);
+}
+
+test "validate rejects token material in http probe body" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "capabilities": [
+        \\        {
+        \\          "name": "chat:max",
+        \\          "probe": {
+        \\            "method": "POST",
+        \\            "url": "https://example.invalid/v1/probe",
+        \\            "body": "{\"access_token\":\"secret\"}"
+        \\          }
+        \\        }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "probe.body must not contain token material") != null);
+}
+
+test "validate rejects http probe body without post" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "capabilities": [
+        \\        {
+        \\          "name": "chat:max",
+        \\          "probe": {
+        \\            "method": "GET",
+        \\            "url": "https://example.invalid/v1/probe",
+        \\            "body": "{}"
+        \\          }
+        \\        }
+        \\      ],
+        \\      "failure_rules": [
+        \\        { "status": 401, "class": { "dead": "token_revoked" } }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "probe.body requires method POST") != null);
+}
+
+test "validate rejects token header auth without header name" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "capabilities": [
+        \\        {
+        \\          "name": "identity",
+        \\          "probe": {
+        \\            "method": "GET",
+        \\            "url": "https://example.invalid/v1/me",
+        \\            "auth": "token_header"
+        \\          }
+        \\        }
+        \\      ],
+        \\      "failure_rules": [
+        \\        { "status": 403, "class": { "degraded": "scope_insufficient" } }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "probe.auth_header is required when auth is token_header") != null);
+}
+
+test "validate rejects authorization as custom token header" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "capabilities": [
+        \\        {
+        \\          "name": "identity",
+        \\          "probe": {
+        \\            "method": "GET",
+        \\            "url": "https://example.invalid/v1/me",
+        \\            "auth": "token_header",
+        \\            "auth_header": "Authorization"
+        \\          }
+        \\        }
+        \\      ],
+        \\      "failure_rules": [
+        \\        { "status": 403, "class": { "degraded": "scope_insufficient" } }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "probe.auth_header must be a non-Authorization HTTP header name") != null);
+}
+
+test "validate rejects auth header without token header auth" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "capabilities": [
+        \\        {
+        \\          "name": "identity",
+        \\          "probe": {
+        \\            "method": "GET",
+        \\            "url": "https://example.invalid/v1/me",
+        \\            "auth": "bearer",
+        \\            "auth_header": "X-Figma-Token"
+        \\          }
+        \\        }
+        \\      ],
+        \\      "failure_rules": [
+        \\        { "status": 403, "class": { "degraded": "scope_insufficient" } }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "probe.auth_header requires auth token_header") != null);
+}
+
+test "validate rejects token material in command probe argv" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "capabilities": [
+        \\        {
+        \\          "name": "chat:max",
+        \\          "probe": {
+        \\            "transport": "command",
+        \\            "command": ["toy", "probe", "--header", "Authorization: Bearer secret"]
+        \\          }
+        \\        }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "probe.command[3] must not contain token material") != null);
+}
+
+test "validate rejects probed provider without failure rules" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "capabilities": [
+        \\        {
+        \\          "name": "chat:max",
+        \\          "probe": {
+        \\            "method": "GET",
+        \\            "url": "https://example.invalid/v1/probe"
+        \\          }
+        \\        }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "must define failure_rules when capabilities include probes") != null);
+}
+
+test "validate rejects catch-all failure rule" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "failure_rules": [
+        \\        { "class": { "degraded": "unknown_4xx" } }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "failure_rules[0] must include at least one matcher") != null);
+}
+
+test "validate rejects empty failure rule hint" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "failure_rules": [
+        \\        { "status": 403, "hint_contains": "", "class": { "degraded": "unknown_4xx" } }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "failure_rules[0].hint_contains must not be empty") != null);
 }
 
 test "resolveSecretBackend keychain" {

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -9,6 +9,8 @@ const paths = @import("paths.zig");
 const log = @import("log.zig");
 const builtin = @import("builtin");
 
+const Pid = if (builtin.os.tag == .windows) u32 else std.posix.pid_t;
+
 pub const DaemonError = error{
     AlreadyRunning,
     SocketError,
@@ -18,6 +20,11 @@ pub const DaemonError = error{
 };
 
 pub fn start(allocator: std.mem.Allocator) DaemonError!void {
+    if (comptime builtin.os.tag == .windows) {
+        log.err("daemon: unsupported on windows", .{});
+        return error.SocketError;
+    }
+
     const sock_path = paths.socketPath(allocator) catch return error.OutOfMemory;
     defer allocator.free(sock_path);
 
@@ -63,6 +70,11 @@ pub fn start(allocator: std.mem.Allocator) DaemonError!void {
 }
 
 pub fn stop(allocator: std.mem.Allocator) !void {
+    if (comptime builtin.os.tag == .windows) {
+        log.err("daemon: unsupported on windows", .{});
+        return;
+    }
+
     const pid_path = try pidPath(allocator);
     defer allocator.free(pid_path);
 
@@ -97,6 +109,10 @@ pub fn status(allocator: std.mem.Allocator, writer: anytype) !void {
 }
 
 fn isRunning(allocator: std.mem.Allocator) bool {
+    if (comptime builtin.os.tag == .windows) {
+        return false;
+    }
+
     const pid_path = pidPath(allocator) catch return false;
     defer allocator.free(pid_path);
 
@@ -108,13 +124,16 @@ fn isRunning(allocator: std.mem.Allocator) bool {
 }
 
 fn runLoop(allocator: std.mem.Allocator, sock_path: []const u8) !void {
+    if (comptime builtin.os.tag == .windows) {
+        return error.Unsupported;
+    }
+
     // Remove stale socket
     std.fs.deleteFileAbsolute(sock_path) catch {};
 
     const addr = std.net.Address.initUnix(sock_path) catch return error.Unexpected;
     var server = addr.listen(.{ .reuse_address = true }) catch return error.Unexpected;
     defer server.deinit();
-
 
     log.info("daemon: listening on {s}", .{sock_path});
 
@@ -241,7 +260,7 @@ fn pidPath(allocator: std.mem.Allocator) ![]const u8 {
     return std.fs.path.join(allocator, &.{ dir, "daemon.pid" });
 }
 
-fn writePidFile(path: []const u8, pid: std.posix.pid_t) !void {
+fn writePidFile(path: []const u8, pid: Pid) !void {
     if (std.fs.path.dirname(path)) |dir| {
         std.fs.makeDirAbsolute(dir) catch |e| switch (e) {
             error.PathAlreadyExists => {},
@@ -253,14 +272,14 @@ fn writePidFile(path: []const u8, pid: std.posix.pid_t) !void {
     try file.writer().print("{d}", .{pid});
 }
 
-fn readPidFile(allocator: std.mem.Allocator, path: []const u8) !std.posix.pid_t {
+fn readPidFile(allocator: std.mem.Allocator, path: []const u8) !Pid {
     const file = try std.fs.openFileAbsolute(path, .{});
     defer file.close();
     var buf: [32]u8 = undefined;
     const n = try file.readAll(&buf);
     const pid_str = std.mem.trim(u8, buf[0..n], " \t\n\r");
     _ = allocator;
-    return std.fmt.parseInt(std.posix.pid_t, pid_str, 10) catch return error.InvalidCharacter;
+    return std.fmt.parseInt(Pid, pid_str, 10) catch return error.InvalidCharacter;
 }
 
 test "isRunning returns false when no daemon" {

--- a/src/env.zig
+++ b/src/env.zig
@@ -1,0 +1,19 @@
+const std = @import("std");
+
+pub fn get(allocator: std.mem.Allocator, name: []const u8) !?[]u8 {
+    return std.process.getEnvVarOwned(allocator, name) catch |e| switch (e) {
+        error.EnvironmentVariableNotFound => null,
+        error.OutOfMemory => error.OutOfMemory,
+        else => null,
+    };
+}
+
+pub fn has(name: []const u8) bool {
+    const allocator = std.heap.page_allocator;
+    const value = get(allocator, name) catch return false;
+    if (value) |v| {
+        allocator.free(v);
+        return true;
+    }
+    return false;
+}

--- a/src/fixture_redaction.zig
+++ b/src/fixture_redaction.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+
+const max_fixture_bytes = 1024 * 1024;
+
+const forbidden_markers = [_][]const u8{
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "client_secret",
+    "authorization:",
+    "authorization=",
+    "bearer ",
+    "bearer%20",
+    "set-cookie:",
+    "cookie:",
+    "sk-",
+    "sess-",
+};
+
+fn assertRedactedFixture(path: []const u8, bytes: []const u8) !void {
+    for (forbidden_markers) |marker| {
+        if (indexOfIgnoreCase(bytes, marker) != null) {
+            std.debug.print("fixture redaction error: {s} contains forbidden marker '{s}'\n", .{ path, marker });
+            return error.UnredactedFixture;
+        }
+    }
+}
+
+fn indexOfIgnoreCase(haystack: []const u8, needle: []const u8) ?usize {
+    if (needle.len == 0) return 0;
+    if (needle.len > haystack.len) return null;
+
+    var i: usize = 0;
+    while (i + needle.len <= haystack.len) : (i += 1) {
+        if (std.ascii.eqlIgnoreCase(haystack[i .. i + needle.len], needle)) return i;
+    }
+
+    return null;
+}
+
+test "test fixtures contain no obvious OAuth secrets" {
+    var root = std.fs.cwd().openDir("test/fixtures", .{ .iterate = true }) catch |err| switch (err) {
+        error.FileNotFound => return error.FixtureDirectoryMissing,
+        else => return err,
+    };
+    defer root.close();
+
+    var walker = try root.walk(std.testing.allocator);
+    defer walker.deinit();
+
+    var scanned: usize = 0;
+    while (try walker.next()) |entry| {
+        if (entry.kind != .file) continue;
+        scanned += 1;
+
+        const bytes = try root.readFileAlloc(std.testing.allocator, entry.path, max_fixture_bytes);
+        defer std.testing.allocator.free(bytes);
+
+        try assertRedactedFixture(entry.path, bytes);
+    }
+
+    try std.testing.expect(scanned > 0);
+}

--- a/src/health.zig
+++ b/src/health.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 const paths = @import("paths.zig");
+const provider_schema = @import("provider_schema.zig");
 const log = @import("log.zig");
 
 pub const AccountHealth = struct {
@@ -9,10 +10,155 @@ pub const AccountHealth = struct {
     bucket: types.TokenBucket = .{},
     liveness: types.CredentialLiveness = .{ .live = .{ .availability = .available } },
     last_http_status: ?u16 = null,
+    last_probe_source: ?ProbeEvidenceSource = null,
+    last_probe_observed_at: ?i64 = null,
+    last_probe_retry_after_s: ?u32 = null,
+    last_probe_hint_class: ?ProbeHintClass = null,
+    last_probe_decision: ?types.MuxDecision = null,
     consecutive_failures: u32 = 0,
     quota_exhausted_until: ?i64 = null,
     rate_limited_until: ?i64 = null,
 };
+
+pub const ProbeEvidenceSource = enum {
+    credential_validation,
+    capability_probe,
+    http_status,
+};
+
+pub const ProbeHintClass = enum {
+    none,
+    rate_limit,
+    quota_exhausted,
+    auth_dead,
+    provider_degraded,
+    tier_insufficient,
+    subscription_paused,
+    scope_insufficient,
+    schema_invalid,
+    terms_required,
+    step_up_required,
+    pending_verification,
+    unknown_4xx,
+    failure,
+};
+
+pub const HealthKey = struct {
+    provider: []const u8,
+    account: []const u8,
+    capability: ?[]const u8 = null,
+};
+
+pub const KeyBuf = struct {
+    buf: [256]u8 = undefined,
+    len: usize = 0,
+
+    pub fn slice(self: *const KeyBuf) []const u8 {
+        return self.buf[0..self.len];
+    }
+
+    fn append(self: *KeyBuf, value: []const u8) void {
+        for (value) |c| {
+            if (self.len >= self.buf.len) break;
+            self.buf[self.len] = c;
+            self.len += 1;
+        }
+    }
+
+    fn appendByte(self: *KeyBuf, value: u8) void {
+        if (self.len >= self.buf.len) return;
+        self.buf[self.len] = value;
+        self.len += 1;
+    }
+};
+
+pub fn accountKey(provider: []const u8, account: []const u8) KeyBuf {
+    var kb = KeyBuf{};
+    kb.append(provider);
+    kb.appendByte(':');
+    kb.append(account);
+    return kb;
+}
+
+pub fn capabilityKey(provider: []const u8, account: []const u8, capability: []const u8) KeyBuf {
+    var kb = accountKey(provider, account);
+    kb.appendByte('#');
+    kb.append(capability);
+    return kb;
+}
+
+pub fn parseHealthKey(key: []const u8) ?HealthKey {
+    const colon = std.mem.indexOf(u8, key, ":") orelse return null;
+    if (colon == 0 or colon + 1 >= key.len) return null;
+
+    const rest = key[colon + 1 ..];
+    if (std.mem.indexOf(u8, rest, "#")) |hash| {
+        if (hash == 0 or hash + 1 >= rest.len) return null;
+        return .{
+            .provider = key[0..colon],
+            .account = rest[0..hash],
+            .capability = rest[hash + 1 ..],
+        };
+    }
+
+    return .{
+        .provider = key[0..colon],
+        .account = rest,
+    };
+}
+
+pub fn writeLivenessSummary(writer: anytype, liveness: types.CredentialLiveness) !void {
+    switch (liveness) {
+        .live => |live| switch (live.availability) {
+            .available => try writer.writeAll("available"),
+            .rate_limited => |rl| try writer.print("rate_limited:{s}:{d}s", .{
+                @tagName(rl.window),
+                rl.retry_after_s,
+            }),
+            .quota_exhausted => |q| {
+                if (q.window_resets_at) |reset| {
+                    try writer.print("quota_exhausted:reset@{d}", .{reset});
+                } else {
+                    try writer.writeAll("quota_exhausted");
+                }
+            },
+            .cooldown => |c| try writer.print("cooldown:until@{d}", .{c.until}),
+        },
+        .degraded => |d| try writer.print("degraded:{s}", .{@tagName(d.reason)}),
+        .dead => |d| try writer.print("dead:{s}", .{@tagName(d.reason)}),
+    }
+}
+
+pub fn hintClassFromClassification(classification: types.HttpClassification) ProbeHintClass {
+    return switch (classification) {
+        .success => .none,
+        .rate_limited => .rate_limit,
+        .quota_exhausted => .quota_exhausted,
+        .dead => .auth_dead,
+        .provider_degraded => .provider_degraded,
+        .degraded => |reason| switch (reason) {
+            .tier_insufficient => .tier_insufficient,
+            .subscription_paused => .subscription_paused,
+            .scope_insufficient => .scope_insufficient,
+            .schema_invalid => .schema_invalid,
+            .terms_required => .terms_required,
+            .step_up_required => .step_up_required,
+            .pending_verification => .pending_verification,
+            .provider_degraded => .provider_degraded,
+            .unknown_4xx => .unknown_4xx,
+        },
+        .failure => .failure,
+    };
+}
+
+pub fn decisionFromClassification(classification: types.HttpClassification) types.MuxDecision {
+    return switch (classification) {
+        .success => .use_this,
+        .rate_limited => .wait_and_retry,
+        .quota_exhausted, .dead, .degraded, .failure => .try_next_account,
+        .provider_degraded => .try_next_provider,
+    };
+}
 
 pub const HealthStore = struct {
     allocator: std.mem.Allocator,
@@ -63,6 +209,22 @@ pub const HealthStore = struct {
             },
             else => {},
         }
+    }
+
+    pub fn recordProbeEvidence(
+        self: *HealthStore,
+        key: []const u8,
+        source: ProbeEvidenceSource,
+        retry_after_s: ?u32,
+        hint_class: ProbeHintClass,
+        decision: types.MuxDecision,
+    ) void {
+        const health = self.getOrCreate(key) catch return;
+        health.last_probe_source = source;
+        health.last_probe_observed_at = std.time.timestamp();
+        health.last_probe_retry_after_s = retry_after_s;
+        health.last_probe_hint_class = hint_class;
+        health.last_probe_decision = decision;
     }
 
     pub fn recordFailure(self: *HealthStore, key: []const u8, kind: FailureKind) void {
@@ -147,16 +309,22 @@ pub const HealthStore = struct {
     }
 
     pub fn load(allocator: std.mem.Allocator, hc: types.HealthConfig) HealthStore {
-        var store = init(allocator, hc);
-
-        const path = paths.healthFilePath(allocator) catch return store;
+        const path = paths.healthFilePath(allocator) catch return init(allocator, hc);
         defer allocator.free(path);
 
-        const file = std.fs.openFileAbsolute(path, .{}) catch return store;
+        const file = std.fs.openFileAbsolute(path, .{}) catch return init(allocator, hc);
         defer file.close();
 
-        const bytes = file.readToEndAlloc(allocator, 256 * 1024) catch return store;
+        const bytes = file.readToEndAlloc(allocator, 256 * 1024) catch return init(allocator, hc);
         defer allocator.free(bytes);
+
+        var store = loadFromBytes(allocator, hc, bytes);
+        log.debug("health: loaded {d} accounts from {s}", .{ store.accounts.count(), path });
+        return store;
+    }
+
+    pub fn loadFromBytes(allocator: std.mem.Allocator, hc: types.HealthConfig, bytes: []const u8) HealthStore {
+        var store = init(allocator, hc);
 
         const parsed = std.json.parseFromSlice(HealthFile, allocator, bytes, .{
             .ignore_unknown_fields = true,
@@ -165,27 +333,9 @@ pub const HealthStore = struct {
         defer parsed.deinit();
 
         for (parsed.value.accounts) |entry| {
-            const key = allocator.dupe(u8, entry.key) catch continue;
-            store.accounts.put(key, .{
-                .score = .{
-                    .score = entry.score,
-                    .successes = entry.successes,
-                    .failures = entry.failures,
-                    .rate_limits = entry.rate_limits,
-                    .last_updated = entry.last_updated,
-                },
-                .circuit = if (entry.circuit_open) .{ .open = .{
-                    .opened_at = entry.last_updated,
-                    .failure_count = entry.failures,
-                    .retry_at = entry.last_updated + 30,
-                } } else .closed,
-            }) catch {
-                allocator.free(key);
-                continue;
-            };
+            store.putHealthEntry(entry) catch continue;
         }
 
-        log.debug("health: loaded {d} accounts from {s}", .{ store.accounts.count(), path });
         return store;
     }
 
@@ -203,33 +353,47 @@ pub const HealthStore = struct {
         const file = std.fs.createFileAbsolute(path, .{ .mode = 0o600 }) catch return;
         defer file.close();
 
-        const writer = file.writer();
-        writer.writeAll("{\"accounts\":[") catch return;
+        writeJson(self, file.writer()) catch return;
+        log.debug("health: persisted {d} accounts to {s}", .{ self.accounts.count(), path });
+    }
+
+    fn writeJson(self: *HealthStore, writer: anytype) !void {
+        try writer.writeAll("{\"accounts\":[");
         var first = true;
         var it = self.accounts.iterator();
         while (it.next()) |entry| {
-            if (!first) writer.writeByte(',') catch return;
+            if (!first) try writer.writeByte(',');
             first = false;
             const h = entry.value_ptr.*;
-            writer.print(
-                "{{\"key\":\"{s}\",\"score\":{d},\"successes\":{d},\"failures\":{d},\"rate_limits\":{d},\"last_updated\":{d},\"circuit_open\":{s}}}",
+            try writer.writeByte('{');
+            try writer.writeAll("\"key\":");
+            try writeJsonString(writer, entry.key_ptr.*);
+            try writer.print(
+                ",\"score\":{d},\"window_start\":{d},\"successes\":{d},\"failures\":{d},\"rate_limits\":{d},\"last_updated\":{d},\"circuit_open\":{s},\"consecutive_failures\":{d}",
                 .{
-                    entry.key_ptr.*,
                     h.score.score,
+                    h.score.window_start,
                     h.score.successes,
                     h.score.failures,
                     h.score.rate_limits,
                     h.score.last_updated,
                     if (h.circuit.isClosed()) "false" else "true",
+                    h.consecutive_failures,
                 },
-            ) catch return;
+            );
+            try writeOptU16Field(writer, "last_http_status", h.last_http_status);
+            try writeProbeEvidenceFields(writer, h);
+            try writeOptI64Field(writer, "quota_exhausted_until", h.quota_exhausted_until);
+            try writeOptI64Field(writer, "rate_limited_until", h.rate_limited_until);
+            try writer.writeAll(",\"liveness\":");
+            try writeLiveness(writer, h.liveness);
+            try writer.writeByte('}');
         }
-        writer.writeAll("]}") catch return;
-
-        log.debug("health: persisted {d} accounts to {s}", .{ self.accounts.count(), path });
+        try writer.writeAll("],\"version\":2}");
     }
 
     const HealthFile = struct {
+        version: u32 = 1,
         accounts: []const HealthEntry = &.{},
     };
 
@@ -239,78 +403,382 @@ pub const HealthStore = struct {
         successes: u32 = 0,
         failures: u32 = 0,
         rate_limits: u32 = 0,
+        window_start: i64 = 0,
         last_updated: i64 = 0,
         circuit_open: bool = false,
+        last_http_status: ?u16 = null,
+        last_probe_source: ?[]const u8 = null,
+        last_probe_observed_at: ?i64 = null,
+        last_probe_retry_after_s: ?u32 = null,
+        last_probe_hint_class: ?[]const u8 = null,
+        last_probe_decision: ?[]const u8 = null,
+        consecutive_failures: u32 = 0,
+        quota_exhausted_until: ?i64 = null,
+        rate_limited_until: ?i64 = null,
+        liveness: ?LivenessEntry = null,
     };
 
+    const LivenessEntry = struct {
+        state: []const u8,
+        availability: ?[]const u8 = null,
+        reason: ?[]const u8 = null,
+        since: ?i64 = null,
+        retry_at: ?i64 = null,
+        retry_after_s: ?u32 = null,
+        limited_at: ?i64 = null,
+        window: ?[]const u8 = null,
+        window_resets_at: ?i64 = null,
+        usage_pct: ?u8 = null,
+        exhausted_at: ?i64 = null,
+        cooldown_until: ?i64 = null,
+        cooldown_reason: ?[]const u8 = null,
+    };
+
+    fn putHealthEntry(self: *HealthStore, entry: HealthEntry) !void {
+        const key = try self.allocator.dupe(u8, entry.key);
+        self.accounts.put(key, .{
+            .score = .{
+                .score = entry.score,
+                .window_start = entry.window_start,
+                .successes = entry.successes,
+                .failures = entry.failures,
+                .rate_limits = entry.rate_limits,
+                .last_updated = entry.last_updated,
+            },
+            .circuit = if (entry.circuit_open) .{ .open = .{
+                .opened_at = entry.last_updated,
+                .failure_count = entry.failures,
+                .retry_at = entry.last_updated + 30,
+            } } else .closed,
+            .liveness = if (entry.liveness) |le| livenessFromEntry(le) else .{ .live = .{ .availability = .available } },
+            .last_http_status = entry.last_http_status,
+            .last_probe_source = if (entry.last_probe_source) |source| probeEvidenceSourceFromString(source) else null,
+            .last_probe_observed_at = entry.last_probe_observed_at,
+            .last_probe_retry_after_s = entry.last_probe_retry_after_s,
+            .last_probe_hint_class = if (entry.last_probe_hint_class) |hint| probeHintClassFromString(hint) else null,
+            .last_probe_decision = if (entry.last_probe_decision) |decision| muxDecisionFromString(decision) else null,
+            .consecutive_failures = entry.consecutive_failures,
+            .quota_exhausted_until = entry.quota_exhausted_until,
+            .rate_limited_until = entry.rate_limited_until,
+        }) catch |e| {
+            self.allocator.free(key);
+            return e;
+        };
+    }
+
+    fn livenessFromEntry(entry: LivenessEntry) types.CredentialLiveness {
+        if (std.mem.eql(u8, entry.state, "dead")) {
+            return .{ .dead = .{
+                .reason = deadReasonFromString(entry.reason orelse "auth_permanently_failed"),
+                .since = entry.since orelse 0,
+            } };
+        }
+
+        if (std.mem.eql(u8, entry.state, "degraded")) {
+            return .{ .degraded = .{
+                .reason = degradedReasonFromString(entry.reason orelse "unknown_4xx"),
+                .since = entry.since orelse 0,
+                .retry_at = entry.retry_at,
+            } };
+        }
+
+        const availability_name = entry.availability orelse "available";
+        if (std.mem.eql(u8, availability_name, "rate_limited")) {
+            return .{ .live = .{ .availability = .{ .rate_limited = .{
+                .retry_after_s = entry.retry_after_s orelse 0,
+                .limited_at = entry.limited_at orelse 0,
+                .window = rateLimitWindowFromString(entry.window orelse "unknown"),
+            } } } };
+        }
+        if (std.mem.eql(u8, availability_name, "quota_exhausted")) {
+            return .{ .live = .{ .availability = .{ .quota_exhausted = .{
+                .window_resets_at = entry.window_resets_at,
+                .usage_pct = entry.usage_pct,
+                .exhausted_at = entry.exhausted_at orelse 0,
+            } } } };
+        }
+        if (std.mem.eql(u8, availability_name, "cooldown")) {
+            return .{ .live = .{ .availability = .{ .cooldown = .{
+                .until = entry.cooldown_until orelse 0,
+                .reason = "persisted",
+            } } } };
+        }
+
+        return .{ .live = .{ .availability = .available } };
+    }
+
+    fn degradedReasonFromString(s: []const u8) types.DegradedReason {
+        inline for (std.meta.fields(types.DegradedReason)) |field| {
+            if (std.mem.eql(u8, s, field.name)) return @enumFromInt(field.value);
+        }
+        return .unknown_4xx;
+    }
+
+    fn deadReasonFromString(s: []const u8) types.DeadReason {
+        inline for (std.meta.fields(types.DeadReason)) |field| {
+            if (std.mem.eql(u8, s, field.name)) return @enumFromInt(field.value);
+        }
+        return .auth_permanently_failed;
+    }
+
+    fn rateLimitWindowFromString(s: []const u8) types.RateLimitWindow {
+        inline for (std.meta.fields(types.RateLimitWindow)) |field| {
+            if (std.mem.eql(u8, s, field.name)) return @enumFromInt(field.value);
+        }
+        return .unknown;
+    }
+
+    fn probeEvidenceSourceFromString(s: []const u8) ?ProbeEvidenceSource {
+        inline for (std.meta.fields(ProbeEvidenceSource)) |field| {
+            if (std.mem.eql(u8, s, field.name)) return @enumFromInt(field.value);
+        }
+        return null;
+    }
+
+    fn probeHintClassFromString(s: []const u8) ?ProbeHintClass {
+        inline for (std.meta.fields(ProbeHintClass)) |field| {
+            if (std.mem.eql(u8, s, field.name)) return @enumFromInt(field.value);
+        }
+        return null;
+    }
+
+    fn muxDecisionFromString(s: []const u8) ?types.MuxDecision {
+        inline for (std.meta.fields(types.MuxDecision)) |field| {
+            if (std.mem.eql(u8, s, field.name)) return @enumFromInt(field.value);
+        }
+        return null;
+    }
+
+    fn writeProbeEvidenceFields(writer: anytype, health: AccountHealth) !void {
+        try writer.writeAll(",\"last_probe_source\":");
+        if (health.last_probe_source) |source| {
+            try writeJsonString(writer, @tagName(source));
+        } else {
+            try writer.writeAll("null");
+        }
+        try writeOptI64Field(writer, "last_probe_observed_at", health.last_probe_observed_at);
+        try writer.writeAll(",\"last_probe_retry_after_s\":");
+        if (health.last_probe_retry_after_s) |retry_after| {
+            try writer.print("{d}", .{retry_after});
+        } else {
+            try writer.writeAll("null");
+        }
+        try writer.writeAll(",\"last_probe_hint_class\":");
+        if (health.last_probe_hint_class) |hint_class| {
+            try writeJsonString(writer, @tagName(hint_class));
+        } else {
+            try writer.writeAll("null");
+        }
+        try writer.writeAll(",\"last_probe_decision\":");
+        if (health.last_probe_decision) |decision| {
+            try writeJsonString(writer, @tagName(decision));
+        } else {
+            try writer.writeAll("null");
+        }
+    }
+
+    fn writeLiveness(writer: anytype, liveness: types.CredentialLiveness) !void {
+        try writer.writeByte('{');
+        switch (liveness) {
+            .live => |live| {
+                try writer.writeAll("\"state\":\"live\"");
+                switch (live.availability) {
+                    .available => try writer.writeAll(",\"availability\":\"available\""),
+                    .rate_limited => |rl| {
+                        try writer.writeAll(",\"availability\":\"rate_limited\"");
+                        try writer.print(",\"retry_after_s\":{d},\"limited_at\":{d},\"window\":\"{s}\"", .{
+                            rl.retry_after_s,
+                            rl.limited_at,
+                            @tagName(rl.window),
+                        });
+                    },
+                    .quota_exhausted => |q| {
+                        try writer.writeAll(",\"availability\":\"quota_exhausted\"");
+                        try writeOptI64Field(writer, "window_resets_at", q.window_resets_at);
+                        try writeOptU8Field(writer, "usage_pct", q.usage_pct);
+                        try writer.print(",\"exhausted_at\":{d}", .{q.exhausted_at});
+                    },
+                    .cooldown => |c| {
+                        try writer.writeAll(",\"availability\":\"cooldown\"");
+                        try writer.print(",\"cooldown_until\":{d},\"cooldown_reason\":", .{c.until});
+                        try writeJsonString(writer, c.reason);
+                    },
+                }
+            },
+            .degraded => |d| {
+                try writer.print("\"state\":\"degraded\",\"reason\":\"{s}\",\"since\":{d}", .{
+                    @tagName(d.reason),
+                    d.since,
+                });
+                try writeOptI64Field(writer, "retry_at", d.retry_at);
+            },
+            .dead => |d| {
+                try writer.print("\"state\":\"dead\",\"reason\":\"{s}\",\"since\":{d}", .{
+                    @tagName(d.reason),
+                    d.since,
+                });
+            },
+        }
+        try writer.writeByte('}');
+    }
+
+    fn writeJsonString(writer: anytype, value: []const u8) !void {
+        try std.json.stringify(value, .{}, writer);
+    }
+
+    fn writeOptI64Field(writer: anytype, name: []const u8, value: ?i64) !void {
+        try writer.print(",\"{s}\":", .{name});
+        if (value) |v| {
+            try writer.print("{d}", .{v});
+        } else {
+            try writer.writeAll("null");
+        }
+    }
+
+    fn writeOptU16Field(writer: anytype, name: []const u8, value: ?u16) !void {
+        try writer.print(",\"{s}\":", .{name});
+        if (value) |v| {
+            try writer.print("{d}", .{v});
+        } else {
+            try writer.writeAll("null");
+        }
+    }
+
+    fn writeOptU8Field(writer: anytype, name: []const u8, value: ?u8) !void {
+        try writer.print(",\"{s}\":", .{name});
+        if (value) |v| {
+            try writer.print("{d}", .{v});
+        } else {
+            try writer.writeAll("null");
+        }
+    }
+
     pub fn recordHttpStatus(self: *HealthStore, key: []const u8, status: u16, retry_after: ?u32) void {
+        self.recordHttpStatusForProvider(key, provider_schema.generic_def, status, retry_after, null);
+    }
+
+    pub fn recordCapabilityHttpStatus(
+        self: *HealthStore,
+        provider_name: []const u8,
+        account_name: []const u8,
+        capability: []const u8,
+        status: u16,
+        retry_after: ?u32,
+    ) void {
+        const key = capabilityKey(provider_name, account_name, capability);
+        self.recordHttpStatus(key.slice(), status, retry_after);
+    }
+
+    pub fn recordCapabilityHttpStatusForProvider(
+        self: *HealthStore,
+        provider_name: []const u8,
+        account_name: []const u8,
+        capability: []const u8,
+        def: provider_schema.ProviderDefinition,
+        status: u16,
+        retry_after: ?u32,
+        hint: ?[]const u8,
+    ) void {
+        const key = capabilityKey(provider_name, account_name, capability);
+        self.recordHttpStatusForProvider(key.slice(), def, status, retry_after, hint);
+    }
+
+    pub fn recordHttpStatusForProvider(
+        self: *HealthStore,
+        key: []const u8,
+        def: provider_schema.ProviderDefinition,
+        status: u16,
+        retry_after: ?u32,
+        hint: ?[]const u8,
+    ) void {
+        const classification = provider_schema.classifyHttp(def, status, retry_after, hint);
+        self.recordHttpClassification(key, status, classification);
+        self.recordProbeEvidence(
+            key,
+            .http_status,
+            retry_after,
+            hintClassFromClassification(classification),
+            decisionFromClassification(classification),
+        );
+    }
+
+    pub fn recordHttpClassification(
+        self: *HealthStore,
+        key: []const u8,
+        status: u16,
+        classification: types.HttpClassification,
+    ) void {
         const health = self.getOrCreate(key) catch return;
         const now = std.time.timestamp();
         health.last_http_status = status;
 
-        switch (status) {
-            200...299 => {
+        switch (classification) {
+            .success => {
                 self.recordSuccess(key);
                 health.consecutive_failures = 0;
                 health.liveness = .{ .live = .{ .availability = .available } };
                 health.rate_limited_until = null;
+                health.quota_exhausted_until = null;
             },
-            429 => {
-                // Distinguish rate limit (short) from quota exhaustion (long)
-                const wait = retry_after orelse 30;
+            .rate_limited => |rl| {
                 health.score.rate_limits += 1;
                 health.score.score += self.config.rate_limit_penalty;
                 health.score.clamp();
                 health.score.last_updated = now;
-
-                if (wait > 3600) {
-                    // Long wait = quota exhausted for the billing window
-                    health.quota_exhausted_until = now + @as(i64, wait);
-                    health.liveness = .{ .live = .{ .availability = .{
-                        .quota_exhausted = .{
-                            .exhausted_at = now,
-                            .window_resets_at = now + @as(i64, wait),
-                        },
-                    } } };
-                    log.info("health: {s} quota exhausted, window resets in {d}s", .{ key, wait });
-                } else {
-                    // Short wait = per-minute/per-hour rate limit
-                    health.rate_limited_until = now + @as(i64, wait);
-                    health.liveness = .{ .live = .{ .availability = .{
-                        .rate_limited = .{
-                            .retry_after_s = wait,
-                            .limited_at = now,
-                            .window = if (wait <= 60) .per_minute else if (wait <= 3600) .per_hour else .per_day,
-                        },
-                    } } };
-                    log.debug("health: {s} rate limited for {d}s", .{ key, wait });
-                }
+                health.quota_exhausted_until = null;
+                health.rate_limited_until = now + @as(i64, rl.retry_after_s);
+                health.liveness = .{ .live = .{ .availability = .{
+                    .rate_limited = .{
+                        .retry_after_s = rl.retry_after_s,
+                        .limited_at = now,
+                        .window = rl.window,
+                    },
+                } } };
+                log.debug("health: {s} rate limited for {d}s", .{ key, rl.retry_after_s });
             },
-            401 => {
-                // Auth failure — credential is dead
+            .quota_exhausted => |quota| {
+                health.score.rate_limits += 1;
+                health.score.score += self.config.rate_limit_penalty;
+                health.score.clamp();
+                health.score.last_updated = now;
+                health.rate_limited_until = null;
+                health.quota_exhausted_until = now + @as(i64, quota.retry_after_s);
+                health.liveness = .{ .live = .{ .availability = .{
+                    .quota_exhausted = .{
+                        .exhausted_at = now,
+                        .window_resets_at = now + @as(i64, quota.retry_after_s),
+                    },
+                } } };
+                log.info("health: {s} quota exhausted, window resets in {d}s", .{ key, quota.retry_after_s });
+            },
+            .dead => |reason| {
+                health.rate_limited_until = null;
+                health.quota_exhausted_until = null;
                 health.liveness = .{ .dead = .{
-                    .reason = .token_revoked,
+                    .reason = reason,
                     .since = now,
                 } };
                 health.score.score = -100;
                 health.score.last_updated = now;
-                log.warn("health: {s} auth failed (401), marking dead", .{key});
+                log.warn("health: {s} auth failed ({d}), marking dead", .{ key, status });
             },
-            403 => {
-                // Forbidden — could be tier, suspension, or scope
+            .degraded => |reason| {
+                health.rate_limited_until = null;
+                health.quota_exhausted_until = null;
                 health.consecutive_failures += 1;
                 health.liveness = .{ .degraded = .{
-                    .reason = .tier_insufficient,
+                    .reason = reason,
                     .since = now,
                     .retry_at = now + 3600,
                 } };
                 health.score.score += self.config.failure_penalty;
                 health.score.clamp();
                 health.score.last_updated = now;
-                log.warn("health: {s} forbidden (403), marking degraded", .{key});
+                log.warn("health: {s} status {d}, marking degraded", .{ key, status });
             },
-            500...599 => {
-                // Provider-side error — not the account's fault
+            .provider_degraded => {
+                health.rate_limited_until = null;
+                health.quota_exhausted_until = null;
                 health.consecutive_failures += 1;
                 health.liveness = .{ .degraded = .{
                     .reason = .provider_degraded,
@@ -320,7 +788,7 @@ pub const HealthStore = struct {
                 health.score.last_updated = now;
                 log.debug("health: {s} provider error ({d})", .{ key, status });
             },
-            else => {
+            .failure => {
                 self.recordFailure(key, .error_response);
             },
         }
@@ -335,10 +803,14 @@ pub const HealthStore = struct {
             .dead => return .try_next_account,
             .degraded => |d| {
                 if (d.retry_at) |ra| {
-                    if (now < ra) return .try_next_account;
+                    if (now < ra) {
+                        if (d.reason == .provider_degraded) return .try_next_provider;
+                        return .try_next_account;
+                    }
                     // Retry window passed, upgrade to live
                     health.liveness = .{ .live = .{ .availability = .available } };
                 } else {
+                    if (d.reason == .provider_degraded) return .try_next_provider;
                     return .try_next_account;
                 }
             },
@@ -377,6 +849,24 @@ pub const HealthStore = struct {
         // Check token bucket
         const now_ns: i128 = @as(i128, now) * 1_000_000_000;
         if (!health.bucket.tryConsume(now_ns)) return .wait_and_retry;
+
+        return .use_this;
+    }
+
+    pub fn muxDecisionFor(
+        self: *HealthStore,
+        provider_name: []const u8,
+        account_name: []const u8,
+        capability: ?[]const u8,
+    ) types.MuxDecision {
+        const base_key = accountKey(provider_name, account_name);
+        const base_decision = self.muxDecision(base_key.slice());
+        if (base_decision != .use_this) return base_decision;
+
+        if (capability) |cap| {
+            const route_key = capabilityKey(provider_name, account_name, cap);
+            return self.muxDecision(route_key.slice());
+        }
 
         return .use_this;
     }
@@ -436,6 +926,49 @@ test "HealthStore muxDecision with typed failures" {
     // Auth failure → try_next (dead)
     store.recordHttpStatus("codex:plan3", 401, null);
     try std.testing.expectEqual(types.MuxDecision.try_next_account, store.muxDecision("codex:plan3"));
+
+    // Provider-side failure routes away from the provider, not only the account.
+    store.recordHttpStatus("codex:provider", 500, null);
+    try std.testing.expectEqual(types.MuxDecision.try_next_provider, store.muxDecision("codex:provider"));
+}
+
+test "HealthStore capability route decisions do not poison account" {
+    var store = HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+
+    store.recordCapabilityHttpStatus("codex", "max-1", "codex-max", 429, 7200);
+
+    try std.testing.expectEqual(
+        types.MuxDecision.try_next_account,
+        store.muxDecisionFor("codex", "max-1", "codex-max"),
+    );
+    try std.testing.expectEqual(
+        types.MuxDecision.use_this,
+        store.muxDecisionFor("codex", "max-1", "codex-mini"),
+    );
+}
+
+test "HealthStore account decisions dominate capability route decisions" {
+    var store = HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+
+    store.recordHttpStatus("codex:max-1", 401, null);
+    try std.testing.expectEqual(
+        types.MuxDecision.try_next_account,
+        store.muxDecisionFor("codex", "max-1", "codex-max"),
+    );
+}
+
+test "parseHealthKey supports account and capability routes" {
+    const account = parseHealthKey("codex:max-1").?;
+    try std.testing.expectEqualStrings("codex", account.provider);
+    try std.testing.expectEqualStrings("max-1", account.account);
+    try std.testing.expect(account.capability == null);
+
+    const route = parseHealthKey("codex:max-1#codex-max").?;
+    try std.testing.expectEqualStrings("codex", route.provider);
+    try std.testing.expectEqualStrings("max-1", route.account);
+    try std.testing.expectEqualStrings("codex-max", route.capability.?);
 }
 
 test "HealthStore 429 distinguishes rate limit from quota exhaustion" {
@@ -463,6 +996,102 @@ test "HealthStore 429 distinguishes rate limit from quota exhaustion" {
         },
         else => return error.TestUnexpectedResult,
     }
+}
+
+test "HealthStore persists typed liveness" {
+    var store = HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+
+    store.recordHttpStatus("codex:max-1", 429, 30);
+    store.recordHttpStatus("codex:max-2", 429, 7200);
+    store.recordHttpStatus("codex:max-3", 401, null);
+
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+    try store.writeJson(buf.writer());
+
+    var loaded = HealthStore.loadFromBytes(std.testing.allocator, .{}, buf.items);
+    defer loaded.deinit();
+
+    try std.testing.expectEqual(types.MuxDecision.wait_and_retry, loaded.muxDecision("codex:max-1"));
+    try std.testing.expectEqual(types.MuxDecision.try_next_account, loaded.muxDecision("codex:max-2"));
+    try std.testing.expectEqual(types.MuxDecision.try_next_account, loaded.muxDecision("codex:max-3"));
+
+    const rate_limited = loaded.accounts.get("codex:max-1").?;
+    try std.testing.expectEqual(ProbeEvidenceSource.http_status, rate_limited.last_probe_source.?);
+    try std.testing.expect(rate_limited.last_probe_observed_at != null);
+    try std.testing.expectEqual(@as(?u32, 30), rate_limited.last_probe_retry_after_s);
+    try std.testing.expectEqual(ProbeHintClass.rate_limit, rate_limited.last_probe_hint_class.?);
+    try std.testing.expectEqual(types.MuxDecision.wait_and_retry, rate_limited.last_probe_decision.?);
+
+    const quota = loaded.accounts.get("codex:max-2").?;
+    try std.testing.expectEqual(@as(?u16, 429), quota.last_http_status);
+    switch (quota.liveness) {
+        .live => |l| switch (l.availability) {
+            .quota_exhausted => |q| try std.testing.expect(q.window_resets_at != null),
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "HealthStore loads legacy health file without liveness" {
+    const json =
+        \\{"accounts":[{"key":"codex:legacy","score":40,"successes":1,"failures":0,"rate_limits":1,"last_updated":123,"circuit_open":false}]}
+    ;
+
+    var loaded = HealthStore.loadFromBytes(std.testing.allocator, .{}, json);
+    defer loaded.deinit();
+
+    const health = loaded.accounts.get("codex:legacy").?;
+    try std.testing.expectEqual(@as(i32, 40), health.score.score);
+    try std.testing.expectEqual(@as(u32, 1), health.score.successes);
+    switch (health.liveness) {
+        .live => |l| switch (l.availability) {
+            .available => {},
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "writeLivenessSummary redacts to typed labels" {
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+
+    try writeLivenessSummary(buf.writer(), .{ .degraded = .{
+        .reason = .step_up_required,
+        .since = 123,
+        .retry_at = null,
+    } });
+    try std.testing.expectEqualStrings("degraded:step_up_required", buf.items);
+
+    buf.clearRetainingCapacity();
+    try writeLivenessSummary(buf.writer(), .{ .dead = .{
+        .reason = .token_revoked,
+        .since = 123,
+    } });
+    try std.testing.expectEqualStrings("dead:token_revoked", buf.items);
+}
+
+test "HealthStore provider classifier handles MCP step-up" {
+    var store = HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+
+    store.recordHttpStatusForProvider(
+        "mcp:figma",
+        provider_schema.mcp_def,
+        403,
+        null,
+        "mcp step_up required",
+    );
+
+    const health = store.accounts.get("mcp:figma").?;
+    switch (health.liveness) {
+        .degraded => |d| try std.testing.expectEqual(types.DegradedReason.step_up_required, d.reason),
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqual(types.MuxDecision.try_next_account, store.muxDecision("mcp:figma"));
 }
 
 test "HealthStore rate limit penalty" {

--- a/src/log.zig
+++ b/src/log.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const env = @import("env.zig");
 
 pub const Level = enum {
     debug,
@@ -39,10 +40,10 @@ pub fn setColor(enabled: bool) void {
 }
 
 pub fn init() void {
-    if (std.posix.getenv("OMUX_DEBUG")) |_| {
+    if (env.has("OMUX_DEBUG")) {
         min_level = .debug;
     }
-    if (std.posix.getenv("NO_COLOR")) |_| {
+    if (env.has("NO_COLOR")) {
         use_color = false;
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,6 +8,7 @@ const types = @import("types.zig");
 const pipeline = @import("pipeline.zig");
 const health_mod = @import("health.zig");
 const provider = @import("provider.zig");
+const provider_schema = @import("provider_schema.zig");
 const daemon = @import("daemon.zig");
 
 pub fn main() !void {
@@ -40,7 +41,11 @@ pub fn main() !void {
                 log.err("config: {s}", .{@errorName(e)});
                 std.process.exit(types.ExitCode.config_error.int());
             };
-            parsed.deinit();
+            defer parsed.deinit();
+            config.validate(parsed.value, stdout) catch |e| {
+                log.err("config: {s}", .{@errorName(e)});
+                std.process.exit(types.ExitCode.config_error.int());
+            };
             try stdout.writeAll("config: valid\n");
         },
 
@@ -51,6 +56,13 @@ pub fn main() !void {
         .env => |env_args| {
             runEnv(allocator, stdout, env_args) catch |e| {
                 log.err("env: {s}", .{@errorName(e)});
+                std.process.exit(exitCodeFromPipelineError(e));
+            };
+        },
+
+        .probe => |probe_args| {
+            runProbe(allocator, stdout, probe_args) catch |e| {
+                log.err("probe: {s}", .{@errorName(e)});
                 std.process.exit(exitCodeFromPipelineError(e));
             };
         },
@@ -164,6 +176,7 @@ fn runEnv(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.EnvAr
 
     ctx.profile_name = args.profile;
     ctx.provider_name = args.provider;
+    ctx.capability_name = args.capability;
     ctx.shell = if (args.shell) |s| blk: {
         const map = std.StaticStringMap(types.ShellKind).initComptime(.{
             .{ "fish", .fish },
@@ -179,6 +192,33 @@ fn runEnv(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.EnvAr
     try shell.emitEnv(writer, ctx.shell, ctx.env_pairs.items);
 
     store.persist();
+}
+
+fn runProbe(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.ProbeArgs) !void {
+    const parsed = config.load(allocator) catch {
+        return error.ConfigNotFound;
+    };
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+
+    var ctx = pipeline.Context.init(allocator, parsed.value, &store);
+    defer ctx.deinit();
+
+    ctx.profile_name = args.profile;
+    ctx.provider_name = args.provider;
+    ctx.account_name = args.account;
+    ctx.capability_name = args.capability;
+
+    try pipeline.runProbe(&ctx);
+    store.persist();
+
+    if (args.json) {
+        try writeProbeJson(writer, &store, &ctx);
+    } else {
+        try writeProbeText(writer, &store, &ctx);
+    }
 }
 
 fn runExec(allocator: std.mem.Allocator, args: cli.Command.ExecArgs) !void {
@@ -200,6 +240,7 @@ fn runExec(allocator: std.mem.Allocator, args: cli.Command.ExecArgs) !void {
 
     ctx.profile_name = args.profile;
     ctx.provider_name = args.provider;
+    ctx.capability_name = args.capability;
     ctx.target_argv = args.target_argv;
 
     pipeline.runExec(&ctx) catch |e| return e;
@@ -222,6 +263,117 @@ fn runExec(allocator: std.mem.Allocator, args: cli.Command.ExecArgs) !void {
     };
 }
 
+const HealthSelection = struct {
+    key: health_mod.KeyBuf,
+    health: ?health_mod.AccountHealth,
+};
+
+fn selectedHealth(store: *health_mod.HealthStore, ctx: *const pipeline.Context) HealthSelection {
+    const prov = ctx.provider_name orelse "";
+    const acct = ctx.account_name orelse "";
+    if (ctx.capability_name) |capability| {
+        const route_key = health_mod.capabilityKey(prov, acct, capability);
+        if (store.accounts.get(route_key.slice())) |health| {
+            return .{ .key = route_key, .health = health };
+        }
+    }
+
+    const account_key = health_mod.accountKey(prov, acct);
+    return .{ .key = account_key, .health = store.accounts.get(account_key.slice()) };
+}
+
+fn writeProbeText(writer: anytype, store: *health_mod.HealthStore, ctx: *const pipeline.Context) !void {
+    const provider_name = ctx.provider_name orelse "-";
+    const account_name = ctx.account_name orelse "-";
+    try writer.writeAll("oauth-mux probe\n\n");
+    try writer.print("  selected: {s}:{s}", .{ provider_name, account_name });
+    if (ctx.capability_name) |capability| {
+        try writer.print("#{s}", .{capability});
+    }
+    try writer.writeByte('\n');
+
+    if (ctx.last_probe_executed) {
+        try writer.writeAll("  probe:    executed status=");
+        if (ctx.last_probe_status) |status| {
+            try writer.print("{d}", .{status});
+        } else {
+            try writer.writeAll("-");
+        }
+        try writer.print(" decision={s}\n", .{@tagName(ctx.last_probe_decision orelse .use_this)});
+    } else if (ctx.capability_name != null) {
+        try writer.writeAll("  probe:    no configured probe plan for capability\n");
+    } else {
+        try writer.writeAll("  probe:    no capability requested; credential parse/expiry validation only\n");
+    }
+
+    const selection = selectedHealth(store, ctx);
+    try writer.print("  health:   {s} ", .{selection.key.slice()});
+    if (selection.health) |health| {
+        try health_mod.writeLivenessSummary(writer, health.liveness);
+        if (health.last_http_status) |status| {
+            try writer.print(" http={d}", .{status});
+        }
+        if (health.last_probe_source) |source| {
+            try writer.print("\n  evidence: source={s}", .{@tagName(source)});
+            if (health.last_probe_observed_at) |observed_at| {
+                try writer.print(" observed_at={d}", .{observed_at});
+            }
+            if (health.last_probe_retry_after_s) |retry_after| {
+                try writer.print(" retry_after_s={d}", .{retry_after});
+            }
+            if (health.last_probe_hint_class) |hint_class| {
+                try writer.print(" hint={s}", .{@tagName(hint_class)});
+            }
+            if (health.last_probe_decision) |decision| {
+                try writer.print(" decision={s}", .{@tagName(decision)});
+            }
+        }
+    } else {
+        try writer.writeAll("unrecorded");
+    }
+    try writer.writeByte('\n');
+}
+
+fn writeProbeJson(writer: anytype, store: *health_mod.HealthStore, ctx: *const pipeline.Context) !void {
+    const selection = selectedHealth(store, ctx);
+    try writer.writeByte('{');
+    try writer.writeAll("\"provider\":");
+    try std.json.stringify(ctx.provider_name orelse "", .{}, writer);
+    try writer.writeAll(",\"account\":");
+    try std.json.stringify(ctx.account_name orelse "", .{}, writer);
+    try writer.writeAll(",\"capability\":");
+    if (ctx.capability_name) |capability| {
+        try std.json.stringify(capability, .{}, writer);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"probe_executed\":");
+    try writer.writeAll(if (ctx.last_probe_executed) "true" else "false");
+    try writer.writeAll(",\"probe_status\":");
+    if (ctx.last_probe_status) |status| {
+        try writer.print("{d}", .{status});
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"decision\":");
+    try std.json.stringify(@tagName(ctx.last_probe_decision orelse .use_this), .{}, writer);
+    try writer.writeAll(",\"health_key\":");
+    try std.json.stringify(selection.key.slice(), .{}, writer);
+    try writer.writeAll(",\"liveness\":");
+    if (selection.health) |health| {
+        try writeLivenessJson(writer, health.liveness);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"last_probe\":");
+    if (selection.health) |health| {
+        try writeProbeEvidenceJson(writer, health);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll("}\n");
+}
+
 fn runHealth(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.HealthArgs) !void {
     var store = health_mod.HealthStore.load(allocator, .{});
     defer store.deinit();
@@ -237,20 +389,30 @@ fn runHealth(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.He
         return;
     }
 
+    if (args.json) {
+        try writeHealthJson(writer, &store, args.provider);
+        return;
+    }
+
+    try writeHealthText(writer, &store, args.provider);
+}
+
+fn writeHealthText(writer: anytype, store: *health_mod.HealthStore, provider_filter: ?[]const u8) !void {
     try writer.print("oauth-mux health\n\n", .{});
-    if (store.accounts.count() == 0) {
+    if (matchingHealthCount(store, provider_filter) == 0) {
         try writer.writeAll("  no health data recorded yet\n");
     } else {
-        try writer.print("  {s:<30} {s:>6} {s:>5} {s:>5} {s:>5}  {s}\n", .{
-            "Account", "Score", "OK", "Fail", "Rate", "Circuit",
+        try writer.print("  {s:<30} {s:>6} {s:>5} {s:>5} {s:>5}  {s:<9} {s:>5}  {s}\n", .{
+            "Account", "Score", "OK", "Fail", "Rate", "Circuit", "HTTP", "Liveness",
         });
-        try writer.print("  {s:-<30} {s:->6} {s:->5} {s:->5} {s:->5}  {s:-<9}\n", .{
-            "", "", "", "", "", "",
+        try writer.print("  {s:-<30} {s:->6} {s:->5} {s:->5} {s:->5}  {s:-<9} {s:->5}  {s:-<24}\n", .{
+            "", "", "", "", "", "", "", "",
         });
         var it = store.accounts.iterator();
         while (it.next()) |entry| {
+            if (!matchesProvider(entry.key_ptr.*, provider_filter)) continue;
             const h = entry.value_ptr.*;
-            try writer.print("  {s:<30} {d:>5}% {d:>5} {d:>5} {d:>5}  {s}\n", .{
+            try writer.print("  {s:<30} {d:>5}% {d:>5} {d:>5} {d:>5}  {s:<9} ", .{
                 entry.key_ptr.*,
                 h.score.score,
                 h.score.successes,
@@ -262,12 +424,165 @@ fn runHealth(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.He
                     .half_open => "half-open",
                 },
             });
+            if (h.last_http_status) |status| {
+                try writer.print("{d:>5}  ", .{status});
+            } else {
+                try writer.writeAll("    -  ");
+            }
+            try health_mod.writeLivenessSummary(writer, h.liveness);
+            try writer.writeByte('\n');
         }
     }
 }
 
+fn writeHealthJson(writer: anytype, store: *health_mod.HealthStore, provider_filter: ?[]const u8) !void {
+    try writer.writeAll("{\"accounts\":[");
+    var first = true;
+    var it = store.accounts.iterator();
+    while (it.next()) |entry| {
+        if (!matchesProvider(entry.key_ptr.*, provider_filter)) continue;
+        if (!first) try writer.writeByte(',');
+        first = false;
+        const h = entry.value_ptr.*;
+        try writer.writeByte('{');
+        try writer.writeAll("\"key\":");
+        try std.json.stringify(entry.key_ptr.*, .{}, writer);
+        if (health_mod.parseHealthKey(entry.key_ptr.*)) |parts| {
+            try writer.writeAll(",\"provider\":");
+            try std.json.stringify(parts.provider, .{}, writer);
+            try writer.writeAll(",\"account\":");
+            try std.json.stringify(parts.account, .{}, writer);
+            try writer.writeAll(",\"capability\":");
+            if (parts.capability) |capability| {
+                try std.json.stringify(capability, .{}, writer);
+            } else {
+                try writer.writeAll("null");
+            }
+        }
+        try writer.print(
+            ",\"score\":{d},\"successes\":{d},\"failures\":{d},\"rate_limits\":{d},\"circuit\":\"{s}\"",
+            .{
+                h.score.score,
+                h.score.successes,
+                h.score.failures,
+                h.score.rate_limits,
+                switch (h.circuit) {
+                    .closed => "closed",
+                    .open => "open",
+                    .half_open => "half_open",
+                },
+            },
+        );
+        try writer.writeAll(",\"last_http_status\":");
+        if (h.last_http_status) |status| {
+            try writer.print("{d}", .{status});
+        } else {
+            try writer.writeAll("null");
+        }
+        try writer.writeAll(",\"liveness\":");
+        try writeLivenessJson(writer, h.liveness);
+        try writer.writeAll(",\"last_probe\":");
+        try writeProbeEvidenceJson(writer, h);
+        try writer.writeByte('}');
+    }
+    try writer.writeAll("]}\n");
+}
+
+fn writeProbeEvidenceJson(writer: anytype, health: health_mod.AccountHealth) !void {
+    if (health.last_probe_source == null and
+        health.last_probe_observed_at == null and
+        health.last_probe_retry_after_s == null and
+        health.last_probe_hint_class == null and
+        health.last_probe_decision == null)
+    {
+        try writer.writeAll("null");
+        return;
+    }
+
+    try writer.writeByte('{');
+    try writer.writeAll("\"source\":");
+    if (health.last_probe_source) |source| {
+        try std.json.stringify(@tagName(source), .{}, writer);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"observed_at\":");
+    if (health.last_probe_observed_at) |observed_at| {
+        try writer.print("{d}", .{observed_at});
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"retry_after_s\":");
+    if (health.last_probe_retry_after_s) |retry_after| {
+        try writer.print("{d}", .{retry_after});
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"hint_class\":");
+    if (health.last_probe_hint_class) |hint_class| {
+        try std.json.stringify(@tagName(hint_class), .{}, writer);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"decision\":");
+    if (health.last_probe_decision) |decision| {
+        try std.json.stringify(@tagName(decision), .{}, writer);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeByte('}');
+}
+
+fn writeLivenessJson(writer: anytype, liveness: types.CredentialLiveness) !void {
+    try writer.writeByte('{');
+    try writer.writeAll("\"summary\":");
+    try writer.writeByte('"');
+    try health_mod.writeLivenessSummary(writer, liveness);
+    try writer.writeByte('"');
+
+    switch (liveness) {
+        .live => |live| {
+            try writer.writeAll(",\"state\":\"live\"");
+            switch (live.availability) {
+                .available => try writer.writeAll(",\"availability\":\"available\""),
+                .rate_limited => |rl| try writer.print(
+                    ",\"availability\":\"rate_limited\",\"retry_after_s\":{d},\"window\":\"{s}\"",
+                    .{ rl.retry_after_s, @tagName(rl.window) },
+                ),
+                .quota_exhausted => |q| {
+                    try writer.writeAll(",\"availability\":\"quota_exhausted\",\"window_resets_at\":");
+                    if (q.window_resets_at) |reset| {
+                        try writer.print("{d}", .{reset});
+                    } else {
+                        try writer.writeAll("null");
+                    }
+                },
+                .cooldown => |c| try writer.print(",\"availability\":\"cooldown\",\"until\":{d}", .{c.until}),
+            }
+        },
+        .degraded => |d| try writer.print(",\"state\":\"degraded\",\"reason\":\"{s}\"", .{@tagName(d.reason)}),
+        .dead => |d| try writer.print(",\"state\":\"dead\",\"reason\":\"{s}\"", .{@tagName(d.reason)}),
+    }
+    try writer.writeByte('}');
+}
+
+fn matchingHealthCount(store: *health_mod.HealthStore, provider_filter: ?[]const u8) usize {
+    var count: usize = 0;
+    var it = store.accounts.iterator();
+    while (it.next()) |entry| {
+        if (matchesProvider(entry.key_ptr.*, provider_filter)) count += 1;
+    }
+    return count;
+}
+
+fn matchesProvider(key: []const u8, provider_filter: ?[]const u8) bool {
+    const filter = provider_filter orelse return true;
+    if (std.mem.eql(u8, key, filter)) return true;
+    if (!std.mem.startsWith(u8, key, filter)) return false;
+    return key.len > filter.len and key[filter.len] == ':';
+}
+
 fn runInit(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.InitArgs) !void {
-    _ = args;
     const path = try paths.configFilePath(allocator);
     defer allocator.free(path);
 
@@ -284,7 +599,7 @@ fn runInit(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Init
         };
     }
 
-    const starter_config =
+    const generic_starter_config =
         \\{
         \\  "version": 1,
         \\  "defaults": {
@@ -383,12 +698,132 @@ fn runInit(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Init
         \\  }
         \\}
     ;
+    const codex_max_starter_config =
+        \\{
+        \\  "version": 1,
+        \\  "defaults": {
+        \\    "provider": "codex",
+        \\    "strategy": "health-weighted",
+        \\    "shell": "fish"
+        \\  },
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "config_dir_env": "CODEX_HOME",
+        \\      "accounts": {
+        \\        "max-1": {
+        \\          "priority": 30,
+        \\          "config_dir": "~/.local/share/oauth-mux/codex/max-1",
+        \\          "secret": {
+        \\            "backend": "file",
+        \\            "path": "~/.local/share/oauth-mux/codex/max-1/auth.json"
+        \\          },
+        \\          "tags": ["subscription", "codex-max"]
+        \\        },
+        \\        "max-2": {
+        \\          "priority": 20,
+        \\          "config_dir": "~/.local/share/oauth-mux/codex/max-2",
+        \\          "secret": {
+        \\            "backend": "file",
+        \\            "path": "~/.local/share/oauth-mux/codex/max-2/auth.json"
+        \\          },
+        \\          "tags": ["subscription", "codex-max"]
+        \\        },
+        \\        "max-3": {
+        \\          "priority": 10,
+        \\          "config_dir": "~/.local/share/oauth-mux/codex/max-3",
+        \\          "secret": {
+        \\            "backend": "file",
+        \\            "path": "~/.local/share/oauth-mux/codex/max-3/auth.json"
+        \\          },
+        \\          "tags": ["subscription", "codex-max"]
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "codex-max": {
+        \\      "providers": [
+        \\        "codex:max-1#codex-max",
+        \\        "codex:max-2#codex-max",
+        \\        "codex:max-3#codex-max"
+        \\      ],
+        \\      "strategy": "health-weighted",
+        \\      "affinity_ttl_minutes": 20
+        \\    },
+        \\    "codex-mini": {
+        \\      "providers": [
+        \\        "codex:max-1#codex-mini",
+        \\        "codex:max-2#codex-mini",
+        \\        "codex:max-3#codex-mini"
+        \\      ],
+        \\      "strategy": "health-weighted",
+        \\      "affinity_ttl_minutes": 20
+        \\    }
+        \\  },
+        \\  "strategies": {
+        \\    "health-weighted": {
+        \\      "kind": "health-weighted",
+        \\      "rate_limit_penalty": -10,
+        \\      "failure_penalty": -20,
+        \\      "success_bonus": 1
+        \\    }
+        \\  }
+        \\}
+    ;
+    const starter_config = if (args.codex_max)
+        codex_max_starter_config
+    else
+        generic_starter_config;
 
     const file = try std.fs.createFileAbsolute(path, .{});
     defer file.close();
     try file.writeAll(starter_config);
 
     try writer.print("created {s}\n", .{path});
+}
+
+test "matchesProvider filters account keys" {
+    try std.testing.expect(matchesProvider("codex:max-1", "codex"));
+    try std.testing.expect(matchesProvider("codex:max-1#codex-max", "codex"));
+    try std.testing.expect(matchesProvider("codex", "codex"));
+    try std.testing.expect(!matchesProvider("codexish:max-1", "codex"));
+    try std.testing.expect(!matchesProvider("claude:work", "codex"));
+}
+
+test "writeHealthJson includes redacted liveness" {
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+
+    store.recordHttpStatus("codex:max-1", 429, 30);
+    store.recordHttpStatus("claude:work", 401, null);
+
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+
+    try writeHealthJson(buf.writer(), &store, "codex");
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"key\":\"codex:max-1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"provider\":\"codex\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"account\":\"max-1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"availability\":\"rate_limited\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"last_probe\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"hint_class\":\"rate_limit\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "claude:work") == null);
+}
+
+test "writeHealthJson includes capability routes" {
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+
+    store.recordCapabilityHttpStatus("codex", "max-1", "codex-max", 429, 7200);
+
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+
+    try writeHealthJson(buf.writer(), &store, "codex");
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"key\":\"codex:max-1#codex-max\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"capability\":\"codex-max\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"availability\":\"quota_exhausted\"") != null);
 }
 
 // Pull in all module tests
@@ -404,7 +839,9 @@ comptime {
     _ = @import("provider.zig");
     _ = @import("pipeline.zig");
     _ = @import("oauth.zig");
+    _ = @import("probe.zig");
     _ = @import("age.zig");
     _ = @import("daemon.zig");
     _ = @import("provider_schema.zig");
+    _ = @import("fixture_redaction.zig");
 }

--- a/src/paths.zig
+++ b/src/paths.zig
@@ -1,38 +1,36 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const env = @import("env.zig");
 
 pub const app_name = "oauth-mux";
 
 pub fn configDir(allocator: std.mem.Allocator) ![]const u8 {
-    if (std.posix.getenv("OMUX_CONFIG_DIR")) |dir| {
-        return try allocator.dupe(u8, dir);
-    }
+    if (try env.get(allocator, "OMUX_CONFIG_DIR")) |dir| return dir;
     return xdgOrMacOS(allocator, "XDG_CONFIG_HOME", ".config", "Application Support");
 }
 
 pub fn stateDir(allocator: std.mem.Allocator) ![]const u8 {
-    if (std.posix.getenv("OMUX_STATE_DIR")) |dir| {
-        return try allocator.dupe(u8, dir);
-    }
+    if (try env.get(allocator, "OMUX_STATE_DIR")) |dir| return dir;
     return xdgOrMacOS(allocator, "XDG_STATE_HOME", ".local/state", "Application Support");
 }
 
 pub fn runtimeDir(allocator: std.mem.Allocator) ![]const u8 {
-    if (std.posix.getenv("XDG_RUNTIME_DIR")) |dir| {
+    if (try env.get(allocator, "XDG_RUNTIME_DIR")) |dir| {
+        defer allocator.free(dir);
         return std.fs.path.join(allocator, &.{ dir, app_name });
     }
     if (comptime builtin.os.tag == .macos) {
-        const uid = std.posix.getenv("UID") orelse "501";
+        const uid = (try env.get(allocator, "UID")) orelse try allocator.dupe(u8, "501");
+        defer allocator.free(uid);
         return std.fmt.allocPrint(allocator, "/tmp/{s}-{s}", .{ app_name, uid });
     }
-    const home = std.posix.getenv("HOME") orelse "/tmp";
+    const home = (try env.get(allocator, "HOME")) orelse try allocator.dupe(u8, "/tmp");
+    defer allocator.free(home);
     return std.fs.path.join(allocator, &.{ home, ".local", "state", app_name });
 }
 
 pub fn configFilePath(allocator: std.mem.Allocator) ![]const u8 {
-    if (std.posix.getenv("OMUX_CONFIG")) |path| {
-        return try allocator.dupe(u8, path);
-    }
+    if (try env.get(allocator, "OMUX_CONFIG")) |path| return path;
     const dir = try configDir(allocator);
     defer allocator.free(dir);
     return std.fs.path.join(allocator, &.{ dir, "config.json" });
@@ -56,10 +54,12 @@ fn xdgOrMacOS(
     linux_default_suffix: []const u8,
     macos_dir_name: []const u8,
 ) ![]const u8 {
-    if (std.posix.getenv(xdg_env)) |base| {
+    if (try env.get(allocator, xdg_env)) |base| {
+        defer allocator.free(base);
         return std.fs.path.join(allocator, &.{ base, app_name });
     }
-    const home = std.posix.getenv("HOME") orelse return error.OutOfMemory;
+    const home = (try env.get(allocator, "HOME")) orelse return error.OutOfMemory;
+    defer allocator.free(home);
     if (comptime builtin.os.tag == .macos) {
         return std.fs.path.join(allocator, &.{ home, "Library", macos_dir_name, app_name });
     }
@@ -69,7 +69,8 @@ fn xdgOrMacOS(
 pub fn expandTilde(allocator: std.mem.Allocator, path: []const u8) ![]const u8 {
     if (path.len == 0) return try allocator.dupe(u8, path);
     if (path[0] != '~') return try allocator.dupe(u8, path);
-    const home = std.posix.getenv("HOME") orelse return try allocator.dupe(u8, path);
+    const home = (try env.get(allocator, "HOME")) orelse return try allocator.dupe(u8, path);
+    defer allocator.free(home);
     if (path.len == 1) return try allocator.dupe(u8, home);
     return std.fs.path.join(allocator, &.{ home, path[2..] });
 }

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -9,6 +9,8 @@ const shell_mod = @import("shell.zig");
 const paths = @import("paths.zig");
 const log = @import("log.zig");
 const oauth = @import("oauth.zig");
+const probe = @import("probe.zig");
+const env = @import("env.zig");
 
 pub const Context = struct {
     allocator: std.mem.Allocator,
@@ -17,12 +19,16 @@ pub const Context = struct {
     provider_name: ?[]const u8 = null,
     provider_kind: ?types.ProviderKind = null,
     account_name: ?[]const u8 = null,
+    capability_name: ?[]const u8 = null,
     token: ?provider.TokenFields = null,
     health: *health_mod.HealthStore,
     env_pairs: std.ArrayList([2][]const u8),
     allocated_values: std.ArrayList([]const u8),
     target_argv: []const []const u8 = &.{},
     shell: types.ShellKind = .posix,
+    last_probe_executed: bool = false,
+    last_probe_status: ?u16 = null,
+    last_probe_decision: ?types.MuxDecision = null,
 
     pub fn init(allocator: std.mem.Allocator, cfg: config_mod.Config, store: *health_mod.HealthStore) Context {
         return .{
@@ -71,6 +77,11 @@ pub fn runEnv(ctx: *Context) PipelineError!void {
     try injectEnv(ctx);
 }
 
+pub fn runProbe(ctx: *Context) PipelineError!void {
+    try resolveProvider(ctx);
+    try selectWithFallback(ctx);
+}
+
 /// The retry loop: try each candidate account in priority order.
 /// On failure, record the typed failure and move to the next candidate.
 fn selectWithFallback(ctx: *Context) PipelineError!void {
@@ -78,10 +89,17 @@ fn selectWithFallback(ctx: *Context) PipelineError!void {
     if (candidates.len == 0) return error.AllAccountsExhausted;
 
     var last_err: PipelineError = error.AllAccountsExhausted;
+    var skipped_providers: [32][]const u8 = undefined;
+    var skipped_provider_count: usize = 0;
 
     for (candidates) |candidate| {
-        const key = accountKey(candidate.provider, candidate.account);
-        const decision = ctx.health.muxDecision(key.slice());
+        if (providerWasSkipped(skipped_providers[0..skipped_provider_count], candidate.provider)) {
+            log.debug("pipeline: skip {s}:{s} (provider already skipped)", .{ candidate.provider, candidate.account });
+            continue;
+        }
+
+        const key = health_mod.accountKey(candidate.provider, candidate.account);
+        const decision = ctx.health.muxDecisionFor(candidate.provider, candidate.account, candidate.capability);
 
         switch (decision) {
             .try_next_account => {
@@ -89,6 +107,10 @@ fn selectWithFallback(ctx: *Context) PipelineError!void {
                 continue;
             },
             .try_next_provider => {
+                if (skipped_provider_count < skipped_providers.len) {
+                    skipped_providers[skipped_provider_count] = candidate.provider;
+                    skipped_provider_count += 1;
+                }
                 log.debug("pipeline: skip {s}:{s} (health: try_next_provider)", .{ candidate.provider, candidate.account });
                 continue;
             },
@@ -107,30 +129,43 @@ fn selectWithFallback(ctx: *Context) PipelineError!void {
         // Set context for this attempt
         ctx.provider_name = candidate.provider;
         ctx.account_name = candidate.account;
-        ctx.provider_kind = types.ProviderKind.fromString(candidate.provider);
+        ctx.capability_name = candidate.capability;
+        ctx.provider_kind = config_mod.resolveProviderKind(ctx.cfg, candidate.provider);
 
         // Try the read → validate path
         readSecret(ctx) catch |e| {
             ctx.health.recordFailure(key.slice(), .auth_failure);
             last_err = e;
-            // Free any partial token before retrying
-            if (ctx.token) |tok| {
-                ctx.allocator.free(tok.access_token);
-                if (tok.refresh_token) |rt| ctx.allocator.free(rt);
-                ctx.token = null;
-            }
+            freeCurrentToken(ctx);
             continue;
         };
 
         validateToken(ctx) catch |e| {
             last_err = e;
-            if (ctx.token) |tok| {
-                ctx.allocator.free(tok.access_token);
-                if (tok.refresh_token) |rt| ctx.allocator.free(rt);
-                ctx.token = null;
-            }
+            freeCurrentToken(ctx);
             continue;
         };
+
+        const post_probe_decision = probeCapability(ctx) catch |e| {
+            last_err = e;
+            freeCurrentToken(ctx);
+            continue;
+        };
+        switch (post_probe_decision) {
+            .use_this => {},
+            .try_next_provider => {
+                if (skipped_provider_count < skipped_providers.len) {
+                    skipped_providers[skipped_provider_count] = candidate.provider;
+                    skipped_provider_count += 1;
+                }
+                freeCurrentToken(ctx);
+                continue;
+            },
+            .try_next_account, .wait_and_retry, .give_up => {
+                freeCurrentToken(ctx);
+                continue;
+            },
+        }
 
         // Success — this account works
         log.info("pipeline: using {s}:{s}", .{ candidate.provider, candidate.account });
@@ -140,9 +175,25 @@ fn selectWithFallback(ctx: *Context) PipelineError!void {
     return last_err;
 }
 
+fn providerWasSkipped(skipped_providers: []const []const u8, provider_name: []const u8) bool {
+    for (skipped_providers) |skipped| {
+        if (std.mem.eql(u8, skipped, provider_name)) return true;
+    }
+    return false;
+}
+
+fn freeCurrentToken(ctx: *Context) void {
+    if (ctx.token) |tok| {
+        ctx.allocator.free(tok.access_token);
+        if (tok.refresh_token) |rt| ctx.allocator.free(rt);
+        ctx.token = null;
+    }
+}
+
 const Candidate = struct {
     provider: []const u8,
     account: []const u8,
+    capability: ?[]const u8 = null,
     priority: i32,
 };
 
@@ -162,12 +213,16 @@ fn gatherCandidates(ctx: *Context) []const Candidate {
                     if (ctx.provider_name) |filter| {
                         if (!std.mem.eql(u8, pa.provider, filter)) continue;
                     }
+                    if (ctx.account_name) |account_filter| {
+                        if (!std.mem.eql(u8, pa.account, account_filter)) continue;
+                    }
                     if (count < S.buf.len) {
                         const prov_cfg = ctx.cfg.providers.map.get(pa.provider) orelse continue;
                         const acct_cfg = prov_cfg.accounts.map.get(pa.account) orelse continue;
                         S.buf[count] = .{
                             .provider = pa.provider,
                             .account = pa.account,
+                            .capability = pa.capability orelse ctx.capability_name,
                             .priority = acct_cfg.priority,
                         };
                         count += 1;
@@ -182,15 +237,30 @@ fn gatherCandidates(ctx: *Context) []const Candidate {
         const prov_name = ctx.provider_name orelse ctx.cfg.defaults.provider orelse return S.buf[0..0];
         const prov_cfg = ctx.cfg.providers.map.get(prov_name) orelse return S.buf[0..0];
 
-        var it = prov_cfg.accounts.map.iterator();
-        while (it.next()) |entry| {
-            if (count < S.buf.len) {
-                S.buf[count] = .{
-                    .provider = prov_name,
-                    .account = entry.key_ptr.*,
-                    .priority = entry.value_ptr.priority,
-                };
-                count += 1;
+        if (ctx.account_name) |account_filter| {
+            if (prov_cfg.accounts.map.get(account_filter)) |acct_cfg| {
+                if (count < S.buf.len) {
+                    S.buf[count] = .{
+                        .provider = prov_name,
+                        .account = account_filter,
+                        .capability = ctx.capability_name,
+                        .priority = acct_cfg.priority,
+                    };
+                    count += 1;
+                }
+            }
+        } else {
+            var it = prov_cfg.accounts.map.iterator();
+            while (it.next()) |entry| {
+                if (count < S.buf.len) {
+                    S.buf[count] = .{
+                        .provider = prov_name,
+                        .account = entry.key_ptr.*,
+                        .capability = ctx.capability_name,
+                        .priority = entry.value_ptr.priority,
+                    };
+                    count += 1;
+                }
             }
         }
     }
@@ -214,7 +284,7 @@ fn resolveProvider(ctx: *Context) PipelineError!void {
     // If provider already set (from CLI flag), use it
     if (ctx.provider_name != null) {
         if (ctx.provider_name) |name| {
-            ctx.provider_kind = types.ProviderKind.fromString(name);
+            ctx.provider_kind = config_mod.resolveProviderKind(ctx.cfg, name);
         }
         return;
     }
@@ -223,31 +293,26 @@ fn resolveProvider(ctx: *Context) PipelineError!void {
     if (ctx.target_argv.len > 0) {
         if (provider.detectProvider(ctx.target_argv)) |kind| {
             ctx.provider_kind = kind;
-            ctx.provider_name = kind.displayName();
+            ctx.provider_name = @tagName(kind);
             log.debug("pipeline: auto-detected provider {s}", .{kind.displayName()});
             return;
         }
     }
 
-    // Use profile's first provider
+    // A profile supplies an ordered mux lane. Leave provider_name unset here so
+    // gatherCandidates can fan out across every provider listed in the profile.
+    // Explicit --provider and target-command detection are handled above and
+    // still act as provider filters.
     if (ctx.profile_name) |pname| {
         if (ctx.cfg.profiles.map.get(pname)) |profile| {
-            if (profile.providers.len > 0) {
-                const spec = profile.providers[0];
-                if (splitProviderAccount(spec)) |pa| {
-                    ctx.provider_name = pa.provider;
-                    ctx.account_name = pa.account;
-                    ctx.provider_kind = types.ProviderKind.fromString(pa.provider);
-                    return;
-                }
-            }
+            if (profile.providers.len > 0) return;
         }
     }
 
     // Fall back to config default
     if (ctx.cfg.defaults.provider) |def| {
         ctx.provider_name = def;
-        ctx.provider_kind = types.ProviderKind.fromString(def);
+        ctx.provider_kind = config_mod.resolveProviderKind(ctx.cfg, def);
         return;
     }
 
@@ -265,38 +330,27 @@ fn readSecret(ctx: *Context) PipelineError!void {
 
     const raw = secret.read(backend, ctx.allocator) catch |e| {
         log.err("secret: {s}:{s}: {s}", .{ prov_name, acct_name, @errorName(e) });
-        const key = accountKey(prov_name, acct_name);
+        const key = health_mod.accountKey(prov_name, acct_name);
         ctx.health.recordFailure(key.slice(), .auth_failure);
         return error.SecretReadFailed;
     };
     defer ctx.allocator.free(raw);
 
-    // Schema-driven parsing: look up provider definition, parse generically
-    if (provider_schema.findBuiltin(prov_name)) |def| {
-        const generic = provider_schema.parseTokenGeneric(def, raw, ctx.allocator) catch {
-            log.debug("token: schema parse failed for {s}:{s}, trying legacy parser", .{ prov_name, acct_name });
-            // Fall through to legacy parser
-            const kind = ctx.provider_kind orelse types.ProviderKind.fromString(prov_name) orelse return error.ProviderNotFound;
-            ctx.token = provider.parseToken(kind, raw, ctx.allocator) catch {
-                log.err("token: parse failed for {s}:{s}", .{ prov_name, acct_name });
-                return error.TokenParseFailed;
-            };
-            return;
-        };
-        ctx.token = .{
-            .access_token = generic.access_token,
-            .refresh_token = generic.refresh_token,
-            .token_type = generic.token_type,
-            .expires_at = generic.expires_at,
+    const def = config_mod.resolveProviderDefinition(ctx.cfg, prov_name);
+    const generic = provider_schema.parseTokenGeneric(def, raw, ctx.allocator) catch {
+        log.debug("token: schema parse failed for {s}:{s}, trying legacy parser", .{ prov_name, acct_name });
+        const kind = ctx.provider_kind orelse return error.ProviderNotFound;
+        ctx.token = provider.parseToken(kind, raw, ctx.allocator) catch {
+            log.err("token: parse failed for {s}:{s}", .{ prov_name, acct_name });
+            return error.TokenParseFailed;
         };
         return;
-    }
-
-    // No schema definition — use legacy hardcoded parser
-    const kind = ctx.provider_kind orelse types.ProviderKind.fromString(prov_name) orelse return error.ProviderNotFound;
-    ctx.token = provider.parseToken(kind, raw, ctx.allocator) catch {
-        log.err("token: parse failed for {s}:{s}", .{ prov_name, acct_name });
-        return error.TokenParseFailed;
+    };
+    ctx.token = .{
+        .access_token = generic.access_token,
+        .refresh_token = generic.refresh_token,
+        .token_type = generic.token_type,
+        .expires_at = generic.expires_at,
     };
 }
 
@@ -304,12 +358,12 @@ fn validateToken(ctx: *Context) PipelineError!void {
     const tok = ctx.token orelse return error.TokenParseFailed;
     const prov = ctx.provider_name orelse return error.ProviderNotFound;
     const acct = ctx.account_name orelse return error.AccountNotFound;
-    const kind = ctx.provider_kind orelse return error.ProviderNotFound;
 
     // API keys don't expire
     if (tok.token_type == .api_key) {
-        const key = accountKey(prov, acct);
+        const key = health_mod.accountKey(prov, acct);
         ctx.health.recordSuccess(key.slice());
+        ctx.health.recordProbeEvidence(key.slice(), .credential_validation, null, .none, .use_this);
         return;
     }
 
@@ -319,28 +373,143 @@ fn validateToken(ctx: *Context) PipelineError!void {
         if (now >= exp - 30) {
             if (tok.refresh_token) |rt| {
                 log.info("token: expired for {s}:{s}, attempting refresh", .{ prov, acct });
-                try attemptRefresh(ctx, kind, rt);
+                try attemptRefresh(ctx, rt);
             } else {
                 return error.TokenExpired;
             }
         }
     }
 
-    const key = accountKey(prov, acct);
+    const key = health_mod.accountKey(prov, acct);
     ctx.health.recordSuccess(key.slice());
+    ctx.health.recordProbeEvidence(key.slice(), .credential_validation, null, .none, .use_this);
 }
 
-fn attemptRefresh(ctx: *Context, kind: types.ProviderKind, rt: []const u8) PipelineError!void {
-    const url = oauth.refreshUrl(kind) orelse {
-        log.warn("token: no refresh URL for {s}", .{kind.displayName()});
+fn probeCapability(ctx: *Context) PipelineError!types.MuxDecision {
+    const capability = ctx.capability_name orelse return .use_this;
+    const tok = ctx.token orelse return error.TokenParseFailed;
+    const prov = ctx.provider_name orelse return error.ProviderNotFound;
+    const acct = ctx.account_name orelse return error.AccountNotFound;
+    const def = config_mod.resolveProviderDefinition(ctx.cfg, prov);
+    const plan = provider_schema.probePlanForCapability(def, capability) orelse return .use_this;
+
+    var probe_env = buildProbeEnv(ctx, prov, acct, def, plan) catch |e| switch (e) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.ConfigValidationError,
+    };
+    defer probe_env.deinit();
+
+    const result = probe.execute(ctx.allocator, plan, tok.access_token, probe_env.pairs.items) catch |e| switch (e) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.UnsupportedMethod, error.UnsupportedTransport => return error.ConfigValidationError,
+        error.NetworkError => return error.NetworkError,
+    };
+    defer result.deinit(ctx.allocator);
+
+    const classification = probe.classifyResult(ctx.allocator, def, plan, result);
+    ctx.last_probe_executed = true;
+    ctx.last_probe_status = result.status;
+    var evidence_key: health_mod.KeyBuf = undefined;
+    switch (classification) {
+        .dead => {
+            const key = health_mod.accountKey(prov, acct);
+            ctx.health.recordHttpClassification(key.slice(), result.status, classification);
+            evidence_key = key;
+        },
+        else => {
+            const key = health_mod.capabilityKey(prov, acct, capability);
+            ctx.health.recordHttpClassification(key.slice(), result.status, classification);
+            evidence_key = key;
+        },
+    }
+
+    const decision = ctx.health.muxDecisionFor(prov, acct, capability);
+    ctx.last_probe_decision = decision;
+    ctx.health.recordProbeEvidence(
+        evidence_key.slice(),
+        .capability_probe,
+        result.retry_after_s,
+        health_mod.hintClassFromClassification(classification),
+        decision,
+    );
+    return decision;
+}
+
+const ProbeEnv = struct {
+    allocator: std.mem.Allocator,
+    pairs: std.ArrayList([2][]const u8),
+    allocated_values: std.ArrayList([]const u8),
+
+    fn init(allocator: std.mem.Allocator) ProbeEnv {
+        return .{
+            .allocator = allocator,
+            .pairs = std.ArrayList([2][]const u8).init(allocator),
+            .allocated_values = std.ArrayList([]const u8).init(allocator),
+        };
+    }
+
+    fn deinit(self: *ProbeEnv) void {
+        for (self.allocated_values.items) |value| self.allocator.free(value);
+        self.allocated_values.deinit();
+        self.pairs.deinit();
+    }
+
+    fn addOwned(self: *ProbeEnv, key: []const u8, owned_value: []const u8) !void {
+        self.allocated_values.append(owned_value) catch {
+            self.allocator.free(owned_value);
+            return error.OutOfMemory;
+        };
+        self.pairs.append(.{ key, owned_value }) catch return error.OutOfMemory;
+    }
+
+    fn addBorrowed(self: *ProbeEnv, key: []const u8, value: []const u8) !void {
+        self.pairs.append(.{ key, value }) catch return error.OutOfMemory;
+    }
+};
+
+fn buildProbeEnv(
+    ctx: *Context,
+    prov: []const u8,
+    acct: []const u8,
+    def: provider_schema.ProviderDefinition,
+    plan: provider_schema.ProbePlan,
+) !ProbeEnv {
+    var probe_env = ProbeEnv.init(ctx.allocator);
+    errdefer probe_env.deinit();
+
+    if (plan.transport != .command) return probe_env;
+
+    const prov_cfg = ctx.cfg.providers.map.get(prov) orelse return error.ProviderNotFound;
+    const acct_cfg = prov_cfg.accounts.map.get(acct) orelse return error.AccountNotFound;
+    const config_dir_env = providerConfigDirEnv(prov_cfg, def, ctx.provider_kind);
+
+    if (acct_cfg.config_dir) |dir| {
+        if (config_dir_env) |env_var| {
+            const expanded = paths.expandTilde(ctx.allocator, dir) catch return error.OutOfMemory;
+            try probe_env.addOwned(env_var, expanded);
+        }
+    }
+
+    try probe_env.addBorrowed("OMUX_ACTIVE_PROVIDER", prov);
+    try probe_env.addBorrowed("OMUX_ACTIVE_ACCOUNT", acct);
+    try probe_env.addBorrowed("OMUX_ACTIVE_CAPABILITY", plan.capability);
+    if (ctx.profile_name) |profile| try probe_env.addBorrowed("OMUX_ACTIVE_PROFILE", profile);
+
+    return probe_env;
+}
+
+fn attemptRefresh(ctx: *Context, rt: []const u8) PipelineError!void {
+    const prov = ctx.provider_name orelse return error.ProviderNotFound;
+    const def = config_mod.resolveProviderDefinition(ctx.cfg, prov);
+    const url = def.auth.token_endpoint orelse fallbackRefreshUrl(ctx) orelse {
+        log.warn("token: no refresh URL for {s}", .{prov});
         return error.TokenRefreshFailed;
     };
 
-    const result = oauth.refreshToken(ctx.allocator, url, rt, null) catch |e| {
+    const result = oauth.refreshToken(ctx.allocator, url, rt, def.auth.client_id) catch |e| {
         log.err("token: refresh failed: {s}", .{@errorName(e)});
-        const prov = ctx.provider_name orelse return error.ProviderNotFound;
         const acct = ctx.account_name orelse return error.AccountNotFound;
-        const key = accountKey(prov, acct);
+        const key = health_mod.accountKey(prov, acct);
         ctx.health.recordFailure(key.slice(), .auth_failure);
         return error.TokenRefreshFailed;
     };
@@ -359,43 +528,44 @@ fn attemptRefresh(ctx: *Context, kind: types.ProviderKind, rt: []const u8) Pipel
     log.info("token: refreshed successfully", .{});
 }
 
+fn fallbackRefreshUrl(ctx: *Context) ?[]const u8 {
+    const kind = ctx.provider_kind orelse return null;
+    return oauth.refreshUrl(kind);
+}
+
 fn injectEnv(ctx: *Context) PipelineError!void {
     const tok = ctx.token orelse return error.TokenParseFailed;
-    const kind = ctx.provider_kind orelse return error.ProviderNotFound;
     const prov_name = ctx.provider_name orelse return error.ProviderNotFound;
     const acct_name = ctx.account_name orelse return error.AccountNotFound;
+    const def = config_mod.resolveProviderDefinition(ctx.cfg, prov_name);
 
     // Check for persistent config_dir on the account
     const prov_cfg = ctx.cfg.providers.map.get(prov_name) orelse return error.ProviderNotFound;
     const acct_cfg = prov_cfg.accounts.map.get(acct_name) orelse return error.AccountNotFound;
+    const config_dir_env = providerConfigDirEnv(prov_cfg, def, ctx.provider_kind);
 
     if (acct_cfg.config_dir) |dir| {
         // Persistent config dir mode
-        if (kind.configDirEnv()) |env_var| {
+        if (config_dir_env) |env_var| {
             const expanded = paths.expandTilde(ctx.allocator, dir) catch return error.OutOfMemory;
             ctx.addEnvOwned(env_var, expanded) catch return error.OutOfMemory;
         }
-    } else if (kind.configDirEnv()) |env_var| {
+    } else if (config_dir_env) |env_var| {
         // Tmpdir mode: write credential file to temp dir
-        const cred_content = provider.buildCredentialFile(kind, tok, ctx.allocator) catch return error.OutOfMemory;
+        const schema_token = schemaTokenFromProviderToken(tok);
+        const cred_content = provider_schema.buildCredentialGeneric(def, schema_token, ctx.allocator) catch return error.OutOfMemory;
         defer ctx.allocator.free(cred_content);
 
-        const tmp_dir = createTmpCredDir(ctx.allocator, kind, cred_content) catch return error.OutOfMemory;
+        const tmp_dir = createTmpCredDir(ctx.allocator, def.injection.credential_filename, cred_content) catch return error.OutOfMemory;
         ctx.addEnvOwned(env_var, tmp_dir) catch return error.OutOfMemory;
     }
 
-    // For providers without config dir isolation, inject token directly as env var
-    switch (kind) {
-        .github => {
-            ctx.env_pairs.append(.{ "GH_TOKEN", tok.access_token }) catch return error.OutOfMemory;
-        },
-        .vercel => {
-            ctx.env_pairs.append(.{ "VERCEL_TOKEN", tok.access_token }) catch return error.OutOfMemory;
-        },
-        .mcp => {
-            ctx.env_pairs.append(.{ "MCP_TOKEN", tok.access_token }) catch return error.OutOfMemory;
-        },
-        else => {},
+    if (def.injection.direct_env) |direct_env| {
+        for (direct_env) |mapping| {
+            if (tokenFieldValue(tok, mapping[1])) |value| {
+                ctx.env_pairs.append(.{ mapping[0], value }) catch return error.OutOfMemory;
+            }
+        }
     }
 
     // Breadcrumb env vars
@@ -404,11 +574,40 @@ fn injectEnv(ctx: *Context) PipelineError!void {
     if (ctx.profile_name) |pn| {
         ctx.env_pairs.append(.{ "OMUX_ACTIVE_PROFILE", pn }) catch return error.OutOfMemory;
     }
+    if (ctx.capability_name) |capability| {
+        ctx.env_pairs.append(.{ "OMUX_ACTIVE_CAPABILITY", capability }) catch return error.OutOfMemory;
+    }
 }
 
-fn createTmpCredDir(allocator: std.mem.Allocator, kind: types.ProviderKind, content: []const u8) ![]const u8 {
-    const fname = provider.credentialFileName(kind);
-    const tmp_base = std.posix.getenv("TMPDIR") orelse "/tmp";
+fn providerConfigDirEnv(
+    prov_cfg: config_mod.ProviderConfig,
+    def: provider_schema.ProviderDefinition,
+    kind: ?types.ProviderKind,
+) ?[]const u8 {
+    if (prov_cfg.config_dir_env) |env_var| return env_var;
+    if (def.injection.config_dir_env) |env_var| return env_var;
+    if (kind) |k| return k.configDirEnv();
+    return null;
+}
+
+fn schemaTokenFromProviderToken(tok: provider.TokenFields) provider_schema.TokenFields {
+    return .{
+        .access_token = tok.access_token,
+        .refresh_token = tok.refresh_token,
+        .token_type = tok.token_type,
+        .expires_at = tok.expires_at,
+    };
+}
+
+fn tokenFieldValue(tok: provider.TokenFields, field: []const u8) ?[]const u8 {
+    if (std.mem.eql(u8, field, "access_token")) return tok.access_token;
+    if (std.mem.eql(u8, field, "refresh_token")) return tok.refresh_token;
+    return null;
+}
+
+fn createTmpCredDir(allocator: std.mem.Allocator, fname: []const u8, content: []const u8) ![]const u8 {
+    const tmp_base = (try env.get(allocator, "TMPDIR")) orelse try allocator.dupe(u8, "/tmp");
+    defer allocator.free(tmp_base);
     const dir_path = std.fmt.allocPrint(allocator, "{s}/oauth-mux-{d}", .{ tmp_base, std.time.timestamp() }) catch return error.OutOfMemory;
 
     std.fs.makeDirAbsolute(dir_path) catch |e| switch (e) {
@@ -429,50 +628,431 @@ fn createTmpCredDir(allocator: std.mem.Allocator, kind: types.ProviderKind, cont
 const ProviderAccount = struct {
     provider: []const u8,
     account: []const u8,
+    capability: ?[]const u8 = null,
 };
 
 fn splitProviderAccount(spec: []const u8) ?ProviderAccount {
-    if (std.mem.indexOf(u8, spec, ":")) |idx| {
-        return .{
-            .provider = spec[0..idx],
-            .account = spec[idx + 1 ..],
-        };
-    }
-    return null;
-}
-
-const KeyBuf = struct {
-    buf: [128]u8 = undefined,
-    len: usize = 0,
-
-    fn slice(self: *const KeyBuf) []const u8 {
-        return self.buf[0..self.len];
-    }
-};
-
-fn accountKey(prov: []const u8, acct: []const u8) KeyBuf {
-    var kb = KeyBuf{};
-    for (prov) |c| {
-        if (kb.len >= 127) break;
-        kb.buf[kb.len] = c;
-        kb.len += 1;
-    }
-    if (kb.len < 127) {
-        kb.buf[kb.len] = ':';
-        kb.len += 1;
-    }
-    for (acct) |c| {
-        if (kb.len >= 127) break;
-        kb.buf[kb.len] = c;
-        kb.len += 1;
-    }
-    return kb;
+    const parsed = health_mod.parseHealthKey(spec) orelse return null;
+    return .{
+        .provider = parsed.provider,
+        .account = parsed.account,
+        .capability = parsed.capability,
+    };
 }
 
 test "splitProviderAccount" {
     const pa = splitProviderAccount("claude:work").?;
     try std.testing.expectEqualStrings("claude", pa.provider);
     try std.testing.expectEqualStrings("work", pa.account);
+    try std.testing.expect(pa.capability == null);
+
+    const route = splitProviderAccount("codex:max-1#codex-max").?;
+    try std.testing.expectEqualStrings("codex", route.provider);
+    try std.testing.expectEqualStrings("max-1", route.account);
+    try std.testing.expectEqualStrings("codex-max", route.capability.?);
 
     try std.testing.expect(splitProviderAccount("nocolon") == null);
+}
+
+test "runEnv uses configured provider definition" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const auth_file = try tmp.dir.createFile("toy-auth.json", .{});
+    defer auth_file.close();
+    try auth_file.writeAll(
+        \\{"tokens":{"access":"toy-at","refresh":"toy-rt"}}
+    );
+
+    const auth_path = try tmp.dir.realpathAlloc(std.testing.allocator, "toy-auth.json");
+    defer std.testing.allocator.free(auth_path);
+
+    const json = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "defaults": {{ "provider": "toy" }},
+        \\  "provider_definitions": {{
+        \\    "toy": {{
+        \\      "name": "toy",
+        \\      "credential": {{
+        \\        "access_token_path": "tokens.access",
+        \\        "refresh_token_path": "tokens.refresh"
+        \\      }},
+        \\      "injection": {{
+        \\        "direct_env": [["TOY_TOKEN", "access_token"]]
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "providers": {{
+        \\    "toy": {{
+        \\      "kind": "toy",
+        \\      "accounts": {{
+        \\        "default": {{
+        \\          "secret": {{ "backend": "file", "path": "{s}" }}
+        \\        }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{}},
+        \\  "strategies": {{}}
+        \\}}
+    ,
+        .{auth_path},
+    );
+    defer std.testing.allocator.free(json);
+
+    const parsed = try config_mod.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+
+    var ctx = Context.init(std.testing.allocator, parsed.value, &store);
+    defer ctx.deinit();
+
+    try runEnv(&ctx);
+
+    try std.testing.expectEqualStrings("toy", ctx.provider_name.?);
+    try std.testing.expect(ctx.provider_kind == null);
+    try expectEnvPair(ctx.env_pairs.items, "TOY_TOKEN", "toy-at");
+    try expectEnvPair(ctx.env_pairs.items, "OMUX_ACTIVE_PROVIDER", "toy");
+    try expectEnvPair(ctx.env_pairs.items, "OMUX_ACTIVE_ACCOUNT", "default");
+}
+
+test "runEnv honors capability route health from profile" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex1 = try tmp.dir.createFile("codex-1.json", .{});
+    defer codex1.close();
+    try codex1.writeAll(
+        \\{"auth_mode":"chatgpt","tokens":{"access_token":"codex-one","refresh_token":"codex-rt"}}
+    );
+
+    const codex2 = try tmp.dir.createFile("codex-2.json", .{});
+    defer codex2.close();
+    try codex2.writeAll(
+        \\{"auth_mode":"chatgpt","tokens":{"access_token":"codex-two","refresh_token":"codex-rt"}}
+    );
+
+    const codex1_path = try tmp.dir.realpathAlloc(std.testing.allocator, "codex-1.json");
+    defer std.testing.allocator.free(codex1_path);
+    const codex2_path = try tmp.dir.realpathAlloc(std.testing.allocator, "codex-2.json");
+    defer std.testing.allocator.free(codex2_path);
+
+    const json = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "defaults": {{ "provider": "codex" }},
+        \\  "provider_definitions": {{
+        \\    "toy": {{
+        \\      "name": "toy",
+        \\      "credential": {{
+        \\        "access_token_path": "tokens.access_token",
+        \\        "refresh_token_path": "tokens.refresh_token"
+        \\      }},
+        \\      "injection": {{ "direct_env": [["TOY_TOKEN", "access_token"]] }}
+        \\    }}
+        \\  }},
+        \\  "providers": {{
+        \\    "codex": {{
+        \\      "kind": "toy",
+        \\      "accounts": {{
+        \\        "max-1": {{ "priority": 30, "secret": {{ "backend": "file", "path": "{s}" }} }},
+        \\        "max-2": {{ "priority": 20, "secret": {{ "backend": "file", "path": "{s}" }} }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{
+        \\    "mux": {{ "providers": ["codex:max-1#codex-route", "codex:max-2#codex-route"] }}
+        \\  }},
+        \\  "strategies": {{}}
+        \\}}
+    ,
+        .{ codex1_path, codex2_path },
+    );
+    defer std.testing.allocator.free(json);
+
+    const parsed = try config_mod.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    store.recordCapabilityHttpStatus("codex", "max-1", "codex-route", 429, 7200);
+
+    var ctx = Context.init(std.testing.allocator, parsed.value, &store);
+    defer ctx.deinit();
+    ctx.profile_name = "mux";
+
+    try runEnv(&ctx);
+
+    try std.testing.expectEqualStrings("codex", ctx.provider_name.?);
+    try std.testing.expectEqualStrings("max-2", ctx.account_name.?);
+    try std.testing.expectEqualStrings("codex-route", ctx.capability_name.?);
+    try expectEnvPair(ctx.env_pairs.items, "OMUX_ACTIVE_ACCOUNT", "max-2");
+    try expectEnvPair(ctx.env_pairs.items, "OMUX_ACTIVE_CAPABILITY", "codex-route");
+}
+
+test "runEnv routes around degraded capability without poisoning account" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex1 = try tmp.dir.createFile("codex-1.json", .{});
+    defer codex1.close();
+    try codex1.writeAll(
+        \\{"auth_mode":"chatgpt","tokens":{"access_token":"codex-one","refresh_token":"codex-rt"}}
+    );
+
+    const codex2 = try tmp.dir.createFile("codex-2.json", .{});
+    defer codex2.close();
+    try codex2.writeAll(
+        \\{"auth_mode":"chatgpt","tokens":{"access_token":"codex-two","refresh_token":"codex-rt"}}
+    );
+
+    const codex1_path = try tmp.dir.realpathAlloc(std.testing.allocator, "codex-1.json");
+    defer std.testing.allocator.free(codex1_path);
+    const codex2_path = try tmp.dir.realpathAlloc(std.testing.allocator, "codex-2.json");
+    defer std.testing.allocator.free(codex2_path);
+
+    const json = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "provider_definitions": {{
+        \\    "codex": {{
+        \\      "name": "codex",
+        \\      "display_name": "Synthetic Codex",
+        \\      "credential": {{
+        \\        "access_token_path": "tokens.access_token",
+        \\        "refresh_token_path": "tokens.refresh_token"
+        \\      }},
+        \\      "injection": {{
+        \\        "direct_env": [["OPENAI_API_KEY", "access_token"]]
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "defaults": {{ "provider": "codex" }},
+        \\  "providers": {{
+        \\    "codex": {{
+        \\      "kind": "codex",
+        \\      "accounts": {{
+        \\        "max-1": {{ "priority": 30, "secret": {{ "backend": "file", "path": "{s}" }} }},
+        \\        "max-2": {{ "priority": 20, "secret": {{ "backend": "file", "path": "{s}" }} }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{
+        \\    "max": {{ "providers": ["codex:max-1#codex-max", "codex:max-2#codex-max"] }},
+        \\    "mini": {{ "providers": ["codex:max-1#codex-mini", "codex:max-2#codex-mini"] }}
+        \\  }},
+        \\  "strategies": {{}}
+        \\}}
+    ,
+        .{ codex1_path, codex2_path },
+    );
+    defer std.testing.allocator.free(json);
+
+    const parsed = try config_mod.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    const degraded_route = health_mod.capabilityKey("codex", "max-1", "codex-max");
+    store.recordHttpClassification(
+        degraded_route.slice(),
+        403,
+        .{ .degraded = .tier_insufficient },
+    );
+
+    var max_ctx = Context.init(std.testing.allocator, parsed.value, &store);
+    defer max_ctx.deinit();
+    max_ctx.profile_name = "max";
+
+    try runEnv(&max_ctx);
+
+    try std.testing.expectEqualStrings("max-2", max_ctx.account_name.?);
+    try std.testing.expectEqualStrings("codex-max", max_ctx.capability_name.?);
+    try expectEnvPair(max_ctx.env_pairs.items, "OMUX_ACTIVE_ACCOUNT", "max-2");
+    try expectEnvPair(max_ctx.env_pairs.items, "OMUX_ACTIVE_CAPABILITY", "codex-max");
+
+    var mini_ctx = Context.init(std.testing.allocator, parsed.value, &store);
+    defer mini_ctx.deinit();
+    mini_ctx.profile_name = "mini";
+
+    try runEnv(&mini_ctx);
+
+    try std.testing.expectEqualStrings("max-1", mini_ctx.account_name.?);
+    try std.testing.expectEqualStrings("codex-mini", mini_ctx.capability_name.?);
+    try expectEnvPair(mini_ctx.env_pairs.items, "OMUX_ACTIVE_ACCOUNT", "max-1");
+    try expectEnvPair(mini_ctx.env_pairs.items, "OMUX_ACTIVE_CAPABILITY", "codex-mini");
+}
+
+test "runProbe honors explicit account filter without a configured probe plan" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex1 = try tmp.dir.createFile("codex-1.json", .{});
+    defer codex1.close();
+    try codex1.writeAll(
+        \\{"auth_mode":"chatgpt","tokens":{"access_token":"codex-one","refresh_token":"codex-rt"}}
+    );
+
+    const codex2 = try tmp.dir.createFile("codex-2.json", .{});
+    defer codex2.close();
+    try codex2.writeAll(
+        \\{"auth_mode":"chatgpt","tokens":{"access_token":"codex-two","refresh_token":"codex-rt"}}
+    );
+
+    const codex1_path = try tmp.dir.realpathAlloc(std.testing.allocator, "codex-1.json");
+    defer std.testing.allocator.free(codex1_path);
+    const codex2_path = try tmp.dir.realpathAlloc(std.testing.allocator, "codex-2.json");
+    defer std.testing.allocator.free(codex2_path);
+
+    const json = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "defaults": {{ "provider": "codex" }},
+        \\  "providers": {{
+        \\    "codex": {{
+        \\      "kind": "codex",
+        \\      "accounts": {{
+        \\        "max-1": {{ "priority": 30, "secret": {{ "backend": "file", "path": "{s}" }} }},
+        \\        "max-2": {{ "priority": 20, "secret": {{ "backend": "file", "path": "{s}" }} }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{}},
+        \\  "strategies": {{}}
+        \\}}
+    ,
+        .{ codex1_path, codex2_path },
+    );
+    defer std.testing.allocator.free(json);
+
+    const parsed = try config_mod.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+
+    var ctx = Context.init(std.testing.allocator, parsed.value, &store);
+    defer ctx.deinit();
+    ctx.provider_name = "codex";
+    ctx.account_name = "max-2";
+    ctx.capability_name = "codex-route";
+
+    try runProbe(&ctx);
+
+    try std.testing.expectEqualStrings("codex", ctx.provider_name.?);
+    try std.testing.expectEqualStrings("max-2", ctx.account_name.?);
+    try std.testing.expectEqualStrings("codex-route", ctx.capability_name.?);
+    try std.testing.expect(!ctx.last_probe_executed);
+    try std.testing.expect(store.accounts.get("codex:max-2") != null);
+    try std.testing.expect(store.accounts.get("codex:max-1") == null);
+}
+
+test "runEnv skips remaining accounts for degraded provider" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const codex1 = try tmp.dir.createFile("codex-1.json", .{});
+    defer codex1.close();
+    try codex1.writeAll(
+        \\{"auth_mode":"chatgpt","tokens":{"access_token":"codex-one","refresh_token":"codex-rt"}}
+    );
+
+    const codex2 = try tmp.dir.createFile("codex-2.json", .{});
+    defer codex2.close();
+    try codex2.writeAll(
+        \\{"auth_mode":"chatgpt","tokens":{"access_token":"codex-two","refresh_token":"codex-rt"}}
+    );
+
+    const toy_file = try tmp.dir.createFile("toy.json", .{});
+    defer toy_file.close();
+    try toy_file.writeAll(
+        \\{"tokens":{"access":"toy-at"}}
+    );
+
+    const codex1_path = try tmp.dir.realpathAlloc(std.testing.allocator, "codex-1.json");
+    defer std.testing.allocator.free(codex1_path);
+    const codex2_path = try tmp.dir.realpathAlloc(std.testing.allocator, "codex-2.json");
+    defer std.testing.allocator.free(codex2_path);
+    const toy_path = try tmp.dir.realpathAlloc(std.testing.allocator, "toy.json");
+    defer std.testing.allocator.free(toy_path);
+
+    const json = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "defaults": {{ "provider": "codex" }},
+        \\  "provider_definitions": {{
+        \\    "toy": {{
+        \\      "name": "toy",
+        \\      "credential": {{ "access_token_path": "tokens.access" }},
+        \\      "injection": {{ "direct_env": [["TOY_TOKEN", "access_token"]] }}
+        \\    }}
+        \\  }},
+        \\  "providers": {{
+        \\    "codex": {{
+        \\      "kind": "codex",
+        \\      "accounts": {{
+        \\        "max-1": {{ "priority": 30, "secret": {{ "backend": "file", "path": "{s}" }} }},
+        \\        "max-2": {{ "priority": 20, "secret": {{ "backend": "file", "path": "{s}" }} }}
+        \\      }}
+        \\    }},
+        \\    "toy": {{
+        \\      "kind": "toy",
+        \\      "accounts": {{
+        \\        "default": {{ "priority": 10, "secret": {{ "backend": "file", "path": "{s}" }} }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{
+        \\    "mux": {{ "providers": ["codex:max-1", "codex:max-2", "toy:default"] }}
+        \\  }},
+        \\  "strategies": {{}}
+        \\}}
+    ,
+        .{ codex1_path, codex2_path, toy_path },
+    );
+    defer std.testing.allocator.free(json);
+
+    const parsed = try config_mod.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    store.recordHttpClassification("codex:max-1", 500, .provider_degraded);
+
+    var ctx = Context.init(std.testing.allocator, parsed.value, &store);
+    defer ctx.deinit();
+    ctx.profile_name = "mux";
+
+    try runEnv(&ctx);
+
+    try std.testing.expectEqualStrings("toy", ctx.provider_name.?);
+    try std.testing.expectEqualStrings("default", ctx.account_name.?);
+    try expectEnvPair(ctx.env_pairs.items, "TOY_TOKEN", "toy-at");
+    try expectMissingEnvValue(ctx.env_pairs.items, "OMUX_ACTIVE_ACCOUNT", "max-2");
+}
+
+fn expectEnvPair(pairs: []const [2][]const u8, key: []const u8, value: []const u8) !void {
+    for (pairs) |pair| {
+        if (std.mem.eql(u8, pair[0], key)) {
+            try std.testing.expectEqualStrings(value, pair[1]);
+            return;
+        }
+    }
+    return error.TestUnexpectedResult;
+}
+
+fn expectMissingEnvValue(pairs: []const [2][]const u8, key: []const u8, value: []const u8) !void {
+    for (pairs) |pair| {
+        if (std.mem.eql(u8, pair[0], key) and std.mem.eql(u8, pair[1], value)) {
+            return error.TestUnexpectedResult;
+        }
+    }
 }

--- a/src/probe.zig
+++ b/src/probe.zig
@@ -1,0 +1,523 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const types = @import("types.zig");
+const provider_schema = @import("provider_schema.zig");
+
+pub const ProbeError = error{
+    UnsupportedMethod,
+    UnsupportedTransport,
+    NetworkError,
+    OutOfMemory,
+};
+
+pub const ProbeResult = struct {
+    status: u16,
+    retry_after_s: ?u32 = null,
+    hint: ?[]const u8 = null,
+
+    pub fn deinit(self: ProbeResult, allocator: std.mem.Allocator) void {
+        if (self.hint) |hint| allocator.free(hint);
+    }
+};
+
+pub fn classifyResult(
+    allocator: std.mem.Allocator,
+    def: provider_schema.ProviderDefinition,
+    plan: provider_schema.ProbePlan,
+    result: ProbeResult,
+) types.HttpClassification {
+    if (plan.transport == .command) {
+        if (std.mem.eql(u8, def.name, "codex")) {
+            if (result.hint) |hint| {
+                if (provider_schema.classifyCodexExecJsonl(allocator, hint)) |classification| {
+                    return classification;
+                }
+            }
+        }
+    }
+
+    const classified = provider_schema.classifyHttp(def, result.status, result.retry_after_s, result.hint);
+    if (result.status >= plan.success_status_min and result.status <= plan.success_status_max) {
+        return if (classified == .success) .success else classified;
+    }
+    return classified;
+}
+
+pub fn execute(
+    allocator: std.mem.Allocator,
+    plan: provider_schema.ProbePlan,
+    access_token: []const u8,
+    env_pairs: []const [2][]const u8,
+) ProbeError!ProbeResult {
+    return switch (plan.transport) {
+        .http => executeHttp(allocator, plan, access_token),
+        .command => executeCommand(allocator, plan, env_pairs),
+    };
+}
+
+fn executeHttp(
+    allocator: std.mem.Allocator,
+    plan: provider_schema.ProbePlan,
+    access_token: []const u8,
+) ProbeError!ProbeResult {
+    const method = methodFromString(plan.method) orelse return error.UnsupportedMethod;
+    const resolved_url = try expandUrlTemplate(allocator, plan.url);
+    defer allocator.free(resolved_url);
+    const uri = std.Uri.parse(resolved_url) catch return error.NetworkError;
+
+    var bearer_value: ?[]u8 = null;
+    defer if (bearer_value) |value| allocator.free(value);
+
+    var headers_buf: [4]std.http.Header = undefined;
+    var header_count: usize = 0;
+    headers_buf[header_count] = .{ .name = "Accept", .value = "application/json" };
+    header_count += 1;
+
+    switch (plan.auth) {
+        .bearer => {
+            bearer_value = std.fmt.allocPrint(allocator, "Bearer {s}", .{access_token}) catch return error.OutOfMemory;
+            headers_buf[header_count] = .{ .name = "Authorization", .value = bearer_value.? };
+            header_count += 1;
+        },
+        .token_header => {
+            const header_name = plan.auth_header orelse return error.UnsupportedTransport;
+            headers_buf[header_count] = .{ .name = header_name, .value = access_token };
+            header_count += 1;
+        },
+        .none => {},
+    }
+
+    if (plan.body != null) {
+        headers_buf[header_count] = .{ .name = "Content-Type", .value = plan.content_type orelse "application/json" };
+        header_count += 1;
+    }
+
+    var client = std.http.Client{ .allocator = allocator };
+    defer client.deinit();
+
+    var server_header_buf: [16 * 1024]u8 = undefined;
+    var req = client.open(method, uri, .{
+        .server_header_buffer = &server_header_buf,
+        .extra_headers = headers_buf[0..header_count],
+    }) catch return error.NetworkError;
+    defer req.deinit();
+
+    if (plan.body) |body| {
+        req.transfer_encoding = .{ .content_length = body.len };
+    }
+
+    req.send() catch return error.NetworkError;
+    if (plan.body) |body| {
+        req.writeAll(body) catch return error.NetworkError;
+    }
+    req.finish() catch return error.NetworkError;
+    req.wait() catch return error.NetworkError;
+
+    var response_buf: [64 * 1024]u8 = undefined;
+    const response_len = req.readAll(&response_buf) catch return error.NetworkError;
+    const body_hint = if (plan.hint_body and plan.hint_header == null)
+        allocator.dupe(u8, response_buf[0..response_len]) catch return error.OutOfMemory
+    else
+        null;
+    errdefer if (body_hint) |hint| allocator.free(hint);
+
+    return .{
+        .status = @intFromEnum(req.response.status),
+        .retry_after_s = retryAfterSeconds(req.response),
+        .hint = if (plan.hint_header) |header_name|
+            try dupeHeaderValue(allocator, req.response, header_name)
+        else
+            body_hint,
+    };
+}
+
+fn expandUrlTemplate(allocator: std.mem.Allocator, template: []const u8) ProbeError![]const u8 {
+    var out = std.ArrayList(u8).init(allocator);
+    errdefer out.deinit();
+
+    var offset: usize = 0;
+    while (std.mem.indexOfPos(u8, template, offset, "{{")) |start| {
+        try out.appendSlice(template[offset..start]);
+        const name_start = start + 2;
+        const end = std.mem.indexOfPos(u8, template, name_start, "}}") orelse return error.UnsupportedTransport;
+        const name = template[name_start..end];
+        if (!isSafeTemplateName(name)) return error.UnsupportedTransport;
+
+        const value = std.process.getEnvVarOwned(allocator, name) catch |e| switch (e) {
+            error.EnvironmentVariableNotFound => return error.UnsupportedTransport,
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.UnsupportedTransport,
+        };
+        defer allocator.free(value);
+        if (!isSafeTemplateValue(value)) return error.UnsupportedTransport;
+        try out.appendSlice(value);
+        offset = end + 2;
+    }
+
+    if (std.mem.indexOfPos(u8, template, offset, "}}") != null) return error.UnsupportedTransport;
+    try out.appendSlice(template[offset..]);
+    return try out.toOwnedSlice();
+}
+
+fn isSafeTemplateName(name: []const u8) bool {
+    if (name.len == 0) return false;
+    for (name) |c| {
+        if (std.ascii.isAlphanumeric(c) or c == '_') continue;
+        return false;
+    }
+    return true;
+}
+
+fn isSafeTemplateValue(value: []const u8) bool {
+    if (value.len == 0) return false;
+    for (value) |c| {
+        if (std.ascii.isAlphanumeric(c) or c == '-' or c == '.' or c == '_' or c == '~') continue;
+        return false;
+    }
+    return true;
+}
+
+fn executeCommand(
+    allocator: std.mem.Allocator,
+    plan: provider_schema.ProbePlan,
+    env_pairs: []const [2][]const u8,
+) ProbeError!ProbeResult {
+    const argv = plan.command orelse return error.UnsupportedTransport;
+    if (argv.len == 0) return error.UnsupportedTransport;
+
+    var env_map = std.process.getEnvMap(allocator) catch return error.OutOfMemory;
+    defer env_map.deinit();
+    for (env_pairs) |pair| {
+        env_map.put(pair[0], pair[1]) catch return error.OutOfMemory;
+    }
+
+    var child = std.process.Child.init(argv, allocator);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+    child.env_map = &env_map;
+
+    child.spawn() catch |e| {
+        const hint = std.fmt.allocPrint(allocator, "probe command spawn failed: {s}", .{@errorName(e)}) catch return error.OutOfMemory;
+        return .{ .status = 500, .hint = hint };
+    };
+
+    const output = collectCommandOutput(allocator, &child, plan.timeout_ms) catch |e| switch (e) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => {
+            const hint = std.fmt.allocPrint(allocator, "probe command wait failed: {s}", .{@errorName(e)}) catch return error.OutOfMemory;
+            return .{ .status = 500, .hint = hint };
+        },
+    };
+    defer output.deinit(allocator);
+
+    const joined = joinCommandOutput(allocator, output.stdout, output.stderr) catch return error.OutOfMemory;
+    errdefer allocator.free(joined);
+
+    if (output.timed_out) {
+        const hint = std.fmt.allocPrint(allocator, "probe command timed out after {d}ms\n{s}", .{ plan.timeout_ms, joined }) catch return error.OutOfMemory;
+        allocator.free(joined);
+        return .{ .status = 408, .hint = hint };
+    }
+
+    const status: u16 = switch (output.term) {
+        .Exited => |code| if (code == 0) 200 else 400,
+        else => 500,
+    };
+
+    return .{ .status = status, .hint = joined };
+}
+
+fn joinCommandOutput(allocator: std.mem.Allocator, stdout: []const u8, stderr: []const u8) ![]const u8 {
+    if (stderr.len == 0) return try allocator.dupe(u8, stdout);
+    if (stdout.len == 0) return try allocator.dupe(u8, stderr);
+
+    var out = try std.ArrayList(u8).initCapacity(allocator, stdout.len + 1 + stderr.len);
+    errdefer out.deinit();
+    try out.appendSlice(stdout);
+    if (stdout[stdout.len - 1] != '\n') try out.append('\n');
+    try out.appendSlice(stderr);
+    return try out.toOwnedSlice();
+}
+
+const CommandOutput = struct {
+    stdout: []const u8,
+    stderr: []const u8,
+    term: std.process.Child.Term,
+    timed_out: bool = false,
+
+    fn deinit(self: CommandOutput, allocator: std.mem.Allocator) void {
+        allocator.free(self.stdout);
+        allocator.free(self.stderr);
+    }
+};
+
+fn collectCommandOutput(
+    allocator: std.mem.Allocator,
+    child: *std.process.Child,
+    timeout_ms: u32,
+) ProbeError!CommandOutput {
+    var stdout_buf = std.ArrayListUnmanaged(u8){};
+    errdefer stdout_buf.deinit(allocator);
+    var stderr_buf = std.ArrayListUnmanaged(u8){};
+    errdefer stderr_buf.deinit(allocator);
+
+    const timed = try collectOutputWithTimeout(
+        allocator,
+        child,
+        &stdout_buf,
+        &stderr_buf,
+        1024 * 1024,
+        timeout_ms,
+    );
+
+    const term = if (timed)
+        child.kill() catch return error.NetworkError
+    else
+        child.wait() catch return error.NetworkError;
+
+    const stdout = stdout_buf.toOwnedSlice(allocator) catch return error.OutOfMemory;
+    errdefer allocator.free(stdout);
+    const stderr = stderr_buf.toOwnedSlice(allocator) catch return error.OutOfMemory;
+
+    return .{
+        .stdout = stdout,
+        .stderr = stderr,
+        .term = term,
+        .timed_out = timed,
+    };
+}
+
+fn collectOutputWithTimeout(
+    allocator: std.mem.Allocator,
+    child: *std.process.Child,
+    stdout: *std.ArrayListUnmanaged(u8),
+    stderr: *std.ArrayListUnmanaged(u8),
+    max_output_bytes: usize,
+    timeout_ms: u32,
+) ProbeError!bool {
+    var poller = std.io.poll(allocator, enum { stdout, stderr }, .{
+        .stdout = child.stdout.?,
+        .stderr = child.stderr.?,
+    });
+    defer poller.deinit();
+
+    const timeout_ns = @as(i128, timeout_ms) * @as(i128, std.time.ns_per_ms);
+    const deadline_ns = std.time.nanoTimestamp() + timeout_ns;
+
+    while (true) {
+        if (poller.fifo(.stdout).readableLength() > max_output_bytes or
+            poller.fifo(.stderr).readableLength() > max_output_bytes)
+        {
+            _ = child.kill() catch {};
+            return error.NetworkError;
+        }
+
+        const now = std.time.nanoTimestamp();
+        if (now >= deadline_ns) {
+            try appendPollFifo(allocator, stdout, poller.fifo(.stdout));
+            try appendPollFifo(allocator, stderr, poller.fifo(.stderr));
+            return true;
+        }
+
+        const remaining_ns = deadline_ns - now;
+        const poll_ns_i = @min(remaining_ns, @as(i128, 50 * std.time.ns_per_ms));
+        const keep_polling = poller.pollTimeout(@intCast(poll_ns_i)) catch |e| switch (e) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.NetworkError,
+        };
+        if (!keep_polling) {
+            try appendPollFifo(allocator, stdout, poller.fifo(.stdout));
+            try appendPollFifo(allocator, stderr, poller.fifo(.stderr));
+            return false;
+        }
+    }
+}
+
+fn appendPollFifo(
+    allocator: std.mem.Allocator,
+    list: *std.ArrayListUnmanaged(u8),
+    fifo: *std.io.PollFifo,
+) !void {
+    var offset: usize = 0;
+    const total = fifo.readableLength();
+    while (offset < total) {
+        const chunk = fifo.readableSlice(offset);
+        if (chunk.len == 0) break;
+        try list.appendSlice(allocator, chunk);
+        offset += chunk.len;
+    }
+}
+
+fn methodFromString(method: []const u8) ?std.http.Method {
+    if (std.mem.eql(u8, method, "GET")) return .GET;
+    if (std.mem.eql(u8, method, "POST")) return .POST;
+    if (std.mem.eql(u8, method, "HEAD")) return .HEAD;
+    return null;
+}
+
+fn retryAfterSeconds(response: std.http.Client.Response) ?u32 {
+    const value = headerValue(response, "retry-after") orelse return null;
+    return std.fmt.parseInt(u32, std.mem.trim(u8, value, " \t"), 10) catch null;
+}
+
+fn dupeHeaderValue(
+    allocator: std.mem.Allocator,
+    response: std.http.Client.Response,
+    name: []const u8,
+) !?[]const u8 {
+    const value = headerValue(response, name) orelse return null;
+    return try allocator.dupe(u8, value);
+}
+
+fn headerValue(response: std.http.Client.Response, name: []const u8) ?[]const u8 {
+    var it = response.iterateHeaders();
+    while (it.next()) |header| {
+        if (std.ascii.eqlIgnoreCase(header.name, name)) return header.value;
+    }
+    return null;
+}
+
+test "classifyResult honors probe success range" {
+    const plan = provider_schema.ProbePlan{
+        .capability = "chat:max",
+        .transport = .http,
+        .method = "POST",
+        .url = "https://example.invalid/v1/probe",
+        .auth = .bearer,
+        .timeout_ms = 30_000,
+        .success_status_min = 202,
+        .success_status_max = 204,
+    };
+
+    try std.testing.expectEqual(
+        types.HttpClassification.success,
+        classifyResult(std.testing.allocator, provider_schema.generic_def, plan, .{ .status = 204 }),
+    );
+}
+
+test "classifyResult falls back to provider failure rules" {
+    const plan = provider_schema.ProbePlan{
+        .capability = "chat:max",
+        .transport = .http,
+        .method = "POST",
+        .url = "https://example.invalid/v1/probe",
+        .auth = .bearer,
+        .timeout_ms = 30_000,
+        .success_status_min = 200,
+        .success_status_max = 299,
+    };
+    const result = ProbeResult{
+        .status = 429,
+        .retry_after_s = 7200,
+    };
+
+    const classified = classifyResult(std.testing.allocator, provider_schema.generic_def, plan, result);
+    switch (classified) {
+        .quota_exhausted => |quota| try std.testing.expectEqual(@as(u32, 7200), quota.retry_after_s),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "classifyResult uses hint text" {
+    const plan = provider_schema.ProbePlan{
+        .capability = "tools/design-context",
+        .transport = .http,
+        .method = "GET",
+        .url = "https://example.invalid/mcp",
+        .auth = .bearer,
+        .timeout_ms = 30_000,
+        .success_status_min = 200,
+        .success_status_max = 299,
+    };
+    const result = ProbeResult{
+        .status = 403,
+        .hint = "Bearer error=\"insufficient_scope\"",
+    };
+
+    const classified = classifyResult(std.testing.allocator, provider_schema.mcp_def, plan, result);
+    switch (classified) {
+        .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.scope_insufficient, reason),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "expandUrlTemplate rejects malformed placeholder" {
+    try std.testing.expectError(error.UnsupportedTransport, expandUrlTemplate(std.testing.allocator, "https://example.invalid/{{BAD"));
+    try std.testing.expectError(error.UnsupportedTransport, expandUrlTemplate(std.testing.allocator, "https://example.invalid/BAD}}"));
+    try std.testing.expectError(error.UnsupportedTransport, expandUrlTemplate(std.testing.allocator, "https://example.invalid/{{BAD-NAME}}"));
+}
+
+test "classifyResult can downgrade successful GraphQL status from body hint" {
+    const plan = provider_schema.ProbePlan{
+        .capability = "identity",
+        .transport = .http,
+        .method = "POST",
+        .url = "https://api.linear.app/graphql",
+        .body = "{\"query\":\"query Me { viewer { id name email } }\"}",
+        .content_type = "application/json",
+        .auth = .bearer,
+        .timeout_ms = 30_000,
+        .success_status_min = 200,
+        .success_status_max = 299,
+        .hint_body = true,
+    };
+    const result = ProbeResult{
+        .status = 200,
+        .hint = "{\"errors\":[{\"message\":\"Forbidden\"}]}",
+    };
+
+    const classified = classifyResult(std.testing.allocator, provider_schema.linear_def, plan, result);
+    switch (classified) {
+        .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.unknown_4xx, reason),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "classifyResult decodes codex command jsonl" {
+    const plan = provider_schema.ProbePlan{
+        .capability = "codex-mini",
+        .transport = .command,
+        .method = "GET",
+        .url = "",
+        .command = &.{ "codex", "exec" },
+        .auth = .none,
+        .timeout_ms = 30_000,
+        .success_status_min = 200,
+        .success_status_max = 299,
+    };
+    const result = ProbeResult{
+        .status = 400,
+        .hint =
+        \\{"type":"error","message":"{\"type\":\"error\",\"status\":400,\"error\":{\"message\":\"model is not supported when using Codex with a ChatGPT account\"}}"}
+        ,
+    };
+
+    const classified = classifyResult(std.testing.allocator, provider_schema.codex_def, plan, result);
+    switch (classified) {
+        .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.tier_insufficient, reason),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "execute command probe enforces timeout" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+
+    const plan = provider_schema.ProbePlan{
+        .capability = "toy",
+        .transport = .command,
+        .method = "GET",
+        .url = "",
+        .command = &.{ "sh", "-c", "while true; do :; done" },
+        .auth = .none,
+        .timeout_ms = 1,
+        .success_status_min = 200,
+        .success_status_max = 299,
+    };
+
+    const result = try execute(std.testing.allocator, plan, "", &.{});
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(u16, 408), result.status);
+    try std.testing.expect(std.mem.indexOf(u8, result.hint.?, "timed out") != null);
+}

--- a/src/provider_schema.zig
+++ b/src/provider_schema.zig
@@ -19,7 +19,7 @@ const log = @import("log.zig");
 // The schema is informed by:
 //   RFC 8414 — OAuth Authorization Server Metadata
 //   RFC 9728 — Protected Resource Metadata
-//   MCP Auth Spec (2025-11-25) — CIMD + Enterprise-Managed Authorization
+//   MCP Auth Spec (2025-11-25) — HTTP auth, stdio env credentials, CIMD
 //   RFC 9449 — DPoP (sender-constrained tokens)
 //   RFC 8628 — Device Authorization Grant
 
@@ -47,9 +47,20 @@ pub const ProviderDefinition = struct {
     // How to auto-detect this provider from the target command.
     detection: DetectionConfig = .{},
 
-    // ─�� Rate Limit Interpretation ──
+    // ── Capability Probes ──
+    // Optional route/capability probes. These are declarative plans, not
+    // secrets: token material is added by the caller at execution time.
+    capabilities: []const CapabilityDefinition = &.{},
+
+    // ── Rate Limit Interpretation ──
     // How to parse rate limit signals from HTTP responses.
     rate_limits: RateLimitConfig = .{},
+
+    // ── Failure Classification ──
+    // Provider-specific HTTP/status/body hints that override generic OAuth
+    // fallback classification. No regex; only exact status/range and substring
+    // hints so the parser remains std-only.
+    failure_rules: []const FailureRule = &.{},
 };
 
 pub const AuthConfig = struct {
@@ -104,6 +115,56 @@ pub const DetectionConfig = struct {
     env_markers: []const []const u8 = &.{},
 };
 
+pub const CapabilityDefinition = struct {
+    name: []const u8,
+    aliases: []const []const u8 = &.{},
+    probe: ?ProbeDefinition = null,
+};
+
+pub const ProbeDefinition = struct {
+    transport: ProbeTransport = .http,
+    method: []const u8 = "GET",
+    url: []const u8 = "",
+    body: ?[]const u8 = null,
+    content_type: ?[]const u8 = null,
+    command: ?[]const []const u8 = null,
+    auth: ProbeAuth = .bearer,
+    auth_header: ?[]const u8 = null,
+    timeout_ms: u32 = 30_000,
+    success_status_min: u16 = 200,
+    success_status_max: u16 = 299,
+    hint_header: ?[]const u8 = null,
+    hint_body: bool = false,
+};
+
+pub const ProbeTransport = enum {
+    http,
+    command,
+};
+
+pub const ProbeAuth = enum {
+    bearer,
+    token_header,
+    none,
+};
+
+pub const ProbePlan = struct {
+    capability: []const u8,
+    transport: ProbeTransport,
+    method: []const u8,
+    url: []const u8,
+    body: ?[]const u8 = null,
+    content_type: ?[]const u8 = null,
+    command: ?[]const []const u8 = null,
+    auth: ProbeAuth,
+    auth_header: ?[]const u8 = null,
+    timeout_ms: u32,
+    success_status_min: u16,
+    success_status_max: u16,
+    hint_header: ?[]const u8 = null,
+    hint_body: bool = false,
+};
+
 pub const RateLimitConfig = struct {
     // HTTP header names for rate limit info
     retry_after_header: []const u8 = "retry-after",
@@ -112,6 +173,26 @@ pub const RateLimitConfig = struct {
     limit_header: ?[]const u8 = null,
     // Threshold: retry_after above this (seconds) = quota exhaustion, below = rate limit
     quota_threshold_seconds: u32 = 3600,
+};
+
+pub const FailureRule = struct {
+    status: ?u16 = null,
+    status_min: ?u16 = null,
+    status_max: ?u16 = null,
+    retry_after_gte: ?u32 = null,
+    retry_after_lt: ?u32 = null,
+    hint_contains: ?[]const u8 = null,
+    class: FailureClass,
+};
+
+pub const FailureClass = union(enum) {
+    success,
+    rate_limited,
+    quota_exhausted,
+    degraded: types.DegradedReason,
+    dead: types.DeadReason,
+    provider_degraded,
+    failure,
 };
 
 // ── Built-in Provider Definitions ──
@@ -123,7 +204,329 @@ pub const builtin_providers = [_]ProviderDefinition{
     gemini_def,
     vercel_def,
     github_def,
+    linear_def,
+    figma_def,
+    flakehub_def,
     mcp_def,
+};
+
+pub const generic_def = ProviderDefinition{
+    .name = "generic",
+    .display_name = "Generic OAuth Provider",
+};
+
+const claude_failure_rules = [_]FailureRule{
+    .{
+        .status = 400,
+        .hint_contains = "\"loggedIn\": false",
+        .class = .{ .dead = .token_revoked },
+    },
+    .{
+        .status = 400,
+        .hint_contains = "\"loggedIn\":false",
+        .class = .{ .dead = .token_revoked },
+    },
+    .{
+        .status = 400,
+        .class = .{ .degraded = .unknown_4xx },
+    },
+    .{
+        .status_min = 500,
+        .status_max = 599,
+        .class = .provider_degraded,
+    },
+};
+
+const claude_capabilities = [_]CapabilityDefinition{
+    .{
+        .name = "auth-status",
+        .aliases = &.{ "status", "identity", "whoami" },
+        .probe = .{
+            .transport = .command,
+            .auth = .none,
+            .timeout_ms = 30_000,
+            .command = &.{ "claude", "auth", "status", "--json" },
+        },
+    },
+};
+
+const mcp_failure_rules = [_]FailureRule{
+    .{
+        .status = 403,
+        .hint_contains = "insufficient_scope",
+        .class = .{ .degraded = .scope_insufficient },
+    },
+    .{
+        .status = 403,
+        .hint_contains = "step_up",
+        .class = .{ .degraded = .step_up_required },
+    },
+    .{
+        .status = 403,
+        .hint_contains = "pending",
+        .class = .{ .degraded = .pending_verification },
+    },
+    .{
+        .status = 400,
+        .hint_contains = "schema",
+        .class = .{ .degraded = .schema_invalid },
+    },
+    .{
+        .status = 422,
+        .hint_contains = "schema",
+        .class = .{ .degraded = .schema_invalid },
+    },
+};
+
+const mcp_capabilities = [_]CapabilityDefinition{
+    .{
+        .name = "resource-metadata",
+        .aliases = &.{ "metadata", "protected-resource-metadata" },
+        .probe = .{
+            .method = "GET",
+            .url = "{{OMUX_MCP_RESOURCE_METADATA_URL}}",
+            .auth = .none,
+            .hint_body = true,
+        },
+    },
+    .{
+        .name = "resource",
+        .aliases = &.{ "resource-probe", "http" },
+        .probe = .{
+            .method = "GET",
+            .url = "{{OMUX_MCP_RESOURCE_PROBE_URL}}",
+            .auth = .bearer,
+            .hint_header = "www-authenticate",
+        },
+    },
+};
+
+const codex_failure_rules = [_]FailureRule{
+    .{
+        .status = 400,
+        .hint_contains = "not supported when using Codex with a ChatGPT account",
+        .class = .{ .degraded = .tier_insufficient },
+    },
+    .{
+        .status = 400,
+        .hint_contains = "model is not supported",
+        .class = .{ .degraded = .tier_insufficient },
+    },
+};
+
+const github_failure_rules = [_]FailureRule{
+    .{
+        .status = 403,
+        .hint_contains = "0",
+        .class = .rate_limited,
+    },
+    .{
+        .status = 403,
+        .class = .{ .degraded = .scope_insufficient },
+    },
+    .{
+        .status_min = 500,
+        .status_max = 599,
+        .class = .provider_degraded,
+    },
+};
+
+const vercel_failure_rules = [_]FailureRule{
+    .{
+        .status = 403,
+        .hint_contains = "scope",
+        .class = .{ .degraded = .scope_insufficient },
+    },
+    .{
+        .status = 403,
+        .class = .{ .degraded = .tier_insufficient },
+    },
+    .{
+        .status_min = 500,
+        .status_max = 599,
+        .class = .provider_degraded,
+    },
+};
+
+const vercel_capabilities = [_]CapabilityDefinition{
+    .{
+        .name = "identity",
+        .aliases = &.{ "user", "whoami" },
+        .probe = .{
+            .method = "GET",
+            .url = "https://api.vercel.com/v2/user",
+            .auth = .bearer,
+        },
+    },
+};
+
+const github_capabilities = [_]CapabilityDefinition{
+    .{
+        .name = "identity",
+        .aliases = &.{ "user", "whoami" },
+        .probe = .{
+            .method = "GET",
+            .url = "https://api.github.com/user",
+            .auth = .bearer,
+            .hint_header = "x-ratelimit-remaining",
+        },
+    },
+};
+
+const linear_failure_rules = [_]FailureRule{
+    .{
+        .status = 200,
+        .hint_contains = "\"errors\"",
+        .class = .{ .degraded = .unknown_4xx },
+    },
+    .{
+        .status = 403,
+        .class = .{ .degraded = .scope_insufficient },
+    },
+    .{
+        .status_min = 500,
+        .status_max = 599,
+        .class = .provider_degraded,
+    },
+};
+
+const linear_capabilities = [_]CapabilityDefinition{
+    .{
+        .name = "identity",
+        .aliases = &.{ "viewer", "whoami" },
+        .probe = .{
+            .method = "POST",
+            .url = "https://api.linear.app/graphql",
+            .body = "{\"query\":\"query Me { viewer { id name email } }\"}",
+            .content_type = "application/json",
+            .auth = .bearer,
+            .hint_body = true,
+        },
+    },
+};
+
+const figma_failure_rules = [_]FailureRule{
+    .{
+        .status = 403,
+        .class = .{ .degraded = .scope_insufficient },
+    },
+    .{
+        .status = 404,
+        .class = .{ .degraded = .unknown_4xx },
+    },
+    .{
+        .status_min = 500,
+        .status_max = 599,
+        .class = .provider_degraded,
+    },
+};
+
+const figma_capabilities = [_]CapabilityDefinition{
+    .{
+        .name = "identity",
+        .aliases = &.{ "me", "whoami" },
+        .probe = .{
+            .method = "GET",
+            .url = "https://api.figma.com/v1/me",
+            .auth = .bearer,
+        },
+    },
+    .{
+        .name = "identity-pat",
+        .aliases = &.{ "me-pat", "pat" },
+        .probe = .{
+            .method = "GET",
+            .url = "https://api.figma.com/v1/me",
+            .auth = .token_header,
+            .auth_header = "X-Figma-Token",
+        },
+    },
+    .{
+        .name = "file-metadata-plan",
+        .aliases = &.{ "plan-file-meta", "plan-file-metadata", "plan" },
+        .probe = .{
+            .method = "GET",
+            .url = "https://api.figma.com/v1/files/{{OMUX_FIGMA_PLAN_FILE_KEY}}/meta",
+            .auth = .token_header,
+            .auth_header = "X-Figma-Token",
+        },
+    },
+};
+
+const flakehub_failure_rules = [_]FailureRule{
+    .{
+        .status = 200,
+        .hint_contains = "Logged in: false",
+        .class = .{ .dead = .token_revoked },
+    },
+    .{
+        .status = 400,
+        .hint_contains = "Logged in: false",
+        .class = .{ .dead = .token_revoked },
+    },
+    .{
+        .status = 400,
+        .class = .{ .degraded = .unknown_4xx },
+    },
+    .{
+        .status_min = 500,
+        .status_max = 599,
+        .class = .provider_degraded,
+    },
+};
+
+const flakehub_capabilities = [_]CapabilityDefinition{
+    .{
+        .name = "status",
+        .aliases = &.{ "identity", "whoami" },
+        .probe = .{
+            .transport = .command,
+            .auth = .none,
+            .timeout_ms = 30_000,
+            .command = &.{ "determinate-nixd", "status" },
+        },
+    },
+};
+
+const codex_capabilities = [_]CapabilityDefinition{
+    .{
+        .name = "codex-max",
+        .aliases = &.{ "max", "gpt-5.3-codex", "gpt-5.1-codex-max" },
+        .probe = .{
+            .transport = .command,
+            .auth = .none,
+            .timeout_ms = 120_000,
+            .command = &.{
+                "codex",
+                "exec",
+                "--json",
+                "--ephemeral",
+                "--ignore-rules",
+                "-m",
+                "gpt-5.3-codex",
+                "Reply exactly: OMUX_CODEX_MAX_PROBE",
+            },
+        },
+    },
+    .{
+        .name = "codex-mini",
+        .aliases = &.{ "mini", "spark", "gpt-5.3-codex-spark", "gpt-5.1-codex-mini" },
+        .probe = .{
+            .transport = .command,
+            .auth = .none,
+            .timeout_ms = 120_000,
+            .command = &.{
+                "codex",
+                "exec",
+                "--json",
+                "--ephemeral",
+                "--ignore-rules",
+                "-m",
+                "gpt-5.3-codex-spark",
+                "Reply exactly: OMUX_CODEX_MINI_PROBE",
+            },
+        },
+    },
 };
 
 pub const claude_def = ProviderDefinition{
@@ -142,12 +545,14 @@ pub const claude_def = ProviderDefinition{
         .config_dir_env = "CLAUDE_CONFIG_DIR",
         .credential_filename = ".credentials.json",
         .credential_template =
-            \\{"claudeAiOauth":{"accessToken":"{{access_token}}","refreshToken":"{{refresh_token}}"}}
+        \\{"claudeAiOauth":{"accessToken":"{{access_token}}","refreshToken":"{{refresh_token}}"}}
         ,
     },
     .detection = .{
         .binary_names = &.{"claude"},
     },
+    .capabilities = &claude_capabilities,
+    .failure_rules = &claude_failure_rules,
     .rate_limits = .{
         .remaining_header = "x-ratelimit-remaining",
         .reset_header = "x-ratelimit-reset",
@@ -171,7 +576,7 @@ pub const codex_def = ProviderDefinition{
         .config_dir_env = "CODEX_HOME",
         .credential_filename = "auth.json",
         .credential_template =
-            \\{"auth_mode":"chatgpt","tokens":{"access_token":"{{access_token}}","refresh_token":"{{refresh_token}}"}}
+        \\{"auth_mode":"chatgpt","tokens":{"access_token":"{{access_token}}","refresh_token":"{{refresh_token}}"}}
         ,
     },
     .detection = .{
@@ -182,6 +587,8 @@ pub const codex_def = ProviderDefinition{
         .remaining_header = "x-ratelimit-remaining-requests",
         .reset_header = "x-ratelimit-reset-requests",
     },
+    .capabilities = &codex_capabilities,
+    .failure_rules = &codex_failure_rules,
 };
 
 pub const gemini_def = ProviderDefinition{
@@ -221,6 +628,8 @@ pub const vercel_def = ProviderDefinition{
     .detection = .{
         .binary_names = &.{"vercel"},
     },
+    .capabilities = &vercel_capabilities,
+    .failure_rules = &vercel_failure_rules,
 };
 
 pub const github_def = ProviderDefinition{
@@ -239,6 +648,66 @@ pub const github_def = ProviderDefinition{
     .detection = .{
         .binary_names = &.{"gh"},
     },
+    .capabilities = &github_capabilities,
+    .failure_rules = &github_failure_rules,
+};
+
+pub const linear_def = ProviderDefinition{
+    .name = "linear",
+    .display_name = "Linear",
+    .auth = .{
+        .authorization_endpoint = "https://linear.app/oauth/authorize",
+        .token_endpoint = "https://api.linear.app/oauth/token",
+    },
+    .credential = .{
+        .access_token_path = "access_token",
+        .refresh_token_path = "refresh_token",
+        .expires_in_path = "expires_in",
+    },
+    .injection = .{
+        .direct_env = &.{.{ "LINEAR_ACCESS_TOKEN", "access_token" }},
+    },
+    .detection = .{
+        .env_markers = &.{"LINEAR_ACCESS_TOKEN"},
+    },
+    .capabilities = &linear_capabilities,
+    .failure_rules = &linear_failure_rules,
+};
+
+pub const figma_def = ProviderDefinition{
+    .name = "figma",
+    .display_name = "Figma REST API",
+    .auth = .{
+        .authorization_endpoint = "https://www.figma.com/oauth",
+        .token_endpoint = "https://api.figma.com/v1/oauth/token",
+    },
+    .credential = .{
+        .access_token_path = "access_token",
+        .refresh_token_path = "refresh_token",
+        .expires_in_path = "expires_in",
+    },
+    .injection = .{
+        .direct_env = &.{.{ "FIGMA_ACCESS_TOKEN", "access_token" }},
+    },
+    .detection = .{
+        .env_markers = &.{"FIGMA_ACCESS_TOKEN"},
+    },
+    .capabilities = &figma_capabilities,
+    .failure_rules = &figma_failure_rules,
+};
+
+pub const flakehub_def = ProviderDefinition{
+    .name = "flakehub",
+    .display_name = "FlakeHub / Determinate Nix",
+    .credential = .{
+        .access_token_path = "token",
+        .token_type = "api_key",
+    },
+    .detection = .{
+        .binary_names = &.{ "determinate-nixd", "fh" },
+    },
+    .capabilities = &flakehub_capabilities,
+    .failure_rules = &flakehub_failure_rules,
 };
 
 pub const mcp_def = ProviderDefinition{
@@ -255,7 +724,200 @@ pub const mcp_def = ProviderDefinition{
     .injection = .{
         .direct_env = &.{.{ "MCP_TOKEN", "access_token" }},
     },
+    .capabilities = &mcp_capabilities,
+    .failure_rules = &mcp_failure_rules,
 };
+
+// ── HTTP Failure Classifier ──
+
+pub fn classifyHttp(
+    def: ProviderDefinition,
+    status: u16,
+    retry_after: ?u32,
+    hint: ?[]const u8,
+) types.HttpClassification {
+    for (def.failure_rules) |rule| {
+        if (!failureRuleMatches(rule, status, retry_after, hint)) continue;
+        return classificationFromRule(rule.class, retry_after);
+    }
+
+    if (status >= 200 and status <= 299) return .success;
+
+    if (status == 429) {
+        const wait = retry_after orelse 30;
+        if (wait > def.rate_limits.quota_threshold_seconds) {
+            return .{ .quota_exhausted = .{ .retry_after_s = wait } };
+        }
+        return .{ .rate_limited = .{
+            .retry_after_s = wait,
+            .window = windowFromRetryAfter(wait),
+        } };
+    }
+
+    if (status == 401) return .{ .dead = .token_revoked };
+
+    if (status == 403) {
+        if (hint) |h| {
+            if (containsIgnoreAsciiCase(h, "insufficient_scope") or containsIgnoreAsciiCase(h, "scope")) {
+                return .{ .degraded = .scope_insufficient };
+            }
+            if (containsIgnoreAsciiCase(h, "step_up")) {
+                return .{ .degraded = .step_up_required };
+            }
+            if (containsIgnoreAsciiCase(h, "pending") or containsIgnoreAsciiCase(h, "verification")) {
+                return .{ .degraded = .pending_verification };
+            }
+            if (containsIgnoreAsciiCase(h, "terms")) {
+                return .{ .degraded = .terms_required };
+            }
+        }
+        return .{ .degraded = .tier_insufficient };
+    }
+
+    if (status >= 500 and status <= 599) return .provider_degraded;
+
+    if (status >= 400 and status <= 499) return .{ .degraded = .unknown_4xx };
+
+    return .failure;
+}
+
+pub fn probePlanForCapability(def: ProviderDefinition, capability: []const u8) ?ProbePlan {
+    for (def.capabilities) |cap| {
+        if (!capabilityMatches(cap, capability)) continue;
+        const probe = cap.probe orelse return null;
+        return .{
+            .capability = cap.name,
+            .transport = probe.transport,
+            .method = probe.method,
+            .url = probe.url,
+            .body = probe.body,
+            .content_type = probe.content_type,
+            .command = probe.command,
+            .auth = probe.auth,
+            .auth_header = probe.auth_header,
+            .timeout_ms = probe.timeout_ms,
+            .success_status_min = probe.success_status_min,
+            .success_status_max = probe.success_status_max,
+            .hint_header = probe.hint_header,
+            .hint_body = probe.hint_body,
+        };
+    }
+    return null;
+}
+
+pub fn classifyCodexExecJsonl(allocator: std.mem.Allocator, jsonl: []const u8) ?types.HttpClassification {
+    var lines = std.mem.splitScalar(u8, jsonl, '\n');
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (trimmed.len == 0) continue;
+
+        const parsed = std.json.parseFromSlice(std.json.Value, allocator, trimmed, .{}) catch continue;
+        defer parsed.deinit();
+
+        if (resolveJsonString(parsed.value, "type")) |event_type| {
+            if (std.mem.eql(u8, event_type, "turn.completed")) return .success;
+
+            if (std.mem.eql(u8, event_type, "error")) {
+                if (resolveJsonString(parsed.value, "message")) |message| {
+                    return classifyCodexErrorMessage(allocator, message);
+                }
+            }
+        }
+
+        if (classifyCodexErrorValue(parsed.value)) |classification| return classification;
+    }
+
+    return null;
+}
+
+fn classifyCodexErrorMessage(allocator: std.mem.Allocator, message: []const u8) types.HttpClassification {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, message, .{}) catch {
+        return classifyHttp(codex_def, 400, null, message);
+    };
+    defer parsed.deinit();
+    return classifyCodexErrorValue(parsed.value) orelse classifyHttp(codex_def, 400, null, message);
+}
+
+fn classifyCodexErrorValue(value: std.json.Value) ?types.HttpClassification {
+    const status_i = resolveJsonInt(value, "status") orelse return null;
+    if (status_i < 0 or status_i > 65535) return null;
+    const status: u16 = @intCast(status_i);
+    const hint = resolveJsonString(value, "error.message");
+    return classifyHttp(codex_def, status, null, hint);
+}
+
+fn capabilityMatches(cap: CapabilityDefinition, requested: []const u8) bool {
+    if (std.mem.eql(u8, cap.name, requested)) return true;
+    for (cap.aliases) |alias| {
+        if (std.mem.eql(u8, alias, requested)) return true;
+    }
+    return false;
+}
+
+fn failureRuleMatches(rule: FailureRule, status: u16, retry_after: ?u32, hint: ?[]const u8) bool {
+    if (rule.status) |exact| {
+        if (status != exact) return false;
+    }
+    if (rule.status_min) |min| {
+        if (status < min) return false;
+    }
+    if (rule.status_max) |max| {
+        if (status > max) return false;
+    }
+    if (rule.retry_after_gte) |min_wait| {
+        const wait = retry_after orelse return false;
+        if (wait < min_wait) return false;
+    }
+    if (rule.retry_after_lt) |max_wait| {
+        const wait = retry_after orelse return false;
+        if (wait >= max_wait) return false;
+    }
+    if (rule.hint_contains) |needle| {
+        const h = hint orelse return false;
+        if (!containsIgnoreAsciiCase(h, needle)) return false;
+    }
+    return true;
+}
+
+fn classificationFromRule(class: FailureClass, retry_after: ?u32) types.HttpClassification {
+    return switch (class) {
+        .success => .success,
+        .rate_limited => blk: {
+            const wait = retry_after orelse 30;
+            break :blk .{ .rate_limited = .{
+                .retry_after_s = wait,
+                .window = windowFromRetryAfter(wait),
+            } };
+        },
+        .quota_exhausted => .{ .quota_exhausted = .{ .retry_after_s = retry_after orelse 3600 } },
+        .degraded => |reason| .{ .degraded = reason },
+        .dead => |reason| .{ .dead = reason },
+        .provider_degraded => .provider_degraded,
+        .failure => .failure,
+    };
+}
+
+fn windowFromRetryAfter(wait: u32) types.RateLimitWindow {
+    return if (wait <= 60) .per_minute else if (wait <= 3600) .per_hour else .per_day;
+}
+
+fn containsIgnoreAsciiCase(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len == 0) return true;
+    if (needle.len > haystack.len) return false;
+
+    var i: usize = 0;
+    while (i + needle.len <= haystack.len) : (i += 1) {
+        var matched = true;
+        for (needle, 0..) |needle_char, j| {
+            if (std.ascii.toLower(haystack[i + j]) != std.ascii.toLower(needle_char)) {
+                matched = false;
+                break;
+            }
+        }
+        if (matched) return true;
+    }
+    return false;
+}
 
 // ── JSON Path Resolver ──
 // Resolves dot-separated paths like "claudeAiOauth.accessToken" against parsed JSON.
@@ -551,4 +1213,273 @@ test "detectFromCommand" {
     try std.testing.expectEqualStrings("codex", detectFromCommand(&.{"codex"}).?.name);
     try std.testing.expectEqualStrings("github", detectFromCommand(&.{"gh"}).?.name);
     try std.testing.expect(detectFromCommand(&.{"unknown"}) == null);
+}
+
+test "classifyHttp generic rate limit and quota" {
+    const short = classifyHttp(generic_def, 429, 30, null);
+    switch (short) {
+        .rate_limited => |rl| {
+            try std.testing.expectEqual(@as(u32, 30), rl.retry_after_s);
+            try std.testing.expectEqual(types.RateLimitWindow.per_minute, rl.window);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    const long = classifyHttp(generic_def, 429, 7200, null);
+    switch (long) {
+        .quota_exhausted => |q| try std.testing.expectEqual(@as(u32, 7200), q.retry_after_s),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "classifyHttp MCP route failures" {
+    const scope = classifyHttp(mcp_def, 403, null, "Bearer error=\"insufficient_scope\"");
+    switch (scope) {
+        .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.scope_insufficient, reason),
+        else => return error.TestUnexpectedResult,
+    }
+
+    const step_up = classifyHttp(mcp_def, 403, null, "mcp step_up required");
+    switch (step_up) {
+        .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.step_up_required, reason),
+        else => return error.TestUnexpectedResult,
+    }
+
+    const schema = classifyHttp(mcp_def, 422, null, "tool schema invalid");
+    switch (schema) {
+        .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.schema_invalid, reason),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "mcp resource metadata capability uses unauthenticated metadata URL" {
+    const plan = probePlanForCapability(mcp_def, "metadata").?;
+    try std.testing.expectEqual(ProbeTransport.http, plan.transport);
+    try std.testing.expectEqualStrings("resource-metadata", plan.capability);
+    try std.testing.expectEqualStrings("GET", plan.method);
+    try std.testing.expectEqualStrings("{{OMUX_MCP_RESOURCE_METADATA_URL}}", plan.url);
+    try std.testing.expectEqual(ProbeAuth.none, plan.auth);
+    try std.testing.expect(plan.hint_body);
+}
+
+test "mcp resource capability uses bearer resource URL" {
+    const plan = probePlanForCapability(mcp_def, "resource-probe").?;
+    try std.testing.expectEqual(ProbeTransport.http, plan.transport);
+    try std.testing.expectEqualStrings("resource", plan.capability);
+    try std.testing.expectEqualStrings("GET", plan.method);
+    try std.testing.expectEqualStrings("{{OMUX_MCP_RESOURCE_PROBE_URL}}", plan.url);
+    try std.testing.expectEqual(ProbeAuth.bearer, plan.auth);
+    try std.testing.expectEqualStrings("www-authenticate", plan.hint_header.?);
+}
+
+test "probePlanForCapability resolves aliases" {
+    const caps = [_]CapabilityDefinition{
+        .{
+            .name = "chat:max",
+            .aliases = &.{"gpt-5.1-codex-max"},
+            .probe = .{
+                .method = "POST",
+                .url = "https://example.invalid/v1/probe",
+                .hint_header = "www-authenticate",
+            },
+        },
+    };
+    const def = ProviderDefinition{
+        .name = "toy",
+        .capabilities = &caps,
+    };
+
+    const plan = probePlanForCapability(def, "gpt-5.1-codex-max").?;
+    try std.testing.expectEqualStrings("chat:max", plan.capability);
+    try std.testing.expectEqualStrings("POST", plan.method);
+    try std.testing.expectEqual(ProbeAuth.bearer, plan.auth);
+    try std.testing.expectEqualStrings("www-authenticate", plan.hint_header.?);
+    try std.testing.expect(probePlanForCapability(def, "unknown") == null);
+}
+
+test "codex capabilities include semantic max and mini command probes" {
+    try std.testing.expectEqualStrings("codex-max", codex_def.capabilities[0].name);
+    const max_plan = probePlanForCapability(codex_def, "gpt-5.3-codex").?;
+    try std.testing.expectEqual(ProbeTransport.command, max_plan.transport);
+    try std.testing.expectEqualStrings("codex-max", max_plan.capability);
+    try std.testing.expectEqualStrings("codex", max_plan.command.?[0]);
+    try std.testing.expectEqualStrings("gpt-5.3-codex", max_plan.command.?[6]);
+    try std.testing.expectEqual(@as(u32, 120_000), max_plan.timeout_ms);
+    try std.testing.expectEqualStrings("codex-max", probePlanForCapability(codex_def, "max").?.capability);
+    try std.testing.expectEqualStrings("codex-mini", codex_def.capabilities[1].name);
+    const mini_plan = probePlanForCapability(codex_def, "gpt-5.3-codex-spark").?;
+    try std.testing.expectEqual(ProbeTransport.command, mini_plan.transport);
+    try std.testing.expectEqualStrings("codex-mini", mini_plan.capability);
+    try std.testing.expectEqualStrings("gpt-5.3-codex-spark", mini_plan.command.?[6]);
+}
+
+test "claude auth status capability uses admitted command probe" {
+    const plan = probePlanForCapability(claude_def, "whoami").?;
+    try std.testing.expectEqual(ProbeTransport.command, plan.transport);
+    try std.testing.expectEqualStrings("auth-status", plan.capability);
+    try std.testing.expectEqual(ProbeAuth.none, plan.auth);
+    try std.testing.expectEqualStrings("claude", plan.command.?[0]);
+    try std.testing.expectEqualStrings("auth", plan.command.?[1]);
+    try std.testing.expectEqualStrings("status", plan.command.?[2]);
+    try std.testing.expectEqualStrings("--json", plan.command.?[3]);
+}
+
+test "claude failure rules classify logged out status as dead" {
+    const classification = classifyHttp(claude_def, 400, null, "{\"loggedIn\":false}");
+    switch (classification) {
+        .dead => |reason| try std.testing.expectEqual(types.DeadReason.token_revoked, reason),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "github identity capability uses admitted user probe" {
+    const plan = probePlanForCapability(github_def, "whoami").?;
+    try std.testing.expectEqual(ProbeTransport.http, plan.transport);
+    try std.testing.expectEqualStrings("identity", plan.capability);
+    try std.testing.expectEqualStrings("GET", plan.method);
+    try std.testing.expectEqualStrings("https://api.github.com/user", plan.url);
+    try std.testing.expectEqual(ProbeAuth.bearer, plan.auth);
+    try std.testing.expectEqualStrings("x-ratelimit-remaining", plan.hint_header.?);
+}
+
+test "vercel identity capability uses admitted user probe" {
+    const plan = probePlanForCapability(vercel_def, "whoami").?;
+    try std.testing.expectEqual(ProbeTransport.http, plan.transport);
+    try std.testing.expectEqualStrings("identity", plan.capability);
+    try std.testing.expectEqualStrings("GET", plan.method);
+    try std.testing.expectEqualStrings("https://api.vercel.com/v2/user", plan.url);
+    try std.testing.expectEqual(ProbeAuth.bearer, plan.auth);
+}
+
+test "vercel failure rules classify forbidden as tier degradation" {
+    const classification = classifyHttp(vercel_def, 403, null, null);
+    switch (classification) {
+        .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.tier_insufficient, reason),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "linear identity capability uses GraphQL viewer probe" {
+    const plan = probePlanForCapability(linear_def, "viewer").?;
+    try std.testing.expectEqual(ProbeTransport.http, plan.transport);
+    try std.testing.expectEqualStrings("identity", plan.capability);
+    try std.testing.expectEqualStrings("POST", plan.method);
+    try std.testing.expectEqualStrings("https://api.linear.app/graphql", plan.url);
+    try std.testing.expect(plan.body != null);
+    try std.testing.expect(std.mem.indexOf(u8, plan.body.?, "viewer") != null);
+    try std.testing.expectEqualStrings("application/json", plan.content_type.?);
+    try std.testing.expect(plan.hint_body);
+}
+
+test "linear failure rules classify GraphQL errors as degraded" {
+    const classification = classifyHttp(linear_def, 200, null, "{\"errors\":[{\"message\":\"Forbidden\"}]}");
+    switch (classification) {
+        .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.unknown_4xx, reason),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "figma identity capability uses OAuth me probe" {
+    const plan = probePlanForCapability(figma_def, "me").?;
+    try std.testing.expectEqual(ProbeTransport.http, plan.transport);
+    try std.testing.expectEqualStrings("identity", plan.capability);
+    try std.testing.expectEqualStrings("GET", plan.method);
+    try std.testing.expectEqualStrings("https://api.figma.com/v1/me", plan.url);
+    try std.testing.expectEqual(ProbeAuth.bearer, plan.auth);
+}
+
+test "figma pat identity capability uses explicit token header" {
+    const plan = probePlanForCapability(figma_def, "me-pat").?;
+    try std.testing.expectEqual(ProbeTransport.http, plan.transport);
+    try std.testing.expectEqualStrings("identity-pat", plan.capability);
+    try std.testing.expectEqualStrings("GET", plan.method);
+    try std.testing.expectEqualStrings("https://api.figma.com/v1/me", plan.url);
+    try std.testing.expectEqual(ProbeAuth.token_header, plan.auth);
+    try std.testing.expectEqualStrings("X-Figma-Token", plan.auth_header.?);
+}
+
+test "figma plan capability uses resource scoped file metadata probe" {
+    const plan = probePlanForCapability(figma_def, "plan-file-meta").?;
+    try std.testing.expectEqual(ProbeTransport.http, plan.transport);
+    try std.testing.expectEqualStrings("file-metadata-plan", plan.capability);
+    try std.testing.expectEqualStrings("GET", plan.method);
+    try std.testing.expectEqualStrings("https://api.figma.com/v1/files/{{OMUX_FIGMA_PLAN_FILE_KEY}}/meta", plan.url);
+    try std.testing.expectEqual(ProbeAuth.token_header, plan.auth);
+    try std.testing.expectEqualStrings("X-Figma-Token", plan.auth_header.?);
+}
+
+test "figma failure rules classify forbidden as scope degradation" {
+    const classification = classifyHttp(figma_def, 403, null, null);
+    switch (classification) {
+        .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.scope_insufficient, reason),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "figma failure rules classify missing resource as route degradation" {
+    const classification = classifyHttp(figma_def, 404, null, null);
+    switch (classification) {
+        .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.unknown_4xx, reason),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "flakehub status capability uses admitted command probe" {
+    const plan = probePlanForCapability(flakehub_def, "whoami").?;
+    try std.testing.expectEqual(ProbeTransport.command, plan.transport);
+    try std.testing.expectEqualStrings("status", plan.capability);
+    try std.testing.expectEqual(ProbeAuth.none, plan.auth);
+    try std.testing.expectEqualStrings("determinate-nixd", plan.command.?[0]);
+    try std.testing.expectEqualStrings("status", plan.command.?[1]);
+}
+
+test "flakehub failure rules classify logged out status as dead" {
+    const classification = classifyHttp(flakehub_def, 200, null, "Logged in: false");
+    switch (classification) {
+        .dead => |reason| try std.testing.expectEqual(types.DeadReason.token_revoked, reason),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "github failure rules distinguish rate limit from scope degradation" {
+    const limited = classifyHttp(github_def, 403, null, "0");
+    switch (limited) {
+        .rate_limited => |rl| try std.testing.expectEqual(@as(u32, 30), rl.retry_after_s),
+        else => return error.TestUnexpectedResult,
+    }
+
+    const forbidden = classifyHttp(github_def, 403, null, "1");
+    switch (forbidden) {
+        .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.scope_insufficient, reason),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "classifyCodexExecJsonl success cassette" {
+    const jsonl =
+        \\{"type":"thread.started","thread_id":"redacted"}
+        \\{"type":"turn.started"}
+        \\{"type":"item.completed","item":{"type":"agent_message","text":"OMUX_CODEX_SPARK_PROBE"}}
+        \\{"type":"turn.completed","usage":{"input_tokens":26656,"cached_input_tokens":3712,"output_tokens":57,"reasoning_output_tokens":43}}
+        \\
+    ;
+    try std.testing.expectEqual(
+        types.HttpClassification.success,
+        classifyCodexExecJsonl(std.testing.allocator, jsonl).?,
+    );
+}
+
+test "classifyCodexExecJsonl unsupported model cassette" {
+    const jsonl =
+        \\{"type":"thread.started","thread_id":"redacted"}
+        \\{"type":"turn.started"}
+        \\{"type":"error","message":"{\"type\":\"error\",\"status\":400,\"error\":{\"type\":\"invalid_request_error\",\"message\":\"The 'gpt-5.1-codex-max' model is not supported when using Codex with a ChatGPT account.\"}}"}
+        \\{"type":"turn.failed","error":{"message":"redacted"}}
+        \\
+    ;
+    const classification = classifyCodexExecJsonl(std.testing.allocator, jsonl).?;
+    switch (classification) {
+        .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.tier_insufficient, reason),
+        else => return error.TestUnexpectedResult,
+    }
 }

--- a/src/secret.zig
+++ b/src/secret.zig
@@ -3,6 +3,7 @@ const types = @import("types.zig");
 const paths = @import("paths.zig");
 const log = @import("log.zig");
 const age = @import("age.zig");
+const env = @import("env.zig");
 const builtin = @import("builtin");
 
 pub const ReadError = error{
@@ -28,11 +29,11 @@ pub fn read(backend: types.SecretBackend, allocator: std.mem.Allocator) ReadErro
 }
 
 fn readEnv(ref: types.SecretBackend.EnvRef, allocator: std.mem.Allocator) ReadError![]const u8 {
-    const val = std.posix.getenv(ref.variable) orelse {
+    const val = env.get(allocator, ref.variable) catch return error.OutOfMemory;
+    return val orelse {
         log.debug("env: {s} not set", .{ref.variable});
         return error.NotFound;
     };
-    return allocator.dupe(u8, val) catch return error.OutOfMemory;
 }
 
 fn readFile(ref: types.SecretBackend.FileRef, allocator: std.mem.Allocator) ReadError![]const u8 {

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -1,16 +1,21 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const types = @import("types.zig");
+const env = @import("env.zig");
 
 pub fn detect() types.ShellKind {
-    if (std.posix.getenv("OMUX_SHELL")) |s| {
+    const allocator = std.heap.page_allocator;
+    if (env.get(allocator, "OMUX_SHELL") catch null) |s| {
+        defer allocator.free(s);
         return shellFromName(s);
     }
-    if (std.posix.getenv("FISH_VERSION")) |_| return .fish;
-    if (std.posix.getenv("ZSH_VERSION")) |_| return .zsh;
-    if (std.posix.getenv("BASH_VERSION")) |_| return .bash;
-    if (std.posix.getenv("KSH_VERSION")) |_| return .ksh;
+    if (env.has("FISH_VERSION")) return .fish;
+    if (env.has("ZSH_VERSION")) return .zsh;
+    if (env.has("BASH_VERSION")) return .bash;
+    if (env.has("KSH_VERSION")) return .ksh;
 
-    if (std.posix.getenv("SHELL")) |shell| {
+    if (env.get(allocator, "SHELL") catch null) |shell| {
+        defer allocator.free(shell);
         return shellFromPath(shell);
     }
     return .posix;
@@ -43,6 +48,16 @@ pub fn emitEnv(
 
 pub fn execTarget(argv: []const []const u8, env_map: *std.process.EnvMap) error{ExecFailed}!noreturn {
     if (argv.len == 0) return error.ExecFailed;
+
+    if (comptime builtin.os.tag == .windows) {
+        var child = std.process.Child.init(argv, std.heap.page_allocator);
+        child.env_map = env_map;
+        const term = child.spawnAndWait() catch return error.ExecFailed;
+        switch (term) {
+            .Exited => |code| std.process.exit(code),
+            else => std.process.exit(1),
+        }
+    }
 
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();

--- a/src/types.zig
+++ b/src/types.zig
@@ -225,6 +225,11 @@ pub const DegradedReason = enum {
     tier_insufficient,
     subscription_paused,
     provider_degraded,
+    scope_insufficient,
+    schema_invalid,
+    terms_required,
+    step_up_required,
+    pending_verification,
     unknown_4xx,
 };
 
@@ -258,6 +263,25 @@ pub const MuxDecision = enum {
     pub fn isRecoverable(self: MuxDecision) bool {
         return self != .give_up;
     }
+};
+
+pub const HttpClassification = union(enum) {
+    success,
+    rate_limited: RateLimitClassification,
+    quota_exhausted: QuotaClassification,
+    degraded: DegradedReason,
+    dead: DeadReason,
+    provider_degraded,
+    failure,
+
+    pub const RateLimitClassification = struct {
+        retry_after_s: u32,
+        window: RateLimitWindow,
+    };
+
+    pub const QuotaClassification = struct {
+        retry_after_s: u32,
+    };
 };
 
 // ── Health & Circuit Breaker ──

--- a/test/fixtures/cassettes/codex/exec-available-gpt-5.3-codex-spark.jsonl
+++ b/test/fixtures/cassettes/codex/exec-available-gpt-5.3-codex-spark.jsonl
@@ -1,0 +1,4 @@
+{"type":"thread.started","thread_id":"redacted"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"OMUX_CODEX_SPARK_PROBE"}}
+{"type":"turn.completed","usage":{"input_tokens":26656,"cached_input_tokens":3712,"output_tokens":57,"reasoning_output_tokens":43}}

--- a/test/fixtures/cassettes/codex/exec-unsupported-gpt-5.1-codex-max.jsonl
+++ b/test/fixtures/cassettes/codex/exec-unsupported-gpt-5.1-codex-max.jsonl
@@ -1,0 +1,4 @@
+{"type":"thread.started","thread_id":"redacted"}
+{"type":"turn.started"}
+{"type":"error","message":"{\"type\":\"error\",\"status\":400,\"error\":{\"type\":\"invalid_request_error\",\"message\":\"The 'gpt-5.1-codex-max' model is not supported when using Codex with a ChatGPT account.\"}}"}
+{"type":"turn.failed","error":{"message":"redacted"}}


### PR DESCRIPTION
## Summary

PR for the oauth-mux initial implementation. This is a PR-compatible squash branch because `initial-implementation` was created as an independent root history and GitHub cannot open a PR from unrelated histories.

The source branch with full checkpoint history remains `initial-implementation` at `dd107cb`.

This PR introduces the pure Zig oauth-mux prototype: typed credential liveness, route-scoped fallback, schema-driven provider definitions, HTTP and command probes, provider admission docs, Codex Max three-account operator flows, release/check/productization wiring, deterministic local E2E, and GitHub/GloriousFlywheel cache-first CI proof.

Latest productization/status cleanup:
- Repo secrets/variables for the private GF lane are configured: `GF_ACTIONS_TOKEN`, `ATTIC_TOKEN`, and `ATTIC_PUBLIC_KEY`.
- PR CI now checks out `tinyland-inc/GloriousFlywheel` and runs the private cache-first `nix-job` action instead of taking the token-gated skip path.
- Docs and release handoff text now record the current boundary: PR cache-first GF is proven; manual `.github/workflows/release-proof.yml` can be dispatched only after that workflow exists on `main` after merge.
- New no-secret `scripts/e2e-local.sh` builds a temporary provider definition, config, command probe, and state directory.
- `just e2e` / `just e2e-local` prove config validation, env injection, command probes, route-scoped quota fallback, persisted typed health evidence, and `exec` target injection without live OAuth calls.
- `just check-local` now includes the E2E harness after Zig tests, build, and example config validation.
- Hosted CI `test` job now runs the E2E harness before the release build.
- Added `docs/spec/development-timeline-2026-04-27.md` to mark the repo as internal alpha and separate completed core work from remaining production gates.
- Corrected provider-authoring docs and formal-model examples to use the actual tagged-union JSON shape for no-payload failure classes, e.g. `{ "quota_exhausted": {} }`.

Release/productization already in this PR:
- Local release staging via `just release-local <version>` and `scripts/release-local.sh`.
- Release proof via `just release-proof <version>` and `scripts/release-smoke.sh`.
- Non-publishing registry handoff via `just release-handoff <version>` and `scripts/release-handoff.sh`.
- `release-proof-local` stages artifacts, smoke-checks them, and generates `handoff/release-handoff.md`, `handoff/publish-files.txt`, and `handoff/SHA256SUMS.full`.
- Tag release workflow gates GitHub Release upload on artifact smoke plus handoff generation and attaches `v*/handoff/*`.
- Manual GloriousFlywheel release proof workflow remains at `.github/workflows/release-proof.yml`; it runs the same proof through the private cache-first `nix-job` action on `tinyland-nix` once the workflow file exists on `main` after merge.

## Validation

- Local `just e2e-local` passed on 2026-04-27.
- Local `just check` passed on 2026-04-27 with the E2E harness included.
- Local `just release-proof 0.1.0` passed earlier on 2026-04-27 and produced/smoke-checked tarballs, checksums, npm tarballs, Homebrew formula, debs, rpms, checksum-verified installer execution, and release handoff files.
- `just release-handoff 0.1.0` passed against the staged tree.
- Shell syntax checks for release/install/E2E scripts passed.
- Workflow YAML parse, `git diff --check`, and `just --list` passed.
- Local cleanup validation for `dd107cb`: `just check`, `sh -n scripts/release-handoff.sh`, and `git diff --check` passed.
- Hosted PR CI for current bridge commit `1f42de0` passed: `test` including Local E2E, `nix`, all six cross-compile jobs, and real GloriousFlywheel cache-first check.
- Current GF proof: run `25017264107`, job `73268244734`, checked out `tinyland-inc/GloriousFlywheel`, ran the private cache-first `nix-job`, executed `nix develop --command just check-local`, and completed in 3m11s. Cache push was intentionally skipped because PR events set `push-cache: false`.

## Known Follow-ups

- Manual `.github/workflows/release-proof.yml` cannot be dispatched by GitHub until this workflow exists on `main`; run it after merge before publishing tags.
- Add a manual, secret-scoped live-provider QA lane; keep it explicit because Codex/Claude probes spend real subscription calls.
- Turn the generated handoff into authenticated dry-run lanes for npm, Homebrew tap updates, and deb/rpm repository publication.
- Decide the daemon boundary after provider-specific refresh semantics are proven.