### PR TITLE
Add onboarding diagnostics commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ full checksums.
 
 See `docs/release-runbook.md` for release and CI details.
 See `docs/adoption.md` for installation and external-user adoption goals.
+See `docs/install-beta-matrix.md` for current clean-install dogfood evidence.
 See `docs/onboarding.md` for human and agent onboarding.
 See `docs/live-provider-qa.md` for manual secret-scoped provider probes.
 See `docs/registry-dry-runs-and-rollback.md` for publication dry-runs and

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Discover the redacted, agent-safe inventory:
 
 ```bash
 oauth-mux doctor
+oauth-mux report --redacted
+oauth-mux providers list
 oauth-mux discover --json
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ synthetic local E2E harness.
 Discover the redacted, agent-safe inventory:
 
 ```bash
+oauth-mux doctor
 oauth-mux discover --json
 ```
 
@@ -65,6 +66,15 @@ Run the no-spend Codex Max canary:
 
 ```bash
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex canary
+```
+
+First-run Codex subscription path:
+
+```bash
+oauth-mux init --codex-max
+oauth-mux doctor
+oauth-mux setup codex
+oauth-mux codex canary
 ```
 
 Run the deterministic no-secret E2E harness:

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .oauth_mux,
-    .version = "0.1.2",
+    .version = "0.1.3",
     .fingerprint = 0x21c445132f61984e,
     .minimum_zig_version = "0.14.0",
     .paths = .{

--- a/dist/homebrew/oauth-mux.rb
+++ b/dist/homebrew/oauth-mux.rb
@@ -1,6 +1,6 @@
 class OauthMux < Formula
   desc "OAuth fallback muxing for AI harness subscriptions"
-  homepage "https://github.com/Jesssullivan/oauth-mux"
+  homepage "https://omux.xoxd.ai"
   license "MIT"
 
   on_macos do

--- a/dist/nfpm.yaml
+++ b/dist/nfpm.yaml
@@ -3,7 +3,7 @@ arch: "${ARCH}"
 version: "${VERSION}"
 maintainer: "Jess Sullivan <jess@sulliwood.org>"
 description: "OAuth fallback muxing for AI harness subscriptions"
-homepage: "https://github.com/Jesssullivan/oauth-mux"
+homepage: "https://omux.xoxd.ai"
 license: MIT
 contents:
   - src: oauth-mux

--- a/dist/npm/package.json
+++ b/dist/npm/package.json
@@ -4,6 +4,7 @@
   "description": "OAuth fallback muxing for AI harness subscriptions",
   "license": "MIT",
   "repository": "Jesssullivan/oauth-mux",
+  "homepage": "https://omux.xoxd.ai",
   "files": [
     "bin",
     "install.js"

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -24,6 +24,7 @@ The happy path should stay small:
 
 ```bash
 oauth-mux init
+oauth-mux doctor
 oauth-mux config validate
 oauth-mux discover --json
 ```
@@ -32,7 +33,8 @@ For Codex subscription users working from a source checkout today:
 
 ```bash
 oauth-mux init --codex-max
-oauth-mux codex onboard
+oauth-mux doctor
+oauth-mux setup codex
 oauth-mux codex canary
 ```
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -84,6 +84,9 @@ External users may use any secret backend that fits their environment:
 No adoption flow should require the lab repo, Tinyland SOPS keys,
 GloriousFlywheel, or Codex Max accounts.
 
+Clean-install proof is tracked in `docs/install-beta-matrix.md`. Keep that
+matrix current whenever a published or staged install lane changes state.
+
 ## Product Adoption Sprint
 
 The current adoption plan is tracked in

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -25,6 +25,8 @@ The happy path should stay small:
 ```bash
 oauth-mux init
 oauth-mux doctor
+oauth-mux report --redacted
+oauth-mux providers list
 oauth-mux config validate
 oauth-mux discover --json
 ```
@@ -63,6 +65,10 @@ A new provider should usually start as data, not Zig:
 
 Compiled Zig changes should be reserved for new transports, parser primitives,
 or core liveness algebra changes.
+
+Provider authors should use `oauth-mux providers list --json` to verify whether
+their provider is currently `built_in`, `schema_modeled`, `live_proven`, or still
+waiting on `needs_operator_proof`.
 
 ## Non-Tinyland Deployments
 

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -1,0 +1,107 @@
+# Install Beta Matrix
+
+Updated: 2026-04-29
+
+This matrix tracks clean-install proof for the public adoption surfaces. It is
+operator evidence, not a credential runbook: do not paste OAuth stores, `.env`
+files, SOPS plaintext, or token-shaped values here.
+
+## Current Status
+
+| Surface | Version | Host | Source | Result | Caveat |
+| --- | --- | --- | --- | --- | --- |
+| npm global install | 0.1.2 | macOS arm64 | public npm registry | Pass | Published metadata still points at `tinyland-inc/oauth-mux`; v0.1.3 templates now point at `Jesssullivan/oauth-mux` and `https://omux.xoxd.ai`. |
+| GitHub release tarball | 0.1.2 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Repo visibility must remain public for unauthenticated downloads. |
+| `curl | sh` installer | 0.1.2 | macOS arm64 | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass with `REPO=Jesssullivan/oauth-mux` | The v0.1.2 installer asset was generated before the canonical repo transfer. v0.1.3 uses the corrected default. |
+| Homebrew formula | 0.1.3 staged | macOS arm64 | generated formula in temporary tap | Pass audit | Needs real tap install proof after release assets exist. |
+| deb package | 0.1.3 staged | Linux target | generated `nfpm` artifact | Pass artifact smoke | Needs Debian/Ubuntu host or container install proof. |
+| rpm package | 0.1.3 staged | Linux target | generated `nfpm` artifact | Pass artifact smoke | Needs Fedora/Rocky host or container install proof. |
+| lab dogfood | v0.1.3 branch | lab machines | installed `oauth-mux` CLI | Pending | Use installed commands, not repo-local `just` wrappers, once v0.1.3 is published. |
+
+## Evidence Commands
+
+npm clean install:
+
+```bash
+tmp="$(mktemp -d)"
+npm_config_cache="$tmp/cache" \
+  npm install --prefix "$tmp/app" --install-strategy=shallow oauth-mux@0.1.2 \
+  --ignore-scripts=false --no-audit --no-fund
+"$tmp/app/node_modules/.bin/oauth-mux" version
+rm -rf "$tmp"
+```
+
+Expected output includes:
+
+```text
+oauth-mux 0.1.2
+```
+
+Raw release tarball:
+
+```bash
+tmp="$(mktemp -d)"
+curl -fsSL -o "$tmp/oauth-mux-aarch64-macos.tar.gz" \
+  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.2/oauth-mux-aarch64-macos.tar.gz
+curl -fsSL -o "$tmp/SHA256SUMS" \
+  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.2/SHA256SUMS
+(cd "$tmp" && shasum -a 256 -c --ignore-missing SHA256SUMS)
+tar -xzf "$tmp/oauth-mux-aarch64-macos.tar.gz" -C "$tmp"
+"$tmp/oauth-mux" version
+rm -rf "$tmp"
+```
+
+Expected output includes:
+
+```text
+oauth-mux-aarch64-macos.tar.gz: OK
+oauth-mux 0.1.2
+```
+
+Public installer for v0.1.2:
+
+```bash
+tmp="$(mktemp -d)"
+REPO=Jesssullivan/oauth-mux \
+VERSION=0.1.2 \
+INSTALL_DIR="$tmp/bin" \
+  sh -c 'curl -fsSL https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.2/install.sh | sh'
+"$tmp/bin/oauth-mux" version
+rm -rf "$tmp"
+```
+
+Expected output includes:
+
+```text
+oauth-mux 0.1.2
+```
+
+The `REPO` override above is intentional for v0.1.2 only. v0.1.3 release
+artifacts should install from the canonical public repository by default.
+
+Staged v0.1.3 Homebrew audit:
+
+```bash
+tmp="$(mktemp -d)"
+git -C "$tmp" init -q
+OMUX_REGISTRY_DRY_RUN_CONFIRM=registry-dry-run \
+OMUX_REGISTRY_LANES=homebrew \
+OMUX_HOMEBREW_TAP_DIR="$tmp" \
+HOMEBREW_NO_AUTO_UPDATE=1 \
+  ./scripts/registry-dry-run.sh 0.1.3
+rm -rf "$tmp"
+```
+
+Expected report entry:
+
+```text
+brew audit --strict OK
+```
+
+## Next Proof
+
+1. Publish v0.1.3 artifacts from the corrected templates.
+2. Re-run the public installer command without `REPO=...`.
+3. Install the generated Homebrew formula from the selected tap.
+4. Install generated deb and rpm packages on Linux hosts or containers.
+5. Update this matrix with host, version, result, and caveat for each lane.

--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -96,6 +96,19 @@ Hosted evidence from run `25029923810`:
 - The uploaded artifact contains valid per-probe JSON files and separate
   redacted probe logs.
 
+Hosted evidence from PR-branch run `25134175687` on 2026-04-29:
+
+- Branch `codex/v013-doctor-onboarding` at `06e1ab0`.
+- `codex-mini`: `max-1`, `max-2`, and `max-3` returned
+  `live/available`, HTTP 200, and `decision=use_this`.
+- `codex-max`: `max-1`, `max-2`, and `max-3` returned
+  `live/available`, HTTP 200, and `decision=use_this`.
+- The first rerun failed before provider probing because
+  `OMUX_LIVE_QA_CONFIG_B64` was missing after the repository transfer. The fix
+  was to refresh `OMUX_LIVE_QA_CONFIG_B64` and set
+  `OMUX_LIVE_QA_STORE_TGZ_B64` from a minimized credential bundle containing
+  only `auth.json`, `installation_id`, and per-account `config.toml` files.
+
 ## GitHub Workflow
 
 `.github/workflows/live-provider-qa.yml` is manual-only. It requires the

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -35,6 +35,7 @@ Generic starter:
 
 ```bash
 oauth-mux init
+oauth-mux doctor
 oauth-mux config validate
 oauth-mux discover
 ```
@@ -43,29 +44,36 @@ Codex Max three-account starter:
 
 ```bash
 oauth-mux init --codex-max
-oauth-mux codex onboard
+oauth-mux doctor
+oauth-mux setup codex
 oauth-mux codex canary
 ```
 
-`oauth-mux codex onboard` creates the expected isolated `CODEX_HOME` directories,
-runs `codex login` for accounts that are not logged in, prints login status, and
-then prints `oauth-mux discover`. It does not run live route probes unless the
-operator explicitly opts in:
+`oauth-mux doctor` is the no-spend readiness report. It checks whether config is
+present and valid, counts configured providers/accounts/profiles, reports
+whether health state exists, and prints the next safe commands for the current
+state.
+
+`oauth-mux setup codex` is the user-facing alias for
+`oauth-mux codex onboard` / `oauth-mux codex setup`. It creates the expected
+isolated `CODEX_HOME` directories, runs `codex login` for accounts that are not
+logged in, prints login status, and then prints `oauth-mux discover`. It does
+not run live route probes unless the operator explicitly opts in:
 
 ```bash
-oauth-mux codex onboard --live
+oauth-mux setup codex --live
 ```
 
 For device-code login instead of browser login:
 
 ```bash
-oauth-mux codex onboard --device
+oauth-mux setup codex --device
 ```
 
 For status-only inspection:
 
 ```bash
-oauth-mux codex onboard --status-only
+oauth-mux setup codex --status-only
 ```
 
 For a no-spend canary after onboarding:
@@ -90,14 +98,16 @@ oauth-mux codex probe-all --capability codex-mini --json
 ```
 
 Source checkouts keep `just codex-max-onboard` and `just codex-max-canary` as
-thin aliases for installed commands. `just codex-max-probe-all` is likewise a
-thin alias for `oauth-mux codex probe-all`.
+thin aliases for installed commands. `just codex-max-setup` is a thin alias for
+`oauth-mux setup codex`, and `just codex-max-probe-all` is likewise a thin alias
+for `oauth-mux codex probe-all`.
 
 ## Agent Discovery Contract
 
 Agents should start with:
 
 ```bash
+oauth-mux doctor --json
 oauth-mux discover --json
 oauth-mux status --json
 oauth-mux health --json
@@ -134,7 +144,7 @@ templates. It does not include token material.
 2. Add named accounts and secret backends.
 3. Add profiles that encode provider/account/capability fallback order.
 4. Run `oauth-mux config validate`.
-5. Run `oauth-mux discover --json`.
+5. Run `oauth-mux doctor --json` and `oauth-mux discover --json`.
 6. Run no-spend checks first: `status`, `health`, and credential parse probes.
 7. Run live probes only through `scripts/live-provider-qa.sh` or the manual
    Live Provider QA workflow.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -108,6 +108,8 @@ Agents should start with:
 
 ```bash
 oauth-mux doctor --json
+oauth-mux report --redacted --json
+oauth-mux providers list --json
 oauth-mux discover --json
 oauth-mux status --json
 oauth-mux health --json
@@ -138,13 +140,24 @@ Agents must not:
 providers, account names, secret backend names, tags, profiles, and safe command
 templates. It does not include token material.
 
+`report --redacted --json` is the support-bundle surface. It adds platform,
+config shape, provider/account labels, command availability, health summaries,
+and recent probe evidence. It never reads credential values and omits credential
+paths unless the user explicitly passes `--include-paths`.
+
+`providers list --json` separates support status from proof status. `codex` is
+`live_proven`; shipped schemas are `built_in`; user JSON providers are
+`schema_modeled`; non-Codex providers still carry `needs_operator_proof` until
+live provider QA proves them.
+
 ## Provider Onboarding Checklist
 
 1. Add or select a provider definition.
 2. Add named accounts and secret backends.
 3. Add profiles that encode provider/account/capability fallback order.
 4. Run `oauth-mux config validate`.
-5. Run `oauth-mux doctor --json` and `oauth-mux discover --json`.
+5. Run `oauth-mux doctor --json`, `oauth-mux report --redacted --json`, and
+   `oauth-mux discover --json`.
 6. Run no-spend checks first: `status`, `health`, and credential parse probes.
 7. Run live probes only through `scripts/live-provider-qa.sh` or the manual
    Live Provider QA workflow.
@@ -153,6 +166,9 @@ templates. It does not include token material.
 
 - Config validates.
 - `discover --json` is usable by agents.
+- `report --redacted --json` is usable for a support bundle without token
+  material.
+- `providers list --json` states provider support and proof status precisely.
 - `status --json` shows expected providers and accounts.
 - `health --json` is redacted.
 - First live QA run is captured under `dist/live-qa/`.

--- a/docs/spec/product-adoption-sprint-2026-04-28.md
+++ b/docs/spec/product-adoption-sprint-2026-04-28.md
@@ -185,10 +185,21 @@ Candidate CLI additions:
   - reports provider status as `built_in`, `schema_modeled`, `live_proven`, or
     `needs_operator_proof`.
 
+Initial implementation status:
+
+- `oauth-mux doctor [--json]` now provides a no-spend readiness report covering
+  config path, state path, config validation, provider/account/profile counts,
+  health state presence, and safe next commands.
+- `oauth-mux setup codex` and `oauth-mux codex setup` both route to the Codex
+  onboarding flow.
+- `discover --json` now advertises `doctor --json` as an agent-safe command.
+- Redacted support bundles and provider status listing remain follow-up scope.
+
 Acceptance:
 
 - `just check` passes.
-- no-secret E2E covers `doctor` and redacted report output.
+- no-secret E2E covers `doctor`; redacted report output is covered when
+  `report --redacted` lands.
 - docs and website first-run examples use installed commands only.
 - hosted live QA reruns for the Codex matrix before publication.
 - full registry dry-run reruns for the bumped version before CI-only publish.

--- a/docs/spec/product-adoption-sprint-2026-04-28.md
+++ b/docs/spec/product-adoption-sprint-2026-04-28.md
@@ -192,14 +192,22 @@ Initial implementation status:
   health state presence, and safe next commands.
 - `oauth-mux setup codex` and `oauth-mux codex setup` both route to the Codex
   onboarding flow.
-- `discover --json` now advertises `doctor --json` as an agent-safe command.
-- Redacted support bundles and provider status listing remain follow-up scope.
+- `oauth-mux report --redacted [--json]` now produces a support bundle with
+  version, platform, config shape, redacted provider/account labels, command
+  availability, health summaries, and recent probe evidence. Credential values
+  are never read, and credential paths are omitted unless `--include-paths` is
+  supplied.
+- `oauth-mux providers list [--json]` now reports built-in providers, custom
+  schema-modeled providers, configured account counts, capabilities, probes,
+  command detection, and separate proof status.
+- `discover --json` now advertises `doctor --json`, `report --redacted --json`,
+  and `providers list --json` as agent-safe commands.
 
 Acceptance:
 
 - `just check` passes.
-- no-secret E2E covers `doctor`; redacted report output is covered when
-  `report --redacted` lands.
+- no-secret E2E covers `doctor`, `report --redacted --json`, and
+  `providers list --json`.
 - docs and website first-run examples use installed commands only.
 - hosted live QA reruns for the Codex matrix before publication.
 - full registry dry-run reruns for the bumped version before CI-only publish.

--- a/justfile
+++ b/justfile
@@ -35,6 +35,12 @@ status: build
 doctor: build
     ./zig-out/bin/oauth-mux doctor
 
+report: build
+    ./zig-out/bin/oauth-mux report --redacted
+
+providers: build
+    ./zig-out/bin/oauth-mux providers list
+
 health: build
     ./zig-out/bin/oauth-mux health
 

--- a/justfile
+++ b/justfile
@@ -32,6 +32,9 @@ version: build
 status: build
     ./zig-out/bin/oauth-mux status --json
 
+doctor: build
+    ./zig-out/bin/oauth-mux doctor
+
 health: build
     ./zig-out/bin/oauth-mux health
 
@@ -63,6 +66,9 @@ codex-max-login-status-all: build
 
 codex-max-onboard: build
     OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux codex onboard
+
+codex-max-setup: build
+    OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux setup codex
 
 codex-max-canary: build
     OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux codex canary

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -190,6 +190,13 @@ expect_contains() {
 printf 'e2e: validate generated config\n'
 omux config validate >/dev/null
 
+printf 'e2e: doctor reports configured readiness\n'
+doctor_json="$(omux doctor --json)"
+expect_contains "$doctor_json" '"ok":true' "doctor reports ready config"
+expect_contains "$doctor_json" '"providers":1' "doctor counts configured provider"
+expect_contains "$doctor_json" '"accounts":2' "doctor counts configured accounts"
+expect_contains "$doctor_json" '"oauth-mux discover --json"' "doctor recommends agent discovery"
+
 printf 'e2e: cheap route selects first healthy account\n'
 cheap_env="$(omux env --profile cheap --capability cheap --shell bash)"
 expect_contains "$cheap_env" "export TOY_TOKEN='omux-e2e-a1'" "cheap env injects account a1 token"

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -196,6 +196,21 @@ expect_contains "$doctor_json" '"ok":true' "doctor reports ready config"
 expect_contains "$doctor_json" '"providers":1' "doctor counts configured provider"
 expect_contains "$doctor_json" '"accounts":2' "doctor counts configured accounts"
 expect_contains "$doctor_json" '"oauth-mux discover --json"' "doctor recommends agent discovery"
+expect_contains "$doctor_json" '"oauth-mux report --redacted --json"' "doctor recommends redacted report"
+
+printf 'e2e: redacted report does not expose secret values\n'
+report_json="$(omux report --redacted --json)"
+expect_contains "$report_json" '"redacted":true' "report is redacted"
+expect_contains "$report_json" '"secret_backend":"env"' "report includes secret backend class"
+expect_contains "$report_json" '"secret_location":"redacted"' "report redacts secret location by default"
+expect_contains "$report_json" '"health":[]' "report includes empty health array before probes"
+
+printf 'e2e: providers list reports schema-modeled custom provider\n'
+providers_json="$(omux providers list --json)"
+expect_contains "$providers_json" '"name":"toy"' "providers list includes custom toy provider"
+expect_contains "$providers_json" '"support_status":"schema_modeled"' "providers list classifies custom provider"
+expect_contains "$providers_json" '"proof_status":"needs_operator_proof"' "providers list marks custom provider proof state"
+expect_contains "$providers_json" '"configured_accounts":2' "providers list counts custom provider accounts"
 
 printf 'e2e: cheap route selects first healthy account\n'
 cheap_env="$(omux env --profile cheap --capability cheap --shell bash)"

--- a/scripts/registry-dry-run.sh
+++ b/scripts/registry-dry-run.sh
@@ -23,11 +23,17 @@ out_dir="$repo_root/dist/out/v${version}"
 handoff_dir="$out_dir/handoff"
 report="$handoff_dir/registry-dry-run.md"
 tmp_files=()
+tmp_taps=()
 
 cleanup() {
   for file in "${tmp_files[@]}"; do
     rm -f "$file"
   done
+  if command -v brew >/dev/null 2>&1; then
+    for tap in "${tmp_taps[@]}"; do
+      brew untap "$tap" >/dev/null 2>&1 || true
+    done
+  fi
 }
 trap cleanup EXIT
 
@@ -140,26 +146,24 @@ for lane in "${lanes[@]}"; do
         audit_args+=(--online)
         audit_label="brew audit --strict --online"
       fi
-      if [ -n "${OMUX_HOMEBREW_TAP_NAME:-}" ]; then
-        "$brew_cmd" tap "$OMUX_HOMEBREW_TAP_NAME" "$OMUX_HOMEBREW_TAP_DIR" >/dev/null
-        tapped_repo="$("$brew_cmd" --repository "$OMUX_HOMEBREW_TAP_NAME")"
-        mkdir -p "$tapped_repo/Formula"
-        cp "$formula" "$tapped_repo/Formula/oauth-mux.rb"
-        if ! "$brew_cmd" "${audit_args[@]}" oauth-mux >"$audit_log" 2>&1; then
-          cat "$audit_log" >&2
-          exit 1
-        fi
-      else
-        if ! "$brew_cmd" "${audit_args[@]}" "$tap_formula" >"$audit_log" 2>&1; then
-          cat "$audit_log" >&2
-          exit 1
-        fi
+      tap_name="${OMUX_HOMEBREW_TAP_NAME:-}"
+      if [ -z "$tap_name" ]; then
+        tap_name="tinyland-inc/oauth-mux-dry-run-$$"
+        tmp_taps+=("$tap_name")
+      fi
+      "$brew_cmd" tap "$tap_name" "$OMUX_HOMEBREW_TAP_DIR" >/dev/null
+      tapped_repo="$("$brew_cmd" --repository "$tap_name")"
+      mkdir -p "$tapped_repo/Formula"
+      cp "$formula" "$tapped_repo/Formula/oauth-mux.rb"
+      if ! "$brew_cmd" "${audit_args[@]}" "${tap_name}/oauth-mux" >"$audit_log" 2>&1; then
+        cat "$audit_log" >&2
+        exit 1
       fi
       append "## homebrew"
       append
       append "- formula copied to tap checkout"
       append "- git diff --check OK"
-      append "- ${audit_label} OK"
+      append "- ${audit_label} OK via \`${tap_name}/oauth-mux\`"
       append
       ;;
 

--- a/scripts/release-local.sh
+++ b/scripts/release-local.sh
@@ -66,6 +66,7 @@ package_binary() {
   "description": "Platform binary for oauth-mux",
   "license": "MIT",
   "repository": "Jesssullivan/oauth-mux",
+  "homepage": "https://omux.xoxd.ai",
   "os": ["${npm_os}"],
   "cpu": ["${npm_cpu}"],
   "files": ["bin"]
@@ -128,7 +129,7 @@ arch: "${arch}"
 version: "${version}"
 maintainer: "Jess Sullivan <jess@sulliwood.org>"
 description: "OAuth fallback muxing for AI harness subscriptions"
-homepage: "https://github.com/Jesssullivan/oauth-mux"
+homepage: "https://omux.xoxd.ai"
 license: MIT
 contents:
   - src: ${src}

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -8,6 +8,8 @@ pub const Command = union(enum) {
     env: EnvArgs,
     probe: ProbeArgs,
     doctor: DoctorArgs,
+    report: ReportArgs,
+    providers: ProvidersArgs,
     status: StatusArgs,
     health: HealthArgs,
     discover: DiscoverArgs,
@@ -46,6 +48,21 @@ pub const Command = union(enum) {
     };
 
     pub const DoctorArgs = struct {
+        json: bool = false,
+    };
+
+    pub const ReportArgs = struct {
+        json: bool = false,
+        redacted: bool = true,
+        include_paths: bool = false,
+    };
+
+    pub const ProvidersAction = enum {
+        list,
+    };
+
+    pub const ProvidersArgs = struct {
+        action: ProvidersAction = .list,
         json: bool = false,
     };
 
@@ -107,6 +124,8 @@ pub fn parse(args: []const []const u8) Command {
     if (eql(cmd, "env")) return parseEnv(rest);
     if (eql(cmd, "probe")) return parseProbe(rest);
     if (eql(cmd, "doctor")) return parseDoctor(rest);
+    if (eql(cmd, "report")) return parseReport(rest);
+    if (eql(cmd, "providers")) return parseProviders(rest);
     if (eql(cmd, "status")) return parseStatus(rest);
     if (eql(cmd, "health")) return parseHealth(rest);
     if (eql(cmd, "discover")) return parseDiscover(rest);
@@ -209,6 +228,33 @@ fn parseDoctor(args: []const []const u8) Command {
         if (eql(arg, "--json")) result.json = true;
     }
     return .{ .doctor = result };
+}
+
+fn parseReport(args: []const []const u8) Command {
+    var result = Command.ReportArgs{};
+    for (args) |arg| {
+        if (eql(arg, "--json")) {
+            result.json = true;
+        } else if (eql(arg, "--redacted")) {
+            result.redacted = true;
+        } else if (eql(arg, "--include-paths")) {
+            result.include_paths = true;
+        }
+    }
+    return .{ .report = result };
+}
+
+fn parseProviders(args: []const []const u8) Command {
+    var result = Command.ProvidersArgs{};
+    var i: usize = 0;
+    if (args.len > 0 and eql(args[0], "list")) {
+        result.action = .list;
+        i = 1;
+    }
+    while (i < args.len) : (i += 1) {
+        if (eql(args[i], "--json")) result.json = true;
+    }
+    return .{ .providers = result };
 }
 
 fn parseStatus(args: []const []const u8) Command {
@@ -359,6 +405,12 @@ pub fn printUsage(writer: anytype) !void {
         \\  doctor [--json]
         \\      Run no-spend readiness checks and print first-run next commands.
         \\
+        \\  report [--redacted] [--json] [--include-paths]
+        \\      Print a redacted support bundle without reading credential values.
+        \\
+        \\  providers list [--json]
+        \\      Show built-in and configured provider support status.
+        \\
         \\  status [--json] [--provider <name>]
         \\      Show active accounts, health scores, and circuit states.
         \\
@@ -471,6 +523,31 @@ test "parse doctor json" {
     }
 }
 
+test "parse report redacted json include paths" {
+    const args = [_][]const u8{ "report", "--redacted", "--json", "--include-paths" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .report => |report| {
+            try std.testing.expect(report.redacted);
+            try std.testing.expect(report.json);
+            try std.testing.expect(report.include_paths);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse providers list json" {
+    const args = [_][]const u8{ "providers", "list", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .providers => |providers| {
+            try std.testing.expect(providers.action == .list);
+            try std.testing.expect(providers.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 test "parse init codex max" {
     const args = [_][]const u8{ "init", "--codex-max" };
     const cmd = parse(&args);
@@ -575,6 +652,8 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n __fish_use_subcommand -a env -d 'Print shell exports'
             \\complete -c oauth-mux -n __fish_use_subcommand -a probe -d 'Probe account liveness'
             \\complete -c oauth-mux -n __fish_use_subcommand -a doctor -d 'Run readiness checks'
+            \\complete -c oauth-mux -n __fish_use_subcommand -a report -d 'Print redacted support report'
+            \\complete -c oauth-mux -n __fish_use_subcommand -a providers -d 'List provider support'
             \\complete -c oauth-mux -n __fish_use_subcommand -a status -d 'Show status'
             \\complete -c oauth-mux -n __fish_use_subcommand -a health -d 'Show health data'
             \\complete -c oauth-mux -n __fish_use_subcommand -a discover -d 'Show agent-safe inventory'
@@ -590,6 +669,10 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe' -l capability -d 'Route capability' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from probe' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -l json -d 'JSON output'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from report providers' -l json -d 'JSON output'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from report' -l redacted -d 'Redact credential paths and values'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from report' -l include-paths -d 'Include non-token paths'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from providers' -a 'list' -d 'Provider subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from env' -l shell -d 'Shell type' -r -a 'fish zsh bash ksh'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from status' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from discover' -l json -d 'JSON output'
@@ -609,6 +692,8 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\    'env:Print shell exports'
             \\    'probe:Probe account liveness'
             \\    'doctor:Run readiness checks'
+            \\    'report:Print redacted support report'
+            \\    'providers:List provider support'
             \\    'status:Show status'
             \\    'health:Show health data'
             \\    'discover:Show agent-safe inventory'
@@ -628,7 +713,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
         try writer.writeAll(
             \\_oauth_mux_completions() {
             \\  local cur="${COMP_WORDS[COMP_CWORD]}"
-            \\  COMPREPLY=($(compgen -W "exec env probe doctor status health discover config init setup codex version completions" -- "$cur"))
+            \\  COMPREPLY=($(compgen -W "exec env probe doctor report providers status health discover config init setup codex version completions" -- "$cur"))
             \\}
             \\complete -F _oauth_mux_completions oauth-mux
             \\

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1,12 +1,13 @@
 const std = @import("std");
 const types = @import("types.zig");
 
-pub const version = "0.1.2";
+pub const version = "0.1.3";
 
 pub const Command = union(enum) {
     exec: ExecArgs,
     env: EnvArgs,
     probe: ProbeArgs,
+    doctor: DoctorArgs,
     status: StatusArgs,
     health: HealthArgs,
     discover: DiscoverArgs,
@@ -41,6 +42,10 @@ pub const Command = union(enum) {
         provider: ?[]const u8 = null,
         account: ?[]const u8 = null,
         capability: ?[]const u8 = null,
+        json: bool = false,
+    };
+
+    pub const DoctorArgs = struct {
         json: bool = false,
     };
 
@@ -101,11 +106,13 @@ pub fn parse(args: []const []const u8) Command {
     if (eql(cmd, "exec")) return parseExec(rest);
     if (eql(cmd, "env")) return parseEnv(rest);
     if (eql(cmd, "probe")) return parseProbe(rest);
+    if (eql(cmd, "doctor")) return parseDoctor(rest);
     if (eql(cmd, "status")) return parseStatus(rest);
     if (eql(cmd, "health")) return parseHealth(rest);
     if (eql(cmd, "discover")) return parseDiscover(rest);
     if (eql(cmd, "config")) return parseConfig(rest);
     if (eql(cmd, "init")) return parseInit(rest);
+    if (eql(cmd, "setup")) return parseSetup(rest);
     if (eql(cmd, "codex")) return parseCodex(rest);
     if (eql(cmd, "version") or eql(cmd, "--version") or eql(cmd, "-v")) return .version_cmd;
     if (eql(cmd, "daemon")) {
@@ -196,6 +203,14 @@ fn parseProbe(args: []const []const u8) Command {
     return .{ .probe = result };
 }
 
+fn parseDoctor(args: []const []const u8) Command {
+    var result = Command.DoctorArgs{};
+    for (args) |arg| {
+        if (eql(arg, "--json")) result.json = true;
+    }
+    return .{ .doctor = result };
+}
+
 fn parseStatus(args: []const []const u8) Command {
     var result = Command.StatusArgs{};
     for (args) |arg| {
@@ -245,6 +260,16 @@ fn parseInit(args: []const []const u8) Command {
     return .{ .init = result };
 }
 
+fn parseSetup(args: []const []const u8) Command {
+    if (args.len == 0) return .help;
+    if (eql(args[0], "codex")) {
+        var result = Command.CodexArgs{ .action = .onboard };
+        parseCodexOptions(&result, args, 1);
+        return .{ .codex = result };
+    }
+    return .help;
+}
+
 fn parseCodex(args: []const []const u8) Command {
     var result = Command.CodexArgs{};
     var option_start: usize = 0;
@@ -253,6 +278,8 @@ fn parseCodex(args: []const []const u8) Command {
         option_start = 1;
         if (eql(args[0], "bootstrap-dirs")) {
             result.action = .bootstrap_dirs;
+        } else if (eql(args[0], "setup")) {
+            result.action = .onboard;
         } else if (eql(args[0], "login")) {
             result.action = .login;
         } else if (eql(args[0], "login-device")) {
@@ -274,6 +301,13 @@ fn parseCodex(args: []const []const u8) Command {
         }
     }
 
+    parseCodexOptions(&result, args, option_start);
+
+    if (result.action == .login_device) result.device = true;
+    return .{ .codex = result };
+}
+
+fn parseCodexOptions(result: *Command.CodexArgs, args: []const []const u8, option_start: usize) void {
     var i = option_start;
     while (i < args.len) : (i += 1) {
         if (eql(args[i], "--account")) {
@@ -300,9 +334,6 @@ fn parseCodex(args: []const []const u8) Command {
             result.account = args[i];
         }
     }
-
-    if (result.action == .login_device) result.device = true;
-    return .{ .codex = result };
 }
 
 fn eql(a: []const u8, b: []const u8) bool {
@@ -325,6 +356,9 @@ pub fn printUsage(writer: anytype) !void {
         \\  probe [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
         \\      Validate a selected account and run its capability probe when configured.
         \\
+        \\  doctor [--json]
+        \\      Run no-spend readiness checks and print first-run next commands.
+        \\
         \\  status [--json] [--provider <name>]
         \\      Show active accounts, health scores, and circuit states.
         \\
@@ -344,7 +378,10 @@ pub fn printUsage(writer: anytype) !void {
         \\  init [--interactive] [--codex-max]
         \\      Generate a starter config file.
         \\
-        \\  codex onboard [--accounts a,b,c] [--device|--status-only] [--live]
+        \\  setup codex [--accounts a,b,c] [--device|--status-only] [--live]
+        \\      First-run Codex setup alias.
+        \\
+        \\  codex setup|onboard [--accounts a,b,c] [--device|--status-only] [--live]
         \\      Bootstrap isolated Codex account stores and login flow.
         \\
         \\  codex canary [--accounts a,b,c] [--capabilities c1,c2] [--live]
@@ -425,6 +462,15 @@ test "parse probe with account capability and json" {
     }
 }
 
+test "parse doctor json" {
+    const args = [_][]const u8{ "doctor", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .doctor => |doctor| try std.testing.expect(doctor.json),
+        else => return error.Unexpected,
+    }
+}
+
 test "parse init codex max" {
     const args = [_][]const u8{ "init", "--codex-max" };
     const cmd = parse(&args);
@@ -443,6 +489,31 @@ test "parse codex canary" {
             try std.testing.expectEqualStrings("max-1,max-2", codex.accounts);
             try std.testing.expectEqualStrings("codex-mini", codex.capabilities);
             try std.testing.expect(codex.live);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse codex setup alias" {
+    const args = [_][]const u8{ "codex", "setup", "--accounts", "work,personal" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex => |codex| {
+            try std.testing.expect(codex.action == .onboard);
+            try std.testing.expectEqualStrings("work,personal", codex.accounts);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse setup codex alias" {
+    const args = [_][]const u8{ "setup", "codex", "--accounts", "work,personal", "--device" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex => |codex| {
+            try std.testing.expect(codex.action == .onboard);
+            try std.testing.expectEqualStrings("work,personal", codex.accounts);
+            try std.testing.expect(codex.device);
         },
         else => return error.Unexpected,
     }
@@ -503,11 +574,13 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n __fish_use_subcommand -a exec -d 'Execute with muxed credentials'
             \\complete -c oauth-mux -n __fish_use_subcommand -a env -d 'Print shell exports'
             \\complete -c oauth-mux -n __fish_use_subcommand -a probe -d 'Probe account liveness'
+            \\complete -c oauth-mux -n __fish_use_subcommand -a doctor -d 'Run readiness checks'
             \\complete -c oauth-mux -n __fish_use_subcommand -a status -d 'Show status'
             \\complete -c oauth-mux -n __fish_use_subcommand -a health -d 'Show health data'
             \\complete -c oauth-mux -n __fish_use_subcommand -a discover -d 'Show agent-safe inventory'
             \\complete -c oauth-mux -n __fish_use_subcommand -a config -d 'Config operations'
             \\complete -c oauth-mux -n __fish_use_subcommand -a init -d 'Generate config'
+            \\complete -c oauth-mux -n __fish_use_subcommand -a setup -d 'First-run setup'
             \\complete -c oauth-mux -n __fish_use_subcommand -a codex -d 'Codex account onboarding'
             \\complete -c oauth-mux -n __fish_use_subcommand -a version -d 'Print version'
             \\complete -c oauth-mux -n __fish_use_subcommand -a completions -d 'Generate completions'
@@ -516,12 +589,14 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from probe' -l account -d 'Account name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe' -l capability -d 'Route capability' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from probe' -l json -d 'JSON output'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from env' -l shell -d 'Shell type' -r -a 'fish zsh bash ksh'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from status' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from discover' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'onboard canary probe-all bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary probe-all bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
             \\
         );
     } else if (eql(shell_name, "zsh")) {
@@ -533,11 +608,13 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\    'exec:Execute with muxed credentials'
             \\    'env:Print shell exports'
             \\    'probe:Probe account liveness'
+            \\    'doctor:Run readiness checks'
             \\    'status:Show status'
             \\    'health:Show health data'
             \\    'discover:Show agent-safe inventory'
             \\    'config:Config operations'
             \\    'init:Generate config'
+            \\    'setup:First-run setup'
             \\    'codex:Codex account onboarding'
             \\    'version:Print version'
             \\    'completions:Generate completions'
@@ -551,7 +628,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
         try writer.writeAll(
             \\_oauth_mux_completions() {
             \\  local cur="${COMP_WORDS[COMP_CWORD]}"
-            \\  COMPREPLY=($(compgen -W "exec env probe status health discover config init codex version completions" -- "$cur"))
+            \\  COMPREPLY=($(compgen -W "exec env probe doctor status health discover config init setup codex version completions" -- "$cur"))
             \\}
             \\complete -F _oauth_mux_completions oauth-mux
             \\

--- a/src/main.zig
+++ b/src/main.zig
@@ -1866,10 +1866,7 @@ fn runInit(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Init
     } else |_| {}
 
     if (std.fs.path.dirname(path)) |dir| {
-        std.fs.makeDirAbsolute(dir) catch |e| switch (e) {
-            error.PathAlreadyExists => {},
-            else => return e,
-        };
+        try std.fs.cwd().makePath(dir);
     }
 
     const generic_starter_config =

--- a/src/main.zig
+++ b/src/main.zig
@@ -67,6 +67,10 @@ pub fn main() !void {
             };
         },
 
+        .doctor => |doctor_args| {
+            try runDoctor(allocator, stdout, doctor_args);
+        },
+
         .exec => |exec_args| {
             runExec(allocator, exec_args) catch |e| {
                 log.err("exec: {s}", .{@errorName(e)});
@@ -191,6 +195,8 @@ fn runDiscover(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.
             try writeCommandJson(writer, "oauth-mux init");
             try writer.writeByte(',');
             try writeCommandJson(writer, "oauth-mux init --codex-max");
+            try writer.writeByte(',');
+            try writeCommandJson(writer, "oauth-mux doctor");
             try writer.writeAll("]}\n");
         } else {
             try writer.writeAll("oauth-mux discover\n\n");
@@ -199,6 +205,7 @@ fn runDiscover(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.
             try writer.writeAll("  next:\n");
             try writer.writeAll("    oauth-mux init\n");
             try writer.writeAll("    oauth-mux init --codex-max\n");
+            try writer.writeAll("    oauth-mux doctor\n");
             try writer.writeAll("    oauth-mux config validate\n");
         }
         return;
@@ -267,6 +274,7 @@ fn writeDiscoverText(writer: anytype, cfg: config.Config, config_path: []const u
 
     try writer.writeAll("\n  agent-safe commands:\n");
     try writer.writeAll("    oauth-mux config validate\n");
+    try writer.writeAll("    oauth-mux doctor --json\n");
     try writer.writeAll("    oauth-mux status --json\n");
     try writer.writeAll("    oauth-mux health --json\n");
     try writer.writeAll("    oauth-mux probe --profile <profile> --capability <capability> --json\n");
@@ -353,6 +361,7 @@ fn writeDiscoverJson(writer: anytype, cfg: config.Config, config_path: []const u
     try writer.writeAll("],\"agent_safe_commands\":[");
     const commands = [_][]const u8{
         "oauth-mux config validate",
+        "oauth-mux doctor --json",
         "oauth-mux status --json",
         "oauth-mux health --json",
         "oauth-mux probe --profile <profile> --capability <capability> --json",
@@ -368,6 +377,262 @@ fn writeDiscoverJson(writer: anytype, cfg: config.Config, config_path: []const u
 
 fn writeCommandJson(writer: anytype, command: []const u8) !void {
     try std.json.stringify(command, .{}, writer);
+}
+
+const DoctorStats = struct {
+    configured: bool = false,
+    config_valid: bool = false,
+    config_error: ?[]const u8 = null,
+    provider_count: usize = 0,
+    account_count: usize = 0,
+    profile_count: usize = 0,
+    strategy_count: usize = 0,
+    codex_configured: bool = false,
+    health_file_exists: bool = false,
+    health_entries: usize = 0,
+
+    fn ok(self: DoctorStats) bool {
+        return self.configured and self.config_valid and self.provider_count > 0 and self.account_count > 0;
+    }
+};
+
+fn runDoctor(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.DoctorArgs) !void {
+    const config_path = try paths.configFilePath(allocator);
+    defer allocator.free(config_path);
+    const state_dir = try paths.stateDir(allocator);
+    defer allocator.free(state_dir);
+    const health_path = try paths.healthFilePath(allocator);
+    defer allocator.free(health_path);
+
+    var stats = DoctorStats{
+        .health_file_exists = fileExistsAbsolute(health_path),
+    };
+
+    var validation_messages = std.ArrayList(u8).init(allocator);
+    defer validation_messages.deinit();
+
+    if (config.load(allocator)) |parsed| {
+        defer parsed.deinit();
+        stats.configured = true;
+        stats.provider_count = parsed.value.providers.map.count();
+        stats.account_count = countConfiguredAccounts(parsed.value);
+        stats.profile_count = parsed.value.profiles.map.count();
+        stats.strategy_count = parsed.value.strategies.map.count();
+        stats.codex_configured = parsed.value.providers.map.get("codex") != null;
+
+        config.validate(parsed.value, validation_messages.writer()) catch |e| {
+            stats.config_error = @errorName(e);
+        };
+        stats.config_valid = stats.config_error == null;
+    } else |e| {
+        stats.config_error = @errorName(e);
+    }
+
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+    stats.health_entries = store.accounts.count();
+
+    if (args.json) {
+        try writeDoctorJson(writer, stats, config_path, state_dir, health_path, validation_messages.items);
+    } else {
+        try writeDoctorText(writer, stats, config_path, state_dir, health_path, validation_messages.items);
+    }
+}
+
+fn writeDoctorText(
+    writer: anytype,
+    stats: DoctorStats,
+    config_path: []const u8,
+    state_dir: []const u8,
+    health_path: []const u8,
+    validation_messages: []const u8,
+) !void {
+    try writer.writeAll("oauth-mux doctor\n\n");
+    try writer.print("  config: {s}\n", .{config_path});
+    if (!stats.configured) {
+        try writer.print("    status: missing ({s})\n", .{stats.config_error orelse "not_found"});
+    } else if (!stats.config_valid) {
+        try writer.print("    status: invalid ({s})\n", .{stats.config_error orelse "validation_failed"});
+    } else {
+        try writer.writeAll("    status: valid\n");
+    }
+    try writer.print("    providers={d} accounts={d} profiles={d} strategies={d}\n", .{
+        stats.provider_count,
+        stats.account_count,
+        stats.profile_count,
+        stats.strategy_count,
+    });
+    try writer.print("  state:  {s}\n", .{state_dir});
+    try writer.print("  health: {s} ({s}, entries={d})\n", .{
+        health_path,
+        if (stats.health_file_exists) "present" else "not recorded",
+        stats.health_entries,
+    });
+    try writer.print("  readiness: {s}\n", .{if (stats.ok()) "ready" else "action_needed"});
+
+    if (validation_messages.len != 0) {
+        try writer.writeAll("\n  validation:\n");
+        var lines = std.mem.splitScalar(u8, validation_messages, '\n');
+        while (lines.next()) |line| {
+            if (line.len == 0) continue;
+            try writer.print("    {s}\n", .{line});
+        }
+    }
+
+    try writer.writeAll("\n  next:\n");
+    try writeDoctorNextCommandsText(writer, stats);
+}
+
+fn writeDoctorJson(
+    writer: anytype,
+    stats: DoctorStats,
+    config_path: []const u8,
+    state_dir: []const u8,
+    health_path: []const u8,
+    validation_messages: []const u8,
+) !void {
+    try writer.writeByte('{');
+    try writer.writeAll("\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"ok\":");
+    try writer.writeAll(if (stats.ok()) "true" else "false");
+    try writer.writeAll(",\"configured\":");
+    try writer.writeAll(if (stats.configured) "true" else "false");
+    try writer.writeAll(",\"config_path\":");
+    try std.json.stringify(config_path, .{}, writer);
+    try writer.writeAll(",\"state_dir\":");
+    try std.json.stringify(state_dir, .{}, writer);
+    try writer.writeAll(",\"health_path\":");
+    try std.json.stringify(health_path, .{}, writer);
+    try writer.writeAll(",\"config_valid\":");
+    try writer.writeAll(if (stats.config_valid) "true" else "false");
+    try writer.writeAll(",\"config_error\":");
+    if (stats.config_error) |err| {
+        try std.json.stringify(err, .{}, writer);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.print(
+        ",\"providers\":{d},\"accounts\":{d},\"profiles\":{d},\"strategies\":{d},\"health_file_exists\":{s},\"health_entries\":{d},\"codex_configured\":{s}",
+        .{
+            stats.provider_count,
+            stats.account_count,
+            stats.profile_count,
+            stats.strategy_count,
+            if (stats.health_file_exists) "true" else "false",
+            stats.health_entries,
+            if (stats.codex_configured) "true" else "false",
+        },
+    );
+    try writer.writeAll(",\"checks\":[");
+    try writeDoctorChecksJson(writer, stats, validation_messages);
+    try writer.writeAll("],\"next_commands\":[");
+    try writeDoctorNextCommandsJson(writer, stats);
+    try writer.writeAll("]}\n");
+}
+
+fn writeDoctorChecksJson(writer: anytype, stats: DoctorStats, validation_messages: []const u8) !void {
+    var first = true;
+    try writeDoctorCheckJson(writer, &first, "config_found", stats.configured, if (stats.configured) "ok" else "error", if (stats.configured) "config file found" else "config file missing");
+    const valid_message = if (validation_messages.len == 0)
+        if (stats.config_valid) "config validates" else "config could not be loaded"
+    else
+        validation_messages;
+    try writeDoctorCheckJson(writer, &first, "config_valid", stats.config_valid, if (stats.config_valid) "ok" else "error", valid_message);
+    try writeDoctorCheckJson(writer, &first, "accounts_configured", stats.account_count > 0, if (stats.account_count > 0) "ok" else "error", if (stats.account_count > 0) "one or more accounts configured" else "no muxable accounts configured");
+    try writeDoctorCheckJson(writer, &first, "profiles_configured", stats.profile_count > 0, if (stats.profile_count > 0) "ok" else "warning", if (stats.profile_count > 0) "one or more profiles configured" else "no profiles configured");
+    try writeDoctorCheckJson(writer, &first, "health_recorded", stats.health_entries > 0, if (stats.health_entries > 0) "ok" else "info", if (stats.health_entries > 0) "health state recorded" else "no health state recorded yet");
+}
+
+fn writeDoctorCheckJson(
+    writer: anytype,
+    first: *bool,
+    name: []const u8,
+    ok: bool,
+    severity: []const u8,
+    message: []const u8,
+) !void {
+    if (!first.*) try writer.writeByte(',');
+    first.* = false;
+    try writer.writeAll("{\"name\":");
+    try std.json.stringify(name, .{}, writer);
+    try writer.writeAll(",\"ok\":");
+    try writer.writeAll(if (ok) "true" else "false");
+    try writer.writeAll(",\"severity\":");
+    try std.json.stringify(severity, .{}, writer);
+    try writer.writeAll(",\"message\":");
+    try std.json.stringify(message, .{}, writer);
+    try writer.writeByte('}');
+}
+
+fn writeDoctorNextCommandsText(writer: anytype, stats: DoctorStats) !void {
+    if (!stats.configured) {
+        try writer.writeAll("    oauth-mux init\n");
+        try writer.writeAll("    oauth-mux init --codex-max\n");
+        try writer.writeAll("    oauth-mux doctor\n");
+        return;
+    }
+
+    if (!stats.config_valid) {
+        try writer.writeAll("    oauth-mux config validate\n");
+        try writer.writeAll("    oauth-mux doctor\n");
+        return;
+    }
+
+    try writer.writeAll("    oauth-mux discover --json\n");
+    try writer.writeAll("    oauth-mux status --json\n");
+    try writer.writeAll("    oauth-mux health --json\n");
+    if (stats.codex_configured) {
+        try writer.writeAll("    oauth-mux setup codex\n");
+        try writer.writeAll("    oauth-mux codex canary\n");
+        try writer.writeAll("    oauth-mux codex canary --live\n");
+    }
+}
+
+fn writeDoctorNextCommandsJson(writer: anytype, stats: DoctorStats) !void {
+    var first = true;
+    if (!stats.configured) {
+        try writeDoctorCommandJson(writer, &first, "oauth-mux init");
+        try writeDoctorCommandJson(writer, &first, "oauth-mux init --codex-max");
+        try writeDoctorCommandJson(writer, &first, "oauth-mux doctor");
+        return;
+    }
+
+    if (!stats.config_valid) {
+        try writeDoctorCommandJson(writer, &first, "oauth-mux config validate");
+        try writeDoctorCommandJson(writer, &first, "oauth-mux doctor");
+        return;
+    }
+
+    try writeDoctorCommandJson(writer, &first, "oauth-mux discover --json");
+    try writeDoctorCommandJson(writer, &first, "oauth-mux status --json");
+    try writeDoctorCommandJson(writer, &first, "oauth-mux health --json");
+    if (stats.codex_configured) {
+        try writeDoctorCommandJson(writer, &first, "oauth-mux setup codex");
+        try writeDoctorCommandJson(writer, &first, "oauth-mux codex canary");
+        try writeDoctorCommandJson(writer, &first, "oauth-mux codex canary --live");
+    }
+}
+
+fn writeDoctorCommandJson(writer: anytype, first: *bool, command: []const u8) !void {
+    if (!first.*) try writer.writeByte(',');
+    first.* = false;
+    try writeCommandJson(writer, command);
+}
+
+fn countConfiguredAccounts(cfg: config.Config) usize {
+    var count: usize = 0;
+    var it = cfg.providers.map.iterator();
+    while (it.next()) |entry| {
+        count += entry.value_ptr.accounts.map.count();
+    }
+    return count;
+}
+
+fn fileExistsAbsolute(path: []const u8) bool {
+    const file = std.fs.openFileAbsolute(path, .{}) catch return false;
+    file.close();
+    return true;
 }
 
 fn runEnv(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.EnvArgs) !void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const cli = @import("cli.zig");
 const config = @import("config.zig");
 const paths = @import("paths.zig");
@@ -69,6 +70,14 @@ pub fn main() !void {
 
         .doctor => |doctor_args| {
             try runDoctor(allocator, stdout, doctor_args);
+        },
+
+        .report => |report_args| {
+            try runReport(allocator, stdout, report_args);
+        },
+
+        .providers => |providers_args| {
+            try runProviders(allocator, stdout, providers_args);
         },
 
         .exec => |exec_args| {
@@ -197,6 +206,10 @@ fn runDiscover(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.
             try writeCommandJson(writer, "oauth-mux init --codex-max");
             try writer.writeByte(',');
             try writeCommandJson(writer, "oauth-mux doctor");
+            try writer.writeByte(',');
+            try writeCommandJson(writer, "oauth-mux providers list");
+            try writer.writeByte(',');
+            try writeCommandJson(writer, "oauth-mux report --redacted");
             try writer.writeAll("]}\n");
         } else {
             try writer.writeAll("oauth-mux discover\n\n");
@@ -206,6 +219,8 @@ fn runDiscover(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.
             try writer.writeAll("    oauth-mux init\n");
             try writer.writeAll("    oauth-mux init --codex-max\n");
             try writer.writeAll("    oauth-mux doctor\n");
+            try writer.writeAll("    oauth-mux providers list\n");
+            try writer.writeAll("    oauth-mux report --redacted\n");
             try writer.writeAll("    oauth-mux config validate\n");
         }
         return;
@@ -275,6 +290,8 @@ fn writeDiscoverText(writer: anytype, cfg: config.Config, config_path: []const u
     try writer.writeAll("\n  agent-safe commands:\n");
     try writer.writeAll("    oauth-mux config validate\n");
     try writer.writeAll("    oauth-mux doctor --json\n");
+    try writer.writeAll("    oauth-mux report --redacted --json\n");
+    try writer.writeAll("    oauth-mux providers list --json\n");
     try writer.writeAll("    oauth-mux status --json\n");
     try writer.writeAll("    oauth-mux health --json\n");
     try writer.writeAll("    oauth-mux probe --profile <profile> --capability <capability> --json\n");
@@ -362,6 +379,8 @@ fn writeDiscoverJson(writer: anytype, cfg: config.Config, config_path: []const u
     const commands = [_][]const u8{
         "oauth-mux config validate",
         "oauth-mux doctor --json",
+        "oauth-mux report --redacted --json",
+        "oauth-mux providers list --json",
         "oauth-mux status --json",
         "oauth-mux health --json",
         "oauth-mux probe --profile <profile> --capability <capability> --json",
@@ -580,6 +599,8 @@ fn writeDoctorNextCommandsText(writer: anytype, stats: DoctorStats) !void {
     }
 
     try writer.writeAll("    oauth-mux discover --json\n");
+    try writer.writeAll("    oauth-mux report --redacted --json\n");
+    try writer.writeAll("    oauth-mux providers list --json\n");
     try writer.writeAll("    oauth-mux status --json\n");
     try writer.writeAll("    oauth-mux health --json\n");
     if (stats.codex_configured) {
@@ -605,6 +626,8 @@ fn writeDoctorNextCommandsJson(writer: anytype, stats: DoctorStats) !void {
     }
 
     try writeDoctorCommandJson(writer, &first, "oauth-mux discover --json");
+    try writeDoctorCommandJson(writer, &first, "oauth-mux report --redacted --json");
+    try writeDoctorCommandJson(writer, &first, "oauth-mux providers list --json");
     try writeDoctorCommandJson(writer, &first, "oauth-mux status --json");
     try writeDoctorCommandJson(writer, &first, "oauth-mux health --json");
     if (stats.codex_configured) {
@@ -618,6 +641,728 @@ fn writeDoctorCommandJson(writer: anytype, first: *bool, command: []const u8) !v
     if (!first.*) try writer.writeByte(',');
     first.* = false;
     try writeCommandJson(writer, command);
+}
+
+fn runReport(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.ReportArgs) !void {
+    const config_path = try paths.configFilePath(allocator);
+    defer allocator.free(config_path);
+    const state_dir = try paths.stateDir(allocator);
+    defer allocator.free(state_dir);
+    const health_path = try paths.healthFilePath(allocator);
+    defer allocator.free(health_path);
+
+    var validation_messages = std.ArrayList(u8).init(allocator);
+    defer validation_messages.deinit();
+
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+
+    if (config.load(allocator)) |parsed| {
+        defer parsed.deinit();
+        var config_error: ?[]const u8 = null;
+        config.validate(parsed.value, validation_messages.writer()) catch |e| {
+            config_error = @errorName(e);
+        };
+        const config_valid = config_error == null;
+        if (args.json) {
+            try writeReportJson(writer, allocator, args, config_path, state_dir, health_path, parsed.value, true, config_valid, config_error, validation_messages.items, &store);
+        } else {
+            try writeReportText(writer, allocator, args, config_path, state_dir, health_path, parsed.value, true, config_valid, config_error, validation_messages.items, &store);
+        }
+    } else |e| {
+        const config_error = @errorName(e);
+        if (args.json) {
+            try writeReportJson(writer, allocator, args, config_path, state_dir, health_path, null, false, false, config_error, validation_messages.items, &store);
+        } else {
+            try writeReportText(writer, allocator, args, config_path, state_dir, health_path, null, false, false, config_error, validation_messages.items, &store);
+        }
+    }
+}
+
+fn writeReportText(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    args: cli.Command.ReportArgs,
+    config_path: []const u8,
+    state_dir: []const u8,
+    health_path: []const u8,
+    cfg: ?config.Config,
+    configured: bool,
+    config_valid: bool,
+    config_error: ?[]const u8,
+    validation_messages: []const u8,
+    store: *health_mod.HealthStore,
+) !void {
+    try writer.writeAll("oauth-mux report\n\n");
+    try writer.print("  version:  {s}\n", .{cli.version});
+    try writer.print("  platform: {s}/{s}\n", .{ @tagName(builtin.os.tag), @tagName(builtin.cpu.arch) });
+    try writer.print("  redacted: {s}\n", .{if (args.redacted) "true" else "false"});
+    try writer.print("  config:   {s}\n", .{config_path});
+    try writer.print("  state:    {s}\n", .{state_dir});
+    try writer.print("  health:   {s}\n", .{health_path});
+
+    try writer.writeAll("\n  config status:\n");
+    if (!configured) {
+        try writer.print("    missing ({s})\n", .{config_error orelse "not_found"});
+    } else if (!config_valid) {
+        try writer.print("    invalid ({s})\n", .{config_error orelse "validation_failed"});
+    } else {
+        try writer.writeAll("    valid\n");
+    }
+
+    if (cfg) |loaded| {
+        try writer.print("    providers={d} accounts={d} profiles={d} strategies={d} provider_definitions={d}\n", .{
+            loaded.providers.map.count(),
+            countConfiguredAccounts(loaded),
+            loaded.profiles.map.count(),
+            loaded.strategies.map.count(),
+            loaded.provider_definitions.map.count(),
+        });
+    }
+
+    if (validation_messages.len != 0) {
+        try writer.writeAll("\n  validation:\n");
+        try writeIndentedLines(writer, validation_messages, "    ");
+    }
+
+    try writer.writeAll("\n  providers:\n");
+    if (cfg) |loaded| {
+        if (loaded.providers.map.count() == 0) {
+            try writer.writeAll("    none configured\n");
+        } else {
+            var provider_it = loaded.providers.map.iterator();
+            while (provider_it.next()) |entry| {
+                const provider_name = entry.key_ptr.*;
+                const prov = entry.value_ptr.*;
+                try writer.print("    {s} kind={s} accounts={d}\n", .{ provider_name, prov.kind, prov.accounts.map.count() });
+                var account_it = prov.accounts.map.iterator();
+                while (account_it.next()) |acct_entry| {
+                    const account_name = acct_entry.key_ptr.*;
+                    const account = acct_entry.value_ptr.*;
+                    try writer.print("      {s} priority={d} secret={s}", .{ account_name, account.priority, account.secret.backend });
+                    if (account.config_dir != null) try writer.writeAll(" config_dir=set");
+                    if (args.include_paths) try writeAccountPathHintsText(writer, account);
+                    if (account.tags) |tags| {
+                        try writer.writeAll(" tags=");
+                        for (tags, 0..) |tag, idx| {
+                            if (idx > 0) try writer.writeByte(',');
+                            try writer.writeAll(tag);
+                        }
+                    }
+                    try writer.writeByte('\n');
+                }
+            }
+        }
+    } else {
+        try writer.writeAll("    unavailable until config loads\n");
+    }
+
+    try writer.writeAll("\n  health:\n");
+    if (store.accounts.count() == 0) {
+        try writer.writeAll("    no health data recorded yet\n");
+    } else {
+        var health_it = store.accounts.iterator();
+        while (health_it.next()) |entry| {
+            const health = entry.value_ptr.*;
+            try writer.print("    {s} score={d} circuit={s} http=", .{
+                entry.key_ptr.*,
+                health.score.score,
+                circuitName(health.circuit),
+            });
+            if (health.last_http_status) |status| {
+                try writer.print("{d}", .{status});
+            } else {
+                try writer.writeByte('-');
+            }
+            try writer.writeAll(" liveness=");
+            try health_mod.writeLivenessSummary(writer, health.liveness);
+            try writer.writeByte('\n');
+        }
+    }
+
+    try writer.writeAll("\n  command availability:\n");
+    try writeCommandAvailabilityText(writer, allocator);
+
+    try writer.writeAll("\n  next:\n");
+    try writer.writeAll("    oauth-mux doctor --json\n");
+    try writer.writeAll("    oauth-mux providers list --json\n");
+    try writer.writeAll("    oauth-mux health --json\n");
+}
+
+fn writeReportJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    args: cli.Command.ReportArgs,
+    config_path: []const u8,
+    state_dir: []const u8,
+    health_path: []const u8,
+    cfg: ?config.Config,
+    configured: bool,
+    config_valid: bool,
+    config_error: ?[]const u8,
+    validation_messages: []const u8,
+    store: *health_mod.HealthStore,
+) !void {
+    try writer.writeByte('{');
+    try writer.writeAll("\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"os\":");
+    try std.json.stringify(@tagName(builtin.os.tag), .{}, writer);
+    try writer.writeAll(",\"arch\":");
+    try std.json.stringify(@tagName(builtin.cpu.arch), .{}, writer);
+    try writer.writeAll(",\"redacted\":");
+    try writer.writeAll(if (args.redacted) "true" else "false");
+    try writer.writeAll(",\"include_paths\":");
+    try writer.writeAll(if (args.include_paths) "true" else "false");
+    try writer.writeAll(",\"paths\":{\"config\":");
+    try std.json.stringify(config_path, .{}, writer);
+    try writer.writeAll(",\"state\":");
+    try std.json.stringify(state_dir, .{}, writer);
+    try writer.writeAll(",\"health\":");
+    try std.json.stringify(health_path, .{}, writer);
+    try writer.writeAll("},\"config\":{\"configured\":");
+    try writer.writeAll(if (configured) "true" else "false");
+    try writer.writeAll(",\"valid\":");
+    try writer.writeAll(if (config_valid) "true" else "false");
+    try writer.writeAll(",\"error\":");
+    if (config_error) |err| {
+        try std.json.stringify(err, .{}, writer);
+    } else {
+        try writer.writeAll("null");
+    }
+    if (cfg) |loaded| {
+        try writer.print(",\"providers\":{d},\"accounts\":{d},\"profiles\":{d},\"strategies\":{d},\"provider_definitions\":{d}", .{
+            loaded.providers.map.count(),
+            countConfiguredAccounts(loaded),
+            loaded.profiles.map.count(),
+            loaded.strategies.map.count(),
+            loaded.provider_definitions.map.count(),
+        });
+    } else {
+        try writer.writeAll(",\"providers\":0,\"accounts\":0,\"profiles\":0,\"strategies\":0,\"provider_definitions\":0");
+    }
+    try writer.writeAll(",\"validation_messages\":");
+    try writeLineArrayJson(writer, validation_messages);
+    try writer.writeAll("},\"providers\":");
+    if (cfg) |loaded| {
+        try writeConfiguredProvidersReportJson(writer, args, loaded);
+    } else {
+        try writer.writeAll("[]");
+    }
+    try writer.writeAll(",\"health\":");
+    try writeHealthEntriesJson(writer, store);
+    try writer.writeAll(",\"command_availability\":");
+    try writeCommandAvailabilityJson(writer, allocator);
+    try writer.writeAll(",\"next_commands\":[");
+    try writeCommandJson(writer, "oauth-mux doctor --json");
+    try writer.writeByte(',');
+    try writeCommandJson(writer, "oauth-mux providers list --json");
+    try writer.writeByte(',');
+    try writeCommandJson(writer, "oauth-mux health --json");
+    try writer.writeAll("]}\n");
+}
+
+fn runProviders(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.ProvidersArgs) !void {
+    switch (args.action) {
+        .list => {},
+    }
+
+    if (config.load(allocator)) |parsed| {
+        defer parsed.deinit();
+        if (args.json) {
+            try writeProvidersListJson(writer, allocator, parsed.value, true, null);
+        } else {
+            try writeProvidersListText(writer, allocator, parsed.value, true, null);
+        }
+    } else |e| {
+        if (args.json) {
+            try writeProvidersListJson(writer, allocator, null, false, @errorName(e));
+        } else {
+            try writeProvidersListText(writer, allocator, null, false, @errorName(e));
+        }
+    }
+}
+
+fn writeProvidersListText(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: ?config.Config,
+    config_loaded: bool,
+    config_error: ?[]const u8,
+) !void {
+    try writer.writeAll("oauth-mux providers\n\n");
+    if (!config_loaded) {
+        try writer.print("  config: unavailable ({s}); showing built-ins\n\n", .{config_error orelse "not_found"});
+    }
+
+    try writer.print("  {s:<12} {s:<14} {s:<20} {s:>8} {s:>5} {s:>6}\n", .{
+        "Provider", "Support", "Proof", "Accounts", "Caps", "Probes",
+    });
+    try writer.print("  {s:-<12} {s:-<14} {s:-<20} {s:->8} {s:->5} {s:->6}\n", .{ "", "", "", "", "", "" });
+
+    for (provider_schema.builtin_providers) |def| {
+        try writeProviderListTextRow(writer, cfg, def.name, def, true);
+    }
+
+    if (cfg) |loaded| {
+        var def_it = loaded.provider_definitions.map.iterator();
+        while (def_it.next()) |entry| {
+            const def_key = entry.key_ptr.*;
+            const def = entry.value_ptr.*;
+            if (isBuiltinDefinition(def_key, def.name)) continue;
+            try writeProviderListTextRow(writer, cfg, def_key, def, false);
+        }
+    }
+
+    try writer.writeAll("\n  support: live_proven means hosted secret-scoped QA has proved a real route.\n");
+    try writer.writeAll("  proof: needs_operator_proof means the schema exists but needs live provider evidence.\n");
+    _ = allocator;
+}
+
+fn writeProviderListTextRow(writer: anytype, cfg: ?config.Config, def_key: []const u8, def: provider_schema.ProviderDefinition, built_in: bool) !void {
+    const accounts = configuredAccountCountForDefinition(cfg, def_key, def.name);
+    try writer.print("  {s:<12} {s:<14} {s:<20} {d:>8} {d:>5} {d:>6}\n", .{
+        def.name,
+        supportStatus(def.name, built_in),
+        proofStatus(def.name),
+        accounts,
+        def.capabilities.len,
+        countProviderProbes(def),
+    });
+}
+
+fn writeProvidersListJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: ?config.Config,
+    config_loaded: bool,
+    config_error: ?[]const u8,
+) !void {
+    try writer.writeByte('{');
+    try writer.writeAll("\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"config_loaded\":");
+    try writer.writeAll(if (config_loaded) "true" else "false");
+    try writer.writeAll(",\"config_error\":");
+    if (config_error) |err| {
+        try std.json.stringify(err, .{}, writer);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"providers\":[");
+
+    var first = true;
+    for (provider_schema.builtin_providers) |def| {
+        try writeProviderListJsonEntry(writer, allocator, &first, cfg, def.name, def, true);
+    }
+
+    if (cfg) |loaded| {
+        var def_it = loaded.provider_definitions.map.iterator();
+        while (def_it.next()) |entry| {
+            const def_key = entry.key_ptr.*;
+            const def = entry.value_ptr.*;
+            if (isBuiltinDefinition(def_key, def.name)) continue;
+            try writeProviderListJsonEntry(writer, allocator, &first, cfg, def_key, def, false);
+        }
+    }
+
+    try writer.writeAll("]}\n");
+}
+
+fn writeProviderListJsonEntry(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    first: *bool,
+    cfg: ?config.Config,
+    def_key: []const u8,
+    def: provider_schema.ProviderDefinition,
+    built_in: bool,
+) !void {
+    if (!first.*) try writer.writeByte(',');
+    first.* = false;
+
+    const accounts = configuredAccountCountForDefinition(cfg, def_key, def.name);
+    try writer.writeByte('{');
+    try writer.writeAll("\"definition_key\":");
+    try std.json.stringify(def_key, .{}, writer);
+    try writer.writeByte(',');
+    try writer.writeAll("\"name\":");
+    try std.json.stringify(def.name, .{}, writer);
+    try writer.writeAll(",\"display_name\":");
+    try std.json.stringify(providerDisplayName(def), .{}, writer);
+    try writer.writeAll(",\"support_status\":");
+    try std.json.stringify(supportStatus(def.name, built_in), .{}, writer);
+    try writer.writeAll(",\"proof_status\":");
+    try std.json.stringify(proofStatus(def.name), .{}, writer);
+    try writer.writeAll(",\"built_in\":");
+    try writer.writeAll(if (built_in) "true" else "false");
+    try writer.writeAll(",\"configured\":");
+    try writer.writeAll(if (accounts > 0) "true" else "false");
+    try writer.print(",\"configured_accounts\":{d},\"capabilities\":{d},\"probes\":{d},\"failure_rules\":{d}", .{
+        accounts,
+        def.capabilities.len,
+        countProviderProbes(def),
+        def.failure_rules.len,
+    });
+    try writer.writeAll(",\"detection_binaries\":");
+    try writeStringArrayJson(writer, def.detection.binary_names);
+    try writer.writeAll(",\"env_markers\":");
+    try writeStringArrayJson(writer, def.detection.env_markers);
+    try writer.writeAll(",\"command_availability\":[");
+    for (def.detection.binary_names, 0..) |binary_name, idx| {
+        if (idx > 0) try writer.writeByte(',');
+        try writer.writeAll("{\"name\":");
+        try std.json.stringify(binary_name, .{}, writer);
+        try writer.writeAll(",\"available\":");
+        try writer.writeAll(if (try commandAvailable(allocator, binary_name)) "true" else "false");
+        try writer.writeByte('}');
+    }
+    try writer.writeByte(']');
+    try writer.writeByte('}');
+}
+
+fn writeConfiguredProvidersReportJson(writer: anytype, args: cli.Command.ReportArgs, cfg: config.Config) !void {
+    try writer.writeByte('[');
+    var provider_first = true;
+    var provider_it = cfg.providers.map.iterator();
+    while (provider_it.next()) |entry| {
+        if (!provider_first) try writer.writeByte(',');
+        provider_first = false;
+        const provider_name = entry.key_ptr.*;
+        const prov = entry.value_ptr.*;
+        try writer.writeByte('{');
+        try writer.writeAll("\"name\":");
+        try std.json.stringify(provider_name, .{}, writer);
+        try writer.writeAll(",\"kind\":");
+        try std.json.stringify(prov.kind, .{}, writer);
+        try writer.writeAll(",\"support_status\":");
+        try std.json.stringify(supportStatusForConfig(cfg, provider_name, prov.kind), .{}, writer);
+        try writer.writeAll(",\"proof_status\":");
+        try std.json.stringify(proofStatus(prov.kind), .{}, writer);
+        try writer.writeAll(",\"config_dir_env\":");
+        if (prov.config_dir_env) |config_dir_env| {
+            try std.json.stringify(config_dir_env, .{}, writer);
+        } else {
+            try writer.writeAll("null");
+        }
+        try writer.writeAll(",\"accounts\":[");
+        var account_first = true;
+        var account_it = prov.accounts.map.iterator();
+        while (account_it.next()) |acct_entry| {
+            if (!account_first) try writer.writeByte(',');
+            account_first = false;
+            try writeAccountReportJson(writer, args, acct_entry.key_ptr.*, acct_entry.value_ptr.*);
+        }
+        try writer.writeAll("]}");
+    }
+    try writer.writeByte(']');
+}
+
+fn writeAccountReportJson(writer: anytype, args: cli.Command.ReportArgs, account_name: []const u8, account: config.AccountConfig) !void {
+    try writer.writeByte('{');
+    try writer.writeAll("\"name\":");
+    try std.json.stringify(account_name, .{}, writer);
+    try writer.print(",\"priority\":{d},\"secret_backend\":", .{account.priority});
+    try std.json.stringify(account.secret.backend, .{}, writer);
+    try writer.writeAll(",\"secret_location\":");
+    if (args.include_paths) {
+        try writeSecretLocationJson(writer, account.secret);
+    } else {
+        try std.json.stringify("redacted", .{}, writer);
+    }
+    try writer.writeAll(",\"config_dir_set\":");
+    try writer.writeAll(if (account.config_dir != null) "true" else "false");
+    try writer.writeAll(",\"config_dir\":");
+    if (args.include_paths) {
+        if (account.config_dir) |config_dir| {
+            try std.json.stringify(config_dir, .{}, writer);
+        } else {
+            try writer.writeAll("null");
+        }
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"tags\":[");
+    if (account.tags) |tags| {
+        for (tags, 0..) |tag, idx| {
+            if (idx > 0) try writer.writeByte(',');
+            try std.json.stringify(tag, .{}, writer);
+        }
+    }
+    try writer.writeAll("]}");
+}
+
+fn writeSecretLocationJson(writer: anytype, secret: config.SecretConfig) !void {
+    try writer.writeByte('{');
+    try writer.writeAll("\"backend\":");
+    try std.json.stringify(secret.backend, .{}, writer);
+
+    if (std.mem.eql(u8, secret.backend, "env")) {
+        try writer.writeAll(",\"variable\":");
+        if (secret.variable) |variable| try std.json.stringify(variable, .{}, writer) else try writer.writeAll("null");
+    } else if (std.mem.eql(u8, secret.backend, "file") or std.mem.eql(u8, secret.backend, "sops")) {
+        try writer.writeAll(",\"path\":");
+        if (secret.path) |path_value| try std.json.stringify(path_value, .{}, writer) else try writer.writeAll("null");
+        try writer.writeAll(",\"key_path\":");
+        if (secret.key_path) |key_path| try std.json.stringify(key_path, .{}, writer) else try writer.writeAll("null");
+    } else if (std.mem.eql(u8, secret.backend, "age")) {
+        try writer.writeAll(",\"path\":");
+        if (secret.path) |path_value| try std.json.stringify(path_value, .{}, writer) else try writer.writeAll("null");
+        try writer.writeAll(",\"identity_set\":");
+        try writer.writeAll(if (secret.identity != null) "true" else "false");
+    } else if (std.mem.eql(u8, secret.backend, "keychain")) {
+        try writer.writeAll(",\"service\":");
+        if (secret.service) |service| try std.json.stringify(service, .{}, writer) else try writer.writeAll("null");
+        try writer.writeAll(",\"account\":");
+        if (secret.account) |account| try std.json.stringify(account, .{}, writer) else try writer.writeAll("null");
+    } else if (std.mem.eql(u8, secret.backend, "command")) {
+        try writer.writeAll(",\"command\":");
+        if (secret.command) |argv| {
+            if (argv.len > 0) {
+                try std.json.stringify(argv[0], .{}, writer);
+            } else {
+                try writer.writeAll("null");
+            }
+            try writer.print(",\"arg_count\":{d}", .{argv.len});
+        } else {
+            try writer.writeAll("null,\"arg_count\":0");
+        }
+    }
+    try writer.writeByte('}');
+}
+
+fn writeHealthEntriesJson(writer: anytype, store: *health_mod.HealthStore) !void {
+    try writer.writeByte('[');
+    var first = true;
+    var it = store.accounts.iterator();
+    while (it.next()) |entry| {
+        if (!first) try writer.writeByte(',');
+        first = false;
+        const h = entry.value_ptr.*;
+        try writer.writeByte('{');
+        try writer.writeAll("\"key\":");
+        try std.json.stringify(entry.key_ptr.*, .{}, writer);
+        if (health_mod.parseHealthKey(entry.key_ptr.*)) |parts| {
+            try writer.writeAll(",\"provider\":");
+            try std.json.stringify(parts.provider, .{}, writer);
+            try writer.writeAll(",\"account\":");
+            try std.json.stringify(parts.account, .{}, writer);
+            try writer.writeAll(",\"capability\":");
+            if (parts.capability) |capability| {
+                try std.json.stringify(capability, .{}, writer);
+            } else {
+                try writer.writeAll("null");
+            }
+        }
+        try writer.print(",\"score\":{d},\"successes\":{d},\"failures\":{d},\"rate_limits\":{d},\"circuit\":", .{
+            h.score.score,
+            h.score.successes,
+            h.score.failures,
+            h.score.rate_limits,
+        });
+        try std.json.stringify(circuitName(h.circuit), .{}, writer);
+        try writer.writeAll(",\"last_http_status\":");
+        if (h.last_http_status) |status| {
+            try writer.print("{d}", .{status});
+        } else {
+            try writer.writeAll("null");
+        }
+        try writer.writeAll(",\"liveness\":");
+        try writeLivenessJson(writer, h.liveness);
+        try writer.writeAll(",\"last_probe\":");
+        try writeProbeEvidenceJson(writer, h);
+        try writer.writeByte('}');
+    }
+    try writer.writeByte(']');
+}
+
+fn writeCommandAvailabilityText(writer: anytype, allocator: std.mem.Allocator) !void {
+    var any = false;
+    for (provider_schema.builtin_providers) |def| {
+        for (def.detection.binary_names) |binary_name| {
+            any = true;
+            try writer.print("    {s}:{s} {s}\n", .{
+                def.name,
+                binary_name,
+                if (try commandAvailable(allocator, binary_name)) "available" else "missing",
+            });
+        }
+    }
+    if (!any) try writer.writeAll("    no command detectors declared\n");
+}
+
+fn writeCommandAvailabilityJson(writer: anytype, allocator: std.mem.Allocator) !void {
+    try writer.writeByte('[');
+    var first = true;
+    for (provider_schema.builtin_providers) |def| {
+        for (def.detection.binary_names) |binary_name| {
+            if (!first) try writer.writeByte(',');
+            first = false;
+            try writer.writeAll("{\"provider\":");
+            try std.json.stringify(def.name, .{}, writer);
+            try writer.writeAll(",\"command\":");
+            try std.json.stringify(binary_name, .{}, writer);
+            try writer.writeAll(",\"available\":");
+            try writer.writeAll(if (try commandAvailable(allocator, binary_name)) "true" else "false");
+            try writer.writeByte('}');
+        }
+    }
+    try writer.writeByte(']');
+}
+
+fn writeAccountPathHintsText(writer: anytype, account: config.AccountConfig) !void {
+    if (account.config_dir) |config_dir| try writer.print(" config_dir={s}", .{config_dir});
+
+    const secret = account.secret;
+    if (std.mem.eql(u8, secret.backend, "env")) {
+        if (secret.variable) |variable| try writer.print(" env={s}", .{variable});
+    } else if (std.mem.eql(u8, secret.backend, "file") or std.mem.eql(u8, secret.backend, "sops") or std.mem.eql(u8, secret.backend, "age")) {
+        if (secret.path) |path_value| try writer.print(" path={s}", .{path_value});
+    } else if (std.mem.eql(u8, secret.backend, "keychain")) {
+        if (secret.service) |service| try writer.print(" keychain_service={s}", .{service});
+        if (secret.account) |account_name| try writer.print(" keychain_account={s}", .{account_name});
+    } else if (std.mem.eql(u8, secret.backend, "command")) {
+        if (secret.command) |argv| {
+            if (argv.len > 0) try writer.print(" command={s} argc={d}", .{ argv[0], argv.len });
+        }
+    }
+}
+
+fn writeIndentedLines(writer: anytype, value: []const u8, indent: []const u8) !void {
+    var lines = std.mem.splitScalar(u8, value, '\n');
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        try writer.print("{s}{s}\n", .{ indent, line });
+    }
+}
+
+fn writeLineArrayJson(writer: anytype, value: []const u8) !void {
+    try writer.writeByte('[');
+    var first = true;
+    var lines = std.mem.splitScalar(u8, value, '\n');
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        if (!first) try writer.writeByte(',');
+        first = false;
+        try std.json.stringify(line, .{}, writer);
+    }
+    try writer.writeByte(']');
+}
+
+fn writeStringArrayJson(writer: anytype, values: []const []const u8) !void {
+    try writer.writeByte('[');
+    for (values, 0..) |value, idx| {
+        if (idx > 0) try writer.writeByte(',');
+        try std.json.stringify(value, .{}, writer);
+    }
+    try writer.writeByte(']');
+}
+
+fn configuredAccountCountForDefinition(cfg: ?config.Config, def_key: []const u8, def_name: []const u8) usize {
+    const loaded = cfg orelse return 0;
+    var count: usize = 0;
+    var provider_it = loaded.providers.map.iterator();
+    while (provider_it.next()) |entry| {
+        const provider_name = entry.key_ptr.*;
+        const prov = entry.value_ptr.*;
+        if (std.mem.eql(u8, provider_name, def_key) or
+            std.mem.eql(u8, provider_name, def_name) or
+            std.mem.eql(u8, prov.kind, def_key) or
+            std.mem.eql(u8, prov.kind, def_name))
+        {
+            count += prov.accounts.map.count();
+        }
+    }
+    return count;
+}
+
+fn supportStatusForConfig(cfg: config.Config, provider_name: []const u8, provider_kind: []const u8) []const u8 {
+    if (provider_schema.findBuiltin(provider_kind) != null) {
+        return supportStatus(provider_kind, true);
+    }
+    if (provider_schema.findBuiltin(provider_name) != null) {
+        return supportStatus(provider_name, true);
+    }
+    if (cfg.provider_definitions.map.get(provider_kind) != null or cfg.provider_definitions.map.get(provider_name) != null) {
+        return "schema_modeled";
+    }
+    return "needs_operator_proof";
+}
+
+fn supportStatus(def_name: []const u8, built_in: bool) []const u8 {
+    if (std.mem.eql(u8, def_name, "codex")) return "live_proven";
+    if (built_in) return "built_in";
+    return "schema_modeled";
+}
+
+fn proofStatus(def_name: []const u8) []const u8 {
+    if (std.mem.eql(u8, def_name, "codex")) return "live_proven";
+    return "needs_operator_proof";
+}
+
+fn providerDisplayName(def: provider_schema.ProviderDefinition) []const u8 {
+    if (def.display_name.len != 0) return def.display_name;
+    return def.name;
+}
+
+fn countProviderProbes(def: provider_schema.ProviderDefinition) usize {
+    var count: usize = 0;
+    for (def.capabilities) |capability| {
+        if (capability.probe != null) count += 1;
+    }
+    return count;
+}
+
+fn isBuiltinDefinition(def_key: []const u8, def_name: []const u8) bool {
+    return provider_schema.findBuiltin(def_key) != null or provider_schema.findBuiltin(def_name) != null;
+}
+
+fn circuitName(circuit: types.CircuitState) []const u8 {
+    return switch (circuit) {
+        .closed => "closed",
+        .open => "open",
+        .half_open => "half_open",
+    };
+}
+
+fn commandAvailable(allocator: std.mem.Allocator, binary_name: []const u8) !bool {
+    if (binary_name.len == 0) return false;
+
+    const path_env = std.process.getEnvVarOwned(allocator, "PATH") catch return false;
+    defer allocator.free(path_env);
+
+    var dirs = std.mem.splitScalar(u8, path_env, pathDelimiter());
+    while (dirs.next()) |dir| {
+        if (dir.len == 0) continue;
+        const candidate = try std.fs.path.join(allocator, &.{ dir, binary_name });
+        defer allocator.free(candidate);
+        if (fileExists(candidate)) return true;
+
+        if (comptime builtin.os.tag == .windows) {
+            if (!std.ascii.endsWithIgnoreCase(binary_name, ".exe")) {
+                const exe_name = try std.fmt.allocPrint(allocator, "{s}.exe", .{binary_name});
+                defer allocator.free(exe_name);
+                const exe_candidate = try std.fs.path.join(allocator, &.{ dir, exe_name });
+                defer allocator.free(exe_candidate);
+                if (fileExists(exe_candidate)) return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+fn pathDelimiter() u8 {
+    return if (builtin.os.tag == .windows) ';' else ':';
+}
+
+fn fileExists(path_value: []const u8) bool {
+    const file = if (std.fs.path.isAbsolute(path_value))
+        std.fs.openFileAbsolute(path_value, .{}) catch return false
+    else
+        std.fs.cwd().openFile(path_value, .{}) catch return false;
+    file.close();
+    return true;
 }
 
 fn countConfiguredAccounts(cfg: config.Config) usize {


### PR DESCRIPTION
## Summary

- add `oauth-mux doctor [--json]` as a no-spend readiness report for first-run and agent discovery
- add `oauth-mux report --redacted [--json] [--include-paths]` as a support bundle that never reads credential values and omits credential paths by default
- add `oauth-mux providers list [--json]` for built-in, schema-modeled, live-proven, and proof-needed provider status
- add `oauth-mux setup codex` plus `oauth-mux codex setup` as friendlier aliases for Codex onboarding
- surface the new diagnostics from discover/help/completions and update first-run docs
- bump the source/build version to `0.1.3`

## Validation

- `zig build test`
- `zig build && ./scripts/e2e-local.sh`
- `just check`
- `git diff --check`
- missing-config spot check for `providers list --json` and `report --redacted --json`

## CI Notes

Hosted PR CI did not start runner steps. GitHub returned the billing/spending-limit annotation: “The job was not started because recent account payments have failed or your spending limit needs to be increased.” GloriousFlywheel also remains queued, matching the expected runner/lab outage. The local canonical gate is green.

## Notes

All new diagnostics are secret-passive. They do not read token files, environment token values, keychain entries, or command-secret output. `--include-paths` only exposes non-token location metadata for deliberate support bundles.