### PR TITLE
Rename Windows npm platform packages

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .oauth_mux,
-    .version = "0.1.0",
+    .version = "0.1.2",
     .fingerprint = 0x21c445132f61984e,
     .minimum_zig_version = "0.14.0",
     .paths = .{

--- a/dist/npm/install.js
+++ b/dist/npm/install.js
@@ -9,8 +9,8 @@ const PLATFORM_MAP = {
   "darwin-x64": "oauth-mux-darwin-x64",
   "linux-arm64": "oauth-mux-linux-arm64",
   "linux-x64": "oauth-mux-linux-x64",
-  "win32-arm64": "oauth-mux-win32-arm64",
-  "win32-x64": "oauth-mux-win32-x64",
+  "win32-arm64": "oauth-mux-windows-arm64",
+  "win32-x64": "oauth-mux-windows-x64",
 };
 
 const key = `${os.platform()}-${os.arch()}`;

--- a/dist/npm/package.json
+++ b/dist/npm/package.json
@@ -19,7 +19,7 @@
     "oauth-mux-darwin-x64": "0.1.0",
     "oauth-mux-linux-arm64": "0.1.0",
     "oauth-mux-linux-x64": "0.1.0",
-    "oauth-mux-win32-arm64": "0.1.0",
-    "oauth-mux-win32-x64": "0.1.0"
+    "oauth-mux-windows-arm64": "0.1.0",
+    "oauth-mux-windows-x64": "0.1.0"
   }
 }

--- a/docs/registry-dry-runs-and-rollback.md
+++ b/docs/registry-dry-runs-and-rollback.md
@@ -79,8 +79,8 @@ then publishes the generated tarballs in this order:
 2. `oauth-mux-linux-arm64`
 3. `oauth-mux-darwin-x64`
 4. `oauth-mux-darwin-arm64`
-5. `oauth-mux-win32-x64`
-6. `oauth-mux-win32-arm64`
+5. `oauth-mux-windows-x64`
+6. `oauth-mux-windows-arm64`
 7. `oauth-mux`
 
 The workflow requests `id-token: write` so

--- a/docs/spec/production-publication-sprint-2026-04-28.md
+++ b/docs/spec/production-publication-sprint-2026-04-28.md
@@ -214,6 +214,14 @@ Execution evidence:
   npm with `--access public`, then failed before publication because npm
   provenance rejects private GitHub source repositories. Registry checks after
   the failure still returned 404 for the checked `0.1.1` package names.
+- Fourth npm publish run `25068115332` used the explicit private-source
+  `provenance=false` path. It published `oauth-mux-linux-x64`,
+  `oauth-mux-linux-arm64`, `oauth-mux-darwin-x64`, and
+  `oauth-mux-darwin-arm64` at `0.1.1`, then failed on
+  `oauth-mux-win32-x64` because npm spam detection rejected that package name.
+- Patch path: publish `0.1.2` with Windows platform packages renamed to
+  `oauth-mux-windows-x64` and `oauth-mux-windows-arm64`, then leave the partial
+  `0.1.1` platform packages unused by the root shim.
 
 ## Explicit Non-Goals
 

--- a/scripts/npm-ci-publish.sh
+++ b/scripts/npm-ci-publish.sh
@@ -16,8 +16,8 @@ platform_tarballs=(
   "oauth-mux-linux-arm64-${version}.tgz"
   "oauth-mux-darwin-x64-${version}.tgz"
   "oauth-mux-darwin-arm64-${version}.tgz"
-  "oauth-mux-win32-x64-${version}.tgz"
-  "oauth-mux-win32-arm64-${version}.tgz"
+  "oauth-mux-windows-x64-${version}.tgz"
+  "oauth-mux-windows-arm64-${version}.tgz"
 )
 root_tarball="oauth-mux-${version}.tgz"
 npm_provenance="${OMUX_NPM_PUBLISH_PROVENANCE:-1}"

--- a/scripts/release-handoff.sh
+++ b/scripts/release-handoff.sh
@@ -37,8 +37,8 @@ npm_platform_tarballs=(
   "oauth-mux-darwin-x64-${version}.tgz"
   "oauth-mux-linux-arm64-${version}.tgz"
   "oauth-mux-linux-x64-${version}.tgz"
-  "oauth-mux-win32-arm64-${version}.tgz"
-  "oauth-mux-win32-x64-${version}.tgz"
+  "oauth-mux-windows-arm64-${version}.tgz"
+  "oauth-mux-windows-x64-${version}.tgz"
 )
 
 npm_root_tarball="oauth-mux-${version}.tgz"

--- a/scripts/release-local.sh
+++ b/scripts/release-local.sh
@@ -80,8 +80,8 @@ package_binary "x86_64-linux" "oauth-mux-x86_64-linux" "oauth-mux-linux-x64" "li
 package_binary "aarch64-linux" "oauth-mux-aarch64-linux" "oauth-mux-linux-arm64" "linux" "arm64" "oauth-mux"
 package_binary "x86_64-macos" "oauth-mux-x86_64-macos" "oauth-mux-darwin-x64" "darwin" "x64" "oauth-mux"
 package_binary "aarch64-macos" "oauth-mux-aarch64-macos" "oauth-mux-darwin-arm64" "darwin" "arm64" "oauth-mux"
-package_binary "x86_64-windows" "oauth-mux-x86_64-windows" "oauth-mux-win32-x64" "win32" "x64" "oauth-mux.exe"
-package_binary "aarch64-windows" "oauth-mux-aarch64-windows" "oauth-mux-win32-arm64" "win32" "arm64" "oauth-mux.exe"
+package_binary "x86_64-windows" "oauth-mux-x86_64-windows" "oauth-mux-windows-x64" "win32" "x64" "oauth-mux.exe"
+package_binary "aarch64-windows" "oauth-mux-aarch64-windows" "oauth-mux-windows-arm64" "win32" "arm64" "oauth-mux.exe"
 
 printf 'writing SHA256SUMS...\n'
 write_artifact_checksums
@@ -110,7 +110,7 @@ chmod 0755 "$root_pkg_dir/bin/oauth-mux.js"
 
 if command -v npm >/dev/null 2>&1; then
   printf 'packing npm tarballs...\n'
-  for pkg_json in "$npm_dir"/oauth-mux-{darwin,linux,win32}-*/package.json; do
+  for pkg_json in "$npm_dir"/oauth-mux-{darwin,linux,windows}-*/package.json; do
     npm pack "$(dirname "$pkg_json")" --pack-destination "$npm_tgz_dir" >/dev/null
   done
   npm pack "$root_pkg_dir" --pack-destination "$npm_tgz_dir" >/dev/null

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -32,8 +32,8 @@ required_npm_tarballs=(
   "oauth-mux-darwin-x64-0.1.0.tgz"
   "oauth-mux-linux-arm64-0.1.0.tgz"
   "oauth-mux-linux-x64-0.1.0.tgz"
-  "oauth-mux-win32-arm64-0.1.0.tgz"
-  "oauth-mux-win32-x64-0.1.0.tgz"
+  "oauth-mux-windows-arm64-0.1.0.tgz"
+  "oauth-mux-windows-x64-0.1.0.tgz"
 )
 
 hash_file() {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 
-pub const version = "0.1.1";
+pub const version = "0.1.2";
 
 pub const Command = union(enum) {
     exec: ExecArgs,


### PR DESCRIPTION
## Summary

- bump release metadata to 0.1.2
- rename npm Windows platform packages to oauth-mux-windows-x64 and oauth-mux-windows-arm64
- update root npm optional dependencies, installer mapping, release smoke, handoff, and CI publish plan
- record the partial 0.1.1 npm publication and spam-detection failure

## Root Cause

CI-only npm publish run 25068115332 published four 0.1.1 platform packages, then npm rejected oauth-mux-win32-x64 with spam detection. The root package was not published. This patch avoids the rejected win32 package-name shape and publishes a clean 0.1.2 root shim that depends on the new Windows package names.

## Validation

- bash -n scripts/release-local.sh scripts/release-smoke.sh scripts/release-handoff.sh scripts/npm-ci-publish.sh scripts/registry-dry-run.sh
- git diff --check
- just release-proof 0.1.2
- OMUX_NPM_PUBLISH_PLAN_ONLY=1 OMUX_NPM_PUBLISH_PROVENANCE=0 ./scripts/npm-ci-publish.sh 0.1.2
- tar -xOf dist/out/v0.1.2/npm-tarballs/oauth-mux-0.1.2.tgz package/package.json | jq '.version,.optionalDependencies'
- just check
- npm view checks show the 0.1.2 names are not currently published