### PR TITLE
Set npm public access for provenance publish

### DIFF
--- a/docs/registry-dry-runs-and-rollback.md
+++ b/docs/registry-dry-runs-and-rollback.md
@@ -82,9 +82,10 @@ then publishes the generated tarballs in this order:
 6. `oauth-mux-win32-arm64`
 7. `oauth-mux`
 
-The workflow requests `id-token: write` so `npm publish --provenance` can attach
-GitHub Actions provenance. Keep `dry_run=true` for the first authenticated
-execution. Set `dry_run=false` only for the actual release publication.
+The workflow requests `id-token: write` so
+`npm publish --provenance --access public` can attach GitHub Actions
+provenance. Keep `dry_run=true` for the first authenticated execution. Set
+`dry_run=false` only for the actual release publication.
 
 The publish script is idempotent by default: if `package@version` already exists
 on npm, it records a skip instead of overwriting or republishing.

--- a/docs/spec/production-publication-sprint-2026-04-28.md
+++ b/docs/spec/production-publication-sprint-2026-04-28.md
@@ -207,6 +207,9 @@ Execution evidence:
 - Patch proof: PR #9 CI run `25064315336` passed `test`, `nix`,
   GloriousFlywheel cache-first validation, and all six cross-compiles; registry
   dry-run `25064352699` passed `plan,npm` for all seven `0.1.1` npm tarballs.
+- Second npm publish run `25065841690` staged `0.1.1` successfully and reached
+  npm with unscoped names, then failed before publication because npm requires
+  `--access public` when generating provenance for a new public package.
 
 ## Explicit Non-Goals
 

--- a/scripts/npm-ci-publish.sh
+++ b/scripts/npm-ci-publish.sh
@@ -104,7 +104,7 @@ publish_one() {
     return
   fi
 
-  local args=(publish "$tarball" --provenance)
+  local args=(publish "$tarball" --provenance --access public)
   if [ "${OMUX_NPM_PUBLISH_DRY_RUN:-0}" = "1" ]; then
     args+=(--dry-run)
   fi

--- a/scripts/registry-dry-run.sh
+++ b/scripts/registry-dry-run.sh
@@ -100,7 +100,7 @@ for lane in "${lanes[@]}"; do
       NPM_CONFIG_USERCONFIG="$npmrc" npm whoami --registry=https://registry.npmjs.org/ >/dev/null
       for tarball in "$out_dir"/npm-tarballs/*.tgz; do
         name="$(basename "$tarball")"
-        NPM_CONFIG_USERCONFIG="$npmrc" npm publish "$tarball" --dry-run ${OMUX_NPM_EXTRA_ARGS:-} >/dev/null
+        NPM_CONFIG_USERCONFIG="$npmrc" npm publish "$tarball" --dry-run --access public ${OMUX_NPM_EXTRA_ARGS:-} >/dev/null
         append "- dry-run OK: \`npm-tarballs/${name}\`"
       done
       append

--- a/scripts/release-handoff.sh
+++ b/scripts/release-handoff.sh
@@ -160,9 +160,9 @@ Publish platform packages first, then the root shim:
 EOF
 
 for tarball in "${npm_platform_tarballs[@]}"; do
-  printf 'npm publish dist/out/v%s/npm-tarballs/%s --provenance\n' "$version" "$tarball" >>"$handoff_file"
+  printf 'npm publish dist/out/v%s/npm-tarballs/%s --provenance --access public\n' "$version" "$tarball" >>"$handoff_file"
 done
-printf 'npm publish dist/out/v%s/npm-tarballs/%s --provenance\n' "$version" "$npm_root_tarball" >>"$handoff_file"
+printf 'npm publish dist/out/v%s/npm-tarballs/%s --provenance --access public\n' "$version" "$npm_root_tarball" >>"$handoff_file"
 
 cat >>"$handoff_file" <<EOF
 \`\`\`


### PR DESCRIPTION
## Summary

This fixes the second npm publication blocker from run `25065841690`.

After unscoped package names reached npm correctly, `npm publish --provenance` rejected the first new package because new public packages need `--access public` when provenance is generated. This makes the CI publish script, registry dry-run lane, and release handoff all use `--provenance --access public` for every tarball.

## Validation

- `git diff --check`
- `./scripts/release-handoff.sh 0.1.1`
- `OMUX_NPM_PUBLISH_PLAN_ONLY=1 ./scripts/npm-ci-publish.sh 0.1.1`

## Release note

No `0.1.1` npm package was published by the failed run. After this merges, rerun the CI-only npm publish workflow for `version=0.1.1` with `dry_run=false`.
