### PR TITLE
Add CI-only npm publication

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,31 +1,33 @@
-name: Registry Dry Run
+name: NPM Publish
 
 on:
   workflow_dispatch:
     inputs:
       confirm:
-        description: "Type registry-dry-run to contact authenticated registry endpoints without publishing"
+        description: "Type publish-npm to publish npm tarballs from CI artifacts"
         required: true
         type: string
       version:
-        description: "Version to stage and dry-run"
+        description: "Version to stage and publish"
         required: false
         default: "0.1.0"
         type: string
-      lanes:
-        description: "Comma-separated lanes: plan,github,npm,homebrew,system"
+      dry_run:
+        description: "Run npm publish --dry-run instead of publishing"
         required: false
-        default: "plan"
-        type: string
+        default: true
+        type: boolean
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
-  registry-dry-run:
-    name: Registry dry-run
-    if: inputs.confirm == 'registry-dry-run'
+  npm-publish:
+    name: npm publish from release derivation
+    if: inputs.confirm == 'publish-npm'
     runs-on: ubuntu-latest
+    environment: npm-production
     env:
       OMUX_GLOBAL_SOPS_B64_PRESENT: ${{ secrets.OMUX_GLOBAL_SOPS_B64 != '' }}
       OMUX_GLOBAL_SOPS_REPOSITORY_PRESENT: ${{ vars.OMUX_GLOBAL_SOPS_REPOSITORY != '' }}
@@ -70,22 +72,24 @@ jobs:
       - name: Stage release proof
         run: nix develop --command just release-proof-local "${{ inputs.version }}"
 
-      - name: Run registry dry-run
+      - name: Publish npm tarballs from staged artifacts
         shell: bash
         env:
-          OMUX_REGISTRY_DRY_RUN_CONFIRM: registry-dry-run
-          OMUX_REGISTRY_LANES: ${{ inputs.lanes }}
+          OMUX_NPM_PUBLISH_CONFIRM: publish-npm
           OMUX_NPM_TOKEN_SOPS_KEY: ${{ vars.OMUX_NPM_TOKEN_SOPS_KEY || '.api.npm_token' }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN || '' }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || '' }}
           SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY || '' }}
-          GITHUB_TOKEN: ${{ github.token }}
-          OMUX_HOMEBREW_TAP_DIR: ${{ vars.OMUX_HOMEBREW_TAP_DIR || '' }}
-        run: nix develop --command ./scripts/registry-dry-run.sh "${{ inputs.version }}"
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            export OMUX_NPM_PUBLISH_DRY_RUN=1
+          fi
+          nix develop --command ./scripts/npm-ci-publish.sh "${{ inputs.version }}"
 
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: registry-dry-run-${{ inputs.version }}
+          name: npm-publish-${{ inputs.version }}
           path: dist/out/**/handoff/
           if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Release attachments, npm publish order, Homebrew tap input, deb/rpm files, and
 full checksums.
 
 See `docs/release-runbook.md` for release and CI details.
+See `docs/adoption.md` for installation and external-user adoption goals.
 See `docs/onboarding.md` for human and agent onboarding.
 See `docs/live-provider-qa.md` for manual secret-scoped provider probes.
 See `docs/registry-dry-runs-and-rollback.md` for publication dry-runs and

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -1,0 +1,76 @@
+# Adoption Path
+
+`oauth-mux` should be usable by people who are not running the Tinyland lab
+stack. Lab SOPS, GloriousFlywheel, and Codex Max canaries are proving grounds;
+they must not become requirements for ordinary users.
+
+## Install Surfaces
+
+Target install surfaces:
+
+- npm: `npm install -g oauth-mux`
+- Homebrew: `brew install tinyland-inc/tap/oauth-mux`
+- curl installer: `curl -fsSL ... | sh`
+- deb/rpm packages for Linux hosts
+- raw release tarballs for air-gapped or policy-managed systems
+
+Each release artifact should be derived from the same CI release tree. npm is
+published only from CI tarballs with provenance; workstation `npm publish` is
+not supported.
+
+## First User Experience
+
+The happy path should stay small:
+
+```bash
+oauth-mux init
+oauth-mux config validate
+oauth-mux discover --json
+```
+
+For Codex subscription users working from a source checkout today:
+
+```bash
+oauth-mux init --codex-max
+just codex-max-onboard
+just codex-max-canary
+```
+
+Before broad npm-facing documentation, the repo-local `just` helpers should be
+promoted into installed `oauth-mux codex ...` commands or packaged helper
+scripts. Public users should not need a source checkout for routine account
+onboarding.
+
+Live probes remain explicit because they can spend subscription calls:
+
+```bash
+OMUX_LIVE_QA_CONFIRM=spend-real-calls just live-qa
+```
+
+## Provider Author Experience
+
+A new provider should usually start as data, not Zig:
+
+1. Write a JSON provider definition with credential parsing, injection, probes,
+   and failure rules.
+2. Add redacted fixtures for the provider's success, rate-limit, quota,
+   degraded, and auth-dead responses.
+3. Run `oauth-mux config validate` and the no-secret E2E harness.
+4. Run live QA only with explicit account-scoped consent.
+
+Compiled Zig changes should be reserved for new transports, parser primitives,
+or core liveness algebra changes.
+
+## Non-Tinyland Deployments
+
+External users may use any secret backend that fits their environment:
+
+- env references
+- files under XDG or platform config dirs
+- keychain or `secret-tool`
+- command backends
+- SOPS/age
+- stdin for short-lived automation
+
+No adoption flow should require the lab repo, Tinyland SOPS keys,
+GloriousFlywheel, or Codex Max accounts.

--- a/docs/registry-dry-runs-and-rollback.md
+++ b/docs/registry-dry-runs-and-rollback.md
@@ -2,8 +2,12 @@
 
 Registry publication is intentionally separate from release artifact proof.
 `just release-proof <version>` proves the release tree and handoff without
-publication credentials. Authenticated registry dry-runs are manual and
-non-publishing.
+publication credentials. Authenticated registry dry-runs are CI/operator gates
+and non-publishing.
+
+npm publication is CI-only. Do not run `npm publish` from a workstation. The
+publish workflow stages the same release derivation, then publishes the
+generated tarballs with npm provenance.
 
 ## Dry-Run
 
@@ -26,10 +30,15 @@ Run authenticated lanes:
 ```bash
 OMUX_REGISTRY_DRY_RUN_CONFIRM=registry-dry-run \
 OMUX_REGISTRY_LANES=github,npm,homebrew,system \
-NPM_TOKEN=... \
+NPM_TOKEN_FILE=/path/to/npm-token \
 OMUX_HOMEBREW_TAP_DIR=/path/to/homebrew-tap \
 just registry-dry-run 0.1.0
 ```
+
+The npm dry-run lane resolves auth in this order: `NPM_TOKEN`,
+`NODE_AUTH_TOKEN`, `NPM_TOKEN_FILE`, `NODE_AUTH_TOKEN_FILE`, then
+`OMUX_NPM_TOKEN_SOPS_FILE` with `OMUX_NPM_TOKEN_SOPS_KEY`. The default SOPS key
+candidate is `.api.npm_token`.
 
 The script writes `dist/out/v<version>/handoff/registry-dry-run.md`.
 
@@ -41,10 +50,35 @@ The script writes `dist/out/v<version>/handoff/registry-dry-run.md`.
 
 Required secret and variable surfaces:
 
-- `NPM_TOKEN` for the npm lane.
+- `NPM_TOKEN` for the npm lane, or SOPS inputs:
+  `OMUX_GLOBAL_SOPS_B64` plus `SOPS_AGE_KEY`, or
+  `OMUX_GLOBAL_SOPS_REPOSITORY` plus `OMUX_GLOBAL_SOPS_FILE` and `SOPS_AGE_KEY`.
+- `OMUX_NPM_TOKEN_SOPS_KEY` repository variable when the npm token is not at
+  `.api.npm_token`.
 - `OMUX_HOMEBREW_TAP_DIR` repository variable for the Homebrew lane when a tap
   checkout is available in the runner environment.
 - The default workflow `GITHUB_TOKEN` for the GitHub lane.
+
+## npm Publish
+
+`.github/workflows/npm-publish.yml` is the only supported npm mutation path. It
+requires `confirm=publish-npm`, stages `just release-proof-local <version>`, and
+then publishes the generated tarballs in this order:
+
+1. `@oauth-mux/linux-x64`
+2. `@oauth-mux/linux-arm64`
+3. `@oauth-mux/darwin-x64`
+4. `@oauth-mux/darwin-arm64`
+5. `@oauth-mux/win32-x64`
+6. `@oauth-mux/win32-arm64`
+7. `oauth-mux`
+
+The workflow requests `id-token: write` so `npm publish --provenance` can attach
+GitHub Actions provenance. Keep `dry_run=true` for the first authenticated
+execution. Set `dry_run=false` only for the actual release publication.
+
+The publish script is idempotent by default: if `package@version` already exists
+on npm, it records a skip instead of overwriting or republishing.
 
 ## Rollback
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -97,6 +97,11 @@ The handoff lists GitHub Release attachments, npm publish order, Homebrew tap
 input, deb/rpm files, and full checksums. It does not use registry credentials
 or publish anything.
 
+npm publication is intentionally separate and CI-only. Use
+`.github/workflows/npm-publish.yml`; it reuses the release derivation, resolves
+auth at runtime, and publishes only the generated tarballs with npm provenance.
+Do not publish npm packages from a workstation.
+
 ## Release Workflow
 
 Tags matching `v*` run `.github/workflows/release.yml`.
@@ -114,6 +119,10 @@ and handoff generation pass. It then attaches these files to the GitHub release:
 - `v*/npm-tarballs/*.tgz`
 - `v*/homebrew/oauth-mux.rb`
 - `v*/handoff/*`
+
+This tag workflow does not publish npm packages. npm publication is handled by
+the manual `NPM Publish` workflow after the release artifacts and registry
+dry-run are reviewed.
 
 The staged `install.sh` verifies the selected tarball against `SHA256SUMS`
 before installing. For local proof, `OMUX_RELEASE_BASE_URL=file://...` points it

--- a/docs/spec/development-timeline-2026-04-27.md
+++ b/docs/spec/development-timeline-2026-04-27.md
@@ -81,6 +81,12 @@ generic degradation or auth death.
   require `spend-real-calls`; `scripts/registry-dry-run.sh` and
   `.github/workflows/registry-dry-run.yml` require `registry-dry-run`.
 
+- CI-only npm publication
+  `.github/workflows/npm-publish.yml` publishes only generated release
+  tarballs, with npm provenance, after `just release-proof-local <version>`.
+  Auth can come from Actions secrets, token files, or SOPS at runtime; token
+  material is never committed or printed.
+
 - Codex canary and secret-scoped live QA
   `just codex-max-canary` captures no-spend config/discovery/status/health and
   per-account `codex login status` artifacts, then delegates to live QA only
@@ -107,7 +113,7 @@ Ready now:
 Not ready yet:
 
 - unattended automatic live-provider probing;
-- public npm/Homebrew/deb/rpm publication;
+- public Homebrew/deb/rpm publication;
 - required self-hosted release gate;
 - background daemon token refresh as an operational dependency;
 - documented rollback for each registry lane;

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
         };
 
         devShells.default = pkgs.mkShell {
-          packages = [ zig pkgs.just pkgs.nodejs pkgs.nfpm ];
+          packages = [ zig pkgs.just pkgs.nodejs pkgs.nfpm pkgs.sops pkgs.age pkgs.jq ];
 
           shellHook = ''
             echo "oauth-mux dev shell — zig $(zig version)"

--- a/scripts/npm-ci-publish.sh
+++ b/scripts/npm-ci-publish.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+version="${1:-${VERSION:-0.1.0}}"
+version="${version#v}"
+out_dir="$repo_root/dist/out/v${version}"
+npm_tgz_dir="$out_dir/npm-tarballs"
+handoff_dir="$out_dir/handoff"
+report="$handoff_dir/npm-ci-publish.md"
+
+platform_tarballs=(
+  "oauth-mux-linux-x64-${version}.tgz"
+  "oauth-mux-linux-arm64-${version}.tgz"
+  "oauth-mux-darwin-x64-${version}.tgz"
+  "oauth-mux-darwin-arm64-${version}.tgz"
+  "oauth-mux-win32-x64-${version}.tgz"
+  "oauth-mux-win32-arm64-${version}.tgz"
+)
+root_tarball="oauth-mux-${version}.tgz"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'missing required command: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+append() {
+  printf '%s\n' "$*" >>"$report"
+}
+
+require_file() {
+  if [ ! -f "$1" ]; then
+    printf 'missing npm publication input: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+package_field() {
+  local tarball="$1"
+  local field="$2"
+  tar -xOf "$tarball" package/package.json | jq -er ".$field"
+}
+
+ensure_ci_boundary() {
+  if [ "${OMUX_NPM_PUBLISH_PLAN_ONLY:-0}" = "1" ]; then
+    return
+  fi
+  if [ "${GITHUB_ACTIONS:-}" != "true" ] && [ "${OMUX_NPM_CI_ALLOW_LOCAL:-0}" != "1" ]; then
+    cat >&2 <<'EOF'
+npm publication is CI-only.
+
+Run through .github/workflows/npm-publish.yml, or set
+OMUX_NPM_CI_ALLOW_LOCAL=1 only for a controlled local dry-run.
+EOF
+    exit 2
+  fi
+}
+
+ensure_confirmed() {
+  if [ "${OMUX_NPM_PUBLISH_PLAN_ONLY:-0}" = "1" ]; then
+    return
+  fi
+  if [ "${OMUX_NPM_PUBLISH_CONFIRM:-}" != "publish-npm" ]; then
+    cat >&2 <<EOF
+npm publication is disabled.
+
+Re-run in CI with:
+
+  OMUX_NPM_PUBLISH_CONFIRM=publish-npm ./scripts/npm-ci-publish.sh ${version}
+EOF
+    exit 2
+  fi
+}
+
+package_exists() {
+  local name="$1"
+  local pkg_version="$2"
+  NPM_CONFIG_USERCONFIG="$npmrc" npm view "${name}@${pkg_version}" version >/dev/null 2>&1
+}
+
+publish_one() {
+  local tarball="$1"
+  local name
+  local pkg_version
+  name="$(package_field "$tarball" name)"
+  pkg_version="$(package_field "$tarball" version)"
+
+  if [ "$pkg_version" != "$version" ]; then
+    printf 'tarball version mismatch for %s: expected %s, found %s\n' "$tarball" "$version" "$pkg_version" >&2
+    exit 1
+  fi
+
+  if [ "${OMUX_NPM_PUBLISH_PLAN_ONLY:-0}" = "1" ]; then
+    append "- plan: \`${name}@${pkg_version}\` from \`npm-tarballs/$(basename "$tarball")\`"
+    return
+  fi
+
+  if [ "${OMUX_NPM_SKIP_EXISTING:-1}" = "1" ] && package_exists "$name" "$pkg_version"; then
+    append "- skipped existing: \`${name}@${pkg_version}\`"
+    return
+  fi
+
+  local args=(publish "$tarball" --provenance)
+  case "$name" in
+    @oauth-mux/*)
+      args+=(--access public)
+      ;;
+  esac
+  if [ "${OMUX_NPM_PUBLISH_DRY_RUN:-0}" = "1" ]; then
+    args+=(--dry-run)
+  fi
+
+  NPM_CONFIG_USERCONFIG="$npmrc" npm "${args[@]}"
+  if [ "${OMUX_NPM_PUBLISH_DRY_RUN:-0}" = "1" ]; then
+    append "- dry-run OK: \`${name}@${pkg_version}\`"
+  else
+    append "- published: \`${name}@${pkg_version}\`"
+  fi
+}
+
+ensure_ci_boundary
+ensure_confirmed
+
+if [ ! -d "$out_dir" ]; then
+  printf 'release output does not exist: %s\n' "$out_dir" >&2
+  printf 'run in CI after: just release-proof-local %s\n' "$version" >&2
+  exit 1
+fi
+
+require_command npm
+require_command jq
+require_command tar
+
+mkdir -p "$handoff_dir"
+
+for tarball in "${platform_tarballs[@]}" "$root_tarball"; do
+  require_file "$npm_tgz_dir/$tarball"
+done
+
+cat >"$report" <<EOF
+# oauth-mux v${version} npm CI Publish
+
+Generated: $(date -u '+%Y-%m-%dT%H:%M:%SZ')
+Release tree: \`dist/out/v${version}\`
+
+This report records CI-only npm publication from prebuilt tarballs. It must not
+include token material.
+
+EOF
+
+if [ "${OMUX_NPM_PUBLISH_PLAN_ONLY:-0}" = "1" ]; then
+  append "## plan"
+  append
+else
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/oauth-mux-npm-publish.XXXXXX")"
+  trap 'rm -rf "$tmp"' EXIT
+  npmrc="$tmp/npmrc"
+  "$repo_root/scripts/resolve-npm-token.sh" --npmrc "$npmrc" >/dev/null
+
+  append "## npm identity"
+  append
+  npm_user="$(NPM_CONFIG_USERCONFIG="$npmrc" npm whoami --registry=https://registry.npmjs.org/)"
+  append "- authenticated as: \`${npm_user}\`"
+  if [ "${OMUX_NPM_PUBLISH_DRY_RUN:-0}" = "1" ]; then
+    append "- mode: dry-run"
+  else
+    append "- mode: publish"
+  fi
+  append "- provenance: enabled"
+  append
+  append "## packages"
+  append
+fi
+
+for tarball in "${platform_tarballs[@]}"; do
+  publish_one "$npm_tgz_dir/$tarball"
+done
+publish_one "$npm_tgz_dir/$root_tarball"
+
+printf 'npm CI publish report: %s\n' "$report"

--- a/scripts/registry-dry-run.sh
+++ b/scripts/registry-dry-run.sh
@@ -92,28 +92,20 @@ for lane in "${lanes[@]}"; do
 
     npm)
       require_command npm
-      npm_token="${NPM_TOKEN:-${NODE_AUTH_TOKEN:-}}"
-      if [ -z "$npm_token" ]; then
-        printf 'npm lane requires NPM_TOKEN or NODE_AUTH_TOKEN\n' >&2
-        exit 1
-      fi
       npmrc="$(mktemp)"
       tmp_files+=("$npmrc")
-      {
-        printf 'registry=https://registry.npmjs.org/\n'
-        printf '//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n'
-      } >"$npmrc"
+      "$repo_root/scripts/resolve-npm-token.sh" --npmrc "$npmrc" >/dev/null
       append "## npm"
       append
-      NPM_CONFIG_USERCONFIG="$npmrc" NPM_TOKEN="$npm_token" npm whoami --registry=https://registry.npmjs.org/ >/dev/null
+      NPM_CONFIG_USERCONFIG="$npmrc" npm whoami --registry=https://registry.npmjs.org/ >/dev/null
       for tarball in "$out_dir"/npm-tarballs/*.tgz; do
         name="$(basename "$tarball")"
         case "$name" in
           oauth-mux-darwin-*|oauth-mux-linux-*|oauth-mux-win32-*)
-            NPM_CONFIG_USERCONFIG="$npmrc" NPM_TOKEN="$npm_token" npm publish "$tarball" --dry-run --access public ${OMUX_NPM_EXTRA_ARGS:-} >/dev/null
+            NPM_CONFIG_USERCONFIG="$npmrc" npm publish "$tarball" --dry-run --access public ${OMUX_NPM_EXTRA_ARGS:-} >/dev/null
             ;;
           *)
-            NPM_CONFIG_USERCONFIG="$npmrc" NPM_TOKEN="$npm_token" npm publish "$tarball" --dry-run ${OMUX_NPM_EXTRA_ARGS:-} >/dev/null
+            NPM_CONFIG_USERCONFIG="$npmrc" npm publish "$tarball" --dry-run ${OMUX_NPM_EXTRA_ARGS:-} >/dev/null
             ;;
         esac
         append "- dry-run OK: \`npm-tarballs/${name}\`"

--- a/scripts/release-handoff.sh
+++ b/scripts/release-handoff.sh
@@ -222,8 +222,9 @@ cat >>"$handoff_file" <<EOF
 ## Boundary
 
 This step does not use npm, Homebrew, package-repository, or GitHub release
-write credentials. Publication should remain manual until each registry lane has
-its own authenticated dry run and rollback runbook.
+write credentials. npm publication is CI-only via `.github/workflows/npm-publish.yml`
+and must publish the tarballs listed above, never locally rebuilt or hand-edited
+package contents.
 EOF
 
 printf 'release handoff written:\n'

--- a/scripts/resolve-npm-token.sh
+++ b/scripts/resolve-npm-token.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: resolve-npm-token.sh --npmrc <path>
+
+Resolves npm auth without printing token material. Resolution order:
+
+  1. NPM_TOKEN
+  2. NODE_AUTH_TOKEN
+  3. NPM_TOKEN_FILE
+  4. NODE_AUTH_TOKEN_FILE
+  5. OMUX_NPM_TOKEN_SOPS_FILE + OMUX_NPM_TOKEN_SOPS_KEY
+
+OMUX_NPM_TOKEN_SOPS_KEY is a jq expression. Default candidates are:
+  .api.npm_token
+  .api.npm
+  .infrastructure.npm_token
+  .npm.token
+EOF
+}
+
+npmrc=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --npmrc)
+      npmrc="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$npmrc" ]; then
+  usage
+  exit 2
+fi
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'missing required command: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+trim_token() {
+  tr -d '\r\n'
+}
+
+read_token_file() {
+  local file="$1"
+  if [ -z "$file" ] || [ ! -f "$file" ]; then
+    return 1
+  fi
+  trim_token <"$file"
+}
+
+mask_token() {
+  local token="$1"
+  if [ "${GITHUB_ACTIONS:-}" = "true" ] && [ -n "$token" ]; then
+    printf '::add-mask::%s\n' "$token"
+  fi
+}
+
+extract_sops_token() {
+  local file="${OMUX_NPM_TOKEN_SOPS_FILE:-}"
+  if [ -z "$file" ] || [ ! -f "$file" ]; then
+    return 1
+  fi
+
+  require_command sops
+  require_command jq
+
+  local decrypted
+  decrypted="$(sops -d --output-type json "$file")"
+
+  if [ -n "${OMUX_NPM_TOKEN_SOPS_KEY:-}" ]; then
+    printf '%s' "$decrypted" | jq -er "${OMUX_NPM_TOKEN_SOPS_KEY}" | trim_token
+    return
+  fi
+
+  local key
+  for key in '.api.npm_token' '.api.npm' '.infrastructure.npm_token' '.npm.token'; do
+    if token="$(printf '%s' "$decrypted" | jq -er "$key // empty" 2>/dev/null | trim_token)" && [ -n "$token" ]; then
+      printf '%s' "$token"
+      return
+    fi
+  done
+
+  return 1
+}
+
+token="${NPM_TOKEN:-}"
+if [ -z "$token" ]; then
+  token="${NODE_AUTH_TOKEN:-}"
+fi
+if [ -z "$token" ]; then
+  token="$(read_token_file "${NPM_TOKEN_FILE:-}" || true)"
+fi
+if [ -z "$token" ]; then
+  token="$(read_token_file "${NODE_AUTH_TOKEN_FILE:-}" || true)"
+fi
+if [ -z "$token" ]; then
+  token="$(extract_sops_token || true)"
+fi
+
+if [ -z "$token" ] || [ "$token" = "null" ]; then
+  cat >&2 <<'EOF'
+could not resolve npm token.
+
+Set NPM_TOKEN, NODE_AUTH_TOKEN, NPM_TOKEN_FILE, NODE_AUTH_TOKEN_FILE, or
+OMUX_NPM_TOKEN_SOPS_FILE plus optional OMUX_NPM_TOKEN_SOPS_KEY.
+EOF
+  exit 1
+fi
+
+mask_token "$token"
+mkdir -p "$(dirname "$npmrc")"
+{
+  printf 'registry=https://registry.npmjs.org/\n'
+  printf '//registry.npmjs.org/:_authToken=%s\n' "$token"
+} >"$npmrc"
+chmod 0600 "$npmrc"
+printf 'npm auth written to %s\n' "$npmrc"


### PR DESCRIPTION
## Summary

Adds the npm publication lane as a CI-only artifact derivation.

- New `scripts/resolve-npm-token.sh` resolves npm auth without printing token material from `NPM_TOKEN`, token files, or SOPS (`OMUX_NPM_TOKEN_SOPS_FILE` + `OMUX_NPM_TOKEN_SOPS_KEY`).
- New `scripts/npm-ci-publish.sh` publishes only staged `dist/out/v*/npm-tarballs` in platform-first order, with npm provenance, idempotent skip-existing behavior, and a plan-only mode for non-mutating validation.
- New `.github/workflows/npm-publish.yml` stages `just release-proof-local <version>` in CI, then publishes/dry-runs from the generated tarballs. Workstation `npm publish` is not a supported path.
- Registry dry-run now uses the same token resolver and supports global SOPS materialization/checkouts.
- Added `docs/adoption.md` and updated release/registry/timeline docs for CI-only npm and external-user adoption goals.
- Dev shell now includes `sops`, `age`, and `jq` for the SOPS-backed registry paths.

## Validation

- `just check` passed.
- `bash -n` and `sh -n` passed for changed scripts.
- `git diff --check` passed.
- Workflow YAML parsed locally with `yq`.
- Token resolver smoke test wrote an npmrc from a dummy token without printing the token.
- `npm-ci-publish.sh` plan-only mode was exercised against a temporary fake tarball tree and produced the expected platform-first publish plan.
- npm registry availability check returned 404 for `oauth-mux` and `@oauth-mux/linux-x64`, so the names are not currently published.

## Notes

I attempted a full local `just release-proof-local 0.1.0`, but stopped it after the six release cross-builds stayed active for more than 14 minutes. PR CI should run the full release derivation in the appropriate environment; local validation covered the normal repo gate and the new script behavior without contacting npm with credentials.

Repository variables prepared for the SOPS path:

- `OMUX_GLOBAL_SOPS_REPOSITORY=tinyland-inc/lab`
- `OMUX_GLOBAL_SOPS_FILE=nix/secrets/common.yaml`
- `OMUX_NPM_TOKEN_SOPS_KEY=.api.npm_token`

Remaining credential setup before authenticated npm dry-run/publish:

- add encrypted `api.npm_token` to the global SOPS file, or provide `NPM_TOKEN` as an Actions secret;
- add `SOPS_AGE_KEY` as an Actions secret if using the SOPS path.
