### PR TITLE
Add Homebrew install QA

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -9,7 +9,7 @@ they must not become requirements for ordinary users.
 Target install surfaces:
 
 - npm: `npm install -g oauth-mux`
-- Homebrew: `brew install tinyland-inc/tools/oauth-mux`
+- Homebrew: `brew tap tinyland/tools https://github.com/tinyland-inc/homebrew-tools.git && brew install tinyland/tools/oauth-mux`
 - curl installer: `curl -fsSL ... | sh`
 - deb/rpm packages for Linux hosts
 - raw release tarballs for air-gapped or policy-managed systems

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -14,7 +14,7 @@ files, SOPS plaintext, or token-shaped values here.
 | npm one-shot | 0.1.3 | `../lab` on macOS arm64 | public npm registry | Pass | `npx -y oauth-mux@0.1.3 version` returns `oauth-mux 0.1.3`. |
 | GitHub release tarball | 0.1.3 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Repo visibility must remain public for unauthenticated downloads. |
 | `curl | sh` installer | 0.1.3 | macOS arm64 and `../lab` | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass | Default installer repo is now canonical; no `REPO=...` override needed. |
-| Homebrew formula | 0.1.3 | macOS arm64 | `tinyland/tools` tap | Pass | Tap install and rollback passed after `tinyland-inc/homebrew-tools#2`; tap repo is still private. |
+| Homebrew formula | 0.1.3 | macOS arm64 | `tinyland/tools` tap | Pass | `just homebrew-qa 0.1.3` installs from the private `tinyland-inc/homebrew-tools` tap, runs `brew audit`, `brew test`, `oauth-mux version`, and `oauth-mux doctor --json`. |
 | deb package | 0.1.3 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25137323710` installed package and ran `/usr/bin/oauth-mux version`. |
 | rpm package | 0.1.3 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25137323710` installed package and ran `/usr/bin/oauth-mux version`. |
 | lab dogfood | 0.1.3 | `../lab` on macOS arm64 | installed `oauth-mux` CLI | Pass | Installed `oauth-mux doctor --json` reports `ok: true` against local config/state. |
@@ -79,18 +79,44 @@ oauth-mux 0.1.3
 Homebrew tap install:
 
 ```bash
-HOMEBREW_NO_AUTO_UPDATE=1 \
-  brew tap tinyland/tools https://github.com/tinyland-inc/homebrew-tools.git
-brew install tinyland/tools/oauth-mux
-oauth-mux version
-brew uninstall oauth-mux
-brew untap tinyland/tools
+just homebrew-qa 0.1.3
 ```
 
 Expected output includes:
 
 ```text
-oauth-mux 0.1.3
+Homebrew install QA passed for oauth-mux 0.1.3 via tinyland/tools/oauth-mux
+```
+
+To keep the formula installed after dogfood QA:
+
+```bash
+OMUX_HOMEBREW_KEEP_INSTALLED=1 OMUX_HOMEBREW_KEEP_TAP=1 just homebrew-qa 0.1.3
+```
+
+To include the three-account Codex canary from the installed Homebrew binary:
+
+```bash
+OMUX_CONFIG=$PWD/examples/codex-max.config.json \
+OMUX_STATE_DIR=/tmp/oauth-mux-brew-codex-live \
+OMUX_HOMEBREW_KEEP_INSTALLED=1 \
+OMUX_HOMEBREW_KEEP_TAP=1 \
+OMUX_HOMEBREW_CODEX_CANARY=1 \
+OMUX_HOMEBREW_CODEX_LIVE=1 \
+OMUX_LIVE_QA_CONFIRM=spend-real-calls \
+  just homebrew-qa 0.1.3
+```
+
+Latest local Homebrew dogfood proof:
+
+```text
+brew tap tinyland/tools https://github.com/tinyland-inc/homebrew-tools.git: pass
+brew install tinyland/tools/oauth-mux: pass
+brew audit --formula --strict tinyland/tools/oauth-mux: pass
+brew test tinyland/tools/oauth-mux: pass
+/opt/homebrew/bin/oauth-mux doctor --json: ok
+Homebrew-installed oauth-mux codex canary --live with examples/codex-max.config.json:
+  max-1, max-2, max-3 available for codex-mini and codex-max
 ```
 
 System package install QA after GitHub Release publication:

--- a/docs/registry-dry-runs-and-rollback.md
+++ b/docs/registry-dry-runs-and-rollback.md
@@ -66,7 +66,7 @@ Required secret and variable surfaces:
 - `OMUX_HOMEBREW_TAP_REPOSITORY` plus optional `OMUX_HOMEBREW_TAP_REF` when
   the workflow should check out the tap before the Homebrew lane.
 - `OMUX_HOMEBREW_TAP_NAME` when Homebrew requires auditing by tap/formula name
-  instead of by formula path, for example `tinyland-inc/tools`.
+  instead of by formula path, for example `tinyland/tools`.
 - `OMUX_BREW_BIN` when the Homebrew executable is not available as `brew`.
   The GitHub workflow installs Homebrew on Ubuntu and sets this automatically.
 - `OMUX_HOMEBREW_AUDIT_ONLINE=1` only after the homepage and release URLs are

--- a/docs/spec/production-publication-sprint-2026-04-28.md
+++ b/docs/spec/production-publication-sprint-2026-04-28.md
@@ -171,7 +171,7 @@ Evidence:
   including Homebrew formula syntax, npm tarball packing, deb/rpm generation,
   curl installer smoke, and handoff regeneration;
 - local Homebrew tap dry-run passed after updating the lane for Homebrew 5.1's
-  tap/name audit path with `OMUX_HOMEBREW_TAP_NAME=tinyland-inc/tools`.
+  tap/name audit path with `OMUX_HOMEBREW_TAP_NAME=tinyland/tools`.
 - full hosted registry dry-run `25031405495` completed successfully on PR #6
   with `plan,github,npm,homebrew,system`; artifact evidence records GitHub auth
   OK, no existing `v0.1.0` release, all seven npm tarballs dry-run OK,

--- a/justfile
+++ b/justfile
@@ -108,6 +108,9 @@ registry-dry-run VERSION="0.1.0":
 system-package-qa VERSION="0.1.3":
     ./scripts/system-package-install-qa.sh {{VERSION}}
 
+homebrew-qa VERSION="0.1.3":
+    ./scripts/homebrew-install-qa.sh {{VERSION}}
+
 npm-deprecate-plan VERSION="0.1.1":
     OMUX_NPM_DEPRECATE_PLAN_ONLY=1 nix develop --command ./scripts/npm-ci-deprecate.sh {{VERSION}}
 

--- a/scripts/homebrew-install-qa.sh
+++ b/scripts/homebrew-install-qa.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:-}"
+if [ -z "$version" ] || [ "$version" = "--help" ] || [ "$version" = "-h" ]; then
+  cat <<'EOF'
+Usage: scripts/homebrew-install-qa.sh <version>
+
+Installs oauth-mux from the configured Homebrew tap, runs brew audit/test, and
+verifies the installed binary version.
+
+Environment:
+  OMUX_HOMEBREW_TAP_NAME       Homebrew tap name. Default: tinyland/tools
+  OMUX_HOMEBREW_TAP_GIT_URL    Tap git URL. Default: https://github.com/tinyland-inc/homebrew-tools.git
+  OMUX_BREW_BIN                brew executable. Default: brew
+  OMUX_HOMEBREW_KEEP_INSTALLED Keep oauth-mux installed after QA. Default: preserve prior state
+  OMUX_HOMEBREW_KEEP_TAP       Keep tap after QA. Default: preserve prior state
+  OMUX_HOMEBREW_CODEX_CANARY   Run oauth-mux codex canary from installed binary. Default: 0
+  OMUX_HOMEBREW_CODEX_LIVE     Add --live to the Codex canary. Requires OMUX_LIVE_QA_CONFIRM=spend-real-calls.
+EOF
+  exit 0
+fi
+
+brew_cmd="${OMUX_BREW_BIN:-brew}"
+tap_name="${OMUX_HOMEBREW_TAP_NAME:-tinyland/tools}"
+tap_url="${OMUX_HOMEBREW_TAP_GIT_URL:-https://github.com/tinyland-inc/homebrew-tools.git}"
+formula="${tap_name}/oauth-mux"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'required command not found: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+require_command "$brew_cmd"
+
+was_tapped=0
+if "$brew_cmd" tap | grep -Fxq "$tap_name"; then
+  was_tapped=1
+fi
+
+was_installed=0
+if "$brew_cmd" list --versions oauth-mux >/dev/null 2>&1; then
+  was_installed=1
+fi
+
+keep_installed="${OMUX_HOMEBREW_KEEP_INSTALLED:-$was_installed}"
+keep_tap="${OMUX_HOMEBREW_KEEP_TAP:-$was_tapped}"
+
+cleanup() {
+  if [ "$keep_installed" != "1" ] && [ "$was_installed" != "1" ]; then
+    "$brew_cmd" uninstall oauth-mux >/dev/null 2>&1 || true
+  fi
+  if [ "$keep_tap" != "1" ] && [ "$was_tapped" != "1" ]; then
+    "$brew_cmd" untap "$tap_name" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+export HOMEBREW_NO_AUTO_UPDATE="${HOMEBREW_NO_AUTO_UPDATE:-1}"
+
+if [ "$was_tapped" != "1" ]; then
+  "$brew_cmd" tap "$tap_name" "$tap_url"
+fi
+
+"$brew_cmd" audit --formula --strict "$formula"
+
+if [ "$was_installed" = "1" ]; then
+  "$brew_cmd" reinstall "$formula"
+else
+  "$brew_cmd" install "$formula"
+fi
+
+"$brew_cmd" test "$formula"
+
+prefix="$("$brew_cmd" --prefix oauth-mux)"
+bin="$prefix/bin/oauth-mux"
+if [ ! -x "$bin" ]; then
+  printf 'installed binary not executable: %s\n' "$bin" >&2
+  exit 1
+fi
+
+actual="$("$bin" version)"
+expected="oauth-mux $version"
+if [ "$actual" != "$expected" ]; then
+  printf 'unexpected oauth-mux version: got %s, expected %s\n' "$actual" "$expected" >&2
+  exit 1
+fi
+
+"$bin" doctor --json >/dev/null
+
+if [ "${OMUX_HOMEBREW_CODEX_CANARY:-0}" = "1" ]; then
+  canary_args=(codex canary)
+  if [ "${OMUX_HOMEBREW_CODEX_LIVE:-0}" = "1" ]; then
+    if [ "${OMUX_LIVE_QA_CONFIRM:-}" != "spend-real-calls" ]; then
+      printf 'live Codex canary requires OMUX_LIVE_QA_CONFIRM=spend-real-calls\n' >&2
+      exit 2
+    fi
+    canary_args+=(--live)
+  fi
+  "$bin" "${canary_args[@]}"
+fi
+
+printf 'Homebrew install QA passed for oauth-mux %s via %s\n' "$version" "$formula"


### PR DESCRIPTION
Summary:
- add a repeatable Homebrew install QA script and `just homebrew-qa`
- verify the installed formula with `brew audit`, `brew test`, `oauth-mux version`, and `oauth-mux doctor --json`
- document the actual `tinyland/tools` tap alias and the Homebrew dogfood evidence

Validation:
- bash -n scripts/homebrew-install-qa.sh
- ./scripts/homebrew-install-qa.sh --help
- just homebrew-qa 0.1.3
- OMUX_CONFIG=$PWD/examples/codex-max.config.json OMUX_STATE_DIR=/tmp/oauth-mux-brew-codex-canary OMUX_HOMEBREW_CODEX_CANARY=1 just homebrew-qa 0.1.3
- OMUX_CONFIG=$PWD/examples/codex-max.config.json OMUX_STATE_DIR=/tmp/oauth-mux-brew-codex-live oauth-mux codex canary --live
- just check

Dogfood notes:
- `brew tap tinyland/tools https://github.com/tinyland-inc/homebrew-tools.git` succeeded against the private tap.
- `brew install tinyland/tools/oauth-mux` installed v0.1.3 to `/opt/homebrew/bin/oauth-mux`.
- The installed Homebrew binary ran the three-account Codex live canary successfully for `codex-mini` and `codex-max` across max-1, max-2, and max-3.

Linear: TIN-737, TIN-812
