### PR TITLE
Add Codex Max no-spend canary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ bazel-*
 dist/build/
 dist/out/
 dist/live-qa/
+dist/codex-canary/
 *.tar.gz
 *.deb
 *.rpm

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Probe a configured account:
 ./zig-out/bin/oauth-mux probe --provider codex --account max-1 --capability codex-mini --json
 ```
 
+Run the no-spend Codex Max canary:
+
+```bash
+just codex-max-canary
+```
+
 Run the deterministic no-secret E2E harness:
 
 ```bash

--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -40,6 +40,18 @@ OMUX_LIVE_QA_CAPABILITIES=codex-max \
 just live-qa
 ```
 
+For the Codex Max three-account path, prefer the canary before any spending
+run:
+
+```bash
+just codex-max-canary
+```
+
+That command validates config, captures discovery/status/health, and checks
+`codex login status` for each account without running probes. Set
+`OMUX_CODEX_CANARY_CONFIRM=spend-real-calls` only when the canary should also
+invoke this live QA matrix.
+
 Artifacts are written under `dist/live-qa/<timestamp>/`:
 
 - `config-validate.txt`

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -44,6 +44,7 @@ Codex Max three-account starter:
 ```bash
 oauth-mux init --codex-max
 just codex-max-onboard
+just codex-max-canary
 ```
 
 `just codex-max-onboard` creates the expected isolated `CODEX_HOME` directories,
@@ -65,6 +66,21 @@ For status-only inspection:
 
 ```bash
 OMUX_CODEX_LOGIN_MODE=status-only just codex-max-onboard
+```
+
+For a no-spend canary after onboarding:
+
+```bash
+just codex-max-canary
+```
+
+The canary validates config, writes redacted `discover`, `status`, and `health`
+JSON artifacts, checks `codex login status` for each expected account, and
+summarizes whether route health has already been recorded. It does not run live
+probes by default. To include bounded route probes:
+
+```bash
+OMUX_CODEX_CANARY_CONFIRM=spend-real-calls just codex-max-canary
 ```
 
 ## Agent Discovery Contract

--- a/docs/spec/development-timeline-2026-04-27.md
+++ b/docs/spec/development-timeline-2026-04-27.md
@@ -53,8 +53,9 @@ generic degradation or auth death.
 
 7. Onboarding and discovery surface.
    `oauth-mux discover --json`, `docs/onboarding.md`, `just codex-max-onboard`,
-   manual live-provider QA, registry dry-run, rollback, and daemon-boundary
-   runbooks now define the operator and agent path.
+   `just codex-max-canary`, manual live-provider QA, registry dry-run,
+   rollback, and daemon-boundary runbooks now define the operator and agent
+   path.
 
 ## Current Gates
 
@@ -79,6 +80,11 @@ generic degradation or auth death.
   `scripts/live-provider-qa.sh` and `.github/workflows/live-provider-qa.yml`
   require `spend-real-calls`; `scripts/registry-dry-run.sh` and
   `.github/workflows/registry-dry-run.yml` require `registry-dry-run`.
+
+- Codex canary and secret-scoped live QA
+  `just codex-max-canary` captures no-spend config/discovery/status/health and
+  per-account `codex login status` artifacts, then delegates to live QA only
+  when explicitly confirmed.
 
 - Secret-scoped Codex live QA
   Local account-matrix QA classified `max-1#codex-max` and
@@ -121,8 +127,5 @@ Not ready yet:
    `main` before publishing tags. GitHub cannot dispatch PR-local workflow
    files until they exist on the default branch.
 
-4. Add a small canary script for the three real Codex Max accounts that reports
-   liveness and route decisions without changing auth state or leaking tokens.
-
-5. Revisit the daemon boundary only after live-provider QA covers refresh,
+4. Revisit the daemon boundary only after live-provider QA covers refresh,
    timeout, quota, and provider-owned CLI session behavior.

--- a/justfile
+++ b/justfile
@@ -75,6 +75,9 @@ codex-max-login-status-all:
 codex-max-onboard: build
     ./scripts/onboard-codex-max.sh
 
+codex-max-canary: build
+    OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./scripts/codex-max-canary.sh
+
 codex-max-probe ACCOUNT CAPABILITY="codex-mini": build
     OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux probe --provider codex --account {{ACCOUNT}} --capability {{CAPABILITY}} --json
 

--- a/scripts/codex-max-canary.sh
+++ b/scripts/codex-max-canary.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+config_path="${OMUX_CONFIG:-$repo_root/examples/codex-max.config.json}"
+accounts_csv="${OMUX_CODEX_ACCOUNTS:-max-1,max-2,max-3}"
+capabilities_csv="${OMUX_CODEX_CANARY_CAPABILITIES:-codex-mini,codex-max}"
+store_root="${OMUX_CODEX_STORE_ROOT:-${XDG_DATA_HOME:-$HOME/.local/share}/oauth-mux/codex}"
+state_dir="${OMUX_STATE_DIR:-/tmp/oauth-mux-codex-max-health}"
+bin="${OMUX_BIN:-$repo_root/zig-out/bin/oauth-mux}"
+
+if [ ! -x "$bin" ]; then
+  printf 'oauth-mux binary not found at %s\n' "$bin" >&2
+  printf 'run: just build\n' >&2
+  exit 1
+fi
+
+if ! command -v codex >/dev/null 2>&1; then
+  printf 'codex CLI not found on PATH\n' >&2
+  exit 1
+fi
+
+stamp="$(date -u '+%Y%m%dT%H%M%SZ')"
+out_dir="${OMUX_CODEX_CANARY_OUT:-$repo_root/dist/codex-canary/$stamp}"
+mkdir -p "$out_dir"
+
+export OMUX_CONFIG="$config_path"
+export OMUX_STATE_DIR="$state_dir"
+
+IFS=',' read -r -a accounts <<<"$accounts_csv"
+IFS=',' read -r -a capabilities <<<"$capabilities_csv"
+
+redact() {
+  sed -E \
+    -e 's/(access_token|refresh_token|id_token|token)["= :]+[^", ]+/\1=<redacted>/gi' \
+    -e 's/(Bearer )[A-Za-z0-9._~+\/=-]+/\1<redacted>/g'
+}
+
+summary="$out_dir/summary.txt"
+
+{
+  printf 'oauth-mux Codex Max canary\n\n'
+  printf 'config:       %s\n' "$config_path"
+  printf 'state:        %s\n' "$state_dir"
+  printf 'store root:   %s\n' "$store_root"
+  printf 'accounts:     %s\n' "$accounts_csv"
+  printf 'capabilities: %s\n' "$capabilities_csv"
+  printf 'artifacts:    %s\n' "$out_dir"
+} | tee "$summary"
+
+printf '\n=== config validate ===\n' | tee -a "$summary"
+"$bin" config validate 2>&1 | redact | tee "$out_dir/config-validate.txt"
+
+printf '\n=== agent discovery ===\n' | tee -a "$summary"
+"$bin" discover --json >"$out_dir/discover.json"
+"$bin" status --json >"$out_dir/status.json"
+"$bin" health --json >"$out_dir/health.json"
+printf 'wrote discover.json, status.json, health.json\n' | tee -a "$summary"
+
+printf '\n=== codex login status ===\n' | tee -a "$summary"
+: >"$out_dir/codex-login-status.txt"
+login_failures=0
+for account in "${accounts[@]}"; do
+  account_dir="$store_root/$account"
+  {
+    printf '=== %s ===\n' "$account"
+    printf 'CODEX_HOME=%s\n' "$account_dir"
+    CODEX_HOME="$account_dir" codex login status
+  } 2>&1 | redact | tee -a "$out_dir/codex-login-status.txt" || login_failures=$((login_failures + 1))
+done
+
+printf '\n=== route liveness snapshot ===\n' | tee -a "$summary"
+printf 'No live probes were run by default. Route decisions below come from existing oauth-mux health state.\n' | tee -a "$summary"
+for account in "${accounts[@]}"; do
+  for capability in "${capabilities[@]}"; do
+    key="codex:${account}#${capability}"
+    if grep -q "\"key\":\"$key\"" "$out_dir/health.json"; then
+      printf '%s: recorded\n' "$key" | tee -a "$summary"
+    else
+      printf '%s: no recorded health yet\n' "$key" | tee -a "$summary"
+    fi
+  done
+done
+
+confirm="${OMUX_CODEX_CANARY_CONFIRM:-${OMUX_LIVE_QA_CONFIRM:-}}"
+if [ "$confirm" = "spend-real-calls" ]; then
+  printf '\n=== live QA ===\n' | tee -a "$summary"
+  OMUX_CONFIG="$config_path" \
+    OMUX_STATE_DIR="$state_dir" \
+    OMUX_LIVE_QA_PROVIDER="${OMUX_LIVE_QA_PROVIDER:-codex}" \
+    OMUX_LIVE_QA_ACCOUNTS="$accounts_csv" \
+    OMUX_LIVE_QA_CAPABILITIES="$capabilities_csv" \
+    OMUX_LIVE_QA_CONFIRM=spend-real-calls \
+    "$repo_root/scripts/live-provider-qa.sh" 2>&1 | redact | tee "$out_dir/live-qa.txt"
+else
+  {
+    printf '\nLive probes not run.\n'
+    printf 'To run bounded route probes, set OMUX_CODEX_CANARY_CONFIRM=spend-real-calls.\n'
+  } | tee -a "$summary"
+fi
+
+if [ "$login_failures" -ne 0 ]; then
+  printf '\nCodex login-status failures: %s\n' "$login_failures" | tee -a "$summary" >&2
+  exit 1
+fi
+
+printf '\nCodex Max canary artifacts: %s\n' "$out_dir"


### PR DESCRIPTION
## Summary

Adds a Codex Max canary for the three-account operator path.

- New `scripts/codex-max-canary.sh` captures config validation, redacted `discover/status/health` JSON, and per-account `codex login status` without running live probes by default.
- New `just codex-max-canary` uses the same Codex Max example config and `/tmp/oauth-mux-codex-max-health` state path as the existing probe helpers.
- The canary delegates to live provider QA only when `OMUX_CODEX_CANARY_CONFIRM=spend-real-calls` is set.
- Docs now put the canary between onboarding and live QA, and generated canary artifacts are ignored under `dist/codex-canary/`.

## Validation

- `just codex-max-canary` passed locally with no live probes and confirmed `max-1`, `max-2`, and `max-3` are logged in via isolated `CODEX_HOME` stores.
- The canary saw recorded health for all six Codex route keys from `/tmp/oauth-mux-codex-max-health`.
- `just check` passed.
- `bash -n scripts/codex-max-canary.sh` passed.
- `sh -n scripts/codex-max-canary.sh` passed.
- `git diff --check` passed.

## Notes

This is an operator/user onboarding improvement, not a daemon boundary change. The default path is no-spend and read-only against existing auth state; live route probes remain explicit.
