### PR TITLE
[codex] Promote Codex matrix probes to CLI

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -45,6 +45,7 @@ Live probes remain explicit because they can spend subscription calls:
 
 ```bash
 oauth-mux codex canary --live
+oauth-mux codex probe-all --capability codex-mini --json
 ```
 
 ## Provider Author Experience

--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -51,6 +51,13 @@ That command validates config, prints discovery/status evidence, and checks
 `codex login status` for each account without running probes. Add `--live` only
 when the canary should also invoke this live QA matrix.
 
+For a focused account matrix on one route class:
+
+```bash
+OMUX_CONFIG=$PWD/examples/codex-max.config.json \
+  oauth-mux codex probe-all --capability codex-mini --json
+```
+
 Artifacts are written under `dist/live-qa/<timestamp>/`:
 
 - `config-validate.txt`

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -83,8 +83,15 @@ include bounded route probes:
 oauth-mux codex canary --live
 ```
 
+To probe one route class across every expected Codex account:
+
+```bash
+oauth-mux codex probe-all --capability codex-mini --json
+```
+
 Source checkouts keep `just codex-max-onboard` and `just codex-max-canary` as
-thin aliases for those installed commands.
+thin aliases for installed commands. `just codex-max-probe-all` is likewise a
+thin alias for `oauth-mux codex probe-all`.
 
 ## Agent Discovery Contract
 
@@ -100,6 +107,7 @@ Agents may run:
 
 ```bash
 oauth-mux probe --profile <profile> --capability <capability> --json
+oauth-mux codex probe-all --capability <capability> --json
 oauth-mux env --profile <profile> --capability <capability> --shell <shell>
 oauth-mux exec --profile <profile> --capability <capability> -- <command>
 ```

--- a/docs/spec/production-publication-sprint-2026-04-28.md
+++ b/docs/spec/production-publication-sprint-2026-04-28.md
@@ -96,6 +96,7 @@ Deliver `oauth-mux codex ...` commands for the Codex Max path:
 - `oauth-mux codex login-status-all`
 - `oauth-mux codex onboard [--device|--status-only] [--accounts a,b,c]`
 - `oauth-mux codex canary [--accounts a,b,c] [--capabilities c1,c2] [--live]`
+- `oauth-mux codex probe-all [--accounts a,b,c] [--capabilities c1,c2] [--json]`
 
 The source-checkout `just codex-max-*` recipes should remain as aliases, not the
 primary public interface.

--- a/justfile
+++ b/justfile
@@ -71,12 +71,7 @@ codex-max-probe ACCOUNT CAPABILITY="codex-mini": build
     OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux probe --provider codex --account {{ACCOUNT}} --capability {{CAPABILITY}} --json
 
 codex-max-probe-all CAPABILITY="codex-mini": build
-    #!/usr/bin/env bash
-    set -euo pipefail
-    for account in max-1 max-2 max-3; do
-      echo "=== ${account} {{CAPABILITY}} ==="
-      OMUX_CONFIG="$PWD/{{codex_max_config}}" OMUX_STATE_DIR="{{codex_max_state}}" ./zig-out/bin/oauth-mux probe --provider codex --account "${account}" --capability "{{CAPABILITY}}" --json
-    done
+    OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux codex probe-all --capability {{CAPABILITY}} --json
 
 # ── Cross-compilation ──
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -72,6 +72,7 @@ pub const Command = union(enum) {
         login_status_all,
         onboard,
         canary,
+        probe_all,
     };
 
     pub const CodexArgs = struct {
@@ -265,6 +266,8 @@ fn parseCodex(args: []const []const u8) Command {
             result.action = .onboard;
         } else if (eql(args[0], "canary")) {
             result.action = .canary;
+        } else if (eql(args[0], "probe-all")) {
+            result.action = .probe_all;
         } else {
             result.action = .canary;
             option_start = 0;
@@ -279,7 +282,7 @@ fn parseCodex(args: []const []const u8) Command {
         } else if (eql(args[i], "--accounts")) {
             i += 1;
             if (i < args.len) result.accounts = args[i];
-        } else if (eql(args[i], "--capabilities")) {
+        } else if (eql(args[i], "--capabilities") or eql(args[i], "--capability")) {
             i += 1;
             if (i < args.len) result.capabilities = args[i];
         } else if (eql(args[i], "--store-root")) {
@@ -346,6 +349,9 @@ pub fn printUsage(writer: anytype) !void {
         \\
         \\  codex canary [--accounts a,b,c] [--capabilities c1,c2] [--live]
         \\      Run a no-spend Codex Max readiness check; --live runs probes.
+        \\
+        \\  codex probe-all [--accounts a,b,c] [--capabilities c1,c2] [--json]
+        \\      Probe every selected Codex account/capability route.
         \\
         \\  codex login <account> | login-device <account> | login-status [account] | login-status-all
         \\      Codex account login/status helpers using isolated CODEX_HOME dirs.
@@ -442,6 +448,20 @@ test "parse codex canary" {
     }
 }
 
+test "parse codex probe-all with capability alias" {
+    const args = [_][]const u8{ "codex", "probe-all", "--accounts", "max-1,max-3", "--capability", "codex-mini", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex => |codex| {
+            try std.testing.expect(codex.action == .probe_all);
+            try std.testing.expectEqualStrings("max-1,max-3", codex.accounts);
+            try std.testing.expectEqualStrings("codex-mini", codex.capabilities);
+            try std.testing.expect(codex.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 test "parse codex login account" {
     const args = [_][]const u8{ "codex", "login-device", "max-2" };
     const cmd = parse(&args);
@@ -501,7 +521,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from discover' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'onboard canary bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'onboard canary probe-all bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
             \\
         );
     } else if (eql(shell_name, "zsh")) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1028,6 +1028,7 @@ fn runCodex(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Cod
         .login_status_all => try runCodexLoginStatusAll(allocator, writer, args, root),
         .onboard => try runCodexOnboard(allocator, writer, args, root),
         .canary => try runCodexCanary(allocator, writer, args, root),
+        .probe_all => try runCodexProbeAll(allocator, writer, args),
     }
 }
 
@@ -1070,7 +1071,7 @@ fn runCodexOnboard(allocator: std.mem.Allocator, writer: anytype, args: cli.Comm
     try runDiscover(allocator, writer, .{ .json = false });
 
     if (args.live) {
-        try runCodexLiveProbes(allocator, writer, args);
+        try runCodexLiveProbes(allocator, writer, args, true);
     } else {
         try writer.writeAll("\nLive probes not run. Add --live only when real provider calls are intended.\n");
     }
@@ -1101,10 +1102,22 @@ fn runCodexCanary(allocator: std.mem.Allocator, writer: anytype, args: cli.Comma
 
     if (args.live) {
         try writer.writeAll("\n=== live probes ===\n");
-        try runCodexLiveProbes(allocator, writer, args);
+        try runCodexLiveProbes(allocator, writer, args, true);
     } else {
         try writer.writeAll("\nLive probes not run. Add --live only when real provider calls are intended.\n");
     }
+}
+
+fn runCodexProbeAll(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs) !void {
+    if (!args.json) {
+        try writer.writeAll("oauth-mux Codex probe-all\n\n");
+        try writer.print("accounts:     {s}\n", .{args.accounts});
+        try writer.print("capabilities: {s}\n\n", .{args.capabilities});
+        try writer.writeAll("=== config validate ===\n");
+        try validateCurrentConfig(allocator, writer);
+        try writer.writeAll("\n=== live probes ===\n");
+    }
+    try runCodexLiveProbes(allocator, writer, args, !args.json);
 }
 
 fn validateCurrentConfig(allocator: std.mem.Allocator, writer: anytype) !void {
@@ -1128,7 +1141,7 @@ fn runCodexLoginStatusAll(allocator: std.mem.Allocator, writer: anytype, args: c
     if (failures != 0) return error.CodexCommandFailed;
 }
 
-fn runCodexLiveProbes(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs) !void {
+fn runCodexLiveProbes(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs, emit_headers: bool) !void {
     var account_it = std.mem.splitScalar(u8, args.accounts, ',');
     while (account_it.next()) |raw_account| {
         const account = std.mem.trim(u8, raw_account, " \t\r\n");
@@ -1137,7 +1150,7 @@ fn runCodexLiveProbes(allocator: std.mem.Allocator, writer: anytype, args: cli.C
         while (capability_it.next()) |raw_capability| {
             const capability = std.mem.trim(u8, raw_capability, " \t\r\n");
             if (capability.len == 0) continue;
-            try writer.print("\n--- codex:{s}#{s} ---\n", .{ account, capability });
+            if (emit_headers) try writer.print("\n--- codex:{s}#{s} ---\n", .{ account, capability });
             runProbe(allocator, writer, .{
                 .provider = "codex",
                 .account = account,


### PR DESCRIPTION
## Summary

- Add installed `oauth-mux codex probe-all` for account/capability matrix probes.
- Support `--capability` as a singular alias for `--capabilities` on Codex commands.
- Convert `just codex-max-probe-all` into a thin alias for the installed command and update onboarding/adoption/live-QA docs.

## Validation

- `git diff --check`
- `just check`
- `oauth-mux help` and fish completions include `codex probe-all`
- No-secret smoke with temp `HOME`/`XDG_DATA_HOME` confirmed the command fails before touching real Codex stores when secrets are absent.
