### PR TITLE
[codex] Tighten probe JSON error semantics

### DIFF
--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -73,6 +73,11 @@ rather than a false infrastructure failure. Set
 route is immediately selectable. Dead credentials fail by default; set
 `OMUX_LIVE_QA_ALLOW_DEAD=1` only for negative test fixtures.
 
+Probe artifacts include `ok`, `error`, and `exit_code` fields. A nonzero probe
+exit with typed non-dead `liveness` is still accepted unless
+`OMUX_LIVE_QA_REQUIRE_AVAILABLE=1`; missing or unreadable credentials classify
+as `dead` and fail the run by default.
+
 Operator-provided Codex state on 2026-04-28:
 
 - `max-1#codex-max` and `max-2#codex-max` are expected to classify as

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -112,6 +112,11 @@ oauth-mux env --profile <profile> --capability <capability> --shell <shell>
 oauth-mux exec --profile <profile> --capability <capability> -- <command>
 ```
 
+Probe JSON includes `ok`, `error`, and `exit_code` alongside typed
+`liveness`. Agents should use `liveness` to distinguish `rate_limited`,
+`quota_exhausted`, `degraded`, and `dead` instead of treating every nonzero
+probe exit as the same failure class.
+
 Agents must not:
 
 - read files referenced by `secret.path`;

--- a/docs/spec/production-publication-sprint-2026-04-28.md
+++ b/docs/spec/production-publication-sprint-2026-04-28.md
@@ -106,6 +106,8 @@ Acceptance:
 - `zig build test` passes.
 - `just check` passes.
 - Docs point public users at installed commands.
+- Probe JSON carries `ok`, `error`, `exit_code`, and typed `liveness` so AX
+  agents can route quota, rate-limit, degraded, and dead states distinctly.
 
 ### 2. Secret-Scoped Live QA
 

--- a/src/health.zig
+++ b/src/health.zig
@@ -278,6 +278,20 @@ pub const HealthStore = struct {
             },
             else => {},
         }
+
+        if (kind == .auth_failure) {
+            health.rate_limited_until = null;
+            health.quota_exhausted_until = null;
+            health.liveness = .{ .dead = .{
+                .reason = .auth_permanently_failed,
+                .since = now,
+            } };
+            health.last_probe_source = .credential_validation;
+            health.last_probe_observed_at = now;
+            health.last_probe_retry_after_s = null;
+            health.last_probe_hint_class = .auth_dead;
+            health.last_probe_decision = .try_next_account;
+        }
     }
 
     pub fn isAvailable(self: *HealthStore, key: []const u8) bool {
@@ -1110,4 +1124,19 @@ test "HealthStore rate limit penalty" {
     const health = store.accounts.get("gemini:default").?;
     try std.testing.expectEqual(@as(i32, 40), health.score.score); // 50 + (-10)
     try std.testing.expectEqual(@as(u32, 1), health.score.rate_limits);
+}
+
+test "HealthStore auth failure marks credential dead" {
+    var store = HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+
+    store.recordFailure("codex:max-1", .auth_failure);
+
+    const health = store.accounts.get("codex:max-1").?;
+    switch (health.liveness) {
+        .dead => |dead| try std.testing.expectEqual(types.DeadReason.auth_permanently_failed, dead.reason),
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqual(ProbeHintClass.auth_dead, health.last_probe_hint_class.?);
+    try std.testing.expectEqual(types.MuxDecision.try_next_account, store.muxDecision("codex:max-1"));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -425,8 +425,13 @@ fn runProbe(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Pro
     const result = pipeline.runProbe(&ctx);
     store.persist();
 
+    var probe_error: ?types.PipelineError = null;
+    if (result) |_| {} else |e| {
+        probe_error = e;
+    }
+
     if (args.json) {
-        try writeProbeJson(writer, &store, &ctx);
+        try writeProbeJson(writer, &store, &ctx, probe_error);
     } else {
         try writeProbeText(writer, &store, &ctx);
     }
@@ -486,6 +491,14 @@ const HealthSelection = struct {
 fn selectedHealth(store: *health_mod.HealthStore, ctx: *const pipeline.Context) HealthSelection {
     const prov = ctx.provider_name orelse "";
     const acct = ctx.account_name orelse "";
+    const account_key = health_mod.accountKey(prov, acct);
+    const account_health = store.accounts.get(account_key.slice());
+    if (account_health) |health| {
+        if (accountLivenessBlocksRoute(health.liveness)) {
+            return .{ .key = account_key, .health = health };
+        }
+    }
+
     if (ctx.capability_name) |capability| {
         const route_key = health_mod.capabilityKey(prov, acct, capability);
         if (store.accounts.get(route_key.slice())) |health| {
@@ -493,8 +506,28 @@ fn selectedHealth(store: *health_mod.HealthStore, ctx: *const pipeline.Context) 
         }
     }
 
-    const account_key = health_mod.accountKey(prov, acct);
-    return .{ .key = account_key, .health = store.accounts.get(account_key.slice()) };
+    return .{ .key = account_key, .health = account_health };
+}
+
+fn accountLivenessBlocksRoute(liveness: types.CredentialLiveness) bool {
+    return switch (liveness) {
+        .dead, .degraded => true,
+        .live => |live| switch (live.availability) {
+            .available => false,
+            .rate_limited, .quota_exhausted, .cooldown => true,
+        },
+    };
+}
+
+fn probeDecision(ctx: *const pipeline.Context, probe_error: ?types.PipelineError) types.MuxDecision {
+    if (probe_error) |err| {
+        return switch (err) {
+            error.NetworkError => .try_next_provider,
+            error.AllAccountsExhausted => ctx.last_probe_decision orelse .give_up,
+            else => .try_next_account,
+        };
+    }
+    return ctx.last_probe_decision orelse .use_this;
 }
 
 fn writeProbeText(writer: anytype, store: *health_mod.HealthStore, ctx: *const pipeline.Context) !void {
@@ -549,8 +582,9 @@ fn writeProbeText(writer: anytype, store: *health_mod.HealthStore, ctx: *const p
     try writer.writeByte('\n');
 }
 
-fn writeProbeJson(writer: anytype, store: *health_mod.HealthStore, ctx: *const pipeline.Context) !void {
+fn writeProbeJson(writer: anytype, store: *health_mod.HealthStore, ctx: *const pipeline.Context, probe_error: ?types.PipelineError) !void {
     const selection = selectedHealth(store, ctx);
+    const decision = probeDecision(ctx, probe_error);
     try writer.writeByte('{');
     try writer.writeAll("\"provider\":");
     try std.json.stringify(ctx.provider_name orelse "", .{}, writer);
@@ -559,6 +593,20 @@ fn writeProbeJson(writer: anytype, store: *health_mod.HealthStore, ctx: *const p
     try writer.writeAll(",\"capability\":");
     if (ctx.capability_name) |capability| {
         try std.json.stringify(capability, .{}, writer);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"ok\":");
+    try writer.writeAll(if (probe_error == null) "true" else "false");
+    try writer.writeAll(",\"error\":");
+    if (probe_error) |err| {
+        try std.json.stringify(@errorName(err), .{}, writer);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"exit_code\":");
+    if (probe_error) |err| {
+        try writer.print("{d}", .{exitCodeFromPipelineError(err)});
     } else {
         try writer.writeAll("null");
     }
@@ -571,7 +619,7 @@ fn writeProbeJson(writer: anytype, store: *health_mod.HealthStore, ctx: *const p
         try writer.writeAll("null");
     }
     try writer.writeAll(",\"decision\":");
-    try std.json.stringify(@tagName(ctx.last_probe_decision orelse .use_this), .{}, writer);
+    try std.json.stringify(@tagName(decision), .{}, writer);
     try writer.writeAll(",\"health_key\":");
     try std.json.stringify(selection.key.slice(), .{}, writer);
     try writer.writeAll(",\"liveness\":");
@@ -1303,6 +1351,32 @@ test "writeHealthJson includes capability routes" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"key\":\"codex:max-1#codex-max\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"capability\":\"codex-max\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"availability\":\"quota_exhausted\"") != null);
+}
+
+test "writeProbeJson includes terminal pipeline error" {
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+
+    store.recordFailure("codex:max-1", .auth_failure);
+    _ = try store.getOrCreate("codex:max-1#codex-mini");
+
+    var ctx = pipeline.Context.init(std.testing.allocator, .{}, &store);
+    defer ctx.deinit();
+    ctx.provider_name = "codex";
+    ctx.account_name = "max-1";
+    ctx.capability_name = "codex-mini";
+
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+
+    try writeProbeJson(buf.writer(), &store, &ctx, error.SecretReadFailed);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"ok\":false") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"error\":\"SecretReadFailed\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"exit_code\":202") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"decision\":\"try_next_account\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"health_key\":\"codex:max-1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"state\":\"dead\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"hint_class\":\"auth_dead\"") != null);
 }
 
 // Pull in all module tests

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -134,19 +134,21 @@ fn selectWithFallback(ctx: *Context) PipelineError!void {
 
         // Try the read → validate path
         readSecret(ctx) catch |e| {
-            ctx.health.recordFailure(key.slice(), .auth_failure);
+            recordCandidateFailure(ctx, key.slice(), e);
             last_err = e;
             freeCurrentToken(ctx);
             continue;
         };
 
         validateToken(ctx) catch |e| {
+            recordCandidateFailure(ctx, key.slice(), e);
             last_err = e;
             freeCurrentToken(ctx);
             continue;
         };
 
         const post_probe_decision = probeCapability(ctx) catch |e| {
+            recordCandidateFailure(ctx, key.slice(), e);
             last_err = e;
             freeCurrentToken(ctx);
             continue;
@@ -187,6 +189,25 @@ fn freeCurrentToken(ctx: *Context) void {
         ctx.allocator.free(tok.access_token);
         if (tok.refresh_token) |rt| ctx.allocator.free(rt);
         ctx.token = null;
+    }
+}
+
+fn recordCandidateFailure(ctx: *Context, key: []const u8, err: PipelineError) void {
+    switch (err) {
+        error.SecretReadFailed,
+        error.SecretDecryptFailed,
+        error.TokenParseFailed,
+        error.TokenExpired,
+        error.TokenRefreshFailed,
+        error.TokenRevoked,
+        => ctx.health.recordFailure(key, .auth_failure),
+        error.RateLimited => ctx.health.recordFailure(key, .rate_limited),
+        error.NetworkError => ctx.health.recordFailure(key, .timeout),
+        error.ConfigNotFound,
+        error.ConfigParseError,
+        error.ConfigValidationError,
+        => {},
+        else => ctx.health.recordFailure(key, .error_response),
     }
 }
 
@@ -330,8 +351,6 @@ fn readSecret(ctx: *Context) PipelineError!void {
 
     const raw = secret.read(backend, ctx.allocator) catch |e| {
         log.err("secret: {s}:{s}: {s}", .{ prov_name, acct_name, @errorName(e) });
-        const key = health_mod.accountKey(prov_name, acct_name);
-        ctx.health.recordFailure(key.slice(), .auth_failure);
         return error.SecretReadFailed;
     };
     defer ctx.allocator.free(raw);
@@ -508,9 +527,6 @@ fn attemptRefresh(ctx: *Context, rt: []const u8) PipelineError!void {
 
     const result = oauth.refreshToken(ctx.allocator, url, rt, def.auth.client_id) catch |e| {
         log.err("token: refresh failed: {s}", .{@errorName(e)});
-        const acct = ctx.account_name orelse return error.AccountNotFound;
-        const key = health_mod.accountKey(prov, acct);
-        ctx.health.recordFailure(key.slice(), .auth_failure);
         return error.TokenRefreshFailed;
     };
 


### PR DESCRIPTION
## Summary

- add `ok`, `error`, and `exit_code` to probe JSON output
- make account-level auth failures classify as dead credential liveness with auth-dead evidence
- prefer account-level dead/degraded/unavailable state over optimistic capability route placeholders in probe JSON
- document the probe JSON contract for onboarding and live-provider QA

## Validation

- `just check`
- isolated no-secret Codex probe smoke with temp HOME, XDG_STATE_HOME, and OMUX_STATE_DIR: `SecretReadFailed`, exit 202, `decision:"try_next_account"`, `state:"dead"`
