### PR TITLE
Gate npm provenance for private source releases

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,6 +17,11 @@ on:
         required: false
         default: true
         type: boolean
+      provenance:
+        description: "Attach npm provenance; requires a public GitHub source repository"
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
@@ -84,6 +89,9 @@ jobs:
           set -euo pipefail
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             export OMUX_NPM_PUBLISH_DRY_RUN=1
+          fi
+          if [ "${{ inputs.provenance }}" != "true" ]; then
+            export OMUX_NPM_PUBLISH_PROVENANCE=0
           fi
           nix develop --command ./scripts/npm-ci-publish.sh "${{ inputs.version }}"
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -15,8 +15,8 @@ Target install surfaces:
 - raw release tarballs for air-gapped or policy-managed systems
 
 Each release artifact should be derived from the same CI release tree. npm is
-published only from CI tarballs with provenance; workstation `npm publish` is
-not supported.
+published only from CI tarballs; workstation `npm publish` is not supported.
+Use npm provenance when the GitHub source repository is public.
 
 ## First User Experience
 

--- a/docs/registry-dry-runs-and-rollback.md
+++ b/docs/registry-dry-runs-and-rollback.md
@@ -7,7 +7,8 @@ and non-publishing.
 
 npm publication is CI-only. Do not run `npm publish` from a workstation. The
 publish workflow stages the same release derivation, then publishes the
-generated tarballs with npm provenance.
+generated tarballs. npm provenance is enabled by default and requires a public
+source repository.
 
 ## Dry-Run
 
@@ -84,8 +85,12 @@ then publishes the generated tarballs in this order:
 
 The workflow requests `id-token: write` so
 `npm publish --provenance --access public` can attach GitHub Actions
-provenance. Keep `dry_run=true` for the first authenticated execution. Set
-`dry_run=false` only for the actual release publication.
+provenance. npm only accepts GitHub Actions provenance from public source
+repositories. If the repository is still private at publication time, either
+make the source repository public before publishing or set `provenance=false`
+after explicitly accepting a no-provenance npm release. Keep `dry_run=true` for
+the first authenticated execution. Set `dry_run=false` only for the actual
+release publication.
 
 The publish script is idempotent by default: if `package@version` already exists
 on npm, it records a skip instead of overwriting or republishing.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -99,8 +99,10 @@ or publish anything.
 
 npm publication is intentionally separate and CI-only. Use
 `.github/workflows/npm-publish.yml`; it reuses the release derivation, resolves
-auth at runtime, and publishes only the generated tarballs with npm provenance.
-Do not publish npm packages from a workstation.
+auth at runtime, and publishes only the generated tarballs. Keep npm provenance
+enabled when the source repository is public; npm rejects GitHub Actions
+provenance from private repositories. Do not publish npm packages from a
+workstation.
 
 ## Release Workflow
 

--- a/docs/spec/development-timeline-2026-04-27.md
+++ b/docs/spec/development-timeline-2026-04-27.md
@@ -84,9 +84,10 @@ degradation or auth death.
 
 - CI-only npm publication
   `.github/workflows/npm-publish.yml` publishes only generated release
-  tarballs, with npm provenance, after `just release-proof-local <version>`.
-  Auth can come from Actions secrets, token files, or SOPS at runtime; token
-  material is never committed or printed.
+  tarballs after `just release-proof-local <version>`. npm provenance stays
+  enabled for public source repositories and can be explicitly disabled for a
+  private-source release. Auth can come from Actions secrets, token files, or
+  SOPS at runtime; token material is never committed or printed.
 
 - Codex canary and secret-scoped live QA
   `oauth-mux codex canary` captures no-spend config/discovery/status/health and

--- a/docs/spec/production-publication-sprint-2026-04-28.md
+++ b/docs/spec/production-publication-sprint-2026-04-28.md
@@ -210,6 +210,10 @@ Execution evidence:
 - Second npm publish run `25065841690` staged `0.1.1` successfully and reached
   npm with unscoped names, then failed before publication because npm requires
   `--access public` when generating provenance for a new public package.
+- Third npm publish run `25067064757` staged `0.1.1` successfully and reached
+  npm with `--access public`, then failed before publication because npm
+  provenance rejects private GitHub source repositories. Registry checks after
+  the failure still returned 404 for the checked `0.1.1` package names.
 
 ## Explicit Non-Goals
 

--- a/scripts/npm-ci-publish.sh
+++ b/scripts/npm-ci-publish.sh
@@ -20,6 +20,16 @@ platform_tarballs=(
   "oauth-mux-win32-arm64-${version}.tgz"
 )
 root_tarball="oauth-mux-${version}.tgz"
+npm_provenance="${OMUX_NPM_PUBLISH_PROVENANCE:-1}"
+
+case "$npm_provenance" in
+  1|true|yes|on) npm_provenance="1" ;;
+  0|false|no|off) npm_provenance="0" ;;
+  *)
+    printf 'invalid OMUX_NPM_PUBLISH_PROVENANCE: %s\n' "$npm_provenance" >&2
+    exit 2
+    ;;
+esac
 
 require_command() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -104,7 +114,10 @@ publish_one() {
     return
   fi
 
-  local args=(publish "$tarball" --provenance --access public)
+  local args=(publish "$tarball" --access public)
+  if [ "$npm_provenance" = "1" ]; then
+    args+=(--provenance)
+  fi
   if [ "${OMUX_NPM_PUBLISH_DRY_RUN:-0}" = "1" ]; then
     args+=(--dry-run)
   fi
@@ -165,7 +178,11 @@ else
   else
     append "- mode: publish"
   fi
-  append "- provenance: enabled"
+  if [ "$npm_provenance" = "1" ]; then
+    append "- provenance: enabled"
+  else
+    append "- provenance: disabled"
+  fi
   append
   append "## packages"
   append

--- a/scripts/release-handoff.sh
+++ b/scripts/release-handoff.sh
@@ -167,6 +167,10 @@ printf 'npm publish dist/out/v%s/npm-tarballs/%s --provenance --access public\n'
 cat >>"$handoff_file" <<EOF
 \`\`\`
 
+npm provenance requires a public GitHub source repository. If the repository is
+still private at publication time, use the CI-only npm workflow with
+\`provenance=false\` after explicitly accepting a no-provenance npm release.
+
 ## Homebrew Tap
 
 Copy the rendered formula into the tap and review the four platform checksums:


### PR DESCRIPTION
## Summary

- add an explicit npm publish workflow provenance input, defaulting on
- let the CI publish script omit --provenance only when explicitly requested
- document npm's public-source provenance requirement and the no-provenance private-repo release path

## Root Cause

npm rejects GitHub Actions provenance for private source repositories. Run 25067064757 reached npm with --access public, then failed with E422 before publishing any package.

## Validation

- bash -n scripts/npm-ci-publish.sh scripts/release-handoff.sh scripts/registry-dry-run.sh
- yq '.on.workflow_dispatch.inputs.provenance' .github/workflows/npm-publish.yml
- OMUX_NPM_PUBLISH_PLAN_ONLY=1 OMUX_NPM_PUBLISH_PROVENANCE=0 ./scripts/npm-ci-publish.sh 0.1.1
- git diff --check
- just check