### PR TITLE
Record main system package QA proof

### DIFF
--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -15,8 +15,8 @@ files, SOPS plaintext, or token-shaped values here.
 | GitHub release tarball | 0.1.3 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Repo visibility must remain public for unauthenticated downloads. |
 | `curl | sh` installer | 0.1.3 | macOS arm64 and `../lab` | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass | Default installer repo is now canonical; no `REPO=...` override needed. |
 | Homebrew formula | 0.1.3 | macOS arm64 | `tinyland/tools` tap | Pass | Tap install and rollback passed after `tinyland-inc/homebrew-tools#2`; tap repo is still private. |
-| deb package | 0.1.3 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25137031548` installed package and ran `/usr/bin/oauth-mux version`. |
-| rpm package | 0.1.3 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25137031548` installed package and ran `/usr/bin/oauth-mux version`. |
+| deb package | 0.1.3 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25137323710` installed package and ran `/usr/bin/oauth-mux version`. |
+| rpm package | 0.1.3 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25137323710` installed package and ran `/usr/bin/oauth-mux version`. |
 | lab dogfood | 0.1.3 | `../lab` on macOS arm64 | installed `oauth-mux` CLI | Pass | Installed `oauth-mux doctor --json` reports `ok: true` against local config/state. |
 
 ## Evidence Commands
@@ -102,8 +102,8 @@ gh workflow run system-package-install-qa.yml -f version=0.1.3
 Latest hosted proof:
 
 ```text
-System Package Install QA run 25137031548: pass
-job 73677864724: deb/rpm install from published release assets
+System Package Install QA run 25137323710: pass
+job 73678810909: deb/rpm install from published release assets
 ```
 
 Local reproduction on a host with healthy Docker:

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -201,7 +201,7 @@ Current release evidence:
 - Main CI run `25032478278` completed `test`, `nix`, all six cross-compiles,
   and real GloriousFlywheel cache-first validation after the evidence docs
   merged.
-- System Package Install QA run `25137031548` completed for v0.1.3 and proved
+- System Package Install QA run `25137323710` completed for v0.1.3 and proved
   published `.deb` and `.rpm` assets install in hosted Debian/Rocky containers
   and execute `/usr/bin/oauth-mux version`.
 


### PR DESCRIPTION
Summary:
- Update the install beta matrix to reference the final main System Package Install QA proof.
- Update the release runbook to cite the same hosted main proof.

Validation:
- git diff --check
- System Package Install QA main run 25137323710 passed, job 73678810909.

Linear: TIN-812, TIN-737
