### PR TITLE
Add Codex Max config candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ oauth-mux codex canary
 oauth-mux repair-plan --profile codex-max --capability codex-max --json
 ```
 
+If an existing config only has a single `codex:default` account, create a safe
+sidecar Codex Max candidate without overwriting it:
+
+```bash
+oauth-mux codex config-candidate
+```
+
 Run the deterministic no-secret E2E harness:
 
 ```bash

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -111,9 +111,19 @@ oauth-mux repair-plan --profile codex-mini --capability codex-mini --json
 If `repair-plan --profile codex-max` reports a config validation error, the
 active config is not the three-account Codex Max shape. That usually means the
 machine still has an older generic config with only `codex:default`. Generate a
-fresh Codex Max config with `oauth-mux init --codex-max` in a clean config
-location, or update the active config so it contains `max-1`, `max-2`, `max-3`,
-`codex-max`, and `codex-mini`.
+safe sidecar candidate without modifying the active config:
+
+```bash
+oauth-mux codex config-candidate
+```
+
+The command writes `codex-max.config.json` next to the active config, refuses to
+overwrite an existing candidate, validates the generated JSON before writing,
+and prints exact `OMUX_CONFIG=...` commands for `config validate`,
+`setup codex --status-only`, `repair-plan`, and `codex canary`. After reviewing
+that candidate, either run commands with `OMUX_CONFIG=<candidate>` or merge the
+`max-1`, `max-2`, `max-3`, `codex-max`, and `codex-mini` blocks into the active
+config deliberately.
 
 Codex subcommand help is non-mutating. These commands print usage without
 creating `CODEX_HOME` directories, checking login status, or running probes:
@@ -139,8 +149,9 @@ just first-run-e2e
 
 That harness runs with a temporary `HOME`, XDG config/state/data/runtime roots,
 and no inherited `OMUX_*` overrides. It proves `init --codex-max`, JSON
-diagnostics, redacted support output, repair-plan route explanation, and
-non-mutating Codex help without touching the operator's real OAuth stores.
+diagnostics, redacted support output, repair-plan route explanation,
+non-clobbering config-candidate generation, and non-mutating Codex help without
+touching the operator's real OAuth stores.
 
 ## Agent Discovery Contract
 

--- a/justfile
+++ b/justfile
@@ -82,6 +82,9 @@ codex-max-canary: build
 codex-max-repair-plan CAPABILITY="codex-max": build
     OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux repair-plan --profile {{CAPABILITY}} --capability {{CAPABILITY}} --json
 
+codex-max-config-candidate OUTPUT="/tmp/oauth-mux-codex-max.config.json": build
+    ./zig-out/bin/oauth-mux codex config-candidate --output {{OUTPUT}}
+
 codex-max-probe ACCOUNT CAPABILITY="codex-mini": build
     OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux probe --provider codex --account {{ACCOUNT}} --capability {{CAPABILITY}} --json
 

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -31,6 +31,7 @@ mkdir -p "$home" "$xdg_config" "$xdg_state" "$xdg_data" "$xdg_runtime"
 chmod 0700 "$xdg_runtime"
 
 config_path="$xdg_config/oauth-mux/config.json"
+candidate_config_path="$xdg_config/oauth-mux/codex-max.config.json"
 store_root="$xdg_data/oauth-mux/codex"
 legacy_store_root="$home/.local/share/oauth-mux/codex"
 
@@ -150,6 +151,28 @@ jq -e '
   and all(.routes[]; .provider == "codex" and .capability == "codex-max" and .action.mutating == false)
   and all(.routes[]; .action.kind == "fix_runtime" or .action.kind == "probe_needed" or .action.kind == "none" or .action.kind == "wait_and_retry" or .action.kind == "wait_for_quota" or .action.kind == "wait_for_cooldown")
 ' "$repair_plan_json" >/dev/null
+
+printf 'first-run e2e: config-candidate writes sidecar without clobbering active config\n'
+config_before="$(cat "$config_path")"
+candidate_json="$tmp/config-candidate.json"
+run_json "$candidate_json" codex config-candidate --json
+jq -e --arg path "$candidate_config_path" '
+  .created == true
+  and .candidate_config == $path
+  and (.next_commands | index("OMUX_CONFIG='\''" + $path + "'\'' oauth-mux repair-plan --profile codex-max --capability codex-max --json") != null)
+' "$candidate_json" >/dev/null
+test -f "$candidate_config_path"
+candidate_config_json="$(cat "$candidate_config_path")"
+expect_contains "$candidate_config_json" "$store_root/max-1/auth.json" "candidate config uses XDG auth path"
+candidate_again_json="$tmp/config-candidate-again.json"
+run_json "$candidate_again_json" codex config-candidate --json
+jq -e '
+  .created == false
+' "$candidate_again_json" >/dev/null
+if [ "$(cat "$config_path")" != "$config_before" ]; then
+  printf 'first-run e2e assertion failed: config-candidate modified active config\n' >&2
+  exit 1
+fi
 
 printf 'first-run e2e: support report is redacted JSON\n'
 report_json="$tmp/report.json"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -106,6 +106,7 @@ pub const Command = union(enum) {
         onboard,
         canary,
         probe_all,
+        config_candidate,
     };
 
     pub const CodexArgs = struct {
@@ -118,6 +119,7 @@ pub const Command = union(enum) {
         status_only: bool = false,
         live: bool = false,
         json: bool = false,
+        output: ?[]const u8 = null,
     };
 
     pub const CompletionsArgs = struct {
@@ -382,6 +384,8 @@ fn parseCodex(args: []const []const u8) Command {
             result.action = .canary;
         } else if (eql(args[0], "probe-all")) {
             result.action = .probe_all;
+        } else if (eql(args[0], "config-candidate")) {
+            result.action = .config_candidate;
         } else {
             result.action = .canary;
             option_start = 0;
@@ -409,6 +413,9 @@ fn parseCodexOptions(result: *Command.CodexArgs, args: []const []const u8, optio
         } else if (eql(args[i], "--store-root")) {
             i += 1;
             if (i < args.len) result.store_root = args[i];
+        } else if (eql(args[i], "--output")) {
+            i += 1;
+            if (i < args.len) result.output = args[i];
         } else if (eql(args[i], "--device")) {
             result.device = true;
         } else if (eql(args[i], "--status-only")) {
@@ -494,6 +501,9 @@ pub fn printUsage(writer: anytype) !void {
         \\  codex probe-all [--accounts a,b,c] [--capabilities c1,c2] [--json]
         \\      Probe every selected Codex account/capability route.
         \\
+        \\  codex config-candidate [--output path] [--store-root path] [--json]
+        \\      Write a non-overwriting Codex Max config candidate.
+        \\
         \\  codex login <account> | login-device <account> | login-status [account] | login-status-all
         \\      Codex account login/status helpers using isolated CODEX_HOME dirs.
         \\
@@ -525,6 +535,7 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\  oauth-mux codex setup|onboard [--accounts a,b,c] [--device|--status-only] [--live]
         \\  oauth-mux codex canary [--accounts a,b,c] [--capabilities c1,c2] [--live]
         \\  oauth-mux codex probe-all [--accounts a,b,c] [--capability c] [--json]
+        \\  oauth-mux codex config-candidate [--output path] [--store-root path] [--json]
         \\  oauth-mux codex bootstrap-dirs [--accounts a,b,c] [--store-root path]
         \\  oauth-mux codex login <account> [--store-root path]
         \\  oauth-mux codex login-device <account> [--store-root path]
@@ -660,6 +671,19 @@ test "parse codex subcommand help as non-mutating help" {
 
     const setup_args = [_][]const u8{ "setup", "codex", "--help" };
     try std.testing.expect(parse(&setup_args) == .codex_help);
+}
+
+test "parse codex config candidate" {
+    const args = [_][]const u8{ "codex", "config-candidate", "--output", "/tmp/codex-max.config.json", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex => |codex| {
+            try std.testing.expect(codex.action == .config_candidate);
+            try std.testing.expectEqualStrings("/tmp/codex-max.config.json", codex.output.?);
+            try std.testing.expect(codex.json);
+        },
+        else => return error.Unexpected,
+    }
 }
 
 test "parse codex setup alias" {
@@ -807,7 +831,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary probe-all bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary probe-all config-candidate bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run start stop status' -d 'Daemon subcommand'
             \\
         );

--- a/src/main.zig
+++ b/src/main.zig
@@ -2701,6 +2701,7 @@ fn runCodex(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Cod
         .onboard => try runCodexOnboard(allocator, writer, args, root),
         .canary => try runCodexCanary(allocator, writer, args, root),
         .probe_all => try runCodexProbeAll(allocator, writer, args),
+        .config_candidate => try runCodexConfigCandidate(allocator, writer, args, root),
     }
 }
 
@@ -2794,6 +2795,127 @@ fn runCodexProbeAll(allocator: std.mem.Allocator, writer: anytype, args: cli.Com
         try writer.writeAll("\n=== live probes ===\n");
     }
     try runCodexLiveProbes(allocator, writer, args, !args.json);
+}
+
+fn runCodexConfigCandidate(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    args: cli.Command.CodexArgs,
+    root: []const u8,
+) !void {
+    const active_config_path = try paths.configFilePath(allocator);
+    defer allocator.free(active_config_path);
+
+    const candidate_path = if (args.output) |output|
+        try paths.expandTilde(allocator, output)
+    else
+        try defaultCodexConfigCandidatePath(allocator, active_config_path);
+    defer allocator.free(candidate_path);
+
+    var config_buf = std.ArrayList(u8).init(allocator);
+    defer config_buf.deinit();
+    try writeCodexMaxStarterConfig(allocator, config_buf.writer(), root);
+
+    const parsed = try config.loadFromBytes(allocator, config_buf.items);
+    defer parsed.deinit();
+    try config.validate(parsed.value, std.io.null_writer);
+
+    if (std.fs.openFileAbsolute(candidate_path, .{})) |file| {
+        file.close();
+        try writeCodexConfigCandidateResult(writer, allocator, active_config_path, candidate_path, false, args.json);
+        return;
+    } else |e| switch (e) {
+        error.FileNotFound => {},
+        else => return e,
+    }
+
+    if (std.fs.path.dirname(candidate_path)) |dir| try std.fs.cwd().makePath(dir);
+
+    const file = std.fs.createFileAbsolute(candidate_path, .{ .exclusive = true, .mode = 0o600 }) catch |e| switch (e) {
+        error.PathAlreadyExists => {
+            try writeCodexConfigCandidateResult(writer, allocator, active_config_path, candidate_path, false, args.json);
+            return;
+        },
+        else => return e,
+    };
+    defer file.close();
+    try file.writeAll(config_buf.items);
+
+    try writeCodexConfigCandidateResult(writer, allocator, active_config_path, candidate_path, true, args.json);
+}
+
+fn defaultCodexConfigCandidatePath(allocator: std.mem.Allocator, active_config_path: []const u8) ![]const u8 {
+    if (std.fs.path.dirname(active_config_path)) |dir| {
+        return try std.fs.path.join(allocator, &.{ dir, "codex-max.config.json" });
+    }
+    return try allocator.dupe(u8, "codex-max.config.json");
+}
+
+fn writeCodexConfigCandidateResult(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    active_config_path: []const u8,
+    candidate_path: []const u8,
+    created: bool,
+    json: bool,
+) !void {
+    const quoted_candidate_path = try shellQuoteAlloc(allocator, candidate_path);
+    defer allocator.free(quoted_candidate_path);
+
+    const validate_cmd = try std.fmt.allocPrint(allocator, "OMUX_CONFIG={s} oauth-mux config validate", .{quoted_candidate_path});
+    defer allocator.free(validate_cmd);
+    const status_cmd = try std.fmt.allocPrint(allocator, "OMUX_CONFIG={s} oauth-mux setup codex --status-only", .{quoted_candidate_path});
+    defer allocator.free(status_cmd);
+    const repair_cmd = try std.fmt.allocPrint(allocator, "OMUX_CONFIG={s} oauth-mux repair-plan --profile codex-max --capability codex-max --json", .{quoted_candidate_path});
+    defer allocator.free(repair_cmd);
+    const canary_cmd = try std.fmt.allocPrint(allocator, "OMUX_CONFIG={s} oauth-mux codex canary", .{quoted_candidate_path});
+    defer allocator.free(canary_cmd);
+
+    if (json) {
+        try writer.writeAll("{\"created\":");
+        try writer.writeAll(if (created) "true" else "false");
+        try writer.writeAll(",\"active_config\":");
+        try std.json.stringify(active_config_path, .{}, writer);
+        try writer.writeAll(",\"candidate_config\":");
+        try std.json.stringify(candidate_path, .{}, writer);
+        try writer.writeAll(",\"next_commands\":[");
+        try writeCommandJson(writer, validate_cmd);
+        try writer.writeByte(',');
+        try writeCommandJson(writer, status_cmd);
+        try writer.writeByte(',');
+        try writeCommandJson(writer, repair_cmd);
+        try writer.writeByte(',');
+        try writeCommandJson(writer, canary_cmd);
+        try writer.writeAll("]}\n");
+        return;
+    }
+
+    try writer.writeAll("oauth-mux Codex Max config candidate\n\n");
+    try writer.print("active config:    {s}\n", .{active_config_path});
+    try writer.print("candidate config: {s}\n", .{candidate_path});
+    try writer.print("created:          {s}\n\n", .{if (created) "yes" else "no, already exists"});
+    try writer.writeAll("The active config was not modified.\n\n");
+    try writer.writeAll("next:\n");
+    try writer.print("  {s}\n", .{validate_cmd});
+    try writer.print("  {s}\n", .{status_cmd});
+    try writer.print("  {s}\n", .{repair_cmd});
+    try writer.print("  {s}\n", .{canary_cmd});
+}
+
+fn shellQuoteAlloc(allocator: std.mem.Allocator, value: []const u8) ![]const u8 {
+    var out = std.ArrayList(u8).init(allocator);
+    errdefer out.deinit();
+
+    try out.append('\'');
+    for (value) |c| {
+        if (c == '\'') {
+            try out.appendSlice("'\\''");
+        } else {
+            try out.append(c);
+        }
+    }
+    try out.append('\'');
+    return out.toOwnedSlice();
 }
 
 fn validateCurrentConfig(allocator: std.mem.Allocator, writer: anytype) !void {
@@ -3165,6 +3287,16 @@ test "writeRepairActionJson emits codex reauth command without running it" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"interactive\":true") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"mutating\":true") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"command\":\"oauth-mux codex login-device max-1\"") != null);
+}
+
+test "shellQuoteAlloc protects config paths with spaces" {
+    const quoted = try shellQuoteAlloc(std.testing.allocator, "/Users/me/Library/Application Support/oauth-mux/codex-max.config.json");
+    defer std.testing.allocator.free(quoted);
+    try std.testing.expectEqualStrings("'/Users/me/Library/Application Support/oauth-mux/codex-max.config.json'", quoted);
+
+    const with_quote = try shellQuoteAlloc(std.testing.allocator, "/tmp/it's-here.json");
+    defer std.testing.allocator.free(with_quote);
+    try std.testing.expectEqualStrings("'/tmp/it'\\''s-here.json'", with_quote);
 }
 
 test "writeProbeJson includes terminal pipeline error" {


### PR DESCRIPTION
## Summary

- add oauth-mux codex config-candidate to write a validated Codex Max sidecar config without modifying the active config
- quote generated OMUX_CONFIG commands so macOS paths with spaces remain copy-pastable
- extend first-run E2E and docs for the single-account codex:default drift case

## Validation

- zig build test
- ./scripts/first-run-e2e.sh
- space-path config-candidate smoke
- just check
- just release
- just codex-max-config-candidate

## Notes

This is intentionally not an in-place config migration. It writes/reuses a candidate file and prints exact next commands for review and dogfooding.