### PR TITLE
Promote Codex onboarding to native CLI

### DIFF
--- a/.github/workflows/live-provider-qa.yml
+++ b/.github/workflows/live-provider-qa.yml
@@ -24,6 +24,26 @@ on:
         required: false
         default: "codex-mini"
         type: string
+      install_codex:
+        description: "Install the Codex CLI before command probes"
+        required: false
+        default: true
+        type: boolean
+      codex_cli_version:
+        description: "Codex CLI npm package version"
+        required: false
+        default: "0.125.0"
+        type: string
+      require_available:
+        description: "Fail if probed routes are typed but unavailable"
+        required: false
+        default: false
+        type: boolean
+      allow_dead:
+        description: "Allow dead credentials for negative fixtures"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -40,6 +60,21 @@ jobs:
         with:
           version: 0.14.1
 
+      - uses: actions/setup-node@v4
+        if: inputs.install_codex
+        with:
+          node-version: 24
+
+      - name: Install Codex CLI
+        if: inputs.install_codex
+        shell: bash
+        env:
+          CODEX_CLI_VERSION: ${{ inputs.codex_cli_version }}
+        run: |
+          set -euo pipefail
+          npm install -g "@openai/codex@${CODEX_CLI_VERSION}"
+          codex --version
+
       - name: Decode secret-scoped config
         shell: bash
         env:
@@ -54,6 +89,29 @@ jobs:
           printf '%s' "$OMUX_LIVE_QA_CONFIG_B64" | base64 -d > "$RUNNER_TEMP/oauth-mux/config.json"
           echo "OMUX_CONFIG=$RUNNER_TEMP/oauth-mux/config.json" >> "$GITHUB_ENV"
 
+      - name: Decode secret-scoped credential stores
+        shell: bash
+        env:
+          OMUX_LIVE_QA_STORE_TGZ_B64: ${{ secrets.OMUX_LIVE_QA_STORE_TGZ_B64 }}
+        run: |
+          set -euo pipefail
+          if [ -z "${OMUX_LIVE_QA_STORE_TGZ_B64:-}" ]; then
+            echo "OMUX_LIVE_QA_STORE_TGZ_B64 is unset; no hosted credential stores materialized"
+            exit 0
+          fi
+          mkdir -p "$RUNNER_TEMP/oauth-mux"
+          store_tgz="$RUNNER_TEMP/oauth-mux/store.tgz"
+          printf '%s' "$OMUX_LIVE_QA_STORE_TGZ_B64" | base64 -d > "$store_tgz"
+          tar -tzf "$store_tgz" | awk '
+            /^\/|(^|\/)\.\.($|\/)/ {
+              print "unsafe credential bundle path: " $0 > "/dev/stderr"
+              bad = 1
+            }
+            END { exit bad }
+          '
+          tar -xzf "$store_tgz" -C "$HOME"
+          chmod -R go-rwx "$HOME/.local/share/oauth-mux" 2>/dev/null || true
+
       - name: Build oauth-mux
         run: zig build
 
@@ -65,6 +123,8 @@ jobs:
           OMUX_LIVE_QA_PROVIDER: ${{ inputs.provider }}
           OMUX_LIVE_QA_ACCOUNTS: ${{ inputs.accounts }}
           OMUX_LIVE_QA_CAPABILITIES: ${{ inputs.capabilities }}
+          OMUX_LIVE_QA_REQUIRE_AVAILABLE: ${{ inputs.require_available && '1' || '0' }}
+          OMUX_LIVE_QA_ALLOW_DEAD: ${{ inputs.allow_dead && '1' || '0' }}
         run: ./scripts/live-provider-qa.sh
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/registry-dry-run.yml
+++ b/.github/workflows/registry-dry-run.yml
@@ -29,6 +29,8 @@ jobs:
     env:
       OMUX_GLOBAL_SOPS_B64_PRESENT: ${{ secrets.OMUX_GLOBAL_SOPS_B64 != '' }}
       OMUX_GLOBAL_SOPS_REPOSITORY_PRESENT: ${{ vars.OMUX_GLOBAL_SOPS_REPOSITORY != '' }}
+      OMUX_HOMEBREW_TAP_REPOSITORY_PRESENT: ${{ vars.OMUX_HOMEBREW_TAP_REPOSITORY != '' }}
+      OMUX_HOMEBREW_TAP_DIR_PRESENT: ${{ vars.OMUX_HOMEBREW_TAP_DIR != '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -67,6 +69,32 @@ jobs:
           set -euo pipefail
           echo "OMUX_NPM_TOKEN_SOPS_FILE=$PWD/.global-sops/$OMUX_GLOBAL_SOPS_FILE" >> "$GITHUB_ENV"
 
+      - name: Checkout Homebrew tap
+        if: contains(inputs.lanes, 'homebrew') && env.OMUX_HOMEBREW_TAP_REPOSITORY_PRESENT == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ vars.OMUX_HOMEBREW_TAP_REPOSITORY }}
+          ref: ${{ vars.OMUX_HOMEBREW_TAP_REF || 'main' }}
+          path: .homebrew-tap
+          token: ${{ secrets.GF_ACTIONS_TOKEN || github.token }}
+          persist-credentials: false
+
+      - name: Configure Homebrew tap checkout
+        if: contains(inputs.lanes, 'homebrew') && env.OMUX_HOMEBREW_TAP_REPOSITORY_PRESENT == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "OMUX_HOMEBREW_TAP_DIR=$PWD/.homebrew-tap" >> "$GITHUB_ENV"
+
+      - name: Configure existing Homebrew tap path
+        if: contains(inputs.lanes, 'homebrew') && env.OMUX_HOMEBREW_TAP_REPOSITORY_PRESENT != 'true' && env.OMUX_HOMEBREW_TAP_DIR_PRESENT == 'true'
+        shell: bash
+        env:
+          OMUX_HOMEBREW_TAP_DIR_VAR: ${{ vars.OMUX_HOMEBREW_TAP_DIR }}
+        run: |
+          set -euo pipefail
+          echo "OMUX_HOMEBREW_TAP_DIR=$OMUX_HOMEBREW_TAP_DIR_VAR" >> "$GITHUB_ENV"
+
       - name: Stage release proof
         run: nix develop --command just release-proof-local "${{ inputs.version }}"
 
@@ -80,7 +108,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || '' }}
           SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY || '' }}
           GITHUB_TOKEN: ${{ github.token }}
-          OMUX_HOMEBREW_TAP_DIR: ${{ vars.OMUX_HOMEBREW_TAP_DIR || '' }}
+          OMUX_HOMEBREW_TAP_NAME: ${{ vars.OMUX_HOMEBREW_TAP_NAME || '' }}
         run: nix develop --command ./scripts/registry-dry-run.sh "${{ inputs.version }}"
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/registry-dry-run.yml
+++ b/.github/workflows/registry-dry-run.yml
@@ -95,6 +95,20 @@ jobs:
           set -euo pipefail
           echo "OMUX_HOMEBREW_TAP_DIR=$OMUX_HOMEBREW_TAP_DIR_VAR" >> "$GITHUB_ENV"
 
+      - name: Install Homebrew
+        if: contains(inputs.lanes, 'homebrew')
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v brew >/dev/null 2>&1; then
+            brew_path="$(command -v brew)"
+          else
+            NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+            brew_path="/home/linuxbrew/.linuxbrew/bin/brew"
+          fi
+          echo "$(dirname "$brew_path")" >> "$GITHUB_PATH"
+          echo "OMUX_BREW_BIN=$brew_path" >> "$GITHUB_ENV"
+
       - name: Stage release proof
         run: nix develop --command just release-proof-local "${{ inputs.version }}"
 
@@ -109,6 +123,8 @@ jobs:
           SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY || '' }}
           GITHUB_TOKEN: ${{ github.token }}
           OMUX_HOMEBREW_TAP_NAME: ${{ vars.OMUX_HOMEBREW_TAP_NAME || '' }}
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_ENV_HINTS: "1"
         run: nix develop --command ./scripts/registry-dry-run.sh "${{ inputs.version }}"
 
       - uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Probe a configured account:
 Run the no-spend Codex Max canary:
 
 ```bash
-just codex-max-canary
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex canary
 ```
 
 Run the deterministic no-secret E2E harness:
@@ -116,3 +116,5 @@ rollback.
 See `docs/daemon-boundary.md` for the current daemon decision.
 See `docs/spec/development-timeline-2026-04-27.md` for the current
 production-readiness timeline.
+See `docs/spec/production-publication-sprint-2026-04-28.md` for the current
+v0.1.0 sprint gates.

--- a/dist/homebrew/oauth-mux.rb
+++ b/dist/homebrew/oauth-mux.rb
@@ -1,7 +1,6 @@
 class OauthMux < Formula
   desc "OAuth fallback muxing for AI harness subscriptions"
   homepage "https://github.com/tinyland-inc/oauth-mux"
-  version "${VERSION}"
   license "MIT"
 
   on_macos do

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -9,7 +9,7 @@ they must not become requirements for ordinary users.
 Target install surfaces:
 
 - npm: `npm install -g oauth-mux`
-- Homebrew: `brew install tinyland-inc/tap/oauth-mux`
+- Homebrew: `brew install tinyland-inc/tools/oauth-mux`
 - curl installer: `curl -fsSL ... | sh`
 - deb/rpm packages for Linux hosts
 - raw release tarballs for air-gapped or policy-managed systems

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -32,19 +32,19 @@ For Codex subscription users working from a source checkout today:
 
 ```bash
 oauth-mux init --codex-max
-just codex-max-onboard
-just codex-max-canary
+oauth-mux codex onboard
+oauth-mux codex canary
 ```
 
-Before broad npm-facing documentation, the repo-local `just` helpers should be
-promoted into installed `oauth-mux codex ...` commands or packaged helper
-scripts. Public users should not need a source checkout for routine account
-onboarding.
+Those commands are installed CLI surface, not source-checkout-only helpers.
+Users can override the default three-account shape with
+`--accounts work,personal,team` and can point account stores somewhere explicit
+with `--store-root <path>`.
 
 Live probes remain explicit because they can spend subscription calls:
 
 ```bash
-OMUX_LIVE_QA_CONFIRM=spend-real-calls just live-qa
+oauth-mux codex canary --live
 ```
 
 ## Provider Author Experience

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -39,6 +39,7 @@ Until then, user and agent onboarding should use one-shot commands:
 
 ```bash
 oauth-mux discover --json
+oauth-mux codex canary
 oauth-mux probe --profile <profile> --capability <capability> --json
 oauth-mux exec --profile <profile> --capability <capability> -- <command>
 ```

--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -87,8 +87,30 @@ tokens in the workflow file or repository.
 
 For command-probe providers such as Codex, the hosted runner also needs the
 provider CLI and account credential stores available at the paths named by the
-secret-scoped config. A config secret alone is not enough if it points at
-machine-local `CODEX_HOME` directories that only exist on a workstation.
+secret-scoped config. The workflow can install the Codex CLI from
+`@openai/codex` before probes. Pin the version with the `codex_cli_version`
+dispatch input.
+
+Hosted Codex credential stores are materialized from
+`OMUX_LIVE_QA_STORE_TGZ_B64`, a base64-encoded `tar.gz` whose paths are relative
+to `$HOME`. For the standard Codex Max config, include only the minimal files
+needed by each account store:
+
+```text
+.local/share/oauth-mux/codex/max-1/auth.json
+.local/share/oauth-mux/codex/max-1/config.toml        # when present
+.local/share/oauth-mux/codex/max-1/installation_id
+.local/share/oauth-mux/codex/max-2/auth.json
+.local/share/oauth-mux/codex/max-2/config.toml        # when present
+.local/share/oauth-mux/codex/max-2/installation_id
+.local/share/oauth-mux/codex/max-3/auth.json
+.local/share/oauth-mux/codex/max-3/config.toml        # when present
+.local/share/oauth-mux/codex/max-3/installation_id
+```
+
+Omit caches and logs such as `models_cache.json` and `log/`. The workflow
+rejects absolute paths and parent traversal entries before extraction, then
+tightens permissions under `$HOME/.local/share/oauth-mux`.
 
 ## Policy
 

--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -44,13 +44,12 @@ For the Codex Max three-account path, prefer the canary before any spending
 run:
 
 ```bash
-just codex-max-canary
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex canary
 ```
 
-That command validates config, captures discovery/status/health, and checks
-`codex login status` for each account without running probes. Set
-`OMUX_CODEX_CANARY_CONFIRM=spend-real-calls` only when the canary should also
-invoke this live QA matrix.
+That command validates config, prints discovery/status evidence, and checks
+`codex login status` for each account without running probes. Add `--live` only
+when the canary should also invoke this live QA matrix.
 
 Artifacts are written under `dist/live-qa/<timestamp>/`:
 
@@ -67,13 +66,13 @@ rather than a false infrastructure failure. Set
 route is immediately selectable. Dead credentials fail by default; set
 `OMUX_LIVE_QA_ALLOW_DEAD=1` only for negative test fixtures.
 
-Current Codex behavior observed on 2026-04-27:
+Operator-provided Codex state on 2026-04-28:
 
-- `max-1`, `max-2`, and `max-3` are all logged in and remain
-  `live/available` on `codex-mini`.
-- `max-1#codex-max`, `max-2#codex-max`, and `max-3#codex-max` currently return
-  `live/quota_exhausted` with distinct reset windows. The accounts are not
-  auth-dead; only the max route is exhausted.
+- `max-1#codex-max` and `max-2#codex-max` are expected to classify as
+  `live/quota_exhausted` until weekly limits refresh.
+- `max-3` is expected to remain active for API-backed usage.
+- These are not auth-dead accounts; the useful proof is preserving the
+  distinction between weekly quota exhaustion and usable fallback routes.
 
 ## GitHub Workflow
 
@@ -85,6 +84,11 @@ For private configs, store a base64-encoded config in the repository secret
 `OMUX_CONFIG` for the job. Keep the config secret-scoped and prefer secret
 backends such as command, keychain, sops, age, or env references. Do not put raw
 tokens in the workflow file or repository.
+
+For command-probe providers such as Codex, the hosted runner also needs the
+provider CLI and account credential stores available at the paths named by the
+secret-scoped config. A config secret alone is not enough if it points at
+machine-local `CODEX_HOME` directories that only exist on a workstation.
 
 ## Policy
 

--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -55,7 +55,7 @@ Artifacts are written under `dist/live-qa/<timestamp>/`:
 
 - `config-validate.txt`
 - `discover.json`
-- one JSON file per probe
+- one valid JSON file plus one redacted log file per probe
 - `health.json`
 
 By default, live QA passes when a probe returns a typed, redacted liveness

--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -74,6 +74,16 @@ Operator-provided Codex state on 2026-04-28:
 - These are not auth-dead accounts; the useful proof is preserving the
   distinction between weekly quota exhaustion and usable fallback routes.
 
+Hosted evidence from run `25029923810`:
+
+- `codex-mini`: all three accounts returned `live/available` and
+  `decision=use_this`.
+- `codex-max`: `max-1` and `max-2` returned `live/quota_exhausted` and
+  `decision=try_next_account`; `max-3` returned `live/available` and
+  `decision=use_this`.
+- The uploaded artifact contains valid per-probe JSON files and separate
+  redacted probe logs.
+
 ## GitHub Workflow
 
 `.github/workflows/live-provider-qa.yml` is manual-only. It requires the

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -43,45 +43,48 @@ Codex Max three-account starter:
 
 ```bash
 oauth-mux init --codex-max
-just codex-max-onboard
-just codex-max-canary
+oauth-mux codex onboard
+oauth-mux codex canary
 ```
 
-`just codex-max-onboard` creates the expected isolated `CODEX_HOME` directories,
+`oauth-mux codex onboard` creates the expected isolated `CODEX_HOME` directories,
 runs `codex login` for accounts that are not logged in, prints login status, and
 then prints `oauth-mux discover`. It does not run live route probes unless the
-operator explicitly sets:
+operator explicitly opts in:
 
 ```bash
-OMUX_LIVE_QA_CONFIRM=spend-real-calls just codex-max-onboard
+oauth-mux codex onboard --live
 ```
 
 For device-code login instead of browser login:
 
 ```bash
-OMUX_CODEX_LOGIN_MODE=device just codex-max-onboard
+oauth-mux codex onboard --device
 ```
 
 For status-only inspection:
 
 ```bash
-OMUX_CODEX_LOGIN_MODE=status-only just codex-max-onboard
+oauth-mux codex onboard --status-only
 ```
 
 For a no-spend canary after onboarding:
 
 ```bash
-just codex-max-canary
+oauth-mux codex canary
 ```
 
-The canary validates config, writes redacted `discover`, `status`, and `health`
-JSON artifacts, checks `codex login status` for each expected account, and
-summarizes whether route health has already been recorded. It does not run live
-probes by default. To include bounded route probes:
+The canary validates config, prints redacted discovery, checks
+`codex login status` for each expected account, and summarizes whether route
+health has already been recorded. It does not run live probes by default. To
+include bounded route probes:
 
 ```bash
-OMUX_CODEX_CANARY_CONFIRM=spend-real-calls just codex-max-canary
+oauth-mux codex canary --live
 ```
+
+Source checkouts keep `just codex-max-onboard` and `just codex-max-canary` as
+thin aliases for those installed commands.
 
 ## Agent Discovery Contract
 

--- a/docs/registry-dry-runs-and-rollback.md
+++ b/docs/registry-dry-runs-and-rollback.md
@@ -63,6 +63,9 @@ Required secret and variable surfaces:
   instead of by formula path, for example `tinyland-inc/tools`.
 - `OMUX_BREW_BIN` when the Homebrew executable is not available as `brew`.
   The GitHub workflow installs Homebrew on Ubuntu and sets this automatically.
+- `OMUX_HOMEBREW_AUDIT_ONLINE=1` only after the homepage and release URLs are
+  publicly reachable. Pre-release dry-runs use strict offline audit because the
+  release artifacts are intentionally not published yet.
 - The default workflow `GITHUB_TOKEN` for the GitHub lane.
 
 ## npm Publish

--- a/docs/registry-dry-runs-and-rollback.md
+++ b/docs/registry-dry-runs-and-rollback.md
@@ -61,6 +61,8 @@ Required secret and variable surfaces:
   the workflow should check out the tap before the Homebrew lane.
 - `OMUX_HOMEBREW_TAP_NAME` when Homebrew requires auditing by tap/formula name
   instead of by formula path, for example `tinyland-inc/tools`.
+- `OMUX_BREW_BIN` when the Homebrew executable is not available as `brew`.
+  The GitHub workflow installs Homebrew on Ubuntu and sets this automatically.
 - The default workflow `GITHUB_TOKEN` for the GitHub lane.
 
 ## npm Publish

--- a/docs/registry-dry-runs-and-rollback.md
+++ b/docs/registry-dry-runs-and-rollback.md
@@ -57,6 +57,10 @@ Required secret and variable surfaces:
   `.api.npm_token`.
 - `OMUX_HOMEBREW_TAP_DIR` repository variable for the Homebrew lane when a tap
   checkout is available in the runner environment.
+- `OMUX_HOMEBREW_TAP_REPOSITORY` plus optional `OMUX_HOMEBREW_TAP_REF` when
+  the workflow should check out the tap before the Homebrew lane.
+- `OMUX_HOMEBREW_TAP_NAME` when Homebrew requires auditing by tap/formula name
+  instead of by formula path, for example `tinyland-inc/tools`.
 - The default workflow `GITHUB_TOKEN` for the GitHub lane.
 
 ## npm Publish

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,6 +1,6 @@
 # oauth-mux Release Runbook
 
-Updated: 2026-04-27
+Updated: 2026-04-28
 
 ## Local Quality Gates
 

--- a/docs/spec/development-timeline-2026-04-27.md
+++ b/docs/spec/development-timeline-2026-04-27.md
@@ -1,6 +1,6 @@
 # oauth-mux Development Timeline
 
-Updated: 2026-04-27
+Updated: 2026-04-28
 
 Issue context: Linear `TIN-491`, GitHub `tinyland-inc/lab#197`.
 
@@ -16,11 +16,11 @@ operational hardening: live-provider QA execution with real secrets,
 authenticated package publication dry-runs, rollback rehearsal, and
 post-merge GloriousFlywheel release-proof execution before public tags.
 
-Live Codex QA on 2026-04-27 confirmed the expected subscription permutation:
-all three accounts remain authenticated and selectable on `codex-mini`, while
-all three currently report route-scoped `live/quota_exhausted` on `codex-max`
-with distinct reset windows. That is now represented as route availability, not
-generic degradation or auth death.
+The current Codex operator state is the expected subscription permutation:
+two Codex Max routes are waiting on weekly-limit refresh and should classify as
+route-scoped `live/quota_exhausted`, while a third account remains active for
+API-backed usage. That is represented as route availability, not generic
+degradation or auth death.
 
 ## Completed Arc
 
@@ -52,10 +52,11 @@ generic degradation or auth death.
    and `exec` injection without live credentials or network calls.
 
 7. Onboarding and discovery surface.
-   `oauth-mux discover --json`, `docs/onboarding.md`, `just codex-max-onboard`,
-   `just codex-max-canary`, manual live-provider QA, registry dry-run,
-   rollback, and daemon-boundary runbooks now define the operator and agent
-   path.
+   `oauth-mux discover --json`, `oauth-mux codex onboard`,
+   `oauth-mux codex canary`, `docs/onboarding.md`, manual live-provider QA,
+   registry dry-run, rollback, and daemon-boundary runbooks now define the
+   operator and agent path. Source-checkout `just codex-max-*` recipes are thin
+   aliases over the installed CLI surface.
 
 ## Current Gates
 
@@ -88,16 +89,15 @@ generic degradation or auth death.
   material is never committed or printed.
 
 - Codex canary and secret-scoped live QA
-  `just codex-max-canary` captures no-spend config/discovery/status/health and
-  per-account `codex login status` artifacts, then delegates to live QA only
-  when explicitly confirmed.
+  `oauth-mux codex canary` captures no-spend config/discovery/status/health and
+  per-account `codex login status` evidence, then delegates to live probes only
+  when `--live` is explicitly supplied.
 
 - Secret-scoped Codex live QA
-  Local account-matrix QA classified `max-1#codex-max` and
-  `max-2#codex-max`, and `max-3#codex-max` as `live/quota_exhausted` with
-  reset evidence, while `codex-mini` remains `live/available` for all three
-  accounts. The QA script now treats typed quota/rate/degraded outcomes as
-  valid evidence unless
+  The target hosted run should classify `max-1#codex-max` and
+  `max-2#codex-max` as `live/quota_exhausted` with reset evidence, while
+  keeping the third account available for fallback/API-backed usage. The QA
+  script treats typed quota/rate/degraded outcomes as valid evidence unless
   `OMUX_LIVE_QA_REQUIRE_AVAILABLE=1` is set.
 
 ## Production Readiness
@@ -116,7 +116,6 @@ Not ready yet:
 - public Homebrew/deb/rpm publication;
 - required self-hosted release gate;
 - background daemon token refresh as an operational dependency;
-- documented rollback for each registry lane;
 - formal security review of secret backends and generated config dirs.
 
 ## Next Arc

--- a/docs/spec/production-publication-sprint-2026-04-28.md
+++ b/docs/spec/production-publication-sprint-2026-04-28.md
@@ -15,8 +15,9 @@ Issue context: Linear `TIN-491`, GitHub `tinyland-inc/lab#197`.
   CI-only npm publish path.
 - Hosted CI has passed Zig tests, Nix validation, and all six cross-compiles for
   the recent PR arc.
-- NPM dry-run has passed through CI with the org-level secret and provenance for
-  all seven generated tarballs.
+- The CI npm publish workflow has packed and dry-runed all seven generated
+  tarballs. The stricter registry dry-run still needs a valid npm auth proof:
+  run `25028294061` failed `npm whoami` with 401 Unauthorized.
 - GloriousFlywheel cache-first proof is currently runner-gated; the most recent
   real proof predates the newest `main` commit.
 - Hosted live-provider QA is blocked until a secret-scoped

--- a/docs/spec/production-publication-sprint-2026-04-28.md
+++ b/docs/spec/production-publication-sprint-2026-04-28.md
@@ -22,8 +22,9 @@ Issue context: Linear `TIN-491`, GitHub `tinyland-inc/lab#197`.
 - GloriousFlywheel cache-first proof is currently runner-gated; the most recent
   real proof predates the newest `main` commit.
 - Hosted live-provider QA has workflow support for secret-scoped config,
-  Codex CLI bootstrap, and a minimal hosted credential-store bundle. It still
-  needs a dispatched run with `confirm=spend-real-calls` before release.
+  Codex CLI bootstrap, and a minimal hosted credential-store bundle. Run
+  `25029923810` completed the Codex three-account matrix with
+  `confirm=spend-real-calls`.
 
 ## Sprint Objective
 
@@ -85,6 +86,17 @@ Credential materialization:
 - `OMUX_LIVE_QA_STORE_TGZ_B64` carries a minimal `$HOME`-relative credential
   bundle, excluding caches and logs;
 - the workflow rejects absolute paths and parent traversal before extraction.
+
+Evidence:
+
+- live QA `25029923810` installed `@openai/codex@0.125.0`, decoded the
+  secret-scoped config and store bundle, and uploaded valid per-probe JSON plus
+  redacted logs;
+- `codex-mini`: `max-1`, `max-2`, and `max-3` all returned
+  `live/available` with `decision=use_this`;
+- `codex-max`: `max-1` and `max-2` returned `live/quota_exhausted` with
+  `decision=try_next_account`; `max-3` returned `live/available` with
+  `decision=use_this`.
 
 ### 3. Registry Dry-Runs
 

--- a/docs/spec/production-publication-sprint-2026-04-28.md
+++ b/docs/spec/production-publication-sprint-2026-04-28.md
@@ -21,9 +21,9 @@ Issue context: Linear `TIN-491`, GitHub `tinyland-inc/lab#197`.
   dry-ran all seven npm tarballs.
 - GloriousFlywheel cache-first proof is currently runner-gated; the most recent
   real proof predates the newest `main` commit.
-- Hosted live-provider QA is blocked until a secret-scoped
-  `OMUX_LIVE_QA_CONFIG_B64`, provider CLI bootstrap, and hosted credential-store
-  materialization are available for the workflow.
+- Hosted live-provider QA has workflow support for secret-scoped config,
+  Codex CLI bootstrap, and a minimal hosted credential-store bundle. It still
+  needs a dispatched run with `confirm=spend-real-calls` before release.
 
 ## Sprint Objective
 
@@ -78,6 +78,13 @@ Acceptance:
   before the probe step;
 - dead credentials fail unless the run explicitly opts into negative testing;
 - quota exhaustion is evidence, not a false CI infrastructure failure.
+
+Credential materialization:
+
+- `OMUX_LIVE_QA_CONFIG_B64` carries the mux config;
+- `OMUX_LIVE_QA_STORE_TGZ_B64` carries a minimal `$HOME`-relative credential
+  bundle, excluding caches and logs;
+- the workflow rejects absolute paths and parent traversal before extraction.
 
 ### 3. Registry Dry-Runs
 

--- a/docs/spec/production-publication-sprint-2026-04-28.md
+++ b/docs/spec/production-publication-sprint-2026-04-28.md
@@ -1,0 +1,122 @@
+# Production Publication Sprint
+
+Date: 2026-04-28
+
+Scope: move `oauth-mux` from internal alpha to a controlled public `v0.1.0`
+publication path without adding daemon behavior or secret-bearing repository
+state.
+
+Issue context: Linear `TIN-491`, GitHub `tinyland-inc/lab#197`.
+
+## Current Baseline
+
+- `origin/main` contains the merged core mux, typed liveness, Codex three-account
+  path, onboarding docs, live QA harness, registry dry-run scaffolding, and
+  CI-only npm publish path.
+- Hosted CI has passed Zig tests, Nix validation, and all six cross-compiles for
+  the recent PR arc.
+- NPM dry-run has passed through CI with the org-level secret and provenance for
+  all seven generated tarballs.
+- GloriousFlywheel cache-first proof is currently runner-gated; the most recent
+  real proof predates the newest `main` commit.
+- Hosted live-provider QA is blocked until a secret-scoped
+  `OMUX_LIVE_QA_CONFIG_B64`, provider CLI bootstrap, and hosted credential-store
+  materialization are available for the workflow.
+
+## Sprint Objective
+
+Make the first public release boring:
+
+1. every routine onboarding action is available from the installed binary;
+2. every publication lane has a dry-run or documented deferral;
+3. every spendful or secretful action is opt-in and secret-scoped;
+4. release notes can explain known account states, rollback, and daemon limits;
+5. the tag/publish sequence can be executed from CI without workstation secrets.
+
+## Workstreams
+
+### 1. Installed Onboarding Surface
+
+Deliver `oauth-mux codex ...` commands for the Codex Max path:
+
+- `oauth-mux codex bootstrap-dirs`
+- `oauth-mux codex login <account>`
+- `oauth-mux codex login-device <account>`
+- `oauth-mux codex login-status [account]`
+- `oauth-mux codex login-status-all`
+- `oauth-mux codex onboard [--device|--status-only] [--accounts a,b,c]`
+- `oauth-mux codex canary [--accounts a,b,c] [--capabilities c1,c2] [--live]`
+
+The source-checkout `just codex-max-*` recipes should remain as aliases, not the
+primary public interface.
+
+Acceptance:
+
+- `zig build test` passes.
+- `just check` passes.
+- Docs point public users at installed commands.
+
+### 2. Secret-Scoped Live QA
+
+Run hosted live QA only after the workflow has an encoded config secret and the
+operator intentionally dispatches with `confirm=spend-real-calls`.
+
+Known user-state target for Codex:
+
+- two Codex Max subscription routes may be `live/quota_exhausted` until weekly
+  limits refresh;
+- the third account should remain available for API-backed usage;
+- `quota_exhausted`, `rate_limited`, `degraded`, and `dead` must stay distinct
+  typed outcomes.
+
+Acceptance:
+
+- hosted artifact captures typed liveness without printing token material;
+- command-probe providers such as Codex install or otherwise expose their CLI
+  before the probe step;
+- dead credentials fail unless the run explicitly opts into negative testing;
+- quota exhaustion is evidence, not a false CI infrastructure failure.
+
+### 3. Registry Dry-Runs
+
+Use `.github/workflows/registry-dry-run.yml` for authenticated dry-runs from
+CI. Start with `plan,github,npm,system`; add `homebrew` when a tap checkout is
+available to the runner.
+
+Acceptance:
+
+- npm dry-run remains CI-only and provenance-capable;
+- GitHub release auth check does not create a public release;
+- system package metadata checks complete or record missing host tooling;
+- rollback instructions stay linked from release notes.
+
+### 4. GloriousFlywheel Release Proof
+
+Re-run the cache-first release proof after the `tinyland-nix` runner is healthy.
+Do not claim this gate while jobs are only queued.
+
+Acceptance:
+
+- real GF job checks out the private action and completes
+  `nix develop --command just release-proof-local 0.1.0`;
+- if deferred, the release notes explicitly say which hosted and local gates
+  substituted for it.
+
+### 5. v0.1.0 Cut
+
+Only after the gates above:
+
+1. tag `v0.1.0`;
+2. let release workflow attach artifacts;
+3. review handoff and checksums;
+4. run npm publish workflow first with `dry_run=true`, then with
+   `dry_run=false`;
+5. publish or defer Homebrew/deb/rpm/curl lanes according to dry-run evidence.
+
+## Explicit Non-Goals
+
+- no background daemon as a required product surface;
+- no repository-stored token files or `.env`;
+- no workstation npm publish;
+- no ad hoc provider-specific hacks outside the provider schema unless a new
+  transport/parser primitive is required.

--- a/docs/spec/production-publication-sprint-2026-04-28.md
+++ b/docs/spec/production-publication-sprint-2026-04-28.md
@@ -13,14 +13,17 @@ Issue context: Linear `TIN-491`, GitHub `tinyland-inc/lab#197`.
 - `origin/main` contains the merged core mux, typed liveness, Codex three-account
   path, onboarding docs, live QA harness, registry dry-run scaffolding, and
   CI-only npm publish path.
-- Hosted CI has passed Zig tests, Nix validation, and all six cross-compiles for
-  the recent PR arc.
+- Hosted CI has passed Zig tests, Nix validation, all six cross-compiles, and a
+  real GloriousFlywheel cache-first job for the current PR arc.
 - The CI npm publish workflow has packed and dry-runed all seven generated
   tarballs. The stricter registry dry-run is now green after rotating the npm
   automation token: run `25029047263` passed `plan,github,npm,system` and
   dry-ran all seven npm tarballs.
-- GloriousFlywheel cache-first proof is currently runner-gated; the most recent
-  real proof predates the newest `main` commit.
+- Full hosted registry dry-run `25031405495` passed the PR-head
+  `plan,github,npm,homebrew,system` matrix.
+- GloriousFlywheel cache-first proof is fresh on PR #6: run `25031401075`
+  checked out `tinyland-inc/GloriousFlywheel` on `tinyland-nix`, ran
+  cache-first validation, and completed successfully.
 - Hosted live-provider QA has workflow support for secret-scoped config,
   Codex CLI bootstrap, and a minimal hosted credential-store bundle. Run
   `25029923810` completed the Codex three-account matrix with
@@ -122,11 +125,16 @@ Evidence:
   curl installer smoke, and handoff regeneration;
 - local Homebrew tap dry-run passed after updating the lane for Homebrew 5.1's
   tap/name audit path with `OMUX_HOMEBREW_TAP_NAME=tinyland-inc/tools`.
+- full hosted registry dry-run `25031405495` completed successfully on PR #6
+  with `plan,github,npm,homebrew,system`; artifact evidence records GitHub auth
+  OK, no existing `v0.1.0` release, all seven npm tarballs dry-run OK,
+  Homebrew formula copy plus strict audit OK, and deb/rpm metadata OK.
 
 ### 4. GloriousFlywheel Release Proof
 
-Re-run the cache-first release proof after the `tinyland-nix` runner is healthy.
-Do not claim this gate while jobs are only queued.
+The `tinyland-nix` runner is healthy again for PR validation. Keep the stricter
+release-proof distinction: PR #6 has fresh cache-first `check-local` evidence,
+while the tag/release proof still belongs to the release workflow.
 
 Acceptance:
 
@@ -134,6 +142,15 @@ Acceptance:
   `nix develop --command just release-proof-local 0.1.0`;
 - if deferred, the release notes explicitly say which hosted and local gates
   substituted for it.
+
+Evidence:
+
+- PR #6 CI run `25031401075` checked out the private GloriousFlywheel action on
+  `tinyland-nix`, ran cache-first validation, completed `just check-local`, and
+  reported `all checks passed`.
+- The current GF PR proof is a check/local validation proof, not a tag-release
+  publication proof. The tag workflow should still attach release artifacts
+  before any public `v0.1.0` publish.
 
 ### 5. v0.1.0 Cut
 

--- a/docs/spec/production-publication-sprint-2026-04-28.md
+++ b/docs/spec/production-publication-sprint-2026-04-28.md
@@ -16,8 +16,9 @@ Issue context: Linear `TIN-491`, GitHub `tinyland-inc/lab#197`.
 - Hosted CI has passed Zig tests, Nix validation, and all six cross-compiles for
   the recent PR arc.
 - The CI npm publish workflow has packed and dry-runed all seven generated
-  tarballs. The stricter registry dry-run still needs a valid npm auth proof:
-  run `25028294061` failed `npm whoami` with 401 Unauthorized.
+  tarballs. The stricter registry dry-run is now green after rotating the npm
+  automation token: run `25029047263` passed `plan,github,npm,system` and
+  dry-ran all seven npm tarballs.
 - GloriousFlywheel cache-first proof is currently runner-gated; the most recent
   real proof predates the newest `main` commit.
 - Hosted live-provider QA is blocked until a secret-scoped
@@ -90,6 +91,13 @@ Acceptance:
 - GitHub release auth check does not create a public release;
 - system package metadata checks complete or record missing host tooling;
 - rollback instructions stay linked from release notes.
+
+Evidence:
+
+- registry dry-run `25029047263` completed successfully on `main` with
+  `plan,github,npm,system`;
+- artifact `registry-dry-run-0.1.0` records GitHub auth OK, no existing
+  `v0.1.0` release, all seven npm tarballs dry-run OK, and deb/rpm metadata OK.
 
 ### 4. GloriousFlywheel Release Proof
 

--- a/docs/spec/production-publication-sprint-2026-04-28.md
+++ b/docs/spec/production-publication-sprint-2026-04-28.md
@@ -117,6 +117,11 @@ Evidence:
   `plan,github,npm,system`;
 - artifact `registry-dry-run-0.1.0` records GitHub auth OK, no existing
   `v0.1.0` release, all seven npm tarballs dry-run OK, and deb/rpm metadata OK.
+- local release proof on this branch passed `just release-proof 0.1.0`,
+  including Homebrew formula syntax, npm tarball packing, deb/rpm generation,
+  curl installer smoke, and handoff regeneration;
+- local Homebrew tap dry-run passed after updating the lane for Homebrew 5.1's
+  tap/name audit path with `OMUX_HOMEBREW_TAP_NAME=tinyland-inc/tools`.
 
 ### 4. GloriousFlywheel Release Proof
 

--- a/justfile
+++ b/justfile
@@ -43,40 +43,29 @@ probe *ARGS: build
 codex_max_config := "examples/codex-max.config.json"
 codex_max_state := "/tmp/oauth-mux-codex-max-health"
 
-codex-max-bootstrap-dirs:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    for account in max-1 max-2 max-3; do
-      dir="$HOME/.local/share/oauth-mux/codex/${account}"
-      mkdir -p "$dir"
-      echo "$dir"
-    done
+codex-max-bootstrap-dirs: build
+    ./zig-out/bin/oauth-mux codex bootstrap-dirs
 
 codex-max-validate: build
     OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux config validate
 
-codex-max-login ACCOUNT: codex-max-bootstrap-dirs
-    CODEX_HOME=$HOME/.local/share/oauth-mux/codex/{{ACCOUNT}} codex login
+codex-max-login ACCOUNT: build
+    ./zig-out/bin/oauth-mux codex login {{ACCOUNT}}
 
-codex-max-login-device ACCOUNT: codex-max-bootstrap-dirs
-    CODEX_HOME=$HOME/.local/share/oauth-mux/codex/{{ACCOUNT}} codex login --device-auth
+codex-max-login-device ACCOUNT: build
+    ./zig-out/bin/oauth-mux codex login-device {{ACCOUNT}}
 
-codex-max-login-status ACCOUNT:
-    CODEX_HOME=$HOME/.local/share/oauth-mux/codex/{{ACCOUNT}} codex login status
+codex-max-login-status ACCOUNT: build
+    ./zig-out/bin/oauth-mux codex login-status {{ACCOUNT}}
 
-codex-max-login-status-all:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    for account in max-1 max-2 max-3; do
-      echo "=== ${account} ==="
-      CODEX_HOME="$HOME/.local/share/oauth-mux/codex/${account}" codex login status || true
-    done
+codex-max-login-status-all: build
+    ./zig-out/bin/oauth-mux codex login-status-all
 
 codex-max-onboard: build
-    ./scripts/onboard-codex-max.sh
+    OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux codex onboard
 
 codex-max-canary: build
-    OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./scripts/codex-max-canary.sh
+    OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux codex canary
 
 codex-max-probe ACCOUNT CAPABILITY="codex-mini": build
     OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux probe --provider codex --account {{ACCOUNT}} --capability {{CAPABILITY}} --json

--- a/scripts/live-provider-qa.sh
+++ b/scripts/live-provider-qa.sh
@@ -52,8 +52,22 @@ run_probe() {
   local safe_label
   safe_label="$(printf '%s' "$label" | tr '#:/ ' '____')"
   local output_file="$out_dir/${safe_label}.json"
+  local log_file="$out_dir/${safe_label}.log"
   printf '=== %s ===\n' "$label"
-  if "$bin" probe "$@" --json 2>&1 | redact | tee "$output_file"; then
+  set +e
+  "$bin" probe "$@" --json 2>&1 | redact | tee "$log_file"
+  local probe_status="${PIPESTATUS[0]}"
+  set -e
+
+  local json_line
+  json_line="$(grep -E '^\{' "$log_file" | tail -n 1 || true)"
+  if [ -n "$json_line" ]; then
+    printf '%s\n' "$json_line" >"$output_file"
+  else
+    : >"$output_file"
+  fi
+
+  if [ "$probe_status" -eq 0 ]; then
     return 0
   fi
   if grep -q '"liveness":' "$output_file" && ! grep -q '"liveness":null' "$output_file"; then

--- a/scripts/registry-dry-run.sh
+++ b/scripts/registry-dry-run.sh
@@ -114,7 +114,8 @@ for lane in "${lanes[@]}"; do
       ;;
 
     homebrew)
-      require_command brew
+      brew_cmd="${OMUX_BREW_BIN:-brew}"
+      require_command "$brew_cmd"
       if [ -z "${OMUX_HOMEBREW_TAP_DIR:-}" ]; then
         printf 'homebrew lane requires OMUX_HOMEBREW_TAP_DIR\n' >&2
         exit 1
@@ -125,10 +126,10 @@ for lane in "${lanes[@]}"; do
       cp "$formula" "$tap_formula"
       git -C "$OMUX_HOMEBREW_TAP_DIR" diff --check -- Formula/oauth-mux.rb
       if [ -n "${OMUX_HOMEBREW_TAP_NAME:-}" ]; then
-        brew tap "$OMUX_HOMEBREW_TAP_NAME" "$OMUX_HOMEBREW_TAP_DIR" >/dev/null
-        brew audit --formula --strict --online --tap="$OMUX_HOMEBREW_TAP_NAME" oauth-mux >/dev/null
+        "$brew_cmd" tap "$OMUX_HOMEBREW_TAP_NAME" "$OMUX_HOMEBREW_TAP_DIR" >/dev/null
+        "$brew_cmd" audit --formula --strict --online --tap="$OMUX_HOMEBREW_TAP_NAME" oauth-mux >/dev/null
       else
-        brew audit --formula --strict --online "$tap_formula" >/dev/null
+        "$brew_cmd" audit --formula --strict --online "$tap_formula" >/dev/null
       fi
       append "## homebrew"
       append

--- a/scripts/registry-dry-run.sh
+++ b/scripts/registry-dry-run.sh
@@ -124,7 +124,12 @@ for lane in "${lanes[@]}"; do
       mkdir -p "$(dirname "$tap_formula")"
       cp "$formula" "$tap_formula"
       git -C "$OMUX_HOMEBREW_TAP_DIR" diff --check -- Formula/oauth-mux.rb
-      brew audit --formula --strict --online "$tap_formula" >/dev/null
+      if [ -n "${OMUX_HOMEBREW_TAP_NAME:-}" ]; then
+        brew tap "$OMUX_HOMEBREW_TAP_NAME" "$OMUX_HOMEBREW_TAP_DIR" >/dev/null
+        brew audit --formula --strict --online --tap="$OMUX_HOMEBREW_TAP_NAME" oauth-mux >/dev/null
+      else
+        brew audit --formula --strict --online "$tap_formula" >/dev/null
+      fi
       append "## homebrew"
       append
       append "- formula copied to tap checkout"

--- a/scripts/registry-dry-run.sh
+++ b/scripts/registry-dry-run.sh
@@ -127,14 +127,23 @@ for lane in "${lanes[@]}"; do
       git -C "$OMUX_HOMEBREW_TAP_DIR" diff --check -- Formula/oauth-mux.rb
       audit_log="$(mktemp)"
       tmp_files+=("$audit_log")
+      audit_args=(audit --formula --strict)
+      audit_label="brew audit --strict"
+      if [ "${OMUX_HOMEBREW_AUDIT_ONLINE:-0}" = "1" ]; then
+        audit_args+=(--online)
+        audit_label="brew audit --strict --online"
+      fi
       if [ -n "${OMUX_HOMEBREW_TAP_NAME:-}" ]; then
         "$brew_cmd" tap "$OMUX_HOMEBREW_TAP_NAME" "$OMUX_HOMEBREW_TAP_DIR" >/dev/null
-        if ! "$brew_cmd" audit --formula --strict --online --tap="$OMUX_HOMEBREW_TAP_NAME" oauth-mux >"$audit_log" 2>&1; then
+        tapped_repo="$("$brew_cmd" --repository "$OMUX_HOMEBREW_TAP_NAME")"
+        mkdir -p "$tapped_repo/Formula"
+        cp "$formula" "$tapped_repo/Formula/oauth-mux.rb"
+        if ! "$brew_cmd" "${audit_args[@]}" oauth-mux >"$audit_log" 2>&1; then
           cat "$audit_log" >&2
           exit 1
         fi
       else
-        if ! "$brew_cmd" audit --formula --strict --online "$tap_formula" >"$audit_log" 2>&1; then
+        if ! "$brew_cmd" "${audit_args[@]}" "$tap_formula" >"$audit_log" 2>&1; then
           cat "$audit_log" >&2
           exit 1
         fi
@@ -143,7 +152,7 @@ for lane in "${lanes[@]}"; do
       append
       append "- formula copied to tap checkout"
       append "- git diff --check OK"
-      append "- brew audit OK"
+      append "- ${audit_label} OK"
       append
       ;;
 

--- a/scripts/registry-dry-run.sh
+++ b/scripts/registry-dry-run.sh
@@ -125,11 +125,19 @@ for lane in "${lanes[@]}"; do
       mkdir -p "$(dirname "$tap_formula")"
       cp "$formula" "$tap_formula"
       git -C "$OMUX_HOMEBREW_TAP_DIR" diff --check -- Formula/oauth-mux.rb
+      audit_log="$(mktemp)"
+      tmp_files+=("$audit_log")
       if [ -n "${OMUX_HOMEBREW_TAP_NAME:-}" ]; then
         "$brew_cmd" tap "$OMUX_HOMEBREW_TAP_NAME" "$OMUX_HOMEBREW_TAP_DIR" >/dev/null
-        "$brew_cmd" audit --formula --strict --online --tap="$OMUX_HOMEBREW_TAP_NAME" oauth-mux >/dev/null
+        if ! "$brew_cmd" audit --formula --strict --online --tap="$OMUX_HOMEBREW_TAP_NAME" oauth-mux >"$audit_log" 2>&1; then
+          cat "$audit_log" >&2
+          exit 1
+        fi
       else
-        "$brew_cmd" audit --formula --strict --online "$tap_formula" >/dev/null
+        if ! "$brew_cmd" audit --formula --strict --online "$tap_formula" >"$audit_log" 2>&1; then
+          cat "$audit_log" >&2
+          exit 1
+        fi
       fi
       append "## homebrew"
       append

--- a/scripts/release-handoff.sh
+++ b/scripts/release-handoff.sh
@@ -222,7 +222,7 @@ cat >>"$handoff_file" <<EOF
 ## Boundary
 
 This step does not use npm, Homebrew, package-repository, or GitHub release
-write credentials. npm publication is CI-only via `.github/workflows/npm-publish.yml`
+write credentials. npm publication is CI-only via \`.github/workflows/npm-publish.yml\`
 and must publish the tarballs listed above, never locally rebuilt or hand-edited
 package contents.
 EOF

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -13,6 +13,7 @@ pub const Command = union(enum) {
     config_validate,
     config_path,
     init: InitArgs,
+    codex: CodexArgs,
     completions: CompletionsArgs,
     daemon_start,
     daemon_stop,
@@ -63,6 +64,28 @@ pub const Command = union(enum) {
         codex_max: bool = false,
     };
 
+    pub const CodexAction = enum {
+        bootstrap_dirs,
+        login,
+        login_device,
+        login_status,
+        login_status_all,
+        onboard,
+        canary,
+    };
+
+    pub const CodexArgs = struct {
+        action: CodexAction = .canary,
+        account: ?[]const u8 = null,
+        accounts: []const u8 = "max-1,max-2,max-3",
+        capabilities: []const u8 = "codex-mini,codex-max",
+        store_root: ?[]const u8 = null,
+        device: bool = false,
+        status_only: bool = false,
+        live: bool = false,
+        json: bool = false,
+    };
+
     pub const CompletionsArgs = struct {
         shell: []const u8 = "fish",
     };
@@ -82,6 +105,7 @@ pub fn parse(args: []const []const u8) Command {
     if (eql(cmd, "discover")) return parseDiscover(rest);
     if (eql(cmd, "config")) return parseConfig(rest);
     if (eql(cmd, "init")) return parseInit(rest);
+    if (eql(cmd, "codex")) return parseCodex(rest);
     if (eql(cmd, "version") or eql(cmd, "--version") or eql(cmd, "-v")) return .version_cmd;
     if (eql(cmd, "daemon")) {
         if (rest.len > 0) {
@@ -220,6 +244,64 @@ fn parseInit(args: []const []const u8) Command {
     return .{ .init = result };
 }
 
+fn parseCodex(args: []const []const u8) Command {
+    var result = Command.CodexArgs{};
+    var option_start: usize = 0;
+
+    if (args.len > 0 and !std.mem.startsWith(u8, args[0], "-")) {
+        option_start = 1;
+        if (eql(args[0], "bootstrap-dirs")) {
+            result.action = .bootstrap_dirs;
+        } else if (eql(args[0], "login")) {
+            result.action = .login;
+        } else if (eql(args[0], "login-device")) {
+            result.action = .login_device;
+            result.device = true;
+        } else if (eql(args[0], "login-status")) {
+            result.action = .login_status;
+        } else if (eql(args[0], "login-status-all")) {
+            result.action = .login_status_all;
+        } else if (eql(args[0], "onboard")) {
+            result.action = .onboard;
+        } else if (eql(args[0], "canary")) {
+            result.action = .canary;
+        } else {
+            result.action = .canary;
+            option_start = 0;
+        }
+    }
+
+    var i = option_start;
+    while (i < args.len) : (i += 1) {
+        if (eql(args[i], "--account")) {
+            i += 1;
+            if (i < args.len) result.account = args[i];
+        } else if (eql(args[i], "--accounts")) {
+            i += 1;
+            if (i < args.len) result.accounts = args[i];
+        } else if (eql(args[i], "--capabilities")) {
+            i += 1;
+            if (i < args.len) result.capabilities = args[i];
+        } else if (eql(args[i], "--store-root")) {
+            i += 1;
+            if (i < args.len) result.store_root = args[i];
+        } else if (eql(args[i], "--device")) {
+            result.device = true;
+        } else if (eql(args[i], "--status-only")) {
+            result.status_only = true;
+        } else if (eql(args[i], "--live")) {
+            result.live = true;
+        } else if (eql(args[i], "--json")) {
+            result.json = true;
+        } else if (result.account == null and !std.mem.startsWith(u8, args[i], "-")) {
+            result.account = args[i];
+        }
+    }
+
+    if (result.action == .login_device) result.device = true;
+    return .{ .codex = result };
+}
+
 fn eql(a: []const u8, b: []const u8) bool {
     return std.mem.eql(u8, a, b);
 }
@@ -258,6 +340,15 @@ pub fn printUsage(writer: anytype) !void {
         \\
         \\  init [--interactive] [--codex-max]
         \\      Generate a starter config file.
+        \\
+        \\  codex onboard [--accounts a,b,c] [--device|--status-only] [--live]
+        \\      Bootstrap isolated Codex account stores and login flow.
+        \\
+        \\  codex canary [--accounts a,b,c] [--capabilities c1,c2] [--live]
+        \\      Run a no-spend Codex Max readiness check; --live runs probes.
+        \\
+        \\  codex login <account> | login-device <account> | login-status [account] | login-status-all
+        \\      Codex account login/status helpers using isolated CODEX_HOME dirs.
         \\
         \\  completions <shell> Generate shell completions (fish|zsh|bash).
         \\
@@ -337,6 +428,33 @@ test "parse init codex max" {
     }
 }
 
+test "parse codex canary" {
+    const args = [_][]const u8{ "codex", "canary", "--accounts", "max-1,max-2", "--capabilities", "codex-mini", "--live" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex => |codex| {
+            try std.testing.expect(codex.action == .canary);
+            try std.testing.expectEqualStrings("max-1,max-2", codex.accounts);
+            try std.testing.expectEqualStrings("codex-mini", codex.capabilities);
+            try std.testing.expect(codex.live);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse codex login account" {
+    const args = [_][]const u8{ "codex", "login-device", "max-2" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex => |codex| {
+            try std.testing.expect(codex.action == .login_device);
+            try std.testing.expectEqualStrings("max-2", codex.account.?);
+            try std.testing.expect(codex.device);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 test "parse health json provider" {
     const args = [_][]const u8{ "health", "--json", "--provider", "codex" };
     const cmd = parse(&args);
@@ -370,6 +488,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n __fish_use_subcommand -a discover -d 'Show agent-safe inventory'
             \\complete -c oauth-mux -n __fish_use_subcommand -a config -d 'Config operations'
             \\complete -c oauth-mux -n __fish_use_subcommand -a init -d 'Generate config'
+            \\complete -c oauth-mux -n __fish_use_subcommand -a codex -d 'Codex account onboarding'
             \\complete -c oauth-mux -n __fish_use_subcommand -a version -d 'Print version'
             \\complete -c oauth-mux -n __fish_use_subcommand -a completions -d 'Generate completions'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe' -l profile -s p -d 'Profile name' -r
@@ -382,6 +501,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from discover' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'onboard canary bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
             \\
         );
     } else if (eql(shell_name, "zsh")) {
@@ -398,6 +518,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\    'discover:Show agent-safe inventory'
             \\    'config:Config operations'
             \\    'init:Generate config'
+            \\    'codex:Codex account onboarding'
             \\    'version:Print version'
             \\    'completions:Generate completions'
             \\  )
@@ -410,7 +531,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
         try writer.writeAll(
             \\_oauth_mux_completions() {
             \\  local cur="${COMP_WORDS[COMP_CWORD]}"
-            \\  COMPREPLY=($(compgen -W "exec env probe status health discover config init version completions" -- "$cur"))
+            \\  COMPREPLY=($(compgen -W "exec env probe status health discover config init codex version completions" -- "$cur"))
             \\}
             \\complete -F _oauth_mux_completions oauth-mux
             \\

--- a/src/main.zig
+++ b/src/main.zig
@@ -78,6 +78,13 @@ pub fn main() !void {
             try runInit(allocator, stdout, init_args);
         },
 
+        .codex => |codex_args| {
+            runCodex(allocator, stdout, codex_args) catch |e| {
+                log.err("codex: {s}", .{@errorName(e)});
+                std.process.exit(exitCodeFromPipelineError(e));
+            };
+        },
+
         .health => |health_args| {
             try runHealth(allocator, stdout, health_args);
         },
@@ -989,6 +996,257 @@ fn runInit(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Init
     try file.writeAll(starter_config);
 
     try writer.print("created {s}\n", .{path});
+}
+
+fn runCodex(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs) !void {
+    const root = try codexStoreRoot(allocator, args);
+    defer allocator.free(root);
+
+    switch (args.action) {
+        .bootstrap_dirs => try bootstrapCodexDirs(allocator, writer, args, root),
+        .login => {
+            const account = singleCodexAccount(args) orelse return error.MissingAccount;
+            try bootstrapOneCodexDir(allocator, writer, root, account);
+            const dir = try codexAccountDir(allocator, root, account);
+            defer allocator.free(dir);
+            if (!try runCodexCli(allocator, dir, &.{ "codex", "login" })) return error.CodexCommandFailed;
+        },
+        .login_device => {
+            const account = singleCodexAccount(args) orelse return error.MissingAccount;
+            try bootstrapOneCodexDir(allocator, writer, root, account);
+            const dir = try codexAccountDir(allocator, root, account);
+            defer allocator.free(dir);
+            if (!try runCodexCli(allocator, dir, &.{ "codex", "login", "--device-auth" })) return error.CodexCommandFailed;
+        },
+        .login_status => {
+            const account = singleCodexAccount(args) orelse return error.MissingAccount;
+            const dir = try codexAccountDir(allocator, root, account);
+            defer allocator.free(dir);
+            try writer.print("=== {s} ===\nCODEX_HOME={s}\n", .{ account, dir });
+            if (!try runCodexCli(allocator, dir, &.{ "codex", "login", "status" })) return error.CodexCommandFailed;
+        },
+        .login_status_all => try runCodexLoginStatusAll(allocator, writer, args, root),
+        .onboard => try runCodexOnboard(allocator, writer, args, root),
+        .canary => try runCodexCanary(allocator, writer, args, root),
+    }
+}
+
+fn runCodexOnboard(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs, root: []const u8) !void {
+    try writer.writeAll("oauth-mux Codex Max onboarding\n\n");
+    try writer.print("store root: {s}\n", .{root});
+    try writer.print("accounts:   {s}\n", .{args.accounts});
+    try writer.print("mode:       {s}\n\n", .{if (args.status_only) "status-only" else if (args.device) "device" else "browser"});
+
+    try bootstrapCodexDirs(allocator, writer, args, root);
+    try validateCurrentConfig(allocator, writer);
+
+    var failures: usize = 0;
+    var it = std.mem.splitScalar(u8, args.accounts, ',');
+    while (it.next()) |raw_account| {
+        const account = std.mem.trim(u8, raw_account, " \t\r\n");
+        if (account.len == 0) continue;
+        const dir = try codexAccountDir(allocator, root, account);
+        defer allocator.free(dir);
+
+        try writer.print("\n=== {s} ===\nCODEX_HOME={s}\n", .{ account, dir });
+        if (try runCodexCli(allocator, dir, &.{ "codex", "login", "status" })) continue;
+        if (args.status_only) {
+            failures += 1;
+            continue;
+        }
+
+        const login_argv = if (args.device)
+            &[_][]const u8{ "codex", "login", "--device-auth" }
+        else
+            &[_][]const u8{ "codex", "login" };
+        if (!try runCodexCli(allocator, dir, login_argv)) {
+            failures += 1;
+            continue;
+        }
+        if (!try runCodexCli(allocator, dir, &.{ "codex", "login", "status" })) failures += 1;
+    }
+
+    try writer.writeAll("\n=== oauth-mux discovery ===\n");
+    try runDiscover(allocator, writer, .{ .json = false });
+
+    if (args.live) {
+        try runCodexLiveProbes(allocator, writer, args);
+    } else {
+        try writer.writeAll("\nLive probes not run. Add --live only when real provider calls are intended.\n");
+    }
+
+    if (failures != 0) return error.CodexCommandFailed;
+}
+
+fn runCodexCanary(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs, root: []const u8) !void {
+    try writer.writeAll("oauth-mux Codex Max canary\n\n");
+    try writer.print("store root:   {s}\n", .{root});
+    try writer.print("accounts:     {s}\n", .{args.accounts});
+    try writer.print("capabilities: {s}\n\n", .{args.capabilities});
+
+    try bootstrapCodexDirs(allocator, writer, args, root);
+
+    try writer.writeAll("\n=== config validate ===\n");
+    try validateCurrentConfig(allocator, writer);
+
+    try writer.writeAll("\n=== agent discovery ===\n");
+    try runDiscover(allocator, writer, .{ .json = args.json });
+
+    try writer.writeAll("\n=== codex login status ===\n");
+    try runCodexLoginStatusAll(allocator, writer, args, root);
+
+    try writer.writeAll("\n=== route liveness snapshot ===\n");
+    try writer.writeAll("Existing oauth-mux health state; add --live to refresh with real provider probes.\n");
+    try writeCodexRouteSnapshot(allocator, writer, args);
+
+    if (args.live) {
+        try writer.writeAll("\n=== live probes ===\n");
+        try runCodexLiveProbes(allocator, writer, args);
+    } else {
+        try writer.writeAll("\nLive probes not run. Add --live only when real provider calls are intended.\n");
+    }
+}
+
+fn validateCurrentConfig(allocator: std.mem.Allocator, writer: anytype) !void {
+    const parsed = config.load(allocator) catch return error.ConfigNotFound;
+    defer parsed.deinit();
+    try config.validate(parsed.value, writer);
+    try writer.writeAll("config: valid\n");
+}
+
+fn runCodexLoginStatusAll(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs, root: []const u8) !void {
+    var failures: usize = 0;
+    var it = std.mem.splitScalar(u8, args.accounts, ',');
+    while (it.next()) |raw_account| {
+        const account = std.mem.trim(u8, raw_account, " \t\r\n");
+        if (account.len == 0) continue;
+        const dir = try codexAccountDir(allocator, root, account);
+        defer allocator.free(dir);
+        try writer.print("=== {s} ===\nCODEX_HOME={s}\n", .{ account, dir });
+        if (!try runCodexCli(allocator, dir, &.{ "codex", "login", "status" })) failures += 1;
+    }
+    if (failures != 0) return error.CodexCommandFailed;
+}
+
+fn runCodexLiveProbes(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs) !void {
+    var account_it = std.mem.splitScalar(u8, args.accounts, ',');
+    while (account_it.next()) |raw_account| {
+        const account = std.mem.trim(u8, raw_account, " \t\r\n");
+        if (account.len == 0) continue;
+        var capability_it = std.mem.splitScalar(u8, args.capabilities, ',');
+        while (capability_it.next()) |raw_capability| {
+            const capability = std.mem.trim(u8, raw_capability, " \t\r\n");
+            if (capability.len == 0) continue;
+            try writer.print("\n--- codex:{s}#{s} ---\n", .{ account, capability });
+            runProbe(allocator, writer, .{
+                .provider = "codex",
+                .account = account,
+                .capability = capability,
+                .json = args.json,
+            }) catch |e| switch (e) {
+                error.AllAccountsExhausted => {},
+                else => return e,
+            };
+        }
+    }
+}
+
+fn writeCodexRouteSnapshot(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs) !void {
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+
+    var account_it = std.mem.splitScalar(u8, args.accounts, ',');
+    while (account_it.next()) |raw_account| {
+        const account = std.mem.trim(u8, raw_account, " \t\r\n");
+        if (account.len == 0) continue;
+        var capability_it = std.mem.splitScalar(u8, args.capabilities, ',');
+        while (capability_it.next()) |raw_capability| {
+            const capability = std.mem.trim(u8, raw_capability, " \t\r\n");
+            if (capability.len == 0) continue;
+            const key = try std.fmt.allocPrint(allocator, "codex:{s}#{s}", .{ account, capability });
+            defer allocator.free(key);
+            try writer.print("{s}: ", .{key});
+            if (store.accounts.get(key)) |health| {
+                try health_mod.writeLivenessSummary(writer, health.liveness);
+                if (health.last_http_status) |status| try writer.print(" http={d}", .{status});
+                if (health.last_probe_decision) |decision| try writer.print(" decision={s}", .{@tagName(decision)});
+                if (health.last_probe_observed_at) |observed_at| try writer.print(" observed_at={d}", .{observed_at});
+            } else {
+                try writer.writeAll("no recorded health yet");
+            }
+            try writer.writeByte('\n');
+        }
+    }
+}
+
+fn bootstrapCodexDirs(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs, root: []const u8) !void {
+    var it = std.mem.splitScalar(u8, args.accounts, ',');
+    while (it.next()) |raw_account| {
+        const account = std.mem.trim(u8, raw_account, " \t\r\n");
+        if (account.len == 0) continue;
+        try bootstrapOneCodexDir(allocator, writer, root, account);
+    }
+}
+
+fn bootstrapOneCodexDir(allocator: std.mem.Allocator, writer: anytype, root: []const u8, account: []const u8) !void {
+    const dir = try codexAccountDir(allocator, root, account);
+    defer allocator.free(dir);
+    try std.fs.cwd().makePath(dir);
+    try writer.print("created/verified {s}\n", .{dir});
+}
+
+fn codexStoreRoot(allocator: std.mem.Allocator, args: cli.Command.CodexArgs) ![]const u8 {
+    if (args.store_root) |root| return try paths.expandTilde(allocator, root);
+    if (try getEnvOwnedOrNull(allocator, "OMUX_CODEX_STORE_ROOT")) |root| {
+        defer allocator.free(root);
+        return try paths.expandTilde(allocator, root);
+    }
+    if (try getEnvOwnedOrNull(allocator, "XDG_DATA_HOME")) |xdg| {
+        defer allocator.free(xdg);
+        return try std.fs.path.join(allocator, &.{ xdg, "oauth-mux", "codex" });
+    }
+    const home = (try getEnvOwnedOrNull(allocator, "HOME")) orelse return error.ConfigNotFound;
+    defer allocator.free(home);
+    return try std.fs.path.join(allocator, &.{ home, ".local", "share", "oauth-mux", "codex" });
+}
+
+fn codexAccountDir(allocator: std.mem.Allocator, root: []const u8, account: []const u8) ![]const u8 {
+    return try std.fs.path.join(allocator, &.{ root, account });
+}
+
+fn singleCodexAccount(args: cli.Command.CodexArgs) ?[]const u8 {
+    if (args.account) |account| return account;
+    var it = std.mem.splitScalar(u8, args.accounts, ',');
+    while (it.next()) |raw_account| {
+        const account = std.mem.trim(u8, raw_account, " \t\r\n");
+        if (account.len != 0) return account;
+    }
+    return null;
+}
+
+fn getEnvOwnedOrNull(allocator: std.mem.Allocator, name: []const u8) !?[]const u8 {
+    return std.process.getEnvVarOwned(allocator, name) catch |e| switch (e) {
+        error.EnvironmentVariableNotFound => null,
+        else => return e,
+    };
+}
+
+fn runCodexCli(allocator: std.mem.Allocator, account_dir: []const u8, argv: []const []const u8) !bool {
+    var env_map = try std.process.getEnvMap(allocator);
+    defer env_map.deinit();
+    try env_map.put("CODEX_HOME", account_dir);
+
+    var child = std.process.Child.init(argv, allocator);
+    child.stdin_behavior = .Inherit;
+    child.stdout_behavior = .Inherit;
+    child.stderr_behavior = .Inherit;
+    child.env_map = &env_map;
+
+    const term = child.spawnAndWait() catch return error.CodexCommandFailed;
+    return switch (term) {
+        .Exited => |code| code == 0,
+        else => false,
+    };
 }
 
 test "matchesProvider filters account keys" {


### PR DESCRIPTION
## Summary

- Adds installed `oauth-mux codex ...` onboarding/canary/login helpers for the Codex Max three-account path.
- Rewires source-checkout `just codex-max-*` helpers to call the native CLI instead of bespoke shell loops.
- Formalizes the 2026-04-28 production/publication sprint, including registry dry-runs, hosted live-QA blockers, GF release proof, daemon deferral, and v0.1.0 cut gates.
- Fixes `scripts/release-handoff.sh` so the markdown workflow path is escaped instead of executed during handoff generation.

## Validation

- `zig build test`
- `zig build`
- `./zig-out/bin/oauth-mux codex bootstrap-dirs --store-root /tmp/oauth-mux-cli-smoke --accounts smoke-1,smoke-2`
- `OMUX_CONFIG=$PWD/examples/codex-max.config.json ./zig-out/bin/oauth-mux config validate`
- `OMUX_CONFIG=$PWD/examples/codex-max.config.json ./zig-out/bin/oauth-mux discover --json`
- `OMUX_CONFIG=$PWD/examples/codex-max.config.json OMUX_STATE_DIR=/tmp/oauth-mux-codex-max-health ./zig-out/bin/oauth-mux codex canary --accounts max-1,max-2,max-3 --capabilities codex-mini,codex-max`
- `just codex-max-canary`
- `just check`
- `just release-proof 0.1.0` reached release-local and smoke proof; handoff exposed the pre-existing heredoc bug fixed here
- `just release-handoff 0.1.0` rerun clean after the handoff fix
- `gh workflow run registry-dry-run.yml --ref main -f confirm=registry-dry-run -f version=0.1.0 -f lanes=plan,github,npm,system` dispatched run 25028294061, still in progress at PR creation

## Notes

Hosted Codex live QA remains intentionally gated: it needs the secret-scoped config plus Codex CLI bootstrap and hosted credential-store materialization. A config secret alone is not enough for command-probe providers that depend on provider-owned CLI auth stores.

Linear: TIN-491
