### PR TITLE
[codex] Opt GitHub Actions into Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   cache-first:
     name: GloriousFlywheel cache-first check

--- a/.github/workflows/live-provider-qa.yml
+++ b/.github/workflows/live-provider-qa.yml
@@ -48,6 +48,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   live-provider-qa:
     name: Live provider QA

--- a/.github/workflows/npm-deprecate.yml
+++ b/.github/workflows/npm-deprecate.yml
@@ -31,6 +31,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   npm-deprecate:
     name: npm deprecate package versions

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,6 +27,9 @@ permissions:
   contents: read
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   npm-publish:
     name: npm publish from release derivation

--- a/.github/workflows/registry-dry-run.yml
+++ b/.github/workflows/registry-dry-run.yml
@@ -21,6 +21,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   registry-dry-run:
     name: Registry dry-run

--- a/.github/workflows/release-proof.yml
+++ b/.github/workflows/release-proof.yml
@@ -12,6 +12,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   cache-first-release-proof:
     name: GloriousFlywheel release proof

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` to all repository workflows.
- Proactively exercise existing JavaScript actions under Node 24 ahead of the 2026-06-02 GitHub Actions default change.

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/*.yml`
- `git diff --check`
- `just check`

Hosted PR CI is the intended compatibility proof for the actual action runtime.
