### PR TITLE
Dogfood Codex repair planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ Run the no-spend Codex Max canary:
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex canary
 ```
 
+Explain current Codex Max stay-afloat actions without running probes or
+mutating auth state:
+
+```bash
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair-plan --profile codex-max --capability codex-max --json
+```
+
 First-run Codex subscription path:
 
 ```bash
@@ -77,6 +84,7 @@ oauth-mux init --codex-max
 oauth-mux doctor
 oauth-mux setup codex
 oauth-mux codex canary
+oauth-mux repair-plan --profile codex-max --capability codex-max --json
 ```
 
 Run the deterministic no-secret E2E harness:

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -47,6 +47,7 @@ oauth-mux init --codex-max
 oauth-mux doctor
 oauth-mux setup codex
 oauth-mux codex canary
+oauth-mux repair-plan --profile codex-max --capability codex-max --json
 ```
 
 `oauth-mux doctor` is the no-spend readiness report. It checks whether config is
@@ -84,8 +85,11 @@ oauth-mux codex canary
 
 The canary validates config, prints redacted discovery, checks
 `codex login status` for each expected account, and summarizes whether route
-health has already been recorded. It does not run live probes by default. To
-include bounded route probes:
+health has already been recorded. It also prints the current non-mutating
+repair plan for the configured Codex route profiles, so a user or agent can see
+whether the next action is to fix runtime setup, run an explicit probe, wait for
+quota, or reauthenticate through the upstream Codex CLI. It does not run live
+probes by default. To include bounded route probes:
 
 ```bash
 oauth-mux codex canary --live
@@ -96,6 +100,20 @@ To probe one route class across every expected Codex account:
 ```bash
 oauth-mux codex probe-all --capability codex-mini --json
 ```
+
+To inspect the stay-afloat decision loop without running a canary:
+
+```bash
+oauth-mux repair-plan --profile codex-max --capability codex-max --json
+oauth-mux repair-plan --profile codex-mini --capability codex-mini --json
+```
+
+If `repair-plan --profile codex-max` reports a config validation error, the
+active config is not the three-account Codex Max shape. That usually means the
+machine still has an older generic config with only `codex:default`. Generate a
+fresh Codex Max config with `oauth-mux init --codex-max` in a clean config
+location, or update the active config so it contains `max-1`, `max-2`, `max-3`,
+`codex-max`, and `codex-mini`.
 
 Codex subcommand help is non-mutating. These commands print usage without
 creating `CODEX_HOME` directories, checking login status, or running probes:
@@ -108,8 +126,10 @@ oauth-mux setup codex --help
 
 Source checkouts keep `just codex-max-onboard` and `just codex-max-canary` as
 thin aliases for installed commands. `just codex-max-setup` is a thin alias for
-`oauth-mux setup codex`, and `just codex-max-probe-all` is likewise a thin alias
-for `oauth-mux codex probe-all`.
+`oauth-mux setup codex`, `just codex-max-repair-plan` is a thin alias for
+`oauth-mux repair-plan --profile codex-max --capability codex-max --json`, and
+`just codex-max-probe-all` is likewise a thin alias for
+`oauth-mux codex probe-all`.
 
 The clean no-config first-run path is covered by:
 
@@ -119,8 +139,8 @@ just first-run-e2e
 
 That harness runs with a temporary `HOME`, XDG config/state/data/runtime roots,
 and no inherited `OMUX_*` overrides. It proves `init --codex-max`, JSON
-diagnostics, redacted support output, and non-mutating Codex help without
-touching the operator's real OAuth stores.
+diagnostics, redacted support output, repair-plan route explanation, and
+non-mutating Codex help without touching the operator's real OAuth stores.
 
 ## Agent Discovery Contract
 

--- a/justfile
+++ b/justfile
@@ -79,6 +79,9 @@ codex-max-setup: build
 codex-max-canary: build
     OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux codex canary
 
+codex-max-repair-plan CAPABILITY="codex-max": build
+    OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux repair-plan --profile {{CAPABILITY}} --capability {{CAPABILITY}} --json
+
 codex-max-probe ACCOUNT CAPABILITY="codex-mini": build
     OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux probe --provider codex --account {{ACCOUNT}} --capability {{CAPABILITY}} --json
 

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -128,6 +128,7 @@ jq -e '
   and .providers == 1
   and .accounts == 3
   and (.next_commands | index("oauth-mux setup codex") != null)
+  and (.next_commands | index("oauth-mux repair-plan --json") != null)
 ' "$doctor_after" >/dev/null
 
 printf 'first-run e2e: discovery is redacted and agent-usable\n'
@@ -137,7 +138,18 @@ jq -e '
   .configured == true
   and (.providers[] | select(.name == "codex") | .accounts | length) == 3
   and (.agent_safe_commands | index("oauth-mux report --redacted --json") != null)
+  and (.agent_safe_commands | index("oauth-mux repair-plan --profile <profile> --capability <capability> --json") != null)
 ' "$discover_json" >/dev/null
+
+printf 'first-run e2e: repair-plan explains generated Codex Max routes without mutation\n'
+repair_plan_json="$tmp/repair-plan-codex-max.json"
+run_json "$repair_plan_json" repair-plan --profile codex-max --capability codex-max --json
+jq -e '
+  .profile == "codex-max"
+  and (.routes | length) == 3
+  and all(.routes[]; .provider == "codex" and .capability == "codex-max" and .action.mutating == false)
+  and all(.routes[]; .action.kind == "fix_runtime" or .action.kind == "probe_needed" or .action.kind == "none" or .action.kind == "wait_and_retry" or .action.kind == "wait_for_quota" or .action.kind == "wait_for_cooldown")
+' "$repair_plan_json" >/dev/null
 
 printf 'first-run e2e: support report is redacted JSON\n'
 report_json="$tmp/report.json"

--- a/src/main.zig
+++ b/src/main.zig
@@ -2772,6 +2772,10 @@ fn runCodexCanary(allocator: std.mem.Allocator, writer: anytype, args: cli.Comma
     try writer.writeAll("Existing oauth-mux health state; add --live to refresh with real provider probes.\n");
     try writeCodexRouteSnapshot(allocator, writer, args);
 
+    try writer.writeAll("\n=== repair plan ===\n");
+    try writer.writeAll("Non-mutating next actions from runtime readiness and recorded route liveness.\n");
+    try writeCodexRepairPlanSnapshot(allocator, writer, args);
+
     if (args.live) {
         try writer.writeAll("\n=== live probes ===\n");
         try runCodexLiveProbes(allocator, writer, args, true);
@@ -2861,6 +2865,32 @@ fn writeCodexRouteSnapshot(allocator: std.mem.Allocator, writer: anytype, args: 
             }
             try writer.writeByte('\n');
         }
+    }
+}
+
+fn writeCodexRepairPlanSnapshot(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs) !void {
+    var capability_it = std.mem.splitScalar(u8, args.capabilities, ',');
+    while (capability_it.next()) |raw_capability| {
+        const capability = std.mem.trim(u8, raw_capability, " \t\r\n");
+        if (capability.len == 0) continue;
+
+        if (!args.json) try writer.print("\n--- profile {s} ---\n", .{capability});
+        runRepairPlan(allocator, writer, .{
+            .profile = capability,
+            .capability = capability,
+            .json = args.json,
+        }) catch |e| switch (e) {
+            error.ConfigValidationError => {
+                if (args.json) {
+                    try writer.writeAll("{\"profile\":");
+                    try std.json.stringify(capability, .{}, writer);
+                    try writer.writeAll(",\"skipped\":true,\"error\":\"ConfigValidationError\"}\n");
+                } else {
+                    try writer.print("repair-plan skipped for profile {s}: current config does not define that Codex profile\n", .{capability});
+                }
+            },
+            else => return e,
+        };
     }
 }
 


### PR DESCRIPTION
## Summary

- include non-mutating repair-plan output in the Codex canary path
- extend first-run E2E so generated Codex Max config must be repair-plan-readable
- add a source-checkout Codex Max repair-plan helper and onboarding docs for config drift

## Validation

- zig build test
- ./scripts/first-run-e2e.sh
- just check
- just release
- just codex-max-repair-plan

## Notes

The local active config still rejects codex-max because it is an older/generic config shape. The Codex Max example/generated config now proves the expected three-account repair-plan loop without live probes or auth mutation.