### PR TITLE
Fix npm platform package publication names

### DIFF
--- a/dist/npm/install.js
+++ b/dist/npm/install.js
@@ -5,12 +5,12 @@ const path = require("path");
 const os = require("os");
 
 const PLATFORM_MAP = {
-  "darwin-arm64": "@oauth-mux/darwin-arm64",
-  "darwin-x64": "@oauth-mux/darwin-x64",
-  "linux-arm64": "@oauth-mux/linux-arm64",
-  "linux-x64": "@oauth-mux/linux-x64",
-  "win32-arm64": "@oauth-mux/win32-arm64",
-  "win32-x64": "@oauth-mux/win32-x64",
+  "darwin-arm64": "oauth-mux-darwin-arm64",
+  "darwin-x64": "oauth-mux-darwin-x64",
+  "linux-arm64": "oauth-mux-linux-arm64",
+  "linux-x64": "oauth-mux-linux-x64",
+  "win32-arm64": "oauth-mux-win32-arm64",
+  "win32-x64": "oauth-mux-win32-x64",
 };
 
 const key = `${os.platform()}-${os.arch()}`;

--- a/dist/npm/package.json
+++ b/dist/npm/package.json
@@ -15,11 +15,11 @@
     "postinstall": "node install.js"
   },
   "optionalDependencies": {
-    "@oauth-mux/darwin-arm64": "0.1.0",
-    "@oauth-mux/darwin-x64": "0.1.0",
-    "@oauth-mux/linux-arm64": "0.1.0",
-    "@oauth-mux/linux-x64": "0.1.0",
-    "@oauth-mux/win32-arm64": "0.1.0",
-    "@oauth-mux/win32-x64": "0.1.0"
+    "oauth-mux-darwin-arm64": "0.1.0",
+    "oauth-mux-darwin-x64": "0.1.0",
+    "oauth-mux-linux-arm64": "0.1.0",
+    "oauth-mux-linux-x64": "0.1.0",
+    "oauth-mux-win32-arm64": "0.1.0",
+    "oauth-mux-win32-x64": "0.1.0"
   }
 }

--- a/docs/registry-dry-runs-and-rollback.md
+++ b/docs/registry-dry-runs-and-rollback.md
@@ -74,12 +74,12 @@ Required secret and variable surfaces:
 requires `confirm=publish-npm`, stages `just release-proof-local <version>`, and
 then publishes the generated tarballs in this order:
 
-1. `@oauth-mux/linux-x64`
-2. `@oauth-mux/linux-arm64`
-3. `@oauth-mux/darwin-x64`
-4. `@oauth-mux/darwin-arm64`
-5. `@oauth-mux/win32-x64`
-6. `@oauth-mux/win32-arm64`
+1. `oauth-mux-linux-x64`
+2. `oauth-mux-linux-arm64`
+3. `oauth-mux-darwin-x64`
+4. `oauth-mux-darwin-arm64`
+5. `oauth-mux-win32-x64`
+6. `oauth-mux-win32-arm64`
 7. `oauth-mux`
 
 The workflow requests `id-token: write` so `npm publish --provenance` can attach

--- a/docs/spec/production-publication-sprint-2026-04-28.md
+++ b/docs/spec/production-publication-sprint-2026-04-28.md
@@ -190,6 +190,24 @@ Only after the gates above and explicit operator confirmation:
    `dry_run=false`;
 5. publish or defer Homebrew/deb/rpm/curl lanes according to dry-run evidence.
 
+Execution evidence:
+
+- `v0.1.0` was tagged from `a11236d` and the GitHub Release workflow
+  `25061910479` attached the public release artifacts successfully.
+- Downloaded release assets verified against `SHA256SUMS`; flattened GitHub
+  Release asset names also verified against `handoff/SHA256SUMS.full`.
+- Real npm publish run `25062286236` staged release proof successfully, then
+  failed on the first platform package with npm `E404 Scope not found` for
+  `@oauth-mux/linux-x64`.
+- Registry checks after the failure showed no `0.1.0` npm packages were
+  published. The failure was namespace/scope shape, not token extraction.
+- Patch path: publish `0.1.1` with unscoped platform packages
+  (`oauth-mux-linux-x64`, etc.) so CI can publish through the current npm
+  account without requiring a new npm organization.
+- Patch proof: PR #9 CI run `25064315336` passed `test`, `nix`,
+  GloriousFlywheel cache-first validation, and all six cross-compiles; registry
+  dry-run `25064352699` passed `plan,npm` for all seven `0.1.1` npm tarballs.
+
 ## Explicit Non-Goals
 
 - no background daemon as a required product surface;

--- a/scripts/npm-ci-publish.sh
+++ b/scripts/npm-ci-publish.sh
@@ -105,11 +105,6 @@ publish_one() {
   fi
 
   local args=(publish "$tarball" --provenance)
-  case "$name" in
-    @oauth-mux/*)
-      args+=(--access public)
-      ;;
-  esac
   if [ "${OMUX_NPM_PUBLISH_DRY_RUN:-0}" = "1" ]; then
     args+=(--dry-run)
   fi

--- a/scripts/registry-dry-run.sh
+++ b/scripts/registry-dry-run.sh
@@ -100,14 +100,7 @@ for lane in "${lanes[@]}"; do
       NPM_CONFIG_USERCONFIG="$npmrc" npm whoami --registry=https://registry.npmjs.org/ >/dev/null
       for tarball in "$out_dir"/npm-tarballs/*.tgz; do
         name="$(basename "$tarball")"
-        case "$name" in
-          oauth-mux-darwin-*|oauth-mux-linux-*|oauth-mux-win32-*)
-            NPM_CONFIG_USERCONFIG="$npmrc" npm publish "$tarball" --dry-run --access public ${OMUX_NPM_EXTRA_ARGS:-} >/dev/null
-            ;;
-          *)
-            NPM_CONFIG_USERCONFIG="$npmrc" npm publish "$tarball" --dry-run ${OMUX_NPM_EXTRA_ARGS:-} >/dev/null
-            ;;
-        esac
+        NPM_CONFIG_USERCONFIG="$npmrc" npm publish "$tarball" --dry-run ${OMUX_NPM_EXTRA_ARGS:-} >/dev/null
         append "- dry-run OK: \`npm-tarballs/${name}\`"
       done
       append

--- a/scripts/release-handoff.sh
+++ b/scripts/release-handoff.sh
@@ -160,7 +160,7 @@ Publish platform packages first, then the root shim:
 EOF
 
 for tarball in "${npm_platform_tarballs[@]}"; do
-  printf 'npm publish dist/out/v%s/npm-tarballs/%s --access public --provenance\n' "$version" "$tarball" >>"$handoff_file"
+  printf 'npm publish dist/out/v%s/npm-tarballs/%s --provenance\n' "$version" "$tarball" >>"$handoff_file"
 done
 printf 'npm publish dist/out/v%s/npm-tarballs/%s --provenance\n' "$version" "$npm_root_tarball" >>"$handoff_file"
 

--- a/scripts/release-local.sh
+++ b/scripts/release-local.sh
@@ -55,7 +55,7 @@ package_binary() {
   chmod 0755 "$stage/${binary_name}"
   tar -czf "$artifacts_dir/${artifact}.tar.gz" -C "$stage" "$binary_name"
 
-  local pkg_dir="$npm_dir/@oauth-mux/${npm_pkg#@oauth-mux/}"
+  local pkg_dir="$npm_dir/${npm_pkg}"
   mkdir -p "$pkg_dir/bin"
   cp "$src" "$pkg_dir/bin/${binary_name}"
   chmod 0755 "$pkg_dir/bin/${binary_name}"
@@ -76,12 +76,12 @@ EOF
 printf 'building release binaries...\n'
 zig build release
 
-package_binary "x86_64-linux" "oauth-mux-x86_64-linux" "@oauth-mux/linux-x64" "linux" "x64" "oauth-mux"
-package_binary "aarch64-linux" "oauth-mux-aarch64-linux" "@oauth-mux/linux-arm64" "linux" "arm64" "oauth-mux"
-package_binary "x86_64-macos" "oauth-mux-x86_64-macos" "@oauth-mux/darwin-x64" "darwin" "x64" "oauth-mux"
-package_binary "aarch64-macos" "oauth-mux-aarch64-macos" "@oauth-mux/darwin-arm64" "darwin" "arm64" "oauth-mux"
-package_binary "x86_64-windows" "oauth-mux-x86_64-windows" "@oauth-mux/win32-x64" "win32" "x64" "oauth-mux.exe"
-package_binary "aarch64-windows" "oauth-mux-aarch64-windows" "@oauth-mux/win32-arm64" "win32" "arm64" "oauth-mux.exe"
+package_binary "x86_64-linux" "oauth-mux-x86_64-linux" "oauth-mux-linux-x64" "linux" "x64" "oauth-mux"
+package_binary "aarch64-linux" "oauth-mux-aarch64-linux" "oauth-mux-linux-arm64" "linux" "arm64" "oauth-mux"
+package_binary "x86_64-macos" "oauth-mux-x86_64-macos" "oauth-mux-darwin-x64" "darwin" "x64" "oauth-mux"
+package_binary "aarch64-macos" "oauth-mux-aarch64-macos" "oauth-mux-darwin-arm64" "darwin" "arm64" "oauth-mux"
+package_binary "x86_64-windows" "oauth-mux-x86_64-windows" "oauth-mux-win32-x64" "win32" "x64" "oauth-mux.exe"
+package_binary "aarch64-windows" "oauth-mux-aarch64-windows" "oauth-mux-win32-arm64" "win32" "arm64" "oauth-mux.exe"
 
 printf 'writing SHA256SUMS...\n'
 write_artifact_checksums
@@ -110,7 +110,7 @@ chmod 0755 "$root_pkg_dir/bin/oauth-mux.js"
 
 if command -v npm >/dev/null 2>&1; then
   printf 'packing npm tarballs...\n'
-  for pkg_json in "$npm_dir"/@oauth-mux/*/package.json; do
+  for pkg_json in "$npm_dir"/oauth-mux-{darwin,linux,win32}-*/package.json; do
     npm pack "$(dirname "$pkg_json")" --pack-destination "$npm_tgz_dir" >/dev/null
   done
   npm pack "$root_pkg_dir" --pack-destination "$npm_tgz_dir" >/dev/null

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 
-pub const version = "0.1.0";
+pub const version = "0.1.1";
 
 pub const Command = union(enum) {
     exec: ExecArgs,


### PR DESCRIPTION
## Summary

This patch fixes the npm publication blocker found during the first real `v0.1.0` publish attempt.

The release artifacts used scoped platform package names like `@oauth-mux/linux-x64`, but the current npm account/token does not own an `@oauth-mux` scope. The real publish run failed before any package was published. This changes platform packages to unscoped names such as `oauth-mux-linux-x64`, keeps the root shim as `oauth-mux`, and removes scoped-only `--access public` flags from generated handoffs and CI publish/dry-run scripts.

It also bumps the CLI version to `0.1.1` for the patch release and records the `v0.1.0` publish failure/evidence in the sprint doc.

## Validation

- `just release-proof 0.1.1`
- `just check`
- `git diff --check`

## Release notes

After merge, cut `v0.1.1` rather than reusing `v0.1.0`. The failed npm run published no `0.1.0` packages.
