### PR TITLE
Add system package install QA

### DIFF
--- a/.github/workflows/system-package-install-qa.yml
+++ b/.github/workflows/system-package-install-qa.yml
@@ -1,0 +1,40 @@
+name: System Package Install QA
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/system-package-install-qa.yml"
+      - "scripts/system-package-install-qa.sh"
+      - "docs/install-beta-matrix.md"
+      - "docs/release-runbook.md"
+      - "justfile"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Published version to install from GitHub Release assets"
+        required: false
+        default: "0.1.3"
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  system-package-install-qa:
+    name: deb/rpm install from published release assets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install published deb/rpm packages in Linux containers
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ github.event.inputs.version }}"
+          if [ -z "$version" ]; then
+            version="0.1.3"
+          fi
+          ./scripts/system-package-install-qa.sh "$version"

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -15,8 +15,8 @@ files, SOPS plaintext, or token-shaped values here.
 | GitHub release tarball | 0.1.3 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Repo visibility must remain public for unauthenticated downloads. |
 | `curl | sh` installer | 0.1.3 | macOS arm64 and `../lab` | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass | Default installer repo is now canonical; no `REPO=...` override needed. |
 | Homebrew formula | 0.1.3 | macOS arm64 | `tinyland/tools` tap | Pass | Tap install and rollback passed after `tinyland-inc/homebrew-tools#2`; tap repo is still private. |
-| deb package | 0.1.3 | Linux amd64 container | public GitHub Release `.deb` asset | Pending hosted proof | Use `System Package Install QA` after this workflow lands. |
-| rpm package | 0.1.3 | Linux x86_64 container | public GitHub Release `.rpm` asset | Pending hosted proof | Use `System Package Install QA` after this workflow lands. |
+| deb package | 0.1.3 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25137031548` installed package and ran `/usr/bin/oauth-mux version`. |
+| rpm package | 0.1.3 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25137031548` installed package and ran `/usr/bin/oauth-mux version`. |
 | lab dogfood | 0.1.3 | `../lab` on macOS arm64 | installed `oauth-mux` CLI | Pass | Installed `oauth-mux doctor --json` reports `ok: true` against local config/state. |
 
 ## Evidence Commands
@@ -99,6 +99,13 @@ System package install QA after GitHub Release publication:
 gh workflow run system-package-install-qa.yml -f version=0.1.3
 ```
 
+Latest hosted proof:
+
+```text
+System Package Install QA run 25137031548: pass
+job 73677864724: deb/rpm install from published release assets
+```
+
 Local reproduction on a host with healthy Docker:
 
 ```bash
@@ -107,8 +114,7 @@ just system-package-qa 0.1.3
 
 ## Next Proof
 
-1. Merge the hosted system-package install QA workflow.
-2. Run it for v0.1.3 and record the run ID for deb/rpm proof.
-3. If the hosted proof passes, mark the deb/rpm lanes as pass.
-4. If it fails, fix the package contents or release metadata before widening
-   public install copy.
+1. Keep the hosted system-package install QA workflow in the release checklist.
+2. For each release that changes deb/rpm packaging, run the workflow after the
+   GitHub Release assets exist.
+3. Treat registry metadata checks as insufficient without this install proof.

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -10,13 +10,14 @@ files, SOPS plaintext, or token-shaped values here.
 
 | Surface | Version | Host | Source | Result | Caveat |
 | --- | --- | --- | --- | --- | --- |
-| npm global install | 0.1.2 | macOS arm64 | public npm registry | Pass | Published metadata still points at `tinyland-inc/oauth-mux`; v0.1.3 templates now point at `Jesssullivan/oauth-mux` and `https://omux.xoxd.ai`. |
-| GitHub release tarball | 0.1.2 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Repo visibility must remain public for unauthenticated downloads. |
-| `curl | sh` installer | 0.1.2 | macOS arm64 | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass with `REPO=Jesssullivan/oauth-mux` | The v0.1.2 installer asset was generated before the canonical repo transfer. v0.1.3 uses the corrected default. |
-| Homebrew formula | 0.1.3 staged | macOS arm64 | generated formula in temporary tap | Pass audit | Needs real tap install proof after release assets exist. |
-| deb package | 0.1.3 staged | Linux target | generated `nfpm` artifact | Pass artifact smoke | Needs Debian/Ubuntu host or container install proof. |
-| rpm package | 0.1.3 staged | Linux target | generated `nfpm` artifact | Pass artifact smoke | Needs Fedora/Rocky host or container install proof. |
-| lab dogfood | v0.1.3 branch | lab machines | installed `oauth-mux` CLI | Pending | Use installed commands, not repo-local `just` wrappers, once v0.1.3 is published. |
+| npm global install | 0.1.3 | macOS arm64 | public npm registry | Pass | Clean temp-prefix global install returns `oauth-mux 0.1.3`. |
+| npm one-shot | 0.1.3 | `../lab` on macOS arm64 | public npm registry | Pass | `npx -y oauth-mux@0.1.3 version` returns `oauth-mux 0.1.3`. |
+| GitHub release tarball | 0.1.3 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Repo visibility must remain public for unauthenticated downloads. |
+| `curl | sh` installer | 0.1.3 | macOS arm64 and `../lab` | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass | Default installer repo is now canonical; no `REPO=...` override needed. |
+| Homebrew formula | 0.1.3 | macOS arm64 | `tinyland/tools` tap | Pass | Tap install and rollback passed after `tinyland-inc/homebrew-tools#2`; tap repo is still private. |
+| deb package | 0.1.3 | Linux amd64 container | public GitHub Release `.deb` asset | Pending hosted proof | Use `System Package Install QA` after this workflow lands. |
+| rpm package | 0.1.3 | Linux x86_64 container | public GitHub Release `.rpm` asset | Pending hosted proof | Use `System Package Install QA` after this workflow lands. |
+| lab dogfood | 0.1.3 | `../lab` on macOS arm64 | installed `oauth-mux` CLI | Pass | Installed `oauth-mux doctor --json` reports `ok: true` against local config/state. |
 
 ## Evidence Commands
 
@@ -25,7 +26,7 @@ npm clean install:
 ```bash
 tmp="$(mktemp -d)"
 npm_config_cache="$tmp/cache" \
-  npm install --prefix "$tmp/app" --install-strategy=shallow oauth-mux@0.1.2 \
+  npm install --prefix "$tmp/app" --install-strategy=shallow oauth-mux@0.1.3 \
   --ignore-scripts=false --no-audit --no-fund
 "$tmp/app/node_modules/.bin/oauth-mux" version
 rm -rf "$tmp"
@@ -34,7 +35,7 @@ rm -rf "$tmp"
 Expected output includes:
 
 ```text
-oauth-mux 0.1.2
+oauth-mux 0.1.3
 ```
 
 Raw release tarball:
@@ -42,9 +43,9 @@ Raw release tarball:
 ```bash
 tmp="$(mktemp -d)"
 curl -fsSL -o "$tmp/oauth-mux-aarch64-macos.tar.gz" \
-  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.2/oauth-mux-aarch64-macos.tar.gz
+  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.3/oauth-mux-aarch64-macos.tar.gz
 curl -fsSL -o "$tmp/SHA256SUMS" \
-  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.2/SHA256SUMS
+  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.3/SHA256SUMS
 (cd "$tmp" && shasum -a 256 -c --ignore-missing SHA256SUMS)
 tar -xzf "$tmp/oauth-mux-aarch64-macos.tar.gz" -C "$tmp"
 "$tmp/oauth-mux" version
@@ -55,17 +56,16 @@ Expected output includes:
 
 ```text
 oauth-mux-aarch64-macos.tar.gz: OK
-oauth-mux 0.1.2
+oauth-mux 0.1.3
 ```
 
-Public installer for v0.1.2:
+Public installer for v0.1.3:
 
 ```bash
 tmp="$(mktemp -d)"
-REPO=Jesssullivan/oauth-mux \
-VERSION=0.1.2 \
+VERSION=0.1.3 \
 INSTALL_DIR="$tmp/bin" \
-  sh -c 'curl -fsSL https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.2/install.sh | sh'
+  sh -c 'curl -fsSL https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.3/install.sh | sh'
 "$tmp/bin/oauth-mux" version
 rm -rf "$tmp"
 ```
@@ -73,35 +73,42 @@ rm -rf "$tmp"
 Expected output includes:
 
 ```text
-oauth-mux 0.1.2
+oauth-mux 0.1.3
 ```
 
-The `REPO` override above is intentional for v0.1.2 only. v0.1.3 release
-artifacts should install from the canonical public repository by default.
-
-Staged v0.1.3 Homebrew audit:
+Homebrew tap install:
 
 ```bash
-tmp="$(mktemp -d)"
-git -C "$tmp" init -q
-OMUX_REGISTRY_DRY_RUN_CONFIRM=registry-dry-run \
-OMUX_REGISTRY_LANES=homebrew \
-OMUX_HOMEBREW_TAP_DIR="$tmp" \
 HOMEBREW_NO_AUTO_UPDATE=1 \
-  ./scripts/registry-dry-run.sh 0.1.3
-rm -rf "$tmp"
+  brew tap tinyland/tools https://github.com/tinyland-inc/homebrew-tools.git
+brew install tinyland/tools/oauth-mux
+oauth-mux version
+brew uninstall oauth-mux
+brew untap tinyland/tools
 ```
 
-Expected report entry:
+Expected output includes:
 
 ```text
-brew audit --strict OK
+oauth-mux 0.1.3
+```
+
+System package install QA after GitHub Release publication:
+
+```bash
+gh workflow run system-package-install-qa.yml -f version=0.1.3
+```
+
+Local reproduction on a host with healthy Docker:
+
+```bash
+just system-package-qa 0.1.3
 ```
 
 ## Next Proof
 
-1. Publish v0.1.3 artifacts from the corrected templates.
-2. Re-run the public installer command without `REPO=...`.
-3. Install the generated Homebrew formula from the selected tap.
-4. Install generated deb and rpm packages on Linux hosts or containers.
-5. Update this matrix with host, version, result, and caveat for each lane.
+1. Merge the hosted system-package install QA workflow.
+2. Run it for v0.1.3 and record the run ID for deb/rpm proof.
+3. If the hosted proof passes, mark the deb/rpm lanes as pass.
+4. If it fails, fix the package contents or release metadata before widening
+   public install copy.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,6 +1,6 @@
 # oauth-mux Release Runbook
 
-Updated: 2026-04-28
+Updated: 2026-04-29
 
 ## Local Quality Gates
 
@@ -130,6 +130,28 @@ The staged `install.sh` verifies the selected tarball against `SHA256SUMS`
 before installing. For local proof, `OMUX_RELEASE_BASE_URL=file://...` points it
 at the staged artifact directory instead of GitHub Releases.
 
+## System Package Install QA
+
+After the GitHub Release exists, run the hosted system-package install proof:
+
+```bash
+gh workflow run system-package-install-qa.yml -f version=0.1.3
+```
+
+This workflow downloads the published `.deb` and `.rpm` release assets, verifies
+them against the published `SHA256SUMS`, installs them in clean Debian and Rocky
+Linux containers on `ubuntu-latest`, and runs `/usr/bin/oauth-mux version`.
+
+For local reproduction on a healthy Docker-compatible host:
+
+```bash
+just system-package-qa 0.1.3
+```
+
+This is stricter than the registry `system` dry-run lane. The dry-run lane
+checks package metadata and release staging; this install QA proves that the
+published packages can be installed and execute from the system path.
+
 ## GloriousFlywheel Release Proof
 
 `.github/workflows/release-proof.yml` is a manual cache-first proof surface for
@@ -184,6 +206,8 @@ Current release evidence:
 
 - `just check` passes.
 - `just release-proof <version>` produces and smoke-checks the release tree.
+- Hosted `System Package Install QA` passes after release assets exist when the
+  release changes deb/rpm packaging.
 - Hosted PR CI passes.
 - GF lane either passes or is explicitly deferred because of runner/token state.
 - Release notes mention any skipped GF proof.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -201,6 +201,9 @@ Current release evidence:
 - Main CI run `25032478278` completed `test`, `nix`, all six cross-compiles,
   and real GloriousFlywheel cache-first validation after the evidence docs
   merged.
+- System Package Install QA run `25137031548` completed for v0.1.3 and proved
+  published `.deb` and `.rpm` assets install in hosted Debian/Rocky containers
+  and execute `/usr/bin/oauth-mux version`.
 
 ## Before Marking A PR Ready
 

--- a/justfile
+++ b/justfile
@@ -105,6 +105,9 @@ release-handoff VERSION="0.1.0":
 registry-dry-run VERSION="0.1.0":
     nix develop --command ./scripts/registry-dry-run.sh {{VERSION}}
 
+system-package-qa VERSION="0.1.3":
+    ./scripts/system-package-install-qa.sh {{VERSION}}
+
 npm-deprecate-plan VERSION="0.1.1":
     OMUX_NPM_DEPRECATE_PLAN_ONLY=1 nix develop --command ./scripts/npm-ci-deprecate.sh {{VERSION}}
 

--- a/scripts/system-package-install-qa.sh
+++ b/scripts/system-package-install-qa.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: system-package-install-qa.sh <version>
+
+Downloads published oauth-mux deb/rpm release assets, verifies them against the
+published SHA256SUMS file, installs them in clean Linux containers, and runs the
+installed /usr/bin/oauth-mux binary.
+
+Environment:
+  OMUX_RELEASE_REPO     GitHub release repo (default: Jesssullivan/oauth-mux)
+  OMUX_DEB_QA_IMAGE     Debian image (default: debian:bookworm-slim)
+  OMUX_RPM_QA_IMAGE     RPM image (default: rockylinux:9)
+  DOCKER                Docker-compatible runtime (default: docker)
+EOF
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+version="${1:-}"
+if [ -z "$version" ]; then
+  usage
+  exit 2
+fi
+
+repo="${OMUX_RELEASE_REPO:-Jesssullivan/oauth-mux}"
+docker_bin="${DOCKER:-docker}"
+deb_image="${OMUX_DEB_QA_IMAGE:-debian:bookworm-slim}"
+rpm_image="${OMUX_RPM_QA_IMAGE:-rockylinux:9}"
+base_url="https://github.com/${repo}/releases/download/v${version}"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'missing required command: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    printf 'missing required command: sha256sum or shasum\n' >&2
+    exit 1
+  fi
+}
+
+download() {
+  local name="$1"
+  curl -fsSL -o "$workdir/$name" "$base_url/$name"
+}
+
+verify_release_checksum() {
+  local name="$1"
+  local expected actual
+  expected="$(awk -v name="$name" '$2 == name {print $1}' "$workdir/SHA256SUMS")"
+  if [ -z "$expected" ]; then
+    printf 'missing checksum entry for %s in SHA256SUMS\n' "$name" >&2
+    exit 1
+  fi
+  actual="$(sha256_file "$workdir/$name")"
+  if [ "$actual" != "$expected" ]; then
+    printf 'checksum mismatch for %s\nexpected: %s\nactual:   %s\n' "$name" "$expected" "$actual" >&2
+    exit 1
+  fi
+  printf '%s: OK\n' "$name"
+}
+
+require_command curl
+require_command awk
+require_command "$docker_bin"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+deb_name="oauth-mux_${version}_amd64.deb"
+rpm_name="oauth-mux-${version}-1.x86_64.rpm"
+
+printf 'downloading oauth-mux %s package assets from %s\n' "$version" "$base_url"
+download SHA256SUMS
+download "$deb_name"
+download "$rpm_name"
+
+verify_release_checksum "$deb_name"
+verify_release_checksum "$rpm_name"
+
+printf 'installing %s in %s\n' "$deb_name" "$deb_image"
+"$docker_bin" run --rm \
+  -v "$workdir:/qa:ro" \
+  "$deb_image" \
+  sh -lc "set -e; dpkg -i /qa/$deb_name >/dev/null; dpkg-query -W oauth-mux; /usr/bin/oauth-mux version | grep 'oauth-mux $version'"
+
+printf 'installing %s in %s\n' "$rpm_name" "$rpm_image"
+"$docker_bin" run --rm \
+  -v "$workdir:/qa:ro" \
+  "$rpm_image" \
+  sh -lc "set -e; rpm -i /qa/$rpm_name; rpm -q oauth-mux; rpm -ql oauth-mux | grep '^/usr/bin/oauth-mux$'; /usr/bin/oauth-mux version | grep 'oauth-mux $version'"
+
+printf 'system package install QA passed for oauth-mux %s\n' "$version"


### PR DESCRIPTION
## Summary
- add a hosted System Package Install QA workflow for published deb/rpm assets
- add `scripts/system-package-install-qa.sh` and `just system-package-qa`
- update release/install docs to distinguish metadata checks from real package install proof

## Why
The v0.1.3 release had metadata and archive proof for `.deb` and `.rpm`, but no successful Linux install execution because local Docker/Podman were unhealthy. This adds a repeatable hosted proof that downloads the public release assets, verifies them against `SHA256SUMS`, installs them in Debian/Rocky containers, and runs `/usr/bin/oauth-mux version`.

## Validation
- `bash -n scripts/system-package-install-qa.sh`
- `./scripts/system-package-install-qa.sh --help`
- `just --list`
- `git diff --check`
- `just check`

Local full package QA remains blocked by the local container substrate. The new PR workflow is the intended Linux install proof.

Linear: TIN-812, TIN-737
