### PR TITLE
Record repository ownership and URL decision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   cache-first:
     name: GloriousFlywheel cache-first check
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: tinyland-nix
     timeout-minutes: 30
     steps:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ connector auth. It selects among configured provider accounts, records typed
 credential liveness, and falls through without poisoning an entire account when
 only one route or capability is unavailable.
 
+`oauth-mux` is a Jess Sullivan FOSS project built with Tinyland release
+infrastructure.
+
 The implementation is pure Zig with no external Zig dependencies.
 
 ## Current Shape
@@ -120,3 +123,5 @@ See `docs/spec/production-publication-sprint-2026-04-28.md` for the current
 v0.1.0 sprint gates.
 See `docs/spec/product-adoption-sprint-2026-04-28.md` for the current website,
 onboarding, launch, and provider-adoption plan.
+See `docs/spec/repository-ownership-and-url-2026-04-28.md` for the repository
+ownership and canonical website URL decision.

--- a/dist/homebrew/oauth-mux.rb
+++ b/dist/homebrew/oauth-mux.rb
@@ -1,24 +1,24 @@
 class OauthMux < Formula
   desc "OAuth fallback muxing for AI harness subscriptions"
-  homepage "https://github.com/tinyland-inc/oauth-mux"
+  homepage "https://github.com/Jesssullivan/oauth-mux"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/tinyland-inc/oauth-mux/releases/download/v${VERSION}/oauth-mux-aarch64-macos.tar.gz"
+      url "https://github.com/Jesssullivan/oauth-mux/releases/download/v${VERSION}/oauth-mux-aarch64-macos.tar.gz"
       sha256 "${SHA_MACOS_ARM64}"
     else
-      url "https://github.com/tinyland-inc/oauth-mux/releases/download/v${VERSION}/oauth-mux-x86_64-macos.tar.gz"
+      url "https://github.com/Jesssullivan/oauth-mux/releases/download/v${VERSION}/oauth-mux-x86_64-macos.tar.gz"
       sha256 "${SHA_MACOS_X64}"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/tinyland-inc/oauth-mux/releases/download/v${VERSION}/oauth-mux-aarch64-linux.tar.gz"
+      url "https://github.com/Jesssullivan/oauth-mux/releases/download/v${VERSION}/oauth-mux-aarch64-linux.tar.gz"
       sha256 "${SHA_LINUX_ARM64}"
     else
-      url "https://github.com/tinyland-inc/oauth-mux/releases/download/v${VERSION}/oauth-mux-x86_64-linux.tar.gz"
+      url "https://github.com/Jesssullivan/oauth-mux/releases/download/v${VERSION}/oauth-mux-x86_64-linux.tar.gz"
       sha256 "${SHA_LINUX_X64}"
     end
   end

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -2,7 +2,7 @@
 # oauth-mux installer - detects OS/arch, verifies checksums, installs the binary
 set -eu
 
-REPO="${REPO:-tinyland-inc/oauth-mux}"
+REPO="${REPO:-Jesssullivan/oauth-mux}"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 VERSION="${VERSION:-latest}"
 OMUX_RELEASE_BASE_URL="${OMUX_RELEASE_BASE_URL:-}"

--- a/dist/nfpm.yaml
+++ b/dist/nfpm.yaml
@@ -3,7 +3,7 @@ arch: "${ARCH}"
 version: "${VERSION}"
 maintainer: "Jess Sullivan <jess@sulliwood.org>"
 description: "OAuth fallback muxing for AI harness subscriptions"
-homepage: "https://github.com/tinyland-inc/oauth-mux"
+homepage: "https://github.com/Jesssullivan/oauth-mux"
 license: MIT
 contents:
   - src: oauth-mux

--- a/dist/npm/package.json
+++ b/dist/npm/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "OAuth fallback muxing for AI harness subscriptions",
   "license": "MIT",
-  "repository": "tinyland-inc/oauth-mux",
+  "repository": "Jesssullivan/oauth-mux",
   "files": [
     "bin",
     "install.js"

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -86,3 +86,10 @@ The current adoption plan is tracked in
 - launch sequencing and outreach;
 - provider-author feedback loops;
 - follow-up Linear split from `TIN-491`.
+
+## Ownership And URL
+
+The canonical public source repo is `Jesssullivan/oauth-mux`. The preferred
+project URL is `https://omux.xoxd.ai`, with Tinyland remaining the development
+and release-infrastructure partner. See
+`docs/spec/repository-ownership-and-url-2026-04-28.md`.

--- a/docs/spec/product-adoption-sprint-2026-04-28.md
+++ b/docs/spec/product-adoption-sprint-2026-04-28.md
@@ -4,6 +4,10 @@ Date: 2026-04-28
 
 Issue context: Linear `TIN-491`, GitHub `tinyland-inc/lab#197`.
 
+Repository context: the canonical public source repo is
+`Jesssullivan/oauth-mux`; Tinyland remains the release-infrastructure and launch
+partner.
+
 ## Baseline
 
 `oauth-mux` has crossed the line from architecture experiment to usable public
@@ -294,7 +298,7 @@ Write three concise pieces:
 Each post should link to:
 
 - website;
-- GitHub repo;
+- GitHub repo: `https://github.com/Jesssullivan/oauth-mux`;
 - npm package;
 - provider authoring checklist;
 - daemon boundary;

--- a/docs/spec/repository-ownership-and-url-2026-04-28.md
+++ b/docs/spec/repository-ownership-and-url-2026-04-28.md
@@ -1,0 +1,74 @@
+# Repository Ownership And URL Decision
+
+Date: 2026-04-28
+
+## Decision
+
+The canonical public source repository for `oauth-mux` is:
+
+```text
+https://github.com/Jesssullivan/oauth-mux
+```
+
+Ownership model:
+
+- `Jesssullivan/oauth-mux` is the upstream source repo, issue tracker, release
+  home, provider schema, and contributor surface.
+- Tinyland remains the development organization and release-infrastructure
+  partner: GloriousFlywheel proof, Homebrew tap, package publication, website
+  build support, and launch amplification.
+- Public language should describe the project as a Jess Sullivan FOSS devtool
+  built with Tinyland release infrastructure.
+
+This matches the actual stewardship model: the project is authored and
+maintained by Jess Sullivan, while Tinyland provides the operator/release
+substrate that proved the package graph.
+
+## Website URL
+
+Use this as the canonical product URL:
+
+```text
+https://omux.xoxd.ai
+```
+
+Rationale:
+
+- short enough for CLI output and launch posts;
+- belongs to the author-facing `xoxd.ai` namespace rather than making the
+  project look like a Tinyland-owned product;
+- leaves Tinyland free to host or promote a separate org page.
+
+Recommended redirects or secondary surfaces:
+
+- `https://oauth-mux.xoxd.ai` redirects to `https://omux.xoxd.ai`;
+- `https://omux.tinyland.dev` can be a Tinyland project page or redirect to the
+  canonical site;
+- `omux.lmux.ai` is deferred until `lmux.ai` has a clear product-family role.
+
+## Publication Boundary
+
+Before making the source repo public:
+
+1. run a history-aware leak scan;
+2. remove live account credential bundle secrets from the public repo;
+3. keep release links and generated package metadata pointed at
+   `Jesssullivan/oauth-mux`;
+4. keep Tinyland-only proof references documented as optional infrastructure,
+   not an end-user dependency.
+
+Current hardening evidence:
+
+- `gitleaks detect --source . --redact --verbose` scanned 91 commits and found
+  no leaks.
+- DNS currently resolves nameservers for `xoxd.ai`, `tinyland.dev`, and
+  `lmux.ai`; no candidate `omux` host had an address record at decision time.
+
+## Follow-Up Work
+
+- Build the website under `omux.xoxd.ai`.
+- Use Tinyland web/release infrastructure for polish and publication support.
+- Recreate public-repo-safe live QA secrets only in a scoped environment if
+  hosted live provider QA needs to run from the public source repository.
+- Re-enable npm provenance from the public source repo after the next release
+  dry-run proves the new owner and source URL.

--- a/scripts/release-local.sh
+++ b/scripts/release-local.sh
@@ -65,7 +65,7 @@ package_binary() {
   "version": "${version}",
   "description": "Platform binary for oauth-mux",
   "license": "MIT",
-  "repository": "tinyland-inc/oauth-mux",
+  "repository": "Jesssullivan/oauth-mux",
   "os": ["${npm_os}"],
   "cpu": ["${npm_cpu}"],
   "files": ["bin"]
@@ -128,7 +128,7 @@ arch: "${arch}"
 version: "${version}"
 maintainer: "Jess Sullivan <jess@sulliwood.org>"
 description: "OAuth fallback muxing for AI harness subscriptions"
-homepage: "https://github.com/tinyland-inc/oauth-mux"
+homepage: "https://github.com/Jesssullivan/oauth-mux"
 license: MIT
 contents:
   - src: ${src}


### PR DESCRIPTION
## Summary

- document `Jesssullivan/oauth-mux` as the canonical public source repo
- record `https://omux.xoxd.ai` as the preferred project URL, with Tinyland as release-infra partner
- update generated package/release templates from `tinyland-inc/oauth-mux` to `Jesssullivan/oauth-mux`
- remove live QA credential bundle secrets from the transferred repo before public visibility

## Validation

- gitleaks detect --source . --redact --verbose
- git diff --check
- just check
