### PR TITLE
docs(readme): cross-link to https://omux.xoxd.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # oauth-mux
 
+**Site:** https://omux.xoxd.ai — typed-fallback model, install paths, and the live provider matrix.  
+**Source:** github.com/Jesssullivan/oauth-mux
+
 `oauth-mux` is a compiled OAuth fallback mux for AI harness subscriptions and
 connector auth. It selects among configured provider accounts, records typed
 credential liveness, and falls through without poisoning an entire account when


### PR DESCRIPTION
## Summary

Adds a top-of-README cross-link to the oauth-mux marketing/devtool site:

- **Site:** https://omux.xoxd.ai — typed-fallback model, install paths, live provider matrix.
- **Source:** `github.com/Jesssullivan/oauth-mux` (this repo).

The website is public and serving HTTP 200 through GitHub Pages. The website source repo `tinyland-inc/omux.xoxd.ai` is also public, so the earlier visibility hold is cleared.

## Test plan

- [x] Rebased onto current `main` after PR #50
- [x] `just check-local`
- [x] `curl -I https://omux.xoxd.ai` returns HTTP 200
- [x] `gh repo view tinyland-inc/omux.xoxd.ai --json visibility` reports `PUBLIC`

Linear: TIN-784
