### PR TITLE
Classify Codex usage exhaustion as quota

### DIFF
--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -47,6 +47,22 @@ Artifacts are written under `dist/live-qa/<timestamp>/`:
 - one JSON file per probe
 - `health.json`
 
+By default, live QA passes when a probe returns a typed, redacted liveness
+result, even if the route is currently unavailable as `rate_limited`,
+`quota_exhausted`, or `degraded`. That makes quota exhaustion useful evidence
+rather than a false infrastructure failure. Set
+`OMUX_LIVE_QA_REQUIRE_AVAILABLE=1` when the run must fail unless every probed
+route is immediately selectable. Dead credentials fail by default; set
+`OMUX_LIVE_QA_ALLOW_DEAD=1` only for negative test fixtures.
+
+Current Codex behavior observed on 2026-04-27:
+
+- `max-1`, `max-2`, and `max-3` are all logged in and remain
+  `live/available` on `codex-mini`.
+- `max-1#codex-max`, `max-2#codex-max`, and `max-3#codex-max` currently return
+  `live/quota_exhausted` with distinct reset windows. The accounts are not
+  auth-dead; only the max route is exhausted.
+
 ## GitHub Workflow
 
 `.github/workflows/live-provider-qa.yml` is manual-only. It requires the

--- a/docs/spec/architecture-review-2026-04-25.md
+++ b/docs/spec/architecture-review-2026-04-25.md
@@ -270,10 +270,21 @@ just codex-max-probe-all
 codex-mini: max-1, max-2, max-3 -> 200/use_this/live/available
 
 just codex-max-probe-all codex-max
-current review refresh:
-max-1#codex-max -> degraded/unknown_4xx/status 400
-max-2#codex-max -> degraded/unknown_4xx/status 400
-profile-level codex-max fallback -> selected max-3#codex-max with 200/use_this/live/available
+2026-04-27 review refresh:
+max-1#codex-max -> live/quota_exhausted/status 400/try_next_account
+max-2#codex-max -> live/quota_exhausted/status 400/try_next_account
+max-3#codex-max -> live/quota_exhausted/status 400/try_next_account
+
+just codex-max-probe-all codex-mini
+2026-04-27 review refresh:
+max-1#codex-mini -> 200/use_this/live/available
+max-2#codex-mini -> 200/use_this/live/available
+max-3#codex-mini -> 200/use_this/live/available
+
+latest implication:
+all three accounts are authenticated and usable for cheaper Codex routes, while
+the max route is currently exhausted on each account with distinct reset
+windows. This is route availability, not auth death.
 
 just release
 single Zig release graph builds all six documented targets

--- a/docs/spec/development-timeline-2026-04-27.md
+++ b/docs/spec/development-timeline-2026-04-27.md
@@ -16,6 +16,12 @@ operational hardening: live-provider QA execution with real secrets,
 authenticated package publication dry-runs, rollback rehearsal, and
 post-merge GloriousFlywheel release-proof execution before public tags.
 
+Live Codex QA on 2026-04-27 confirmed the expected subscription permutation:
+all three accounts remain authenticated and selectable on `codex-mini`, while
+all three currently report route-scoped `live/quota_exhausted` on `codex-max`
+with distinct reset windows. That is now represented as route availability, not
+generic degradation or auth death.
+
 ## Completed Arc
 
 1. Research and formal model.
@@ -74,6 +80,14 @@ post-merge GloriousFlywheel release-proof execution before public tags.
   require `spend-real-calls`; `scripts/registry-dry-run.sh` and
   `.github/workflows/registry-dry-run.yml` require `registry-dry-run`.
 
+- Secret-scoped Codex live QA
+  Local account-matrix QA classified `max-1#codex-max` and
+  `max-2#codex-max`, and `max-3#codex-max` as `live/quota_exhausted` with
+  reset evidence, while `codex-mini` remains `live/available` for all three
+  accounts. The QA script now treats typed quota/rate/degraded outcomes as
+  valid evidence unless
+  `OMUX_LIVE_QA_REQUIRE_AVAILABLE=1` is set.
+
 ## Production Readiness
 
 Ready now:
@@ -95,8 +109,9 @@ Not ready yet:
 
 ## Next Arc
 
-1. Run the live-provider QA workflow with scoped secrets. Start with
-   `codex-mini`, then higher-cost routes only when explicitly requested.
+1. Run the live-provider QA workflow with scoped secrets from `main` so the
+   hosted artifact path proves the same Codex matrix that has now passed
+   locally.
 
 2. Run authenticated registry dry-run lanes:
    npm dry run, Homebrew formula audit in the tap, GitHub release auth check,

--- a/scripts/live-provider-qa.sh
+++ b/scripts/live-provider-qa.sh
@@ -51,8 +51,21 @@ run_probe() {
   shift
   local safe_label
   safe_label="$(printf '%s' "$label" | tr '#:/ ' '____')"
+  local output_file="$out_dir/${safe_label}.json"
   printf '=== %s ===\n' "$label"
-  if "$bin" probe "$@" --json 2>&1 | redact | tee "$out_dir/${safe_label}.json"; then
+  if "$bin" probe "$@" --json 2>&1 | redact | tee "$output_file"; then
+    return 0
+  fi
+  if grep -q '"liveness":' "$output_file" && ! grep -q '"liveness":null' "$output_file"; then
+    if grep -q '"state":"dead"' "$output_file" && [ "${OMUX_LIVE_QA_ALLOW_DEAD:-0}" != "1" ]; then
+      printf 'probe classified dead credential: %s\n' "$label" >&2
+      return 1
+    fi
+    if [ "${OMUX_LIVE_QA_REQUIRE_AVAILABLE:-0}" = "1" ] && ! grep -q '"decision":"use_this"' "$output_file"; then
+      printf 'probe classified unavailable route: %s\n' "$label" >&2
+      return 1
+    fi
+    printf 'probe classified non-selected route: %s\n' "$label" >&2
     return 0
   fi
   printf 'probe failed: %s\n' "$label" >&2

--- a/src/health.zig
+++ b/src/health.zig
@@ -151,6 +151,14 @@ pub fn hintClassFromClassification(classification: types.HttpClassification) Pro
     };
 }
 
+pub fn retryAfterFromClassification(classification: types.HttpClassification) ?u32 {
+    return switch (classification) {
+        .rate_limited => |rl| rl.retry_after_s,
+        .quota_exhausted => |quota| quota.retry_after_s,
+        else => null,
+    };
+}
+
 pub fn decisionFromClassification(classification: types.HttpClassification) types.MuxDecision {
     return switch (classification) {
         .success => .use_this,

--- a/src/main.zig
+++ b/src/main.zig
@@ -388,7 +388,10 @@ fn runEnv(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.EnvAr
         break :blk map.get(s) orelse shell.detect();
     } else shell.detect();
 
-    pipeline.runEnv(&ctx) catch |e| return e;
+    pipeline.runEnv(&ctx) catch |e| {
+        store.persist();
+        return e;
+    };
 
     try shell.emitEnv(writer, ctx.shell, ctx.env_pairs.items);
 
@@ -412,7 +415,7 @@ fn runProbe(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Pro
     ctx.account_name = args.account;
     ctx.capability_name = args.capability;
 
-    try pipeline.runProbe(&ctx);
+    const result = pipeline.runProbe(&ctx);
     store.persist();
 
     if (args.json) {
@@ -420,6 +423,7 @@ fn runProbe(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Pro
     } else {
         try writeProbeText(writer, &store, &ctx);
     }
+    try result;
 }
 
 fn runExec(allocator: std.mem.Allocator, args: cli.Command.ExecArgs) !void {
@@ -444,7 +448,10 @@ fn runExec(allocator: std.mem.Allocator, args: cli.Command.ExecArgs) !void {
     ctx.capability_name = args.capability;
     ctx.target_argv = args.target_argv;
 
-    pipeline.runExec(&ctx) catch |e| return e;
+    pipeline.runExec(&ctx) catch |e| {
+        store.persist();
+        return e;
+    };
 
     // Build env map from current env + pipeline injections
     var env_map = try std.process.getEnvMap(allocator);

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -428,7 +428,7 @@ fn probeCapability(ctx: *Context) PipelineError!types.MuxDecision {
     ctx.health.recordProbeEvidence(
         evidence_key.slice(),
         .capability_probe,
-        result.retry_after_s,
+        result.retry_after_s orelse health_mod.retryAfterFromClassification(classification),
         health_mod.hintClassFromClassification(classification),
         decision,
     );

--- a/src/provider_schema.zig
+++ b/src/provider_schema.zig
@@ -831,6 +831,8 @@ pub fn classifyCodexExecJsonl(allocator: std.mem.Allocator, jsonl: []const u8) ?
 }
 
 fn classifyCodexErrorMessage(allocator: std.mem.Allocator, message: []const u8) types.HttpClassification {
+    if (classifyCodexPlainErrorMessage(message)) |classification| return classification;
+
     const parsed = std.json.parseFromSlice(std.json.Value, allocator, message, .{}) catch {
         return classifyHttp(codex_def, 400, null, message);
     };
@@ -843,7 +845,125 @@ fn classifyCodexErrorValue(value: std.json.Value) ?types.HttpClassification {
     if (status_i < 0 or status_i > 65535) return null;
     const status: u16 = @intCast(status_i);
     const hint = resolveJsonString(value, "error.message");
+    if (hint) |message| {
+        if (classifyCodexPlainErrorMessage(message)) |classification| return classification;
+    }
     return classifyHttp(codex_def, status, null, hint);
+}
+
+fn classifyCodexPlainErrorMessage(message: []const u8) ?types.HttpClassification {
+    if (!(containsIgnoreAsciiCase(message, "usage limit") or
+        containsIgnoreAsciiCase(message, "purchase more credits") or
+        containsIgnoreAsciiCase(message, "try again at")))
+    {
+        return null;
+    }
+
+    return .{ .quota_exhausted = .{
+        .retry_after_s = parseCodexUsageRetryAfter(message) orelse 86_400,
+    } };
+}
+
+fn parseCodexUsageRetryAfter(message: []const u8) ?u32 {
+    const marker = "try again at ";
+    const start = std.ascii.indexOfIgnoreCase(message, marker) orelse return null;
+    var rest = std.mem.trim(u8, message[start + marker.len ..], " \t\r\n.");
+
+    const month = parseCodexMonth(rest[0..@min(rest.len, 9)]) orelse return null;
+    rest = rest[3..];
+    rest = std.mem.trimLeft(u8, rest, " \t");
+
+    const day_digits = leadingDigitCount(rest);
+    if (day_digits == 0) return null;
+    const day = std.fmt.parseInt(u8, rest[0..day_digits], 10) catch return null;
+    rest = rest[day_digits..];
+    if (std.ascii.startsWithIgnoreCase(rest, "st") or
+        std.ascii.startsWithIgnoreCase(rest, "nd") or
+        std.ascii.startsWithIgnoreCase(rest, "rd") or
+        std.ascii.startsWithIgnoreCase(rest, "th"))
+    {
+        rest = rest[2..];
+    }
+    rest = std.mem.trimLeft(u8, rest, " \t,");
+
+    const year_digits = leadingDigitCount(rest);
+    if (year_digits != 4) return null;
+    const year = std.fmt.parseInt(u16, rest[0..year_digits], 10) catch return null;
+    rest = rest[year_digits..];
+    rest = std.mem.trimLeft(u8, rest, " \t");
+
+    const hour_digits = leadingDigitCount(rest);
+    if (hour_digits == 0 or hour_digits > 2) return null;
+    var hour = std.fmt.parseInt(u8, rest[0..hour_digits], 10) catch return null;
+    rest = rest[hour_digits..];
+    if (rest.len == 0 or rest[0] != ':') return null;
+    rest = rest[1..];
+
+    const minute_digits = leadingDigitCount(rest);
+    if (minute_digits == 0 or minute_digits > 2) return null;
+    const minute = std.fmt.parseInt(u8, rest[0..minute_digits], 10) catch return null;
+    rest = rest[minute_digits..];
+    rest = std.mem.trimLeft(u8, rest, " \t");
+
+    if (std.ascii.startsWithIgnoreCase(rest, "PM")) {
+        if (hour < 12) hour += 12;
+    } else if (std.ascii.startsWithIgnoreCase(rest, "AM")) {
+        if (hour == 12) hour = 0;
+    } else {
+        return null;
+    }
+
+    const target = epochSecondsUtc(year, month, day, hour, minute) orelse return null;
+    const now = std.time.timestamp();
+    if (target <= now) return null;
+    const diff: u64 = @intCast(target - now);
+    return @intCast(@min(diff, std.math.maxInt(u32)));
+}
+
+fn parseCodexMonth(value: []const u8) ?u8 {
+    if (value.len < 3) return null;
+    const prefix = value[0..3];
+    if (std.ascii.eqlIgnoreCase(prefix, "Jan")) return 1;
+    if (std.ascii.eqlIgnoreCase(prefix, "Feb")) return 2;
+    if (std.ascii.eqlIgnoreCase(prefix, "Mar")) return 3;
+    if (std.ascii.eqlIgnoreCase(prefix, "Apr")) return 4;
+    if (std.ascii.eqlIgnoreCase(prefix, "May")) return 5;
+    if (std.ascii.eqlIgnoreCase(prefix, "Jun")) return 6;
+    if (std.ascii.eqlIgnoreCase(prefix, "Jul")) return 7;
+    if (std.ascii.eqlIgnoreCase(prefix, "Aug")) return 8;
+    if (std.ascii.eqlIgnoreCase(prefix, "Sep")) return 9;
+    if (std.ascii.eqlIgnoreCase(prefix, "Oct")) return 10;
+    if (std.ascii.eqlIgnoreCase(prefix, "Nov")) return 11;
+    if (std.ascii.eqlIgnoreCase(prefix, "Dec")) return 12;
+    return null;
+}
+
+fn leadingDigitCount(value: []const u8) usize {
+    var count: usize = 0;
+    while (count < value.len and std.ascii.isDigit(value[count])) : (count += 1) {}
+    return count;
+}
+
+fn epochSecondsUtc(year: u16, month: u8, day: u8, hour: u8, minute: u8) ?i64 {
+    if (year < std.time.epoch.epoch_year or month < 1 or month > 12 or day < 1 or hour > 23 or minute > 59) return null;
+
+    const leap_kind: std.time.epoch.YearLeapKind = if (std.time.epoch.isLeapYear(year)) .leap else .not_leap;
+    const month_enum: std.time.epoch.Month = @enumFromInt(month);
+    if (day > std.time.epoch.getDaysInMonth(leap_kind, month_enum)) return null;
+
+    var days: u64 = 0;
+    var y: u16 = std.time.epoch.epoch_year;
+    while (y < year) : (y += 1) {
+        days += std.time.epoch.getDaysInYear(y);
+    }
+    var m: u8 = 1;
+    while (m < month) : (m += 1) {
+        const current: std.time.epoch.Month = @enumFromInt(m);
+        days += std.time.epoch.getDaysInMonth(leap_kind, current);
+    }
+    days += day - 1;
+
+    return @intCast(days * std.time.epoch.secs_per_day + @as(u64, hour) * 3600 + @as(u64, minute) * 60);
 }
 
 fn capabilityMatches(cap: CapabilityDefinition, requested: []const u8) bool {
@@ -1480,6 +1600,33 @@ test "classifyCodexExecJsonl unsupported model cassette" {
     const classification = classifyCodexExecJsonl(std.testing.allocator, jsonl).?;
     switch (classification) {
         .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.tier_insufficient, reason),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "classifyCodexExecJsonl usage limit as quota exhaustion" {
+    const jsonl =
+        \\{"type":"thread.started","thread_id":"redacted"}
+        \\{"type":"turn.started"}
+        \\{"type":"error","message":"You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Apr 28th, 2099 2:19 PM."}
+        \\{"type":"turn.failed","error":{"message":"You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Apr 28th, 2099 2:19 PM."}}
+        \\
+    ;
+    const classification = classifyCodexExecJsonl(std.testing.allocator, jsonl).?;
+    switch (classification) {
+        .quota_exhausted => |quota| try std.testing.expect(quota.retry_after_s > 0),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "classifyCodexExecJsonl usage limit without reset as quota exhaustion" {
+    const jsonl =
+        \\{"type":"error","message":"You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits."}
+        \\
+    ;
+    const classification = classifyCodexExecJsonl(std.testing.allocator, jsonl).?;
+    switch (classification) {
+        .quota_exhausted => |quota| try std.testing.expectEqual(@as(u32, 86_400), quota.retry_after_s),
         else => return error.TestUnexpectedResult,
     }
 }


### PR DESCRIPTION
## Summary

- classify Codex CLI usage-limit messages as route-scoped `live/quota_exhausted`
- persist failed probe health evidence before returning selection errors, including retry windows derived from typed classification
- make live-provider QA pass on typed unavailable routes by default, with `OMUX_LIVE_QA_REQUIRE_AVAILABLE=1` for strict availability runs
- document the current Codex matrix: `codex-max` exhausted, `codex-mini` available across the three stores

## Validation

- `just check`
- `sh -n scripts/live-provider-qa.sh`
- `git diff --check`
- live QA: `codex-max` matrix classified all three accounts as `live/quota_exhausted` with reset evidence
- live QA: `codex-mini` matrix returned `live/available` for all three accounts
