### PR TITLE
Handle published npm versions in registry dry-run

### DIFF
--- a/docs/registry-dry-runs-and-rollback.md
+++ b/docs/registry-dry-runs-and-rollback.md
@@ -41,6 +41,11 @@ The npm dry-run lane resolves auth in this order: `NPM_TOKEN`,
 `OMUX_NPM_TOKEN_SOPS_FILE` with `OMUX_NPM_TOKEN_SOPS_KEY`. The default SOPS key
 candidate is `.api.npm_token`.
 
+Before publication, the npm lane expects `npm publish --dry-run` to succeed for
+each staged tarball. After publication, npm rejects dry-runs for an existing
+`package@version`; the lane treats that as OK only when `npm view` confirms the
+exact published version.
+
 The script writes `dist/out/v<version>/handoff/registry-dry-run.md`.
 
 ## GitHub Workflow

--- a/docs/spec/production-publication-sprint-2026-04-28.md
+++ b/docs/spec/production-publication-sprint-2026-04-28.md
@@ -8,6 +8,34 @@ state.
 
 Issue context: Linear `TIN-491`, GitHub `tinyland-inc/lab#197`.
 
+## v0.1.2 Publication Status
+
+`v0.1.2` is the first usable public npm release. The earlier `v0.1.1` npm
+attempt published partial platform artifacts but never published the root
+`oauth-mux` shim.
+
+Evidence:
+
+- PR #12 merged as `2f853b6`, renaming Windows npm packages to
+  `oauth-mux-windows-x64` and `oauth-mux-windows-arm64` while preserving npm
+  `os: ["win32"]` metadata.
+- Main CI run `25069588597` passed test, nix, all six cross-compiles, and
+  GloriousFlywheel cache-first validation.
+- GitHub Release `v0.1.2` published successfully on run `25069814477`.
+- CI-only npm publish run `25070103079` published all seven packages with
+  provenance disabled because the source repository is private.
+- Public npm install smoke passed from a fresh temp project:
+  `npm install oauth-mux@0.1.2` followed by `oauth-mux --version` returned
+  `oauth-mux 0.1.2`.
+- Hosted live-provider QA run `25070624314` passed from `main` with
+  secret-scoped Codex stores. `codex-mini` was available for all three
+  accounts. `codex-max` was available for `max-1` and `max-2`; `max-3`
+  returned `live/quota_exhausted` with reset `2026-04-29T18:30:30Z`.
+- Post-publication registry dry-run `25070517243` exposed an idempotence gap:
+  npm rejects `npm publish --dry-run` for an already-published version. The
+  dry-run lane now treats that as OK only when `npm view package@version`
+  confirms the exact published artifact.
+
 ## Current Baseline
 
 - `origin/main` contains the merged core mux, typed liveness, Codex three-account

--- a/scripts/registry-dry-run.sh
+++ b/scripts/registry-dry-run.sh
@@ -100,8 +100,22 @@ for lane in "${lanes[@]}"; do
       NPM_CONFIG_USERCONFIG="$npmrc" npm whoami --registry=https://registry.npmjs.org/ >/dev/null
       for tarball in "$out_dir"/npm-tarballs/*.tgz; do
         name="$(basename "$tarball")"
-        NPM_CONFIG_USERCONFIG="$npmrc" npm publish "$tarball" --dry-run --access public ${OMUX_NPM_EXTRA_ARGS:-} >/dev/null
-        append "- dry-run OK: \`npm-tarballs/${name}\`"
+        publish_log="$(mktemp)"
+        tmp_files+=("$publish_log")
+        if NPM_CONFIG_USERCONFIG="$npmrc" npm publish "$tarball" --dry-run --access public ${OMUX_NPM_EXTRA_ARGS:-} >"$publish_log" 2>&1; then
+          append "- dry-run OK: \`npm-tarballs/${name}\`"
+          continue
+        fi
+
+        package_name="${name%-${version}.tgz}"
+        if grep -qi 'previously published versions' "$publish_log" &&
+          NPM_CONFIG_USERCONFIG="$npmrc" npm view "${package_name}@${version}" version --registry=https://registry.npmjs.org/ >/dev/null 2>&1; then
+          append "- already published OK: \`${package_name}@${version}\`"
+          continue
+        fi
+
+        cat "$publish_log" >&2
+        exit 1
       done
       append
       ;;


### PR DESCRIPTION
## Summary

- treat post-publication npm dry-run rejection as OK only when `npm view package@version` confirms the exact published version
- document the pre-publication vs post-publication npm dry-run behavior
- record the `v0.1.2` publication, npm install smoke, hosted live QA result, and registry dry-run idempotence gap in the production sprint notes

## Validation

- `bash -n scripts/registry-dry-run.sh`
- `git diff --check`
- fake-npm registry dry-run exercising the already-published path for `oauth-mux@0.1.2` and `oauth-mux-windows-x64@0.1.2`
- `just check`
