### PR TITLE
Add CI-only npm deprecation workflow

### DIFF
--- a/.github/workflows/npm-deprecate.yml
+++ b/.github/workflows/npm-deprecate.yml
@@ -1,0 +1,99 @@
+name: NPM Deprecate
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type deprecate-npm to deprecate npm package versions"
+        required: true
+        type: string
+      version:
+        description: "Package version to deprecate"
+        required: false
+        default: "0.1.1"
+        type: string
+      packages:
+        description: "Comma-separated package names"
+        required: false
+        default: "oauth-mux-linux-x64,oauth-mux-linux-arm64,oauth-mux-darwin-x64,oauth-mux-darwin-arm64"
+        type: string
+      message:
+        description: "Deprecation message"
+        required: false
+        default: "oauth-mux 0.1.1 platform package was orphaned by a failed release. Use oauth-mux@0.1.2 or newer."
+        type: string
+      plan_only:
+        description: "Write the deprecation plan without mutating npm"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  npm-deprecate:
+    name: npm deprecate package versions
+    if: inputs.confirm == 'deprecate-npm'
+    runs-on: ubuntu-latest
+    environment: npm-production
+    env:
+      OMUX_GLOBAL_SOPS_B64_PRESENT: ${{ secrets.OMUX_GLOBAL_SOPS_B64 != '' }}
+      OMUX_GLOBAL_SOPS_REPOSITORY_PRESENT: ${{ vars.OMUX_GLOBAL_SOPS_REPOSITORY != '' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v30
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Decode global SOPS file
+        if: env.OMUX_GLOBAL_SOPS_B64_PRESENT == 'true'
+        shell: bash
+        env:
+          OMUX_GLOBAL_SOPS_B64: ${{ secrets.OMUX_GLOBAL_SOPS_B64 }}
+        run: |
+          set -euo pipefail
+          global_sops="$RUNNER_TEMP/omux-global.sops.yaml"
+          printf '%s' "$OMUX_GLOBAL_SOPS_B64" | base64 -d > "$global_sops"
+          chmod 0600 "$global_sops"
+          echo "OMUX_NPM_TOKEN_SOPS_FILE=$global_sops" >> "$GITHUB_ENV"
+
+      - name: Checkout global SOPS repo
+        if: env.OMUX_GLOBAL_SOPS_B64_PRESENT != 'true' && env.OMUX_GLOBAL_SOPS_REPOSITORY_PRESENT == 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ vars.OMUX_GLOBAL_SOPS_REPOSITORY }}
+          ref: ${{ vars.OMUX_GLOBAL_SOPS_REF || 'main' }}
+          path: .global-sops
+          token: ${{ secrets.GF_ACTIONS_TOKEN || github.token }}
+          persist-credentials: false
+
+      - name: Configure checked-out SOPS file
+        if: env.OMUX_GLOBAL_SOPS_B64_PRESENT != 'true' && env.OMUX_GLOBAL_SOPS_REPOSITORY_PRESENT == 'true'
+        shell: bash
+        env:
+          OMUX_GLOBAL_SOPS_FILE: ${{ vars.OMUX_GLOBAL_SOPS_FILE || 'nix/secrets/common.yaml' }}
+        run: |
+          set -euo pipefail
+          echo "OMUX_NPM_TOKEN_SOPS_FILE=$PWD/.global-sops/$OMUX_GLOBAL_SOPS_FILE" >> "$GITHUB_ENV"
+
+      - name: Run npm deprecation plan or mutation
+        shell: bash
+        env:
+          OMUX_NPM_DEPRECATE_CONFIRM: deprecate-npm
+          OMUX_NPM_DEPRECATE_PACKAGES: ${{ inputs.packages }}
+          OMUX_NPM_DEPRECATE_MESSAGE: ${{ inputs.message }}
+          OMUX_NPM_DEPRECATE_PLAN_ONLY: ${{ inputs.plan_only && '1' || '0' }}
+          OMUX_NPM_TOKEN_SOPS_KEY: ${{ vars.OMUX_NPM_TOKEN_SOPS_KEY || '.api.npm_token' }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN || '' }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN || '' }}
+          SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY || '' }}
+        run: nix develop --command ./scripts/npm-ci-deprecate.sh "${{ inputs.version }}"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: npm-deprecate-${{ inputs.version }}
+          path: dist/out/**/handoff/
+          if-no-files-found: ignore

--- a/docs/registry-dry-runs-and-rollback.md
+++ b/docs/registry-dry-runs-and-rollback.md
@@ -100,6 +100,30 @@ release publication.
 The publish script is idempotent by default: if `package@version` already exists
 on npm, it records a skip instead of overwriting or republishing.
 
+## npm Deprecation
+
+`.github/workflows/npm-deprecate.yml` is the only supported npm deprecation
+mutation path. It requires `confirm=deprecate-npm` and defaults to
+`plan_only=true`.
+
+The default target is the orphaned partial `0.1.1` platform package set from the
+failed first publication attempt:
+
+1. `oauth-mux-linux-x64@0.1.1`
+2. `oauth-mux-linux-arm64@0.1.1`
+3. `oauth-mux-darwin-x64@0.1.1`
+4. `oauth-mux-darwin-arm64@0.1.1`
+
+Run the plan locally or in CI before mutating npm:
+
+```bash
+just npm-deprecate-plan 0.1.1
+```
+
+The workflow resolves npm auth through the same SOPS/token surfaces as the
+publish workflow. Set `plan_only=false` only after the uploaded
+`npm-ci-deprecate.md` plan names exactly the versions to deprecate.
+
 ## Rollback
 
 GitHub Release:

--- a/docs/spec/production-publication-sprint-2026-04-28.md
+++ b/docs/spec/production-publication-sprint-2026-04-28.md
@@ -35,6 +35,9 @@ Evidence:
   npm rejects `npm publish --dry-run` for an already-published version. The
   dry-run lane now treats that as OK only when `npm view package@version`
   confirms the exact published artifact.
+- The next npm hygiene step is a CI-only deprecation workflow for the orphaned
+  partial `0.1.1` platform packages. It must default to plan-only and use the
+  org/global SOPS npm token path for any mutation.
 
 ## Current Baseline
 

--- a/justfile
+++ b/justfile
@@ -98,6 +98,9 @@ release-handoff VERSION="0.1.0":
 registry-dry-run VERSION="0.1.0":
     nix develop --command ./scripts/registry-dry-run.sh {{VERSION}}
 
+npm-deprecate-plan VERSION="0.1.1":
+    OMUX_NPM_DEPRECATE_PLAN_ONLY=1 nix develop --command ./scripts/npm-ci-deprecate.sh {{VERSION}}
+
 release-proof VERSION="0.1.0":
     nix develop --command just release-proof-local {{VERSION}}
 

--- a/scripts/npm-ci-deprecate.sh
+++ b/scripts/npm-ci-deprecate.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+version="${1:-${VERSION:-0.1.1}}"
+version="${version#v}"
+packages_csv="${OMUX_NPM_DEPRECATE_PACKAGES:-oauth-mux-linux-x64,oauth-mux-linux-arm64,oauth-mux-darwin-x64,oauth-mux-darwin-arm64}"
+message="${OMUX_NPM_DEPRECATE_MESSAGE:-oauth-mux 0.1.1 platform package was orphaned by a failed release. Use oauth-mux@0.1.2 or newer.}"
+plan_only="${OMUX_NPM_DEPRECATE_PLAN_ONLY:-1}"
+overwrite="${OMUX_NPM_DEPRECATE_OVERWRITE:-0}"
+out_dir="$repo_root/dist/out/v${version}"
+handoff_dir="$out_dir/handoff"
+report="$handoff_dir/npm-ci-deprecate.md"
+
+case "$plan_only" in
+  1|true|yes|on) plan_only="1" ;;
+  0|false|no|off) plan_only="0" ;;
+  *)
+    printf 'invalid OMUX_NPM_DEPRECATE_PLAN_ONLY: %s\n' "$plan_only" >&2
+    exit 2
+    ;;
+esac
+
+case "$overwrite" in
+  1|true|yes|on) overwrite="1" ;;
+  0|false|no|off) overwrite="0" ;;
+  *)
+    printf 'invalid OMUX_NPM_DEPRECATE_OVERWRITE: %s\n' "$overwrite" >&2
+    exit 2
+    ;;
+esac
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'missing required command: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+append() {
+  printf '%s\n' "$*" >>"$report"
+}
+
+ensure_ci_boundary() {
+  if [ "$plan_only" = "1" ]; then
+    return
+  fi
+  if [ "${GITHUB_ACTIONS:-}" != "true" ]; then
+    cat >&2 <<'EOF'
+npm deprecation is CI-only.
+
+Run through .github/workflows/npm-deprecate.yml with plan_only=false.
+EOF
+    exit 2
+  fi
+}
+
+ensure_confirmed() {
+  if [ "$plan_only" = "1" ]; then
+    return
+  fi
+  if [ "${OMUX_NPM_DEPRECATE_CONFIRM:-}" != "deprecate-npm" ]; then
+    cat >&2 <<EOF
+npm deprecation is disabled.
+
+Re-run in CI with:
+
+  OMUX_NPM_DEPRECATE_CONFIRM=deprecate-npm ./scripts/npm-ci-deprecate.sh ${version}
+EOF
+    exit 2
+  fi
+}
+
+package_exists() {
+  local spec="$1"
+  NPM_CONFIG_USERCONFIG="${npmrc:-}" npm view "$spec" version --registry=https://registry.npmjs.org/ >/dev/null 2>&1
+}
+
+current_deprecation() {
+  local spec="$1"
+  NPM_CONFIG_USERCONFIG="${npmrc:-}" npm view "$spec" deprecated --registry=https://registry.npmjs.org/ 2>/dev/null || true
+}
+
+deprecate_one() {
+  local package="$1"
+  package="${package//[[:space:]]/}"
+  if [ -z "$package" ]; then
+    return
+  fi
+
+  local spec="${package}@${version}"
+  if ! package_exists "$spec"; then
+    append "- missing, skipped: \`${spec}\`"
+    return
+  fi
+
+  local existing
+  existing="$(current_deprecation "$spec")"
+  if [ -n "$existing" ]; then
+    if [ "$existing" = "$message" ]; then
+      append "- already deprecated: \`${spec}\`"
+      return
+    fi
+    if [ "$overwrite" != "1" ]; then
+      append "- already deprecated with different message, skipped: \`${spec}\`"
+      return
+    fi
+  fi
+
+  if [ "$plan_only" = "1" ]; then
+    append "- plan: deprecate \`${spec}\`"
+    return
+  fi
+
+  NPM_CONFIG_USERCONFIG="$npmrc" npm deprecate "$spec" "$message" --registry=https://registry.npmjs.org/
+  append "- deprecated: \`${spec}\`"
+}
+
+ensure_ci_boundary
+ensure_confirmed
+require_command npm
+
+mkdir -p "$handoff_dir"
+
+cat >"$report" <<EOF
+# oauth-mux v${version} npm CI Deprecate
+
+Generated: $(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+This report records CI-only npm deprecation planning or mutation. It must not
+include token material.
+
+## mode
+
+- plan_only: \`${plan_only}\`
+- version: \`${version}\`
+- message: \`${message}\`
+
+EOF
+
+if [ "$plan_only" = "0" ]; then
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/oauth-mux-npm-deprecate.XXXXXX")"
+  trap 'rm -rf "$tmp"' EXIT
+  npmrc="$tmp/npmrc"
+  "$repo_root/scripts/resolve-npm-token.sh" --npmrc "$npmrc" >/dev/null
+
+  append "## npm identity"
+  append
+  npm_user="$(NPM_CONFIG_USERCONFIG="$npmrc" npm whoami --registry=https://registry.npmjs.org/)"
+  append "- authenticated as: \`${npm_user}\`"
+  append
+fi
+
+append "## packages"
+append
+
+IFS=',' read -r -a packages <<<"$packages_csv"
+for package in "${packages[@]}"; do
+  deprecate_one "$package"
+done
+
+printf 'npm CI deprecate report: %s\n' "$report"


### PR DESCRIPTION
## Summary

- add a manual `NPM Deprecate` workflow for package-version deprecations
- add `scripts/npm-ci-deprecate.sh`, defaulting to plan-only for the orphaned `0.1.1` platform packages
- document npm deprecation as CI-only and add `just npm-deprecate-plan` for local/operator planning

## Validation

- fake-npm mutation path with `GITHUB_ACTIONS=true`, proving the non-plan branch without touching npm
- `bash -n scripts/npm-ci-deprecate.sh scripts/npm-ci-publish.sh scripts/registry-dry-run.sh`
- `git diff --check`
- `just npm-deprecate-plan 0.1.1`
- `just check`
