### PR TITLE
Onboarding and productization lanes

### DIFF
--- a/.github/workflows/live-provider-qa.yml
+++ b/.github/workflows/live-provider-qa.yml
@@ -1,0 +1,75 @@
+name: Live Provider QA
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type spend-real-calls to run live provider probes"
+        required: true
+        type: string
+      profile:
+        description: "Optional oauth-mux profile to probe"
+        required: false
+        type: string
+      provider:
+        description: "Provider for account matrix probes"
+        required: false
+        type: string
+      accounts:
+        description: "Comma-separated account names for account matrix probes"
+        required: false
+        type: string
+      capabilities:
+        description: "Comma-separated capabilities to probe"
+        required: false
+        default: "codex-mini"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  live-provider-qa:
+    name: Live provider QA
+    if: inputs.confirm == 'spend-real-calls'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.14.1
+
+      - name: Decode secret-scoped config
+        shell: bash
+        env:
+          OMUX_LIVE_QA_CONFIG_B64: ${{ secrets.OMUX_LIVE_QA_CONFIG_B64 }}
+        run: |
+          set -euo pipefail
+          if [ -z "${OMUX_LIVE_QA_CONFIG_B64:-}" ]; then
+            echo "OMUX_LIVE_QA_CONFIG_B64 is unset; using repository/default config path"
+            exit 0
+          fi
+          mkdir -p "$RUNNER_TEMP/oauth-mux"
+          printf '%s' "$OMUX_LIVE_QA_CONFIG_B64" | base64 -d > "$RUNNER_TEMP/oauth-mux/config.json"
+          echo "OMUX_CONFIG=$RUNNER_TEMP/oauth-mux/config.json" >> "$GITHUB_ENV"
+
+      - name: Build oauth-mux
+        run: zig build
+
+      - name: Run live provider QA
+        shell: bash
+        env:
+          OMUX_LIVE_QA_CONFIRM: spend-real-calls
+          OMUX_LIVE_QA_PROFILE: ${{ inputs.profile }}
+          OMUX_LIVE_QA_PROVIDER: ${{ inputs.provider }}
+          OMUX_LIVE_QA_ACCOUNTS: ${{ inputs.accounts }}
+          OMUX_LIVE_QA_CAPABILITIES: ${{ inputs.capabilities }}
+        run: ./scripts/live-provider-qa.sh
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: live-provider-qa
+          path: dist/live-qa/
+          if-no-files-found: ignore

--- a/.github/workflows/registry-dry-run.yml
+++ b/.github/workflows/registry-dry-run.yml
@@ -1,0 +1,55 @@
+name: Registry Dry Run
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type registry-dry-run to contact authenticated registry endpoints without publishing"
+        required: true
+        type: string
+      version:
+        description: "Version to stage and dry-run"
+        required: false
+        default: "0.1.0"
+        type: string
+      lanes:
+        description: "Comma-separated lanes: plan,github,npm,homebrew,system"
+        required: false
+        default: "plan"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  registry-dry-run:
+    name: Registry dry-run
+    if: inputs.confirm == 'registry-dry-run'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Stage release proof
+        run: nix develop --command just release-proof-local "${{ inputs.version }}"
+
+      - name: Run registry dry-run
+        shell: bash
+        env:
+          OMUX_REGISTRY_DRY_RUN_CONFIRM: registry-dry-run
+          OMUX_REGISTRY_LANES: ${{ inputs.lanes }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN || '' }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || '' }}
+          GITHUB_TOKEN: ${{ github.token }}
+          OMUX_HOMEBREW_TAP_DIR: ${{ vars.OMUX_HOMEBREW_TAP_DIR || '' }}
+        run: nix develop --command ./scripts/registry-dry-run.sh "${{ inputs.version }}"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: registry-dry-run-${{ inputs.version }}
+          path: dist/out/**/handoff/
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ bazel-*
 # Distribution artifacts
 dist/build/
 dist/out/
+dist/live-qa/
 *.tar.gz
 *.deb
 *.rpm

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ synthetic local E2E harness.
 
 ## Quick Checks
 
+Discover the redacted, agent-safe inventory:
+
+```bash
+oauth-mux discover --json
+```
+
 Validate an example:
 
 ```bash
@@ -96,5 +102,10 @@ Release attachments, npm publish order, Homebrew tap input, deb/rpm files, and
 full checksums.
 
 See `docs/release-runbook.md` for release and CI details.
+See `docs/onboarding.md` for human and agent onboarding.
+See `docs/live-provider-qa.md` for manual secret-scoped provider probes.
+See `docs/registry-dry-runs-and-rollback.md` for publication dry-runs and
+rollback.
+See `docs/daemon-boundary.md` for the current daemon decision.
 See `docs/spec/development-timeline-2026-04-27.md` for the current
 production-readiness timeline.

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -1,0 +1,44 @@
+# Daemon Boundary
+
+The daemon exists, but it is not a production dependency yet.
+
+## Current Decision
+
+Keep daemon usage optional until provider-specific refresh semantics are proven
+for each OAuth-backed harness. The default production path remains explicit
+selection, explicit probe, env injection, and exec handoff.
+
+## Allowed Now
+
+- `oauth-mux daemon status` for local inspection.
+- Local experimentation with refresh behavior.
+- Future manual QA where daemon activity is bounded and visible.
+
+## Not Allowed Yet
+
+- Background polling of live provider probes.
+- Automatic subscription-spending checks.
+- Silent token refresh for providers whose refresh semantics are owned by an
+  upstream CLI.
+- Any release gate that depends on a long-running daemon.
+
+## Promotion Criteria
+
+The daemon can become a supported operator feature when:
+
+1. provider refresh ownership is documented per provider;
+2. refresh and probe budgets are configurable;
+3. every background action records redacted evidence;
+4. stop/status behavior is reliable on macOS and Linux;
+5. Windows behavior is either implemented or explicitly unsupported in package
+   docs;
+6. live-provider QA covers timeout, auth failure, quota exhaustion, and
+   transient rate-limit behavior.
+
+Until then, user and agent onboarding should use one-shot commands:
+
+```bash
+oauth-mux discover --json
+oauth-mux probe --profile <profile> --capability <capability> --json
+oauth-mux exec --profile <profile> --capability <capability> -- <command>
+```

--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -1,0 +1,68 @@
+# Live Provider QA
+
+Live provider QA is manual and secret-scoped because provider probes can spend
+real subscription calls.
+
+## Local Run
+
+Build first:
+
+```bash
+just build
+```
+
+Probe a profile:
+
+```bash
+OMUX_LIVE_QA_CONFIRM=spend-real-calls \
+OMUX_LIVE_QA_PROFILE=codex-mini \
+OMUX_LIVE_QA_CAPABILITIES=codex-mini \
+just live-qa
+```
+
+Probe an account matrix:
+
+```bash
+OMUX_LIVE_QA_CONFIRM=spend-real-calls \
+OMUX_LIVE_QA_PROVIDER=codex \
+OMUX_LIVE_QA_ACCOUNTS=max-1,max-2,max-3 \
+OMUX_LIVE_QA_CAPABILITIES=codex-mini \
+just live-qa
+```
+
+Escalate to higher-cost routes only after the cheaper route is healthy:
+
+```bash
+OMUX_LIVE_QA_CONFIRM=spend-real-calls \
+OMUX_LIVE_QA_PROVIDER=codex \
+OMUX_LIVE_QA_ACCOUNTS=max-1,max-2,max-3 \
+OMUX_LIVE_QA_CAPABILITIES=codex-max \
+just live-qa
+```
+
+Artifacts are written under `dist/live-qa/<timestamp>/`:
+
+- `config-validate.txt`
+- `discover.json`
+- one JSON file per probe
+- `health.json`
+
+## GitHub Workflow
+
+`.github/workflows/live-provider-qa.yml` is manual-only. It requires the
+dispatch input `confirm=spend-real-calls`.
+
+For private configs, store a base64-encoded config in the repository secret
+`OMUX_LIVE_QA_CONFIG_B64`. The workflow decodes it into `$RUNNER_TEMP` and sets
+`OMUX_CONFIG` for the job. Keep the config secret-scoped and prefer secret
+backends such as command, keychain, sops, age, or env references. Do not put raw
+tokens in the workflow file or repository.
+
+## Policy
+
+- Start with the lowest-cost capability.
+- Use account-specific probes when validating fallback behavior.
+- Treat `rate_limited`, `quota_exhausted`, `degraded`, and `dead` as distinct
+  outcomes.
+- Do not schedule this workflow until budgets and provider terms are explicit.
+- Do not use live QA as a background daemon loop.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,117 @@
+# oauth-mux Onboarding and Discovery
+
+This document defines the user and agent onboarding path for `oauth-mux`.
+The goal is that a user can make expected OAuth accounts muxable with one or
+two intentional commands, and an AI agent can discover the safe command surface
+without reading token files.
+
+## User Stories
+
+1. Multi-subscription Codex user.
+   The user has several ChatGPT/Codex subscription accounts and wants Codex
+   routes to fall through when one route is rate-limited, quota-exhausted, or
+   auth-broken.
+
+2. Agent harness operator.
+   The operator wants Claude, Codex, GitHub, Linear, Figma, Vercel, FlakeHub,
+   and MCP accounts represented as named accounts without storing raw OAuth
+   tokens in `.env`.
+
+3. AI agent.
+   The agent needs to discover configured providers, profiles, health, and safe
+   commands without opening credential stores or printing tokens.
+
+4. Provider author.
+   The author wants to add support for a new OAuth-backed harness through a
+   JSON provider definition and fixtures before writing Zig.
+
+5. Release operator.
+   The operator wants local proof, self-hosted cache-first proof, registry
+   dry-runs, and rollback instructions before any public package publication.
+
+## First-Run Flow
+
+Generic starter:
+
+```bash
+oauth-mux init
+oauth-mux config validate
+oauth-mux discover
+```
+
+Codex Max three-account starter:
+
+```bash
+oauth-mux init --codex-max
+just codex-max-onboard
+```
+
+`just codex-max-onboard` creates the expected isolated `CODEX_HOME` directories,
+runs `codex login` for accounts that are not logged in, prints login status, and
+then prints `oauth-mux discover`. It does not run live route probes unless the
+operator explicitly sets:
+
+```bash
+OMUX_LIVE_QA_CONFIRM=spend-real-calls just codex-max-onboard
+```
+
+For device-code login instead of browser login:
+
+```bash
+OMUX_CODEX_LOGIN_MODE=device just codex-max-onboard
+```
+
+For status-only inspection:
+
+```bash
+OMUX_CODEX_LOGIN_MODE=status-only just codex-max-onboard
+```
+
+## Agent Discovery Contract
+
+Agents should start with:
+
+```bash
+oauth-mux discover --json
+oauth-mux status --json
+oauth-mux health --json
+```
+
+Agents may run:
+
+```bash
+oauth-mux probe --profile <profile> --capability <capability> --json
+oauth-mux env --profile <profile> --capability <capability> --shell <shell>
+oauth-mux exec --profile <profile> --capability <capability> -- <command>
+```
+
+Agents must not:
+
+- read files referenced by `secret.path`;
+- print token-shaped values;
+- copy OAuth stores between accounts;
+- run live probes unless the user explicitly authorized spend.
+
+`discover --json` is intentionally redacted. It reports config path, state path,
+providers, account names, secret backend names, tags, profiles, and safe command
+templates. It does not include token material.
+
+## Provider Onboarding Checklist
+
+1. Add or select a provider definition.
+2. Add named accounts and secret backends.
+3. Add profiles that encode provider/account/capability fallback order.
+4. Run `oauth-mux config validate`.
+5. Run `oauth-mux discover --json`.
+6. Run no-spend checks first: `status`, `health`, and credential parse probes.
+7. Run live probes only through `scripts/live-provider-qa.sh` or the manual
+   Live Provider QA workflow.
+
+## Operator Definition of Done
+
+- Config validates.
+- `discover --json` is usable by agents.
+- `status --json` shows expected providers and accounts.
+- `health --json` is redacted.
+- First live QA run is captured under `dist/live-qa/`.
+- Rollback path is documented before registry publication.

--- a/docs/registry-dry-runs-and-rollback.md
+++ b/docs/registry-dry-runs-and-rollback.md
@@ -1,0 +1,83 @@
+# Registry Dry-Runs and Rollback
+
+Registry publication is intentionally separate from release artifact proof.
+`just release-proof <version>` proves the release tree and handoff without
+publication credentials. Authenticated registry dry-runs are manual and
+non-publishing.
+
+## Dry-Run
+
+Stage and prove artifacts:
+
+```bash
+just release-proof 0.1.0
+```
+
+Run a plan-only dry-run report:
+
+```bash
+OMUX_REGISTRY_DRY_RUN_CONFIRM=registry-dry-run \
+OMUX_REGISTRY_LANES=plan \
+just registry-dry-run 0.1.0
+```
+
+Run authenticated lanes:
+
+```bash
+OMUX_REGISTRY_DRY_RUN_CONFIRM=registry-dry-run \
+OMUX_REGISTRY_LANES=github,npm,homebrew,system \
+NPM_TOKEN=... \
+OMUX_HOMEBREW_TAP_DIR=/path/to/homebrew-tap \
+just registry-dry-run 0.1.0
+```
+
+The script writes `dist/out/v<version>/handoff/registry-dry-run.md`.
+
+## GitHub Workflow
+
+`.github/workflows/registry-dry-run.yml` is manual-only. It requires
+`confirm=registry-dry-run`. It stages the release through
+`just release-proof-local <version>` and then runs selected dry-run lanes.
+
+Required secret and variable surfaces:
+
+- `NPM_TOKEN` for the npm lane.
+- `OMUX_HOMEBREW_TAP_DIR` repository variable for the Homebrew lane when a tap
+  checkout is available in the runner environment.
+- The default workflow `GITHUB_TOKEN` for the GitHub lane.
+
+## Rollback
+
+GitHub Release:
+
+1. Delete or mark the bad release as draft.
+2. Delete the tag only after consumers are notified.
+3. Re-run `just release-proof <version>` before publishing a replacement.
+
+npm:
+
+1. Prefer deprecating bad packages over unpublish after the npm unpublish
+   window or when downstream consumers may already depend on them.
+2. Deprecate platform packages and the root shim with the same message.
+3. Publish a fixed patch version.
+
+Homebrew:
+
+1. Revert the tap formula commit.
+2. Run `brew audit` against the reverted formula.
+3. Publish a fixed formula commit with new checksums.
+
+deb/rpm:
+
+1. Remove the bad package from repository metadata or mark it superseded.
+2. Rebuild repository metadata.
+3. Publish a fixed package with a higher version or release number.
+
+curl installer:
+
+1. Do not mutate a published artifact in place.
+2. Publish a corrected version and checksum set.
+3. Keep old checksums in release notes for forensic comparison.
+
+Rollback must be documented in the release notes for any public publication
+mistake.

--- a/docs/spec/development-timeline-2026-04-27.md
+++ b/docs/spec/development-timeline-2026-04-27.md
@@ -12,9 +12,9 @@ implemented. It is ready for controlled operator use and PR review, but not yet
 for public unattended production use.
 
 The remaining production gap is no longer the core selection model. The gap is
-operational hardening: live-provider QA, authenticated package publication dry
-runs, documented rollback, and post-merge GloriousFlywheel release-proof
-execution before public tags.
+operational hardening: live-provider QA execution with real secrets,
+authenticated package publication dry-runs, rollback rehearsal, and
+post-merge GloriousFlywheel release-proof execution before public tags.
 
 ## Completed Arc
 
@@ -45,6 +45,11 @@ execution before public tags.
    injection, command probes, route-scoped quota fallback, persisted health,
    and `exec` injection without live credentials or network calls.
 
+7. Onboarding and discovery surface.
+   `oauth-mux discover --json`, `docs/onboarding.md`, `just codex-max-onboard`,
+   manual live-provider QA, registry dry-run, rollback, and daemon-boundary
+   runbooks now define the operator and agent path.
+
 ## Current Gates
 
 - `just check`
@@ -63,6 +68,11 @@ execution before public tags.
   `GloriousFlywheel` action checked out, `nix-job` ran on `tinyland-nix`, and
   `nix develop --command just check-local` passed. Cache push is intentionally
   disabled on PR events.
+
+- Manual productization lanes
+  `scripts/live-provider-qa.sh` and `.github/workflows/live-provider-qa.yml`
+  require `spend-real-calls`; `scripts/registry-dry-run.sh` and
+  `.github/workflows/registry-dry-run.yml` require `registry-dry-run`.
 
 ## Production Readiness
 
@@ -85,13 +95,12 @@ Not ready yet:
 
 ## Next Arc
 
-1. Add a live-provider QA workflow that is manual-only, secret-scoped, and
-   budget-aware. It should run `codex-mini` first, then higher-cost routes only
-   when explicitly requested.
+1. Run the live-provider QA workflow with scoped secrets. Start with
+   `codex-mini`, then higher-cost routes only when explicitly requested.
 
-2. Convert the release handoff into authenticated dry-run lanes:
-   npm provenance dry run, Homebrew formula audit in the tap, and deb/rpm
-   repository staging checks.
+2. Run authenticated registry dry-run lanes:
+   npm dry run, Homebrew formula audit in the tap, GitHub release auth check,
+   and deb/rpm metadata checks.
 
 3. After merge, run the manual GloriousFlywheel release-proof workflow from
    `main` before publishing tags. GitHub cannot dispatch PR-local workflow
@@ -100,6 +109,5 @@ Not ready yet:
 4. Add a small canary script for the three real Codex Max accounts that reports
    liveness and route decisions without changing auth state or leaking tokens.
 
-5. Decide the daemon boundary: keep it optional until token refresh semantics
-   and provider-specific refresh safety are proven for each OAuth-backed
-   harness.
+5. Revisit the daemon boundary only after live-provider QA covers refresh,
+   timeout, quota, and provider-owned CLI session behavior.

--- a/justfile
+++ b/justfile
@@ -72,6 +72,9 @@ codex-max-login-status-all:
       CODEX_HOME="$HOME/.local/share/oauth-mux/codex/${account}" codex login status || true
     done
 
+codex-max-onboard: build
+    ./scripts/onboard-codex-max.sh
+
 codex-max-probe ACCOUNT CAPABILITY="codex-mini": build
     OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux probe --provider codex --account {{ACCOUNT}} --capability {{CAPABILITY}} --json
 
@@ -99,6 +102,9 @@ release-smoke VERSION="0.1.0":
 
 release-handoff VERSION="0.1.0":
     nix develop --command ./scripts/release-handoff.sh {{VERSION}}
+
+registry-dry-run VERSION="0.1.0":
+    nix develop --command ./scripts/registry-dry-run.sh {{VERSION}}
 
 release-proof VERSION="0.1.0":
     nix develop --command just release-proof-local {{VERSION}}
@@ -149,6 +155,9 @@ e2e:
 e2e-local:
     zig build
     ./scripts/e2e-local.sh
+
+live-qa:
+    nix develop --command ./scripts/live-provider-qa.sh
 
 # ── Config ──
 

--- a/scripts/live-provider-qa.sh
+++ b/scripts/live-provider-qa.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if [ "${OMUX_LIVE_QA_CONFIRM:-}" != "spend-real-calls" ]; then
+  cat >&2 <<'EOF'
+live-provider QA is disabled.
+
+This command can spend real provider/subscription calls. Re-run with:
+
+  OMUX_LIVE_QA_CONFIRM=spend-real-calls
+
+Also set one of:
+
+  OMUX_LIVE_QA_PROFILE=<profile>
+  OMUX_LIVE_QA_PROVIDER=<provider> OMUX_LIVE_QA_ACCOUNTS=a,b,c
+EOF
+  exit 2
+fi
+
+bin="${OMUX_BIN:-$repo_root/zig-out/bin/oauth-mux}"
+if [ ! -x "$bin" ]; then
+  printf 'oauth-mux binary not found at %s\n' "$bin" >&2
+  printf 'run: just build\n' >&2
+  exit 1
+fi
+
+stamp="$(date -u '+%Y%m%dT%H%M%SZ')"
+out_dir="${OMUX_LIVE_QA_OUT:-$repo_root/dist/live-qa/$stamp}"
+state_dir="${OMUX_STATE_DIR:-$out_dir/state}"
+mkdir -p "$out_dir" "$state_dir"
+export OMUX_STATE_DIR="$state_dir"
+
+profile="${OMUX_LIVE_QA_PROFILE:-}"
+provider="${OMUX_LIVE_QA_PROVIDER:-}"
+accounts_csv="${OMUX_LIVE_QA_ACCOUNTS:-}"
+capabilities_csv="${OMUX_LIVE_QA_CAPABILITIES:-codex-mini}"
+
+IFS=',' read -r -a capabilities <<<"$capabilities_csv"
+
+redact() {
+  sed -E \
+    -e 's/(access_token|refresh_token|id_token|token)["= :]+[^", ]+/\1=<redacted>/gi' \
+    -e 's/(Bearer )[A-Za-z0-9._~+\/=-]+/\1<redacted>/g'
+}
+
+run_probe() {
+  local label="$1"
+  shift
+  local safe_label
+  safe_label="$(printf '%s' "$label" | tr '#:/ ' '____')"
+  printf '=== %s ===\n' "$label"
+  if "$bin" probe "$@" --json 2>&1 | redact | tee "$out_dir/${safe_label}.json"; then
+    return 0
+  fi
+  printf 'probe failed: %s\n' "$label" >&2
+  return 1
+}
+
+"$bin" config validate | tee "$out_dir/config-validate.txt"
+"$bin" discover --json >"$out_dir/discover.json"
+
+failures=0
+if [ -n "$profile" ]; then
+  for capability in "${capabilities[@]}"; do
+    run_probe "profile:${profile}#${capability}" --profile "$profile" --capability "$capability" || failures=$((failures + 1))
+  done
+elif [ -n "$provider" ] && [ -n "$accounts_csv" ]; then
+  IFS=',' read -r -a accounts <<<"$accounts_csv"
+  for account in "${accounts[@]}"; do
+    for capability in "${capabilities[@]}"; do
+      run_probe "${provider}:${account}#${capability}" --provider "$provider" --account "$account" --capability "$capability" || failures=$((failures + 1))
+    done
+  done
+else
+  printf 'set OMUX_LIVE_QA_PROFILE or OMUX_LIVE_QA_PROVIDER plus OMUX_LIVE_QA_ACCOUNTS\n' >&2
+  exit 2
+fi
+
+"$bin" health --json >"$out_dir/health.json"
+
+printf 'live QA artifacts: %s\n' "$out_dir"
+if [ "$failures" -ne 0 ]; then
+  printf 'live QA failures: %s\n' "$failures" >&2
+  exit 1
+fi

--- a/scripts/onboard-codex-max.sh
+++ b/scripts/onboard-codex-max.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+accounts_csv="${OMUX_CODEX_ACCOUNTS:-max-1,max-2,max-3}"
+login_mode="${OMUX_CODEX_LOGIN_MODE:-browser}"
+config_path="${OMUX_CONFIG:-$repo_root/examples/codex-max.config.json}"
+bin="${OMUX_BIN:-$repo_root/zig-out/bin/oauth-mux}"
+
+if [ ! -x "$bin" ]; then
+  printf 'oauth-mux binary not found at %s\n' "$bin" >&2
+  printf 'run: just build\n' >&2
+  exit 1
+fi
+
+case "$login_mode" in
+  browser|device|status-only) ;;
+  *)
+    printf 'OMUX_CODEX_LOGIN_MODE must be browser, device, or status-only\n' >&2
+    exit 1
+    ;;
+esac
+
+IFS=',' read -r -a accounts <<<"$accounts_csv"
+
+printf 'oauth-mux Codex Max onboarding\n\n'
+printf 'config: %s\n' "$config_path"
+printf 'mode:   %s\n\n' "$login_mode"
+
+export OMUX_CONFIG="$config_path"
+"$bin" config validate
+
+for account in "${accounts[@]}"; do
+  dir="$HOME/.local/share/oauth-mux/codex/${account}"
+  mkdir -p "$dir"
+  printf '\n=== %s ===\n' "$account"
+  if CODEX_HOME="$dir" codex login status; then
+    continue
+  fi
+
+  if [ "$login_mode" = "status-only" ]; then
+    printf 'not logged in; rerun with OMUX_CODEX_LOGIN_MODE=browser or device\n'
+    continue
+  fi
+
+  if [ "$login_mode" = "device" ]; then
+    CODEX_HOME="$dir" codex login --device-auth
+  else
+    CODEX_HOME="$dir" codex login
+  fi
+  CODEX_HOME="$dir" codex login status
+done
+
+printf '\n=== oauth-mux inventory ===\n'
+"$bin" discover
+
+if [ "${OMUX_LIVE_QA_CONFIRM:-}" = "spend-real-calls" ]; then
+  printf '\n=== live QA ===\n'
+  OMUX_CONFIG="$config_path" \
+    OMUX_LIVE_QA_PROVIDER="${OMUX_LIVE_QA_PROVIDER:-codex}" \
+    OMUX_LIVE_QA_ACCOUNTS="$accounts_csv" \
+    OMUX_LIVE_QA_CAPABILITIES="${OMUX_LIVE_QA_CAPABILITIES:-codex-mini}" \
+    OMUX_LIVE_QA_CONFIRM=spend-real-calls \
+    "$repo_root/scripts/live-provider-qa.sh"
+else
+  printf '\nLive probes not run. Set OMUX_LIVE_QA_CONFIRM=spend-real-calls to run bounded route probes.\n'
+fi

--- a/scripts/registry-dry-run.sh
+++ b/scripts/registry-dry-run.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+version="${1:-${VERSION:-0.1.0}}"
+version="${version#v}"
+
+if [ "${OMUX_REGISTRY_DRY_RUN_CONFIRM:-}" != "registry-dry-run" ]; then
+  cat >&2 <<EOF
+registry dry-run is disabled.
+
+This command may contact authenticated registry endpoints, but should not publish.
+Re-run with:
+
+  OMUX_REGISTRY_DRY_RUN_CONFIRM=registry-dry-run OMUX_REGISTRY_LANES=plan,npm,github,homebrew,system just registry-dry-run ${version}
+EOF
+  exit 2
+fi
+
+out_dir="$repo_root/dist/out/v${version}"
+handoff_dir="$out_dir/handoff"
+report="$handoff_dir/registry-dry-run.md"
+tmp_files=()
+
+cleanup() {
+  for file in "${tmp_files[@]}"; do
+    rm -f "$file"
+  done
+}
+trap cleanup EXIT
+
+if [ ! -d "$out_dir" ]; then
+  printf 'release output does not exist: %s\n' "$out_dir" >&2
+  printf 'run: just release-proof %s\n' "$version" >&2
+  exit 1
+fi
+
+mkdir -p "$handoff_dir"
+
+lanes_csv="${OMUX_REGISTRY_LANES:-plan}"
+IFS=',' read -r -a lanes <<<"$lanes_csv"
+
+append() {
+  printf '%s\n' "$*" >>"$report"
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'missing required command for lane: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+generated_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+cat >"$report" <<EOF
+# oauth-mux v${version} Registry Dry-Run
+
+Generated: ${generated_at}
+Release tree: \`dist/out/v${version}\`
+
+This report records non-publishing registry checks. It must not include tokens.
+
+EOF
+
+for lane in "${lanes[@]}"; do
+  case "$lane" in
+    plan)
+      append "## plan"
+      append
+      append "- release tree exists"
+      append "- publish list: \`dist/out/v${version}/handoff/publish-files.txt\`"
+      append "- full checksums: \`dist/out/v${version}/handoff/SHA256SUMS.full\`"
+      append
+      ;;
+
+    github)
+      require_command gh
+      append "## github"
+      append
+      gh auth status >/dev/null
+      if gh release view "v${version}" >/dev/null 2>&1; then
+        append "- authenticated gh session OK"
+        append "- release v${version} already exists"
+      else
+        append "- authenticated gh session OK"
+        append "- release v${version} does not exist yet; tag release workflow remains publication path"
+      fi
+      append
+      ;;
+
+    npm)
+      require_command npm
+      npm_token="${NPM_TOKEN:-${NODE_AUTH_TOKEN:-}}"
+      if [ -z "$npm_token" ]; then
+        printf 'npm lane requires NPM_TOKEN or NODE_AUTH_TOKEN\n' >&2
+        exit 1
+      fi
+      npmrc="$(mktemp)"
+      tmp_files+=("$npmrc")
+      {
+        printf 'registry=https://registry.npmjs.org/\n'
+        printf '//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n'
+      } >"$npmrc"
+      append "## npm"
+      append
+      NPM_CONFIG_USERCONFIG="$npmrc" NPM_TOKEN="$npm_token" npm whoami --registry=https://registry.npmjs.org/ >/dev/null
+      for tarball in "$out_dir"/npm-tarballs/*.tgz; do
+        name="$(basename "$tarball")"
+        case "$name" in
+          oauth-mux-darwin-*|oauth-mux-linux-*|oauth-mux-win32-*)
+            NPM_CONFIG_USERCONFIG="$npmrc" NPM_TOKEN="$npm_token" npm publish "$tarball" --dry-run --access public ${OMUX_NPM_EXTRA_ARGS:-} >/dev/null
+            ;;
+          *)
+            NPM_CONFIG_USERCONFIG="$npmrc" NPM_TOKEN="$npm_token" npm publish "$tarball" --dry-run ${OMUX_NPM_EXTRA_ARGS:-} >/dev/null
+            ;;
+        esac
+        append "- dry-run OK: \`npm-tarballs/${name}\`"
+      done
+      append
+      ;;
+
+    homebrew)
+      require_command brew
+      if [ -z "${OMUX_HOMEBREW_TAP_DIR:-}" ]; then
+        printf 'homebrew lane requires OMUX_HOMEBREW_TAP_DIR\n' >&2
+        exit 1
+      fi
+      formula="$out_dir/homebrew/oauth-mux.rb"
+      tap_formula="$OMUX_HOMEBREW_TAP_DIR/Formula/oauth-mux.rb"
+      mkdir -p "$(dirname "$tap_formula")"
+      cp "$formula" "$tap_formula"
+      git -C "$OMUX_HOMEBREW_TAP_DIR" diff --check -- Formula/oauth-mux.rb
+      brew audit --formula --strict --online "$tap_formula" >/dev/null
+      append "## homebrew"
+      append
+      append "- formula copied to tap checkout"
+      append "- git diff --check OK"
+      append "- brew audit OK"
+      append
+      ;;
+
+    system)
+      append "## system packages"
+      append
+      if command -v dpkg-deb >/dev/null 2>&1; then
+        for deb in "$out_dir"/artifacts/*.deb; do
+          dpkg-deb --info "$deb" >/dev/null
+          append "- deb metadata OK: \`artifacts/$(basename "$deb")\`"
+        done
+      else
+        append "- dpkg-deb unavailable; skipped deb metadata check"
+      fi
+      if command -v rpm >/dev/null 2>&1; then
+        for rpm_pkg in "$out_dir"/artifacts/*.rpm; do
+          rpm -qp "$rpm_pkg" >/dev/null
+          append "- rpm metadata OK: \`artifacts/$(basename "$rpm_pkg")\`"
+        done
+      else
+        append "- rpm unavailable; skipped rpm metadata check"
+      fi
+      append
+      ;;
+
+    *)
+      printf 'unknown registry dry-run lane: %s\n' "$lane" >&2
+      exit 1
+      ;;
+  esac
+done
+
+printf 'registry dry-run report: %s\n' "$report"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -9,6 +9,7 @@ pub const Command = union(enum) {
     probe: ProbeArgs,
     status: StatusArgs,
     health: HealthArgs,
+    discover: DiscoverArgs,
     config_validate,
     config_path,
     init: InitArgs,
@@ -53,6 +54,10 @@ pub const Command = union(enum) {
         reset: ?[]const u8 = null,
     };
 
+    pub const DiscoverArgs = struct {
+        json: bool = false,
+    };
+
     pub const InitArgs = struct {
         interactive: bool = false,
         codex_max: bool = false,
@@ -74,6 +79,7 @@ pub fn parse(args: []const []const u8) Command {
     if (eql(cmd, "probe")) return parseProbe(rest);
     if (eql(cmd, "status")) return parseStatus(rest);
     if (eql(cmd, "health")) return parseHealth(rest);
+    if (eql(cmd, "discover")) return parseDiscover(rest);
     if (eql(cmd, "config")) return parseConfig(rest);
     if (eql(cmd, "init")) return parseInit(rest);
     if (eql(cmd, "version") or eql(cmd, "--version") or eql(cmd, "-v")) return .version_cmd;
@@ -190,6 +196,14 @@ fn parseHealth(args: []const []const u8) Command {
     return .{ .health = result };
 }
 
+fn parseDiscover(args: []const []const u8) Command {
+    var result = Command.DiscoverArgs{};
+    for (args) |arg| {
+        if (eql(arg, "--json")) result.json = true;
+    }
+    return .{ .discover = result };
+}
+
 fn parseConfig(args: []const []const u8) Command {
     if (args.len == 0) return .config_path;
     if (eql(args[0], "validate")) return .config_validate;
@@ -231,6 +245,9 @@ pub fn printUsage(writer: anytype) !void {
         \\
         \\  health [--json] [--reset <account>] [--provider <name>]
         \\      Show or reset redacted health and liveness tracking data.
+        \\
+        \\  discover [--json]
+        \\      Print redacted provider/profile inventory and agent-safe next commands.
         \\
         \\  config validate    Validate the configuration file.
         \\  config path        Print the config file path.
@@ -332,6 +349,15 @@ test "parse health json provider" {
     }
 }
 
+test "parse discover json" {
+    const args = [_][]const u8{ "discover", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .discover => |discover| try std.testing.expect(discover.json),
+        else => return error.Unexpected,
+    }
+}
+
 pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
     if (eql(shell_name, "fish")) {
         try writer.writeAll(
@@ -341,6 +367,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n __fish_use_subcommand -a probe -d 'Probe account liveness'
             \\complete -c oauth-mux -n __fish_use_subcommand -a status -d 'Show status'
             \\complete -c oauth-mux -n __fish_use_subcommand -a health -d 'Show health data'
+            \\complete -c oauth-mux -n __fish_use_subcommand -a discover -d 'Show agent-safe inventory'
             \\complete -c oauth-mux -n __fish_use_subcommand -a config -d 'Config operations'
             \\complete -c oauth-mux -n __fish_use_subcommand -a init -d 'Generate config'
             \\complete -c oauth-mux -n __fish_use_subcommand -a version -d 'Print version'
@@ -352,6 +379,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from probe' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from env' -l shell -d 'Shell type' -r -a 'fish zsh bash ksh'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from status' -l json -d 'JSON output'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from discover' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
             \\
@@ -367,6 +395,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\    'probe:Probe account liveness'
             \\    'status:Show status'
             \\    'health:Show health data'
+            \\    'discover:Show agent-safe inventory'
             \\    'config:Config operations'
             \\    'init:Generate config'
             \\    'version:Print version'
@@ -381,7 +410,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
         try writer.writeAll(
             \\_oauth_mux_completions() {
             \\  local cur="${COMP_WORDS[COMP_CWORD]}"
-            \\  COMPREPLY=($(compgen -W "exec env probe status health config init version completions" -- "$cur"))
+            \\  COMPREPLY=($(compgen -W "exec env probe status health discover config init version completions" -- "$cur"))
             \\}
             \\complete -F _oauth_mux_completions oauth-mux
             \\

--- a/src/main.zig
+++ b/src/main.zig
@@ -82,6 +82,10 @@ pub fn main() !void {
             try runHealth(allocator, stdout, health_args);
         },
 
+        .discover => |discover_args| {
+            try runDiscover(allocator, stdout, discover_args);
+        },
+
         .completions => |comp_args| {
             try cli.printCompletions(stdout, comp_args.shell);
         },
@@ -160,6 +164,203 @@ fn runStatus(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.St
             }
         }
     }
+}
+
+fn runDiscover(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.DiscoverArgs) !void {
+    const config_path = try paths.configFilePath(allocator);
+    defer allocator.free(config_path);
+    const state_dir = try paths.stateDir(allocator);
+    defer allocator.free(state_dir);
+
+    const parsed = config.load(allocator) catch {
+        if (args.json) {
+            try writer.writeAll("{\"version\":");
+            try std.json.stringify(cli.version, .{}, writer);
+            try writer.writeAll(",\"configured\":false,\"config_path\":");
+            try std.json.stringify(config_path, .{}, writer);
+            try writer.writeAll(",\"state_dir\":");
+            try std.json.stringify(state_dir, .{}, writer);
+            try writer.writeAll(",\"next_commands\":[");
+            try writeCommandJson(writer, "oauth-mux init");
+            try writer.writeByte(',');
+            try writeCommandJson(writer, "oauth-mux init --codex-max");
+            try writer.writeAll("]}\n");
+        } else {
+            try writer.writeAll("oauth-mux discover\n\n");
+            try writer.print("  config: missing at {s}\n", .{config_path});
+            try writer.print("  state:  {s}\n\n", .{state_dir});
+            try writer.writeAll("  next:\n");
+            try writer.writeAll("    oauth-mux init\n");
+            try writer.writeAll("    oauth-mux init --codex-max\n");
+            try writer.writeAll("    oauth-mux config validate\n");
+        }
+        return;
+    };
+    defer parsed.deinit();
+
+    if (args.json) {
+        try writeDiscoverJson(writer, parsed.value, config_path, state_dir);
+    } else {
+        try writeDiscoverText(writer, parsed.value, config_path, state_dir);
+    }
+}
+
+fn writeDiscoverText(writer: anytype, cfg: config.Config, config_path: []const u8, state_dir: []const u8) !void {
+    try writer.writeAll("oauth-mux discover\n\n");
+    try writer.print("  config: {s}\n", .{config_path});
+    try writer.print("  state:  {s}\n\n", .{state_dir});
+
+    try writer.writeAll("  providers:\n");
+    if (cfg.providers.map.count() == 0) {
+        try writer.writeAll("    none configured\n");
+    } else {
+        var provider_it = cfg.providers.map.iterator();
+        while (provider_it.next()) |entry| {
+            const provider_name = entry.key_ptr.*;
+            const prov = entry.value_ptr.*;
+            try writer.print("    {s} ({s})\n", .{ provider_name, prov.kind });
+            var account_it = prov.accounts.map.iterator();
+            while (account_it.next()) |acct_entry| {
+                const account_name = acct_entry.key_ptr.*;
+                const account = acct_entry.value_ptr.*;
+                try writer.print("      {s} priority={d} secret={s}", .{
+                    account_name,
+                    account.priority,
+                    account.secret.backend,
+                });
+                if (account.config_dir != null) try writer.writeAll(" config_dir=yes");
+                if (account.tags) |tags| {
+                    try writer.writeAll(" tags=");
+                    for (tags, 0..) |tag, idx| {
+                        if (idx > 0) try writer.writeByte(',');
+                        try writer.writeAll(tag);
+                    }
+                }
+                try writer.writeByte('\n');
+            }
+        }
+    }
+
+    try writer.writeAll("\n  profiles:\n");
+    if (cfg.profiles.map.count() == 0) {
+        try writer.writeAll("    none configured\n");
+    } else {
+        var profile_it = cfg.profiles.map.iterator();
+        while (profile_it.next()) |entry| {
+            const profile_name = entry.key_ptr.*;
+            const profile = entry.value_ptr.*;
+            try writer.print("    {s}", .{profile_name});
+            if (profile.strategy) |strategy| try writer.print(" strategy={s}", .{strategy});
+            try writer.writeByte('\n');
+            for (profile.providers) |provider_ref| {
+                try writer.print("      {s}\n", .{provider_ref});
+            }
+        }
+    }
+
+    try writer.writeAll("\n  agent-safe commands:\n");
+    try writer.writeAll("    oauth-mux config validate\n");
+    try writer.writeAll("    oauth-mux status --json\n");
+    try writer.writeAll("    oauth-mux health --json\n");
+    try writer.writeAll("    oauth-mux probe --profile <profile> --capability <capability> --json\n");
+    try writer.writeAll("    oauth-mux env --profile <profile> --capability <capability> --shell <shell>\n");
+    try writer.writeAll("    oauth-mux exec --profile <profile> --capability <capability> -- <command>\n");
+}
+
+fn writeDiscoverJson(writer: anytype, cfg: config.Config, config_path: []const u8, state_dir: []const u8) !void {
+    try writer.writeAll("{\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"configured\":true,\"config_path\":");
+    try std.json.stringify(config_path, .{}, writer);
+    try writer.writeAll(",\"state_dir\":");
+    try std.json.stringify(state_dir, .{}, writer);
+    try writer.writeAll(",\"providers\":[");
+
+    var provider_first = true;
+    var provider_it = cfg.providers.map.iterator();
+    while (provider_it.next()) |entry| {
+        if (!provider_first) try writer.writeByte(',');
+        provider_first = false;
+        const provider_name = entry.key_ptr.*;
+        const prov = entry.value_ptr.*;
+        try writer.writeAll("{\"name\":");
+        try std.json.stringify(provider_name, .{}, writer);
+        try writer.writeAll(",\"kind\":");
+        try std.json.stringify(prov.kind, .{}, writer);
+        try writer.writeAll(",\"config_dir_env\":");
+        if (prov.config_dir_env) |config_dir_env| {
+            try std.json.stringify(config_dir_env, .{}, writer);
+        } else {
+            try writer.writeAll("null");
+        }
+        try writer.writeAll(",\"accounts\":[");
+        var account_first = true;
+        var account_it = prov.accounts.map.iterator();
+        while (account_it.next()) |acct_entry| {
+            if (!account_first) try writer.writeByte(',');
+            account_first = false;
+            const account_name = acct_entry.key_ptr.*;
+            const account = acct_entry.value_ptr.*;
+            try writer.writeAll("{\"name\":");
+            try std.json.stringify(account_name, .{}, writer);
+            try writer.print(",\"priority\":{d},\"secret_backend\":", .{account.priority});
+            try std.json.stringify(account.secret.backend, .{}, writer);
+            try writer.writeAll(",\"config_dir_set\":");
+            try writer.writeAll(if (account.config_dir != null) "true" else "false");
+            try writer.writeAll(",\"tags\":[");
+            if (account.tags) |tags| {
+                for (tags, 0..) |tag, idx| {
+                    if (idx > 0) try writer.writeByte(',');
+                    try std.json.stringify(tag, .{}, writer);
+                }
+            }
+            try writer.writeAll("]}");
+        }
+        try writer.writeAll("]}");
+    }
+
+    try writer.writeAll("],\"profiles\":[");
+    var profile_first = true;
+    var profile_it = cfg.profiles.map.iterator();
+    while (profile_it.next()) |entry| {
+        if (!profile_first) try writer.writeByte(',');
+        profile_first = false;
+        const profile_name = entry.key_ptr.*;
+        const profile = entry.value_ptr.*;
+        try writer.writeAll("{\"name\":");
+        try std.json.stringify(profile_name, .{}, writer);
+        try writer.writeAll(",\"strategy\":");
+        if (profile.strategy) |strategy| {
+            try std.json.stringify(strategy, .{}, writer);
+        } else {
+            try writer.writeAll("null");
+        }
+        try writer.print(",\"affinity_ttl_minutes\":{d},\"providers\":[", .{profile.affinity_ttl_minutes});
+        for (profile.providers, 0..) |provider_ref, idx| {
+            if (idx > 0) try writer.writeByte(',');
+            try std.json.stringify(provider_ref, .{}, writer);
+        }
+        try writer.writeAll("]}");
+    }
+
+    try writer.writeAll("],\"agent_safe_commands\":[");
+    const commands = [_][]const u8{
+        "oauth-mux config validate",
+        "oauth-mux status --json",
+        "oauth-mux health --json",
+        "oauth-mux probe --profile <profile> --capability <capability> --json",
+        "oauth-mux env --profile <profile> --capability <capability> --shell <shell>",
+        "oauth-mux exec --profile <profile> --capability <capability> -- <command>",
+    };
+    for (commands, 0..) |command, idx| {
+        if (idx > 0) try writer.writeByte(',');
+        try writeCommandJson(writer, command);
+    }
+    try writer.writeAll("]}\n");
+}
+
+fn writeCommandJson(writer: anytype, command: []const u8) !void {
+    try std.json.stringify(command, .{}, writer);
 }
 
 fn runEnv(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.EnvArgs) !void {


### PR DESCRIPTION
## Summary

Adds the next productization slice after the initial implementation merge:

- `oauth-mux discover [--json]` for redacted human/agent inventory.
- Codex Max onboarding helper: `scripts/onboard-codex-max.sh` and `just codex-max-onboard`.
- Manual live-provider QA runner and workflow, gated by `OMUX_LIVE_QA_CONFIRM=spend-real-calls` / dispatch input `spend-real-calls`.
- Manual registry dry-run runner and workflow, gated by `OMUX_REGISTRY_DRY_RUN_CONFIRM=registry-dry-run` / dispatch input `registry-dry-run`.
- Onboarding, live QA, registry dry-run/rollback, and daemon-boundary docs.
- `dist/live-qa/` ignore rule for redacted probe artifacts.

## Why

Users and agents need a streamlined path from installed binary to muxable accounts without reading token stores. Operators also need explicit manual gates for live provider spend, authenticated registry checks, rollback, and daemon promotion.

## Validation

- `just check`
- `sh -n scripts/onboard-codex-max.sh scripts/live-provider-qa.sh scripts/registry-dry-run.sh`
- Workflow YAML parse over `.github/workflows/*.yml`
- `git diff --check`
- `OMUX_CONFIG=$PWD/examples/codex-max.config.json ./zig-out/bin/oauth-mux discover --json | jq -e '.configured == true and (.providers[0].accounts | length == 3)'`
- Negative live QA guard exits with code 2 without `OMUX_LIVE_QA_CONFIRM=spend-real-calls`
- Plan-only registry dry-run writes `dist/out/v0.1.0/handoff/registry-dry-run.md`
