### PR TITLE
Add clean first-run e2e proof

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -31,6 +31,12 @@ oauth-mux config validate
 oauth-mux discover --json
 ```
 
+Source checkouts prove this path without touching real operator state:
+
+```bash
+just first-run-e2e
+```
+
 For Codex subscription users working from a source checkout today:
 
 ```bash

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -1,6 +1,6 @@
 # Install Beta Matrix
 
-Updated: 2026-04-29
+Updated: 2026-04-30
 
 This matrix tracks clean-install proof for the public adoption surfaces. It is
 operator evidence, not a credential runbook: do not paste OAuth stores, `.env`
@@ -18,6 +18,7 @@ files, SOPS plaintext, or token-shaped values here.
 | deb package | 0.1.3 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25137323710` installed package and ran `/usr/bin/oauth-mux version`. |
 | rpm package | 0.1.3 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25137323710` installed package and ran `/usr/bin/oauth-mux version`. |
 | lab dogfood | 0.1.3 | `../lab` on macOS arm64 | installed `oauth-mux` CLI | Pass | Installed `oauth-mux doctor --json` reports `ok: true` against local config/state. |
+| first-run source e2e | main | macOS arm64 | source checkout | Pass | `just first-run-e2e` runs with temporary HOME/XDG roots and proves no-config `init --codex-max`, JSON diagnostics, redacted report, and non-mutating Codex help. |
 
 ## Evidence Commands
 
@@ -86,6 +87,18 @@ Expected output includes:
 
 ```text
 Homebrew install QA passed for oauth-mux 0.1.3 via tinyland/tools/oauth-mux
+```
+
+First-run source e2e:
+
+```bash
+just first-run-e2e
+```
+
+Expected output includes:
+
+```text
+first-run e2e passed
 ```
 
 To keep the formula installed after dogfood QA:

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -111,6 +111,17 @@ thin aliases for installed commands. `just codex-max-setup` is a thin alias for
 `oauth-mux setup codex`, and `just codex-max-probe-all` is likewise a thin alias
 for `oauth-mux codex probe-all`.
 
+The clean no-config first-run path is covered by:
+
+```bash
+just first-run-e2e
+```
+
+That harness runs with a temporary `HOME`, XDG config/state/data/runtime roots,
+and no inherited `OMUX_*` overrides. It proves `init --codex-max`, JSON
+diagnostics, redacted support output, and non-mutating Codex help without
+touching the operator's real OAuth stores.
+
 ## Agent Discovery Contract
 
 Agents should start with:

--- a/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
+++ b/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
@@ -102,6 +102,17 @@ Acceptance:
 - diagnostics point to the next safe command;
 - generated config validates from a clean state.
 
+Automated source-checkout proof:
+
+```bash
+just first-run-e2e
+```
+
+This lane runs the required path with a temporary `HOME`, XDG config/state/data
+roots, and no inherited `OMUX_*` overrides. It also verifies the Codex Max
+starter config uses the same resolved store root as Codex setup, so users with
+`XDG_DATA_HOME` or `OMUX_CODEX_STORE_ROOT` do not get split-brain account paths.
+
 ### Story B: Codex Subscription User With Three Accounts
 
 Goal: prove the flagship multi-account subscription use case.

--- a/justfile
+++ b/justfile
@@ -154,7 +154,7 @@ check:
     nix develop --command just check-local
 
 check-local:
-    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh'
+    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh'
     @echo "all checks passed"
 
 e2e:
@@ -163,6 +163,13 @@ e2e:
 e2e-local:
     zig build
     ./scripts/e2e-local.sh
+
+first-run-e2e:
+    nix develop --command just first-run-e2e-local
+
+first-run-e2e-local:
+    zig build
+    ./scripts/first-run-e2e.sh
 
 live-qa:
     nix develop --command ./scripts/live-provider-qa.sh

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+bin="${OMUX_BIN:-$repo_root/zig-out/bin/oauth-mux}"
+
+if [ ! -x "$bin" ]; then
+  printf 'missing oauth-mux binary: %s\n' "$bin" >&2
+  printf 'run `zig build` or `just first-run-e2e` first\n' >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'missing jq; run through `nix develop --command just first-run-e2e-local`\n' >&2
+  exit 1
+fi
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/oauth-mux-first-run.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+
+home="$tmp/home"
+xdg_config="$tmp/xdg-config"
+xdg_state="$tmp/xdg-state"
+xdg_data="$tmp/xdg-data"
+xdg_runtime="$tmp/xdg-runtime"
+operator_home="${HOME:-}"
+
+mkdir -p "$home" "$xdg_config" "$xdg_state" "$xdg_data" "$xdg_runtime"
+chmod 0700 "$xdg_runtime"
+
+config_path="$xdg_config/oauth-mux/config.json"
+store_root="$xdg_data/oauth-mux/codex"
+legacy_store_root="$home/.local/share/oauth-mux/codex"
+
+omux() (
+  unset OMUX_CONFIG
+  unset OMUX_CONFIG_DIR
+  unset OMUX_STATE_DIR
+  unset OMUX_CODEX_STORE_ROOT
+  export HOME="$home"
+  export XDG_CONFIG_HOME="$xdg_config"
+  export XDG_STATE_HOME="$xdg_state"
+  export XDG_DATA_HOME="$xdg_data"
+  export XDG_RUNTIME_DIR="$xdg_runtime"
+  "$bin" "$@"
+)
+
+expect_contains() {
+  haystack="$1"
+  needle="$2"
+  label="$3"
+
+  case "$haystack" in
+    *"$needle"*) ;;
+    *)
+      printf 'first-run e2e assertion failed: %s\n' "$label" >&2
+      printf 'expected to find: %s\n' "$needle" >&2
+      printf 'output was:\n%s\n' "$haystack" >&2
+      exit 1
+      ;;
+  esac
+}
+
+expect_not_contains() {
+  haystack="$1"
+  needle="$2"
+  label="$3"
+
+  if [ -z "$needle" ]; then
+    return
+  fi
+
+  case "$haystack" in
+    *"$needle"*)
+      printf 'first-run e2e assertion failed: %s\n' "$label" >&2
+      printf 'did not expect to find: %s\n' "$needle" >&2
+      printf 'output was:\n%s\n' "$haystack" >&2
+      exit 1
+      ;;
+  esac
+}
+
+run_json() {
+  output_file="$1"
+  shift
+
+  omux "$@" >"$output_file"
+  jq -e type "$output_file" >/dev/null
+}
+
+printf 'first-run e2e: version from isolated environment\n'
+version_out="$(omux version)"
+expect_contains "$version_out" "oauth-mux " "version prints binary version"
+
+printf 'first-run e2e: doctor before config is parseable and actionable\n'
+doctor_before="$tmp/doctor-before.json"
+run_json "$doctor_before" doctor --json
+jq -e '
+  .configured == false
+  and .ok == false
+  and (.next_commands | index("oauth-mux init --codex-max") != null)
+' "$doctor_before" >/dev/null
+
+printf 'first-run e2e: init --codex-max writes only temp-home config\n'
+init_out="$(omux init --codex-max)"
+expect_contains "$init_out" "$config_path" "init reports temp config path"
+test -f "$config_path"
+
+config_json="$(cat "$config_path")"
+expect_contains "$config_json" "$store_root/max-1" "starter config uses XDG data store root"
+expect_contains "$config_json" "$store_root/max-1/auth.json" "starter config uses XDG auth path"
+expect_not_contains "$config_json" "$legacy_store_root" "starter config does not fall back to legacy temp-home store when XDG data is set"
+expect_not_contains "$config_json" "$operator_home" "starter config does not reference operator home"
+
+printf 'first-run e2e: generated config validates\n'
+validate_out="$(omux config validate)"
+expect_contains "$validate_out" "config: valid" "config validate succeeds"
+
+printf 'first-run e2e: doctor after config reports ready shape\n'
+doctor_after="$tmp/doctor-after.json"
+run_json "$doctor_after" doctor --json
+jq -e '
+  .configured == true
+  and .config_valid == true
+  and .codex_configured == true
+  and .providers == 1
+  and .accounts == 3
+  and (.next_commands | index("oauth-mux setup codex") != null)
+' "$doctor_after" >/dev/null
+
+printf 'first-run e2e: discovery is redacted and agent-usable\n'
+discover_json="$tmp/discover.json"
+run_json "$discover_json" discover --json
+jq -e '
+  .configured == true
+  and (.providers[] | select(.name == "codex") | .accounts | length) == 3
+  and (.agent_safe_commands | index("oauth-mux report --redacted --json") != null)
+' "$discover_json" >/dev/null
+
+printf 'first-run e2e: support report is redacted JSON\n'
+report_json="$tmp/report.json"
+run_json "$report_json" report --redacted --json
+jq -e '
+  .redacted == true
+  and .config.configured == true
+  and .config.valid == true
+  and (.providers[] | select(.name == "codex") | .accounts | length) == 3
+' "$report_json" >/dev/null
+expect_not_contains "$(cat "$report_json")" "auth.json" "redacted report omits credential file paths"
+expect_not_contains "$(cat "$report_json")" "$operator_home" "redacted report does not reference operator home"
+
+printf 'first-run e2e: Codex help remains non-mutating\n'
+help_out="$(omux codex canary --help)"
+expect_contains "$help_out" "non-mutating" "Codex help declares non-mutating behavior"
+test ! -e "$store_root"
+test ! -e "$legacy_store_root"
+
+printf 'first-run e2e passed\n'

--- a/src/main.zig
+++ b/src/main.zig
@@ -1969,7 +1969,22 @@ fn runInit(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Init
         \\  }
         \\}
     ;
-    const codex_max_starter_config =
+    const file = try std.fs.createFileAbsolute(path, .{});
+    defer file.close();
+
+    if (args.codex_max) {
+        const store_root = try codexStoreRoot(allocator, .{});
+        defer allocator.free(store_root);
+        try writeCodexMaxStarterConfig(allocator, file.writer(), store_root);
+    } else {
+        try file.writeAll(generic_starter_config);
+    }
+
+    try writer.print("created {s}\n", .{path});
+}
+
+fn writeCodexMaxStarterConfig(allocator: std.mem.Allocator, writer: anytype, store_root: []const u8) !void {
+    try writer.writeAll(
         \\{
         \\  "version": 1,
         \\  "defaults": {
@@ -1982,33 +1997,14 @@ fn runInit(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Init
         \\      "kind": "codex",
         \\      "config_dir_env": "CODEX_HOME",
         \\      "accounts": {
-        \\        "max-1": {
-        \\          "priority": 30,
-        \\          "config_dir": "~/.local/share/oauth-mux/codex/max-1",
-        \\          "secret": {
-        \\            "backend": "file",
-        \\            "path": "~/.local/share/oauth-mux/codex/max-1/auth.json"
-        \\          },
-        \\          "tags": ["subscription", "codex-max"]
-        \\        },
-        \\        "max-2": {
-        \\          "priority": 20,
-        \\          "config_dir": "~/.local/share/oauth-mux/codex/max-2",
-        \\          "secret": {
-        \\            "backend": "file",
-        \\            "path": "~/.local/share/oauth-mux/codex/max-2/auth.json"
-        \\          },
-        \\          "tags": ["subscription", "codex-max"]
-        \\        },
-        \\        "max-3": {
-        \\          "priority": 10,
-        \\          "config_dir": "~/.local/share/oauth-mux/codex/max-3",
-        \\          "secret": {
-        \\            "backend": "file",
-        \\            "path": "~/.local/share/oauth-mux/codex/max-3/auth.json"
-        \\          },
-        \\          "tags": ["subscription", "codex-max"]
-        \\        }
+        \\
+    );
+
+    try writeCodexMaxStarterAccount(allocator, writer, store_root, "max-1", 30, true);
+    try writeCodexMaxStarterAccount(allocator, writer, store_root, "max-2", 20, false);
+    try writeCodexMaxStarterAccount(allocator, writer, store_root, "max-3", 10, false);
+
+    try writer.writeAll(
         \\      }
         \\    }
         \\  },
@@ -2041,17 +2037,41 @@ fn runInit(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Init
         \\    }
         \\  }
         \\}
-    ;
-    const starter_config = if (args.codex_max)
-        codex_max_starter_config
-    else
-        generic_starter_config;
+    );
+}
 
-    const file = try std.fs.createFileAbsolute(path, .{});
-    defer file.close();
-    try file.writeAll(starter_config);
+fn writeCodexMaxStarterAccount(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    store_root: []const u8,
+    account: []const u8,
+    priority: i32,
+    first: bool,
+) !void {
+    const account_dir = try std.fs.path.join(allocator, &.{ store_root, account });
+    defer allocator.free(account_dir);
+    const auth_path = try std.fs.path.join(allocator, &.{ account_dir, "auth.json" });
+    defer allocator.free(auth_path);
 
-    try writer.print("created {s}\n", .{path});
+    if (!first) try writer.writeAll(",\n");
+    try writer.print("        \"{s}\": {{\n", .{account});
+    try writer.print("          \"priority\": {d},\n", .{priority});
+    try writer.writeAll("          \"config_dir\": ");
+    try std.json.stringify(account_dir, .{}, writer);
+    try writer.writeAll(",\n");
+    try writer.writeAll(
+        \\          "secret": {
+        \\            "backend": "file",
+        \\            "path":
+    );
+    try writer.writeByte(' ');
+    try std.json.stringify(auth_path, .{}, writer);
+    try writer.writeAll(
+        \\
+        \\          },
+        \\          "tags": ["subscription", "codex-max"]
+        \\        }
+    );
 }
 
 fn runCodex(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs) !void {
@@ -2324,6 +2344,21 @@ test "matchesProvider filters account keys" {
     try std.testing.expect(matchesProvider("codex", "codex"));
     try std.testing.expect(!matchesProvider("codexish:max-1", "codex"));
     try std.testing.expect(!matchesProvider("claude:work", "codex"));
+}
+
+test "Codex Max starter config uses resolved store root" {
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+
+    try writeCodexMaxStarterConfig(std.testing.allocator, buf.writer(), "/tmp/omux-codex");
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"config_dir\": \"/tmp/omux-codex/max-1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"path\": \"/tmp/omux-codex/max-1/auth.json\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "~/.local/share/oauth-mux/codex") == null);
+
+    const parsed = try config.loadFromBytes(std.testing.allocator, buf.items);
+    defer parsed.deinit();
+    try config.validate(parsed.value, std.io.null_writer);
 }
 
 test "writeHealthJson includes redacted liveness" {


### PR DESCRIPTION
## Summary
- add a temp-home first-run e2e harness for the no-config onboarding story
- wire the harness into `just check` and docs
- generate Codex Max starter config paths from the resolved store root to avoid XDG/OMUX split-brain paths

## Validation
- `zig build test`
- `./scripts/first-run-e2e.sh`
- `git diff --check`
- `just check`

Refs TIN-815.