### PR TITLE
Implement runtime readiness contract

### DIFF
--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -16,6 +16,7 @@ daemon. See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
 
 ## Allowed Now
 
+- `oauth-mux daemon run` as the foreground primitive for any future wrapper.
 - `oauth-mux daemon status` for local inspection.
 - Local experimentation with refresh behavior.
 - Future manual QA where daemon activity is bounded and visible.
@@ -27,6 +28,8 @@ daemon. See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
 - Silent token refresh for providers whose refresh semantics are owned by an
   upstream CLI.
 - Any release gate that depends on a long-running daemon.
+- Treating `systemctl`, `launchctl`, Homebrew services, cron, or Windows
+  Services as part of the core product contract.
 
 ## Promotion Criteria
 

--- a/justfile
+++ b/justfile
@@ -187,6 +187,9 @@ config-validate: build
 
 # ── Daemon ──
 
+daemon-run: build
+    ./zig-out/bin/oauth-mux daemon run
+
 daemon-start: build
     ./zig-out/bin/oauth-mux daemon start
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -18,6 +18,7 @@ pub const Command = union(enum) {
     init: InitArgs,
     codex: CodexArgs,
     completions: CompletionsArgs,
+    daemon_run,
     daemon_start,
     daemon_stop,
     daemon_status,
@@ -137,6 +138,7 @@ pub fn parse(args: []const []const u8) Command {
     if (eql(cmd, "version") or eql(cmd, "--version") or eql(cmd, "-v")) return .version_cmd;
     if (eql(cmd, "daemon")) {
         if (rest.len > 0) {
+            if (eql(rest[0], "run")) return .daemon_run;
             if (eql(rest[0], "start")) return .daemon_start;
             if (eql(rest[0], "stop")) return .daemon_stop;
             if (eql(rest[0], "status")) return .daemon_status;
@@ -435,6 +437,7 @@ pub fn printUsage(writer: anytype) !void {
         \\  config validate    Validate the configuration file.
         \\  config path        Print the config file path.
         \\
+        \\  daemon run         Run the daemon in the foreground.
         \\  daemon start       Start background token refresh daemon.
         \\  daemon stop        Stop the daemon.
         \\  daemon status      Show daemon status.
@@ -695,6 +698,11 @@ test "parse discover json" {
     }
 }
 
+test "parse daemon run" {
+    const args = [_][]const u8{ "daemon", "run" };
+    try std.testing.expect(parse(&args) == .daemon_run);
+}
+
 pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
     if (eql(shell_name, "fish")) {
         try writer.writeAll(
@@ -712,6 +720,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n __fish_use_subcommand -a init -d 'Generate config'
             \\complete -c oauth-mux -n __fish_use_subcommand -a setup -d 'First-run setup'
             \\complete -c oauth-mux -n __fish_use_subcommand -a codex -d 'Codex account onboarding'
+            \\complete -c oauth-mux -n __fish_use_subcommand -a daemon -d 'Daemon operations'
             \\complete -c oauth-mux -n __fish_use_subcommand -a version -d 'Print version'
             \\complete -c oauth-mux -n __fish_use_subcommand -a completions -d 'Generate completions'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe' -l profile -s p -d 'Profile name' -r
@@ -731,6 +740,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary probe-all bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run start stop status' -d 'Daemon subcommand'
             \\
         );
     } else if (eql(shell_name, "zsh")) {
@@ -752,6 +762,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\    'init:Generate config'
             \\    'setup:First-run setup'
             \\    'codex:Codex account onboarding'
+            \\    'daemon:Daemon operations'
             \\    'version:Print version'
             \\    'completions:Generate completions'
             \\  )
@@ -764,7 +775,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
         try writer.writeAll(
             \\_oauth_mux_completions() {
             \\  local cur="${COMP_WORDS[COMP_CWORD]}"
-            \\  COMPREPLY=($(compgen -W "exec env probe doctor report providers status health discover config init setup codex version completions" -- "$cur"))
+            \\  COMPREPLY=($(compgen -W "exec env probe doctor report providers status health discover config init setup codex daemon version completions" -- "$cur"))
             \\}
             \\complete -F _oauth_mux_completions oauth-mux
             \\

--- a/src/config.zig
+++ b/src/config.zig
@@ -280,6 +280,8 @@ fn validateProviderDefinition(def_key: []const u8, def: provider_schema.Provider
         }
     }
 
+    try validateRuntimeConfig(def_key, def.runtime, writer, ok);
+
     var has_capability_probe = false;
     for (def.capabilities, 0..) |capability, idx| {
         if (capability.name.len == 0) {
@@ -297,6 +299,12 @@ fn validateProviderDefinition(def_key: []const u8, def: provider_schema.Provider
                 try writer.print("config error: provider_definitions.{s}.capabilities[{d}].probe success status range is invalid\n", .{ def_key, idx });
                 ok.* = false;
             }
+            if (probe.budget) |budget| {
+                if (!budget.allowedForProbe()) {
+                    try writer.print("config error: provider_definitions.{s}.capabilities[{d}].probe.budget '{s}' is not valid for probes\n", .{ def_key, idx, @tagName(budget) });
+                    ok.* = false;
+                }
+            }
         }
     }
 
@@ -307,6 +315,33 @@ fn validateProviderDefinition(def_key: []const u8, def: provider_schema.Provider
 
     for (def.failure_rules, 0..) |rule, idx| {
         try validateFailureRule(def_key, idx, rule, writer, ok);
+    }
+}
+
+fn validateRuntimeConfig(
+    def_key: []const u8,
+    runtime: provider_schema.RuntimeConfig,
+    writer: anytype,
+    ok: *bool,
+) !void {
+    try validateNonEmptyStringList(def_key, "runtime.required_binaries", runtime.required_binaries, writer, ok);
+    try validateNonEmptyStringList(def_key, "runtime.env_vars", runtime.env_vars, writer, ok);
+    try validateNonEmptyStringList(def_key, "runtime.writable_paths", runtime.writable_paths, writer, ok);
+    try validateNonEmptyStringList(def_key, "runtime.session_paths", runtime.session_paths, writer, ok);
+}
+
+fn validateNonEmptyStringList(
+    def_key: []const u8,
+    field_name: []const u8,
+    values: []const []const u8,
+    writer: anytype,
+    ok: *bool,
+) !void {
+    for (values, 0..) |value, idx| {
+        if (value.len == 0) {
+            try writer.print("config error: provider_definitions.{s}.{s}[{d}] must not be empty\n", .{ def_key, field_name, idx });
+            ok.* = false;
+        }
     }
 }
 
@@ -602,6 +637,14 @@ test "loadFromBytes provider definition override" {
         \\    "toy": {
         \\      "name": "toy",
         \\      "display_name": "Toy CLI",
+        \\      "extension_mode": "command_adapter",
+        \\      "runtime": {
+        \\        "required_binaries": ["toy"],
+        \\        "env_vars": ["TOY_HOME"]
+        \\      },
+        \\      "repair": {
+        \\        "owner": "upstream_cli_login"
+        \\      },
         \\      "credential": {
         \\        "access_token_path": "tokens.access",
         \\        "refresh_token_path": "tokens.refresh"
@@ -616,7 +659,8 @@ test "loadFromBytes provider definition override" {
         \\          "probe": {
         \\            "method": "POST",
         \\            "url": "https://example.invalid/v1/probe",
-        \\            "hint_header": "www-authenticate"
+        \\            "hint_header": "www-authenticate",
+        \\            "budget": "spend_provider"
         \\          }
         \\        }
         \\      ],
@@ -648,11 +692,16 @@ test "loadFromBytes provider definition override" {
 
     const def = resolveProviderDefinition(parsed.value, "toy");
     try std.testing.expectEqualStrings("Toy CLI", def.display_name);
+    try std.testing.expectEqual(types.ProviderExtensionMode.command_adapter, def.extension_mode);
+    try std.testing.expectEqual(types.RepairOwner.upstream_cli_login, def.repair.owner);
+    try std.testing.expectEqualStrings("toy", def.runtime.required_binaries[0]);
+    try std.testing.expectEqualStrings("TOY_HOME", def.runtime.env_vars[0]);
     try std.testing.expectEqualStrings("tokens.access", def.credential.access_token_path);
     try std.testing.expectEqual(@as(usize, 1), def.capabilities.len);
     const plan = provider_schema.probePlanForCapability(def, "codex-max").?;
     try std.testing.expectEqualStrings("chat:max", plan.capability);
     try std.testing.expectEqualStrings("POST", plan.method);
+    try std.testing.expectEqual(types.ActionBudget.spend_provider, plan.budget);
     try std.testing.expectEqual(@as(usize, 1), def.failure_rules.len);
     const classified = provider_schema.classifyHttp(def, 403, null, "missing scope");
     switch (classified) {
@@ -912,6 +961,52 @@ test "validate rejects zero capability probe timeout" {
     defer out.deinit();
     try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
     try std.testing.expect(std.mem.indexOf(u8, out.items, "probe.timeout_ms must be greater than zero") != null);
+}
+
+test "validate rejects interactive probe budget" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "capabilities": [
+        \\        {
+        \\          "name": "chat:max",
+        \\          "probe": {
+        \\            "method": "GET",
+        \\            "url": "https://example.invalid/v1/probe",
+        \\            "budget": "interactive"
+        \\          }
+        \\        }
+        \\      ],
+        \\      "failure_rules": [
+        \\        { "status": 401, "class": { "dead": "token_revoked" } }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "probe.budget 'interactive' is not valid for probes") != null);
 }
 
 test "validate rejects token material in http probe url" {

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -19,6 +19,31 @@ pub const DaemonError = error{
     OutOfMemory,
 };
 
+pub fn run(allocator: std.mem.Allocator) DaemonError!void {
+    if (comptime builtin.os.tag == .windows) {
+        log.err("daemon: foreground socket transport is not implemented on windows", .{});
+        return error.SocketError;
+    }
+
+    const sock_path = paths.socketPath(allocator) catch return error.OutOfMemory;
+    defer allocator.free(sock_path);
+
+    const pid_path = pidPath(allocator) catch return error.OutOfMemory;
+    defer allocator.free(pid_path);
+
+    if (isRunning(allocator)) {
+        log.err("daemon: already running", .{});
+        return error.AlreadyRunning;
+    }
+
+    ensureRuntimeDir(sock_path) catch return error.SocketError;
+
+    writePidFile(pid_path, currentPid()) catch return error.SocketError;
+    defer std.fs.deleteFileAbsolute(pid_path) catch {};
+
+    runLoop(allocator, sock_path) catch return error.SocketError;
+}
+
 pub fn start(allocator: std.mem.Allocator) DaemonError!void {
     if (comptime builtin.os.tag == .windows) {
         log.err("daemon: unsupported on windows", .{});
@@ -37,13 +62,7 @@ pub fn start(allocator: std.mem.Allocator) DaemonError!void {
         return error.AlreadyRunning;
     }
 
-    // Ensure runtime dir exists
-    if (std.fs.path.dirname(sock_path)) |dir| {
-        std.fs.makeDirAbsolute(dir) catch |e| switch (e) {
-            error.PathAlreadyExists => {},
-            else => return error.SocketError,
-        };
-    }
+    ensureRuntimeDir(sock_path) catch return error.SocketError;
 
     // Fork into background
     if (comptime builtin.os.tag == .linux or builtin.os.tag == .macos) {
@@ -67,6 +86,15 @@ pub fn start(allocator: std.mem.Allocator) DaemonError!void {
     // Cleanup
     std.fs.deleteFileAbsolute(sock_path) catch {};
     std.fs.deleteFileAbsolute(pid_path) catch {};
+}
+
+fn ensureRuntimeDir(sock_path: []const u8) !void {
+    if (std.fs.path.dirname(sock_path)) |dir| {
+        std.fs.makeDirAbsolute(dir) catch |e| switch (e) {
+            error.PathAlreadyExists => {},
+            else => return e,
+        };
+    }
 }
 
 pub fn stop(allocator: std.mem.Allocator) !void {
@@ -258,6 +286,14 @@ fn pidPath(allocator: std.mem.Allocator) ![]const u8 {
     const dir = paths.runtimeDir(allocator) catch return error.OutOfMemory;
     defer allocator.free(dir);
     return std.fs.path.join(allocator, &.{ dir, "daemon.pid" });
+}
+
+fn currentPid() Pid {
+    return switch (builtin.os.tag) {
+        .linux => std.os.linux.getpid(),
+        .macos => std.c.getpid(),
+        else => 0,
+    };
 }
 
 fn writePidFile(path: []const u8, pid: Pid) !void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -111,6 +111,12 @@ pub fn main() !void {
             try cli.printCompletions(stdout, comp_args.shell);
         },
 
+        .daemon_run => {
+            daemon.run(allocator) catch |e| {
+                log.err("daemon: {s}", .{@errorName(e)});
+                std.process.exit(types.ExitCode.general_error.int());
+            };
+        },
         .daemon_start => {
             daemon.start(allocator) catch |e| {
                 log.err("daemon: {s}", .{@errorName(e)});
@@ -930,6 +936,7 @@ fn writeProviderListTextRow(writer: anytype, cfg: ?config.Config, def_key: []con
         def.capabilities.len,
         countProviderProbes(def),
     });
+    try writer.print("    mode={s} repair={s}\n", .{ @tagName(def.extension_mode), @tagName(def.repair.owner) });
 }
 
 fn writeProvidersListJson(
@@ -995,6 +1002,10 @@ fn writeProviderListJsonEntry(
     try std.json.stringify(supportStatus(def.name, built_in), .{}, writer);
     try writer.writeAll(",\"proof_status\":");
     try std.json.stringify(proofStatus(def.name), .{}, writer);
+    try writer.writeAll(",\"extension_mode\":");
+    try std.json.stringify(@tagName(def.extension_mode), .{}, writer);
+    try writer.writeAll(",\"repair_owner\":");
+    try std.json.stringify(@tagName(def.repair.owner), .{}, writer);
     try writer.writeAll(",\"built_in\":");
     try writer.writeAll(if (built_in) "true" else "false");
     try writer.writeAll(",\"configured\":");
@@ -1009,6 +1020,10 @@ fn writeProviderListJsonEntry(
     try writeStringArrayJson(writer, def.detection.binary_names);
     try writer.writeAll(",\"env_markers\":");
     try writeStringArrayJson(writer, def.detection.env_markers);
+    try writer.writeAll(",\"runtime\":");
+    try writeProviderRuntimeJson(writer, allocator, def, null);
+    try writer.writeAll(",\"capability_budgets\":");
+    try writeCapabilityBudgetsJson(writer, def);
     try writer.writeAll(",\"command_availability\":[");
     for (def.detection.binary_names, 0..) |binary_name, idx| {
         if (idx > 0) try writer.writeByte(',');
@@ -1020,6 +1035,45 @@ fn writeProviderListJsonEntry(
     }
     try writer.writeByte(']');
     try writer.writeByte('}');
+}
+
+fn writeProviderRuntimeJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    def: provider_schema.ProviderDefinition,
+    capability: ?[]const u8,
+) !void {
+    const readiness = try providerRuntimeReadiness(allocator, def, capability);
+    try writer.writeByte('{');
+    try writer.writeAll("\"readiness\":");
+    try writeRuntimeReadinessJson(writer, readiness);
+    try writer.writeAll(",\"required_binaries\":");
+    try writeStringArrayJson(writer, def.runtime.required_binaries);
+    try writer.writeAll(",\"env_vars\":");
+    try writeStringArrayJson(writer, def.runtime.env_vars);
+    try writer.writeAll(",\"writable_paths\":");
+    try writeStringArrayJson(writer, def.runtime.writable_paths);
+    try writer.writeAll(",\"session_paths\":");
+    try writeStringArrayJson(writer, def.runtime.session_paths);
+    try writer.writeByte('}');
+}
+
+fn writeCapabilityBudgetsJson(writer: anytype, def: provider_schema.ProviderDefinition) !void {
+    try writer.writeByte('[');
+    for (def.capabilities, 0..) |capability, idx| {
+        if (idx > 0) try writer.writeByte(',');
+        try writer.writeByte('{');
+        try writer.writeAll("\"name\":");
+        try std.json.stringify(capability.name, .{}, writer);
+        try writer.writeAll(",\"budget\":");
+        if (capability.probe) |probe_def| {
+            try std.json.stringify(@tagName(probe_def.budget orelse provider_schema.defaultProbeBudget(probe_def.transport)), .{}, writer);
+        } else {
+            try writer.writeAll("null");
+        }
+        try writer.writeByte('}');
+    }
+    try writer.writeByte(']');
 }
 
 fn writeConfiguredProvidersReportJson(writer: anytype, args: cli.Command.ReportArgs, cfg: config.Config) !void {
@@ -1314,6 +1368,80 @@ fn countProviderProbes(def: provider_schema.ProviderDefinition) usize {
     return count;
 }
 
+fn providerRuntimeReadiness(
+    allocator: std.mem.Allocator,
+    def: provider_schema.ProviderDefinition,
+    capability: ?[]const u8,
+) !types.RuntimeReadiness {
+    for (def.runtime.required_binaries) |binary_name| {
+        if (!try commandAvailable(allocator, binary_name)) {
+            return .{ .missing_binary = binary_name };
+        }
+    }
+
+    if (capability) |capability_name| {
+        if (provider_schema.probePlanForCapability(def, capability_name)) |plan| {
+            if (plan.transport == .command) {
+                const argv = plan.command orelse return .{ .session_unavailable = "probe command missing" };
+                if (argv.len == 0) return .{ .session_unavailable = "probe command empty" };
+                if (!try commandAvailable(allocator, argv[0])) {
+                    return .{ .missing_binary = argv[0] };
+                }
+            }
+        }
+    }
+
+    return .ready;
+}
+
+fn runtimeReadinessSummary(readiness: types.RuntimeReadiness) []const u8 {
+    return switch (readiness) {
+        .ready => "ready",
+        .missing_binary => "missing_binary",
+        .permission_denied => "permission_denied",
+        .unwritable_store => "unwritable_store",
+        .session_unavailable => "session_unavailable",
+        .sandbox_blocked => "sandbox_blocked",
+        .needs_reauth => "needs_reauth",
+        .repair_in_progress => "repair_in_progress",
+    };
+}
+
+fn writeRuntimeReadinessJson(writer: anytype, readiness: types.RuntimeReadiness) !void {
+    try writer.writeByte('{');
+    try writer.writeAll("\"state\":");
+    try std.json.stringify(runtimeReadinessSummary(readiness), .{}, writer);
+    switch (readiness) {
+        .ready => {},
+        .missing_binary => |binary| {
+            try writer.writeAll(",\"binary\":");
+            try std.json.stringify(binary, .{}, writer);
+        },
+        .permission_denied => |info| {
+            try writer.writeAll(",\"path\":");
+            try std.json.stringify(info.path, .{}, writer);
+            try writer.writeAll(",\"operation\":");
+            try std.json.stringify(info.operation, .{}, writer);
+        },
+        .unwritable_store, .session_unavailable, .sandbox_blocked => |value| {
+            try writer.writeAll(",\"detail\":");
+            try std.json.stringify(value, .{}, writer);
+        },
+        .needs_reauth => |info| {
+            try writer.writeAll(",\"methods\":");
+            try writeStringArrayJson(writer, info.methods);
+            try writer.writeAll(",\"reason\":");
+            try std.json.stringify(info.reason, .{}, writer);
+        },
+        .repair_in_progress => |info| {
+            try writer.writeAll(",\"account\":");
+            try std.json.stringify(info.account, .{}, writer);
+            try writer.print(",\"started_at\":{d}", .{info.started_at});
+        },
+    }
+    try writer.writeByte('}');
+}
+
 fn isBuiltinDefinition(def_key: []const u8, def_name: []const u8) bool {
     return provider_schema.findBuiltin(def_key) != null or provider_schema.findBuiltin(def_name) != null;
 }
@@ -1442,9 +1570,9 @@ fn runProbe(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Pro
     }
 
     if (args.json) {
-        try writeProbeJson(writer, &store, &ctx, probe_error);
+        try writeProbeJson(writer, allocator, &store, &ctx, probe_error);
     } else {
-        try writeProbeText(writer, &store, &ctx);
+        try writeProbeText(writer, allocator, &store, &ctx);
     }
     try result;
 }
@@ -1541,7 +1669,7 @@ fn probeDecision(ctx: *const pipeline.Context, probe_error: ?types.PipelineError
     return ctx.last_probe_decision orelse .use_this;
 }
 
-fn writeProbeText(writer: anytype, store: *health_mod.HealthStore, ctx: *const pipeline.Context) !void {
+fn writeProbeText(writer: anytype, allocator: std.mem.Allocator, store: *health_mod.HealthStore, ctx: *const pipeline.Context) !void {
     const provider_name = ctx.provider_name orelse "-";
     const account_name = ctx.account_name orelse "-";
     try writer.writeAll("oauth-mux probe\n\n");
@@ -1563,6 +1691,12 @@ fn writeProbeText(writer: anytype, store: *health_mod.HealthStore, ctx: *const p
         try writer.writeAll("  probe:    no configured probe plan for capability\n");
     } else {
         try writer.writeAll("  probe:    no capability requested; credential parse/expiry validation only\n");
+    }
+
+    if (ctx.provider_name) |selected_provider| {
+        const def = config.resolveProviderDefinition(ctx.cfg, selected_provider);
+        const readiness = try providerRuntimeReadiness(allocator, def, ctx.capability_name);
+        try writer.print("  runtime:  {s}\n", .{runtimeReadinessSummary(readiness)});
     }
 
     const selection = selectedHealth(store, ctx);
@@ -1593,7 +1727,7 @@ fn writeProbeText(writer: anytype, store: *health_mod.HealthStore, ctx: *const p
     try writer.writeByte('\n');
 }
 
-fn writeProbeJson(writer: anytype, store: *health_mod.HealthStore, ctx: *const pipeline.Context, probe_error: ?types.PipelineError) !void {
+fn writeProbeJson(writer: anytype, allocator: std.mem.Allocator, store: *health_mod.HealthStore, ctx: *const pipeline.Context, probe_error: ?types.PipelineError) !void {
     const selection = selectedHealth(store, ctx);
     const decision = probeDecision(ctx, probe_error);
     try writer.writeByte('{');
@@ -1631,6 +1765,13 @@ fn writeProbeJson(writer: anytype, store: *health_mod.HealthStore, ctx: *const p
     }
     try writer.writeAll(",\"decision\":");
     try std.json.stringify(@tagName(decision), .{}, writer);
+    try writer.writeAll(",\"runtime\":");
+    if (ctx.provider_name) |provider_name| {
+        const def = config.resolveProviderDefinition(ctx.cfg, provider_name);
+        try writeProviderRuntimeJson(writer, allocator, def, ctx.capability_name);
+    } else {
+        try writer.writeAll("null");
+    }
     try writer.writeAll(",\"health_key\":");
     try std.json.stringify(selection.key.slice(), .{}, writer);
     try writer.writeAll(",\"liveness\":");
@@ -2396,6 +2537,18 @@ test "writeHealthJson includes capability routes" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"availability\":\"quota_exhausted\"") != null);
 }
 
+test "writeProvidersListJson exposes extension and budget metadata" {
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+
+    try writeProvidersListJson(buf.writer(), std.testing.allocator, null, false, "FileNotFound");
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"extension_mode\":\"command_adapter\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"repair_owner\":\"upstream_cli_login\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"runtime\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"capability_budgets\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"budget\":\"spend_provider\"") != null);
+}
+
 test "writeProbeJson includes terminal pipeline error" {
     var store = health_mod.HealthStore.init(std.testing.allocator, .{});
     defer store.deinit();
@@ -2412,11 +2565,12 @@ test "writeProbeJson includes terminal pipeline error" {
     var buf = std.ArrayList(u8).init(std.testing.allocator);
     defer buf.deinit();
 
-    try writeProbeJson(buf.writer(), &store, &ctx, error.SecretReadFailed);
+    try writeProbeJson(buf.writer(), std.testing.allocator, &store, &ctx, error.SecretReadFailed);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"ok\":false") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"error\":\"SecretReadFailed\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"exit_code\":202") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"decision\":\"try_next_account\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"runtime\":{\"readiness\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"health_key\":\"codex:max-1\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"state\":\"dead\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"hint_class\":\"auth_dead\"") != null);

--- a/src/probe.zig
+++ b/src/probe.zig
@@ -388,6 +388,7 @@ test "classifyResult honors probe success range" {
         .timeout_ms = 30_000,
         .success_status_min = 202,
         .success_status_max = 204,
+        .budget = .cheap_provider,
     };
 
     try std.testing.expectEqual(
@@ -406,6 +407,7 @@ test "classifyResult falls back to provider failure rules" {
         .timeout_ms = 30_000,
         .success_status_min = 200,
         .success_status_max = 299,
+        .budget = .cheap_provider,
     };
     const result = ProbeResult{
         .status = 429,
@@ -429,6 +431,7 @@ test "classifyResult uses hint text" {
         .timeout_ms = 30_000,
         .success_status_min = 200,
         .success_status_max = 299,
+        .budget = .cheap_provider,
     };
     const result = ProbeResult{
         .status = 403,
@@ -461,6 +464,7 @@ test "classifyResult can downgrade successful GraphQL status from body hint" {
         .success_status_min = 200,
         .success_status_max = 299,
         .hint_body = true,
+        .budget = .cheap_provider,
     };
     const result = ProbeResult{
         .status = 200,
@@ -485,6 +489,7 @@ test "classifyResult decodes codex command jsonl" {
         .timeout_ms = 30_000,
         .success_status_min = 200,
         .success_status_max = 299,
+        .budget = .spend_provider,
     };
     const result = ProbeResult{
         .status = 400,
@@ -513,6 +518,7 @@ test "execute command probe enforces timeout" {
         .timeout_ms = 1,
         .success_status_min = 200,
         .success_status_max = 299,
+        .budget = .free_command,
     };
 
     const result = try execute(std.testing.allocator, plan, "", &.{});

--- a/src/provider_schema.zig
+++ b/src/provider_schema.zig
@@ -27,6 +27,7 @@ pub const ProviderDefinition = struct {
     // ── Identity ──
     name: []const u8,
     display_name: []const u8 = "",
+    extension_mode: types.ProviderExtensionMode = .schema_only,
 
     // ── OAuth Server ──
     // If discovery_url is set, metadata is fetched at runtime (RFC 8414).
@@ -46,6 +47,13 @@ pub const ProviderDefinition = struct {
     // ── Detection ──
     // How to auto-detect this provider from the target command.
     detection: DetectionConfig = .{},
+
+    // ── Runtime ──
+    // Platform-neutral harness runtime requirements. Service-manager wrappers
+    // live outside this schema; the core only models commands, env, paths, and
+    // repair ownership.
+    runtime: RuntimeConfig = .{},
+    repair: RepairConfig = .{},
 
     // ── Capability Probes ──
     // Optional route/capability probes. These are declarative plans, not
@@ -115,6 +123,17 @@ pub const DetectionConfig = struct {
     env_markers: []const []const u8 = &.{},
 };
 
+pub const RuntimeConfig = struct {
+    required_binaries: []const []const u8 = &.{},
+    env_vars: []const []const u8 = &.{},
+    writable_paths: []const []const u8 = &.{},
+    session_paths: []const []const u8 = &.{},
+};
+
+pub const RepairConfig = struct {
+    owner: types.RepairOwner = .manual_only,
+};
+
 pub const CapabilityDefinition = struct {
     name: []const u8,
     aliases: []const []const u8 = &.{},
@@ -135,6 +154,7 @@ pub const ProbeDefinition = struct {
     success_status_max: u16 = 299,
     hint_header: ?[]const u8 = null,
     hint_body: bool = false,
+    budget: ?types.ActionBudget = null,
 };
 
 pub const ProbeTransport = enum {
@@ -163,6 +183,7 @@ pub const ProbePlan = struct {
     success_status_max: u16,
     hint_header: ?[]const u8 = null,
     hint_body: bool = false,
+    budget: types.ActionBudget,
 };
 
 pub const RateLimitConfig = struct {
@@ -246,6 +267,7 @@ const claude_capabilities = [_]CapabilityDefinition{
             .auth = .none,
             .timeout_ms = 30_000,
             .command = &.{ "claude", "auth", "status", "--json" },
+            .budget = .free_command,
         },
     },
 };
@@ -287,6 +309,7 @@ const mcp_capabilities = [_]CapabilityDefinition{
             .url = "{{OMUX_MCP_RESOURCE_METADATA_URL}}",
             .auth = .none,
             .hint_body = true,
+            .budget = .cheap_provider,
         },
     },
     .{
@@ -297,6 +320,7 @@ const mcp_capabilities = [_]CapabilityDefinition{
             .url = "{{OMUX_MCP_RESOURCE_PROBE_URL}}",
             .auth = .bearer,
             .hint_header = "www-authenticate",
+            .budget = .cheap_provider,
         },
     },
 };
@@ -484,6 +508,7 @@ const flakehub_capabilities = [_]CapabilityDefinition{
             .auth = .none,
             .timeout_ms = 30_000,
             .command = &.{ "determinate-nixd", "status" },
+            .budget = .free_command,
         },
     },
 };
@@ -506,6 +531,7 @@ const codex_capabilities = [_]CapabilityDefinition{
                 "gpt-5.3-codex",
                 "Reply exactly: OMUX_CODEX_MAX_PROBE",
             },
+            .budget = .spend_provider,
         },
     },
     .{
@@ -525,6 +551,7 @@ const codex_capabilities = [_]CapabilityDefinition{
                 "gpt-5.3-codex-spark",
                 "Reply exactly: OMUX_CODEX_MINI_PROBE",
             },
+            .budget = .spend_provider,
         },
     },
 };
@@ -532,6 +559,7 @@ const codex_capabilities = [_]CapabilityDefinition{
 pub const claude_def = ProviderDefinition{
     .name = "claude",
     .display_name = "Claude Code",
+    .extension_mode = .command_adapter,
     .auth = .{
         .token_endpoint = "https://claude.ai/api/auth/oauth/token",
     },
@@ -551,6 +579,13 @@ pub const claude_def = ProviderDefinition{
     .detection = .{
         .binary_names = &.{"claude"},
     },
+    .runtime = .{
+        .required_binaries = &.{"claude"},
+        .env_vars = &.{"CLAUDE_CONFIG_DIR"},
+    },
+    .repair = .{
+        .owner = .upstream_cli_login,
+    },
     .capabilities = &claude_capabilities,
     .failure_rules = &claude_failure_rules,
     .rate_limits = .{
@@ -562,6 +597,7 @@ pub const claude_def = ProviderDefinition{
 pub const codex_def = ProviderDefinition{
     .name = "codex",
     .display_name = "Codex CLI",
+    .extension_mode = .command_adapter,
     .auth = .{
         .token_endpoint = "https://auth0.openai.com/oauth/token",
         .device_authorization_endpoint = "https://auth.openai.com/deviceauth/usercode",
@@ -582,6 +618,15 @@ pub const codex_def = ProviderDefinition{
     .detection = .{
         .binary_names = &.{"codex"},
         .env_markers = &.{"CODEX_HOME"},
+    },
+    .runtime = .{
+        .required_binaries = &.{"codex"},
+        .env_vars = &.{"CODEX_HOME"},
+        .writable_paths = &.{"CODEX_HOME"},
+        .session_paths = &.{"CODEX_HOME/auth.json"},
+    },
+    .repair = .{
+        .owner = .upstream_cli_login,
     },
     .rate_limits = .{
         .remaining_header = "x-ratelimit-remaining-requests",
@@ -699,12 +744,19 @@ pub const figma_def = ProviderDefinition{
 pub const flakehub_def = ProviderDefinition{
     .name = "flakehub",
     .display_name = "FlakeHub / Determinate Nix",
+    .extension_mode = .command_adapter,
     .credential = .{
         .access_token_path = "token",
         .token_type = "api_key",
     },
     .detection = .{
         .binary_names = &.{ "determinate-nixd", "fh" },
+    },
+    .runtime = .{
+        .required_binaries = &.{"determinate-nixd"},
+    },
+    .repair = .{
+        .owner = .upstream_cli_login,
     },
     .capabilities = &flakehub_capabilities,
     .failure_rules = &flakehub_failure_rules,
@@ -800,9 +852,17 @@ pub fn probePlanForCapability(def: ProviderDefinition, capability: []const u8) ?
             .success_status_max = probe.success_status_max,
             .hint_header = probe.hint_header,
             .hint_body = probe.hint_body,
+            .budget = probe.budget orelse defaultProbeBudget(probe.transport),
         };
     }
     return null;
+}
+
+pub fn defaultProbeBudget(transport: ProbeTransport) types.ActionBudget {
+    return switch (transport) {
+        .http => .cheap_provider,
+        .command => .free_command,
+    };
 }
 
 pub fn classifyCodexExecJsonl(allocator: std.mem.Allocator, jsonl: []const u8) ?types.HttpClassification {
@@ -1413,11 +1473,16 @@ test "probePlanForCapability resolves aliases" {
     try std.testing.expectEqualStrings("chat:max", plan.capability);
     try std.testing.expectEqualStrings("POST", plan.method);
     try std.testing.expectEqual(ProbeAuth.bearer, plan.auth);
+    try std.testing.expectEqual(types.ActionBudget.cheap_provider, plan.budget);
     try std.testing.expectEqualStrings("www-authenticate", plan.hint_header.?);
     try std.testing.expect(probePlanForCapability(def, "unknown") == null);
 }
 
 test "codex capabilities include semantic max and mini command probes" {
+    try std.testing.expectEqual(types.ProviderExtensionMode.command_adapter, codex_def.extension_mode);
+    try std.testing.expectEqual(types.RepairOwner.upstream_cli_login, codex_def.repair.owner);
+    try std.testing.expectEqualStrings("codex", codex_def.runtime.required_binaries[0]);
+
     try std.testing.expectEqualStrings("codex-max", codex_def.capabilities[0].name);
     const max_plan = probePlanForCapability(codex_def, "gpt-5.3-codex").?;
     try std.testing.expectEqual(ProbeTransport.command, max_plan.transport);
@@ -1425,12 +1490,14 @@ test "codex capabilities include semantic max and mini command probes" {
     try std.testing.expectEqualStrings("codex", max_plan.command.?[0]);
     try std.testing.expectEqualStrings("gpt-5.3-codex", max_plan.command.?[6]);
     try std.testing.expectEqual(@as(u32, 120_000), max_plan.timeout_ms);
+    try std.testing.expectEqual(types.ActionBudget.spend_provider, max_plan.budget);
     try std.testing.expectEqualStrings("codex-max", probePlanForCapability(codex_def, "max").?.capability);
     try std.testing.expectEqualStrings("codex-mini", codex_def.capabilities[1].name);
     const mini_plan = probePlanForCapability(codex_def, "gpt-5.3-codex-spark").?;
     try std.testing.expectEqual(ProbeTransport.command, mini_plan.transport);
     try std.testing.expectEqualStrings("codex-mini", mini_plan.capability);
     try std.testing.expectEqualStrings("gpt-5.3-codex-spark", mini_plan.command.?[6]);
+    try std.testing.expectEqual(types.ActionBudget.spend_provider, mini_plan.budget);
 }
 
 test "claude auth status capability uses admitted command probe" {
@@ -1438,6 +1505,7 @@ test "claude auth status capability uses admitted command probe" {
     try std.testing.expectEqual(ProbeTransport.command, plan.transport);
     try std.testing.expectEqualStrings("auth-status", plan.capability);
     try std.testing.expectEqual(ProbeAuth.none, plan.auth);
+    try std.testing.expectEqual(types.ActionBudget.free_command, plan.budget);
     try std.testing.expectEqualStrings("claude", plan.command.?[0]);
     try std.testing.expectEqualStrings("auth", plan.command.?[1]);
     try std.testing.expectEqualStrings("status", plan.command.?[2]);

--- a/src/types.zig
+++ b/src/types.zig
@@ -239,6 +239,88 @@ pub const DeadReason = enum {
     auth_permanently_failed,
 };
 
+// ── Provider Extensibility ──
+//
+// These enums mirror the public provider-authoring contract. They are deliberately
+// provider-neutral so future harnesses can enter through data and bounded commands
+// before needing new compiled Zig code.
+
+pub const ProviderExtensionMode = enum {
+    schema_only,
+    command_adapter,
+    secret_backend_adapter,
+    transport_adapter,
+    compiled_provider_adapter,
+};
+
+pub const ActionBudget = enum {
+    free_local,
+    free_command,
+    cheap_provider,
+    spend_provider,
+    interactive,
+    mutating,
+
+    pub fn allowedInDaemonDefault(self: ActionBudget) bool {
+        return switch (self) {
+            .free_local, .free_command => true,
+            .cheap_provider, .spend_provider, .interactive, .mutating => false,
+        };
+    }
+
+    pub fn allowedForProbe(self: ActionBudget) bool {
+        return switch (self) {
+            .free_local, .free_command, .cheap_provider, .spend_provider => true,
+            .interactive, .mutating => false,
+        };
+    }
+};
+
+pub const RepairOwner = enum {
+    oauth_mux_refresh,
+    upstream_cli_login,
+    external_secret_owner,
+    manual_only,
+};
+
+pub const RuntimeReadiness = union(enum) {
+    ready,
+    missing_binary: []const u8,
+    permission_denied: PathOperation,
+    unwritable_store: []const u8,
+    session_unavailable: []const u8,
+    sandbox_blocked: []const u8,
+    needs_reauth: ReauthInfo,
+    repair_in_progress: RepairProgress,
+
+    pub const PathOperation = struct {
+        path: []const u8,
+        operation: []const u8,
+    };
+
+    pub const ReauthInfo = struct {
+        methods: []const []const u8 = &.{},
+        reason: []const u8,
+    };
+
+    pub const RepairProgress = struct {
+        account: []const u8,
+        started_at: i64,
+    };
+
+    pub fn isReady(self: RuntimeReadiness) bool {
+        return self == .ready;
+    }
+};
+
+pub fn selectable(liveness: CredentialLiveness, runtime: RuntimeReadiness) bool {
+    if (!runtime.isReady()) return false;
+    return switch (liveness) {
+        .live => |live| live.availability == .available,
+        .degraded, .dead => false,
+    };
+}
+
 // ── Mux Decision ──
 // What the pipeline should do after probing a credential.
 
@@ -348,6 +430,30 @@ pub const TokenBucket = struct {
         self.last_refill_ns = now_ns;
     }
 };
+
+test "runtime readiness gates selectable credentials" {
+    const live_available = CredentialLiveness{ .live = .{ .availability = .available } };
+    const live_limited = CredentialLiveness{ .live = .{ .availability = .{
+        .rate_limited = .{
+            .retry_after_s = 30,
+            .limited_at = 1,
+            .window = .per_minute,
+        },
+    } } };
+
+    try std.testing.expect(selectable(live_available, .ready));
+    try std.testing.expect(!selectable(live_available, .{ .missing_binary = "codex" }));
+    try std.testing.expect(!selectable(live_limited, .ready));
+}
+
+test "daemon default budget excludes provider spend and mutation" {
+    try std.testing.expect(ActionBudget.free_local.allowedInDaemonDefault());
+    try std.testing.expect(ActionBudget.free_command.allowedInDaemonDefault());
+    try std.testing.expect(!ActionBudget.cheap_provider.allowedInDaemonDefault());
+    try std.testing.expect(!ActionBudget.spend_provider.allowedInDaemonDefault());
+    try std.testing.expect(!ActionBudget.interactive.allowedForProbe());
+    try std.testing.expect(!ActionBudget.mutating.allowedForProbe());
+}
 
 // ── Account Selection ──
 


### PR DESCRIPTION
## Summary
- add provider extension mode, action budget, repair owner, and runtime readiness types
- extend provider definitions with runtime/repair metadata and probe budget classes
- expose runtime readiness and capability budgets in provider/probe JSON
- add portable `oauth-mux daemon run` foreground primitive for future service wrappers

## Validation
- `zig build test`
- `zig build`
- `just check-local`
- `just check`
- `just release`
- `./zig-out/bin/oauth-mux providers list --json`
- `./zig-out/bin/oauth-mux completions fish`

Refs TIN-736, TIN-738.