### PR TITLE
Merge Codex Max config candidates safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,14 @@ sidecar Codex Max candidate without overwriting it:
 
 ```bash
 oauth-mux codex config-candidate
+oauth-mux codex config-merge --candidate ~/.config/oauth-mux/codex-max.config.json
 ```
 
 `oauth-mux doctor --json` and `oauth-mux discover --json` expose
 `codex_max_configured`; when it is false for a Codex config, they recommend that
-same candidate command.
+same candidate command. `config-merge` validates the candidate, backs up the
+active config, and merges only the Codex Max provider/profiles into place so
+other configured providers remain intact.
 
 Run the deterministic no-secret E2E harness:
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -126,10 +126,17 @@ cannot stay afloat.
 The command writes `codex-max.config.json` next to the active config, refuses to
 overwrite an existing candidate, validates the generated JSON before writing,
 and prints exact `OMUX_CONFIG=...` commands for `config validate`,
-`setup codex --status-only`, `repair-plan`, and `codex canary`. After reviewing
-that candidate, either run commands with `OMUX_CONFIG=<candidate>` or merge the
-`max-1`, `max-2`, `max-3`, `codex-max`, and `codex-mini` blocks into the active
-config deliberately.
+`setup codex --status-only`, `repair-plan`, and `codex canary`. It also prints
+a merge command for after review:
+
+```bash
+oauth-mux codex config-merge --candidate ~/.config/oauth-mux/codex-max.config.json
+```
+
+`config-merge` validates the reviewed candidate, refuses invalid Codex Max
+shapes, backs up the active config, and merges only the `codex` provider plus
+the `codex-max` and `codex-mini` profiles. Existing non-Codex providers and
+profiles remain in the active config.
 
 Codex subcommand help is non-mutating. These commands print usage without
 creating `CODEX_HOME` directories, checking login status, or running probes:
@@ -156,8 +163,8 @@ just first-run-e2e
 That harness runs with a temporary `HOME`, XDG config/state/data/runtime roots,
 and no inherited `OMUX_*` overrides. It proves `init --codex-max`, JSON
 diagnostics, redacted support output, repair-plan route explanation,
-non-clobbering config-candidate generation, and non-mutating Codex help without
-touching the operator's real OAuth stores.
+non-clobbering config-candidate generation, config-merge backup behavior, and
+non-mutating Codex help without touching the operator's real OAuth stores.
 
 ## Agent Discovery Contract
 

--- a/justfile
+++ b/justfile
@@ -85,6 +85,9 @@ codex-max-repair-plan CAPABILITY="codex-max": build
 codex-max-config-candidate OUTPUT="/tmp/oauth-mux-codex-max.config.json": build
     ./zig-out/bin/oauth-mux codex config-candidate --output {{OUTPUT}}
 
+codex-max-config-merge CANDIDATE="/tmp/oauth-mux-codex-max.config.json": build
+    ./zig-out/bin/oauth-mux codex config-merge --candidate {{CANDIDATE}}
+
 codex-max-probe ACCOUNT CAPABILITY="codex-mini": build
     OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux probe --provider codex --account {{ACCOUNT}} --capability {{CAPABILITY}} --json
 

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -178,6 +178,92 @@ if [ "$(cat "$config_path")" != "$config_before" ]; then
   exit 1
 fi
 
+printf 'first-run e2e: config-merge backs up drift config and preserves other providers\n'
+drift_dir="$tmp/drift"
+mkdir -p "$drift_dir"
+drift_config="$drift_dir/config.json"
+drift_candidate="$drift_dir/codex-max.config.json"
+drift_backup="$drift_dir/config.backup.json"
+drift_store_root="$tmp/drift-data/codex"
+cat >"$drift_config" <<'JSON'
+{
+  "version": 1,
+  "providers": {
+    "claude": {
+      "kind": "claude",
+      "accounts": {
+        "personal": {
+          "secret": { "backend": "env", "variable": "CLAUDE_TOKEN" }
+        }
+      }
+    },
+    "codex": {
+      "kind": "codex",
+      "config_dir_env": "CODEX_HOME",
+      "accounts": {
+        "default": {
+          "secret": { "backend": "env", "variable": "CODEX_TOKEN" }
+        }
+      }
+    }
+  },
+  "profiles": {
+    "default": {
+      "providers": ["claude:personal", "codex:default"],
+      "strategy": "health-weighted"
+    }
+  },
+  "strategies": {
+    "health-weighted": {
+      "kind": "health-weighted",
+      "rate_limit_penalty": -10,
+      "failure_penalty": -20,
+      "success_bonus": 1
+    }
+  }
+}
+JSON
+drift_omux() (
+  unset OMUX_CONFIG_DIR
+  unset OMUX_STATE_DIR
+  export HOME="$home"
+  export XDG_CONFIG_HOME="$xdg_config"
+  export XDG_STATE_HOME="$xdg_state"
+  export XDG_DATA_HOME="$xdg_data"
+  export XDG_RUNTIME_DIR="$xdg_runtime"
+  export OMUX_CONFIG="$drift_config"
+  export OMUX_CODEX_STORE_ROOT="$drift_store_root"
+  "$bin" "$@"
+)
+drift_candidate_json="$tmp/drift-config-candidate.json"
+drift_omux codex config-candidate --output "$drift_candidate" --json >"$drift_candidate_json"
+jq -e --arg path "$drift_candidate" '
+  .created == true
+  and .candidate_config == $path
+  and any(.next_commands[]; contains("oauth-mux codex config-merge --candidate") and contains($path))
+' "$drift_candidate_json" >/dev/null
+drift_merge_json="$tmp/drift-config-merge.json"
+drift_omux codex config-merge --candidate "$drift_candidate" --backup "$drift_backup" --json >"$drift_merge_json"
+jq -e --arg backup "$drift_backup" '
+  .merged == true
+  and .backup_config == $backup
+  and .reason == "merged_codex_max_candidate"
+' "$drift_merge_json" >/dev/null
+test -f "$drift_backup"
+jq -e '
+  (.providers.claude.accounts.personal.secret.backend == "env")
+  and (.providers.codex.accounts.default.secret.backend == "env")
+  and (.providers.codex.accounts["max-1"].secret.backend == "file")
+  and (.providers.codex.accounts["max-2"].secret.backend == "file")
+  and (.providers.codex.accounts["max-3"].secret.backend == "file")
+  and (.profiles["codex-max"].providers | length) == 3
+  and (.profiles.default.providers | index("claude:personal") != null)
+' "$drift_config" >/dev/null
+jq -e '
+  (.providers.claude.accounts.personal.secret.backend == "env")
+  and (.providers.codex.accounts.default.secret.backend == "env")
+' "$drift_backup" >/dev/null
+
 printf 'first-run e2e: support report is redacted JSON\n'
 report_json="$tmp/report.json"
 run_json "$report_json" report --redacted --json

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -107,6 +107,7 @@ pub const Command = union(enum) {
         canary,
         probe_all,
         config_candidate,
+        config_merge,
     };
 
     pub const CodexArgs = struct {
@@ -120,6 +121,8 @@ pub const Command = union(enum) {
         live: bool = false,
         json: bool = false,
         output: ?[]const u8 = null,
+        candidate: ?[]const u8 = null,
+        backup: ?[]const u8 = null,
     };
 
     pub const CompletionsArgs = struct {
@@ -386,6 +389,8 @@ fn parseCodex(args: []const []const u8) Command {
             result.action = .probe_all;
         } else if (eql(args[0], "config-candidate")) {
             result.action = .config_candidate;
+        } else if (eql(args[0], "config-merge")) {
+            result.action = .config_merge;
         } else {
             result.action = .canary;
             option_start = 0;
@@ -416,6 +421,12 @@ fn parseCodexOptions(result: *Command.CodexArgs, args: []const []const u8, optio
         } else if (eql(args[i], "--output")) {
             i += 1;
             if (i < args.len) result.output = args[i];
+        } else if (eql(args[i], "--candidate")) {
+            i += 1;
+            if (i < args.len) result.candidate = args[i];
+        } else if (eql(args[i], "--backup")) {
+            i += 1;
+            if (i < args.len) result.backup = args[i];
         } else if (eql(args[i], "--device")) {
             result.device = true;
         } else if (eql(args[i], "--status-only")) {
@@ -504,6 +515,9 @@ pub fn printUsage(writer: anytype) !void {
         \\  codex config-candidate [--output path] [--store-root path] [--json]
         \\      Write a non-overwriting Codex Max config candidate.
         \\
+        \\  codex config-merge [--candidate path] [--backup path] [--json]
+        \\      Merge a reviewed Codex Max candidate into the active config with backup.
+        \\
         \\  codex login <account> | login-device <account> | login-status [account] | login-status-all
         \\      Codex account login/status helpers using isolated CODEX_HOME dirs.
         \\
@@ -536,6 +550,7 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\  oauth-mux codex canary [--accounts a,b,c] [--capabilities c1,c2] [--live]
         \\  oauth-mux codex probe-all [--accounts a,b,c] [--capability c] [--json]
         \\  oauth-mux codex config-candidate [--output path] [--store-root path] [--json]
+        \\  oauth-mux codex config-merge [--candidate path] [--backup path] [--json]
         \\  oauth-mux codex bootstrap-dirs [--accounts a,b,c] [--store-root path]
         \\  oauth-mux codex login <account> [--store-root path]
         \\  oauth-mux codex login-device <account> [--store-root path]
@@ -680,6 +695,20 @@ test "parse codex config candidate" {
         .codex => |codex| {
             try std.testing.expect(codex.action == .config_candidate);
             try std.testing.expectEqualStrings("/tmp/codex-max.config.json", codex.output.?);
+            try std.testing.expect(codex.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse codex config merge" {
+    const args = [_][]const u8{ "codex", "config-merge", "--candidate", "/tmp/candidate.json", "--backup", "/tmp/config.backup.json", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex => |codex| {
+            try std.testing.expect(codex.action == .config_merge);
+            try std.testing.expectEqualStrings("/tmp/candidate.json", codex.candidate.?);
+            try std.testing.expectEqualStrings("/tmp/config.backup.json", codex.backup.?);
             try std.testing.expect(codex.json);
         },
         else => return error.Unexpected,
@@ -831,7 +860,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary probe-all config-candidate bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary probe-all config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run start stop status' -d 'Daemon subcommand'
             \\
         );

--- a/src/main.zig
+++ b/src/main.zig
@@ -2777,6 +2777,7 @@ fn runCodex(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Cod
         .canary => try runCodexCanary(allocator, writer, args, root),
         .probe_all => try runCodexProbeAll(allocator, writer, args),
         .config_candidate => try runCodexConfigCandidate(allocator, writer, args, root),
+        .config_merge => try runCodexConfigMerge(allocator, writer, args),
     }
 }
 
@@ -2945,6 +2946,8 @@ fn writeCodexConfigCandidateResult(
     defer allocator.free(repair_cmd);
     const canary_cmd = try std.fmt.allocPrint(allocator, "OMUX_CONFIG={s} oauth-mux codex canary", .{quoted_candidate_path});
     defer allocator.free(canary_cmd);
+    const merge_cmd = try std.fmt.allocPrint(allocator, "oauth-mux codex config-merge --candidate {s}", .{quoted_candidate_path});
+    defer allocator.free(merge_cmd);
 
     if (json) {
         try writer.writeAll("{\"created\":");
@@ -2961,6 +2964,8 @@ fn writeCodexConfigCandidateResult(
         try writeCommandJson(writer, repair_cmd);
         try writer.writeByte(',');
         try writeCommandJson(writer, canary_cmd);
+        try writer.writeByte(',');
+        try writeCommandJson(writer, merge_cmd);
         try writer.writeAll("]}\n");
         return;
     }
@@ -2975,6 +2980,277 @@ fn writeCodexConfigCandidateResult(
     try writer.print("  {s}\n", .{status_cmd});
     try writer.print("  {s}\n", .{repair_cmd});
     try writer.print("  {s}\n", .{canary_cmd});
+    try writer.print("  {s}\n", .{merge_cmd});
+}
+
+const CodexConfigMergeResult = struct {
+    merged: bool,
+    backup_created: bool,
+    reason: []const u8,
+};
+
+fn runCodexConfigMerge(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs) !void {
+    const active_config_path = try paths.configFilePath(allocator);
+    defer allocator.free(active_config_path);
+
+    const candidate_path = if (args.candidate) |candidate|
+        try paths.expandTilde(allocator, candidate)
+    else
+        try defaultCodexConfigCandidatePath(allocator, active_config_path);
+    defer allocator.free(candidate_path);
+
+    const backup_path = if (args.backup) |backup|
+        try paths.expandTilde(allocator, backup)
+    else
+        try defaultCodexConfigBackupPath(allocator, active_config_path);
+    defer allocator.free(backup_path);
+
+    const result = try mergeCodexConfigCandidate(allocator, active_config_path, candidate_path, backup_path);
+    try writeCodexConfigMergeResult(writer, active_config_path, candidate_path, backup_path, result, args.json);
+}
+
+fn defaultCodexConfigBackupPath(allocator: std.mem.Allocator, active_config_path: []const u8) ![]const u8 {
+    return try std.fmt.allocPrint(allocator, "{s}.backup-{d}", .{ active_config_path, std.time.timestamp() });
+}
+
+fn mergeCodexConfigCandidate(
+    allocator: std.mem.Allocator,
+    active_config_path: []const u8,
+    candidate_path: []const u8,
+    backup_path: []const u8,
+) !CodexConfigMergeResult {
+    var active = try config.loadFromPath(allocator, active_config_path);
+    defer active.deinit();
+    try config.validate(active.value, std.io.null_writer);
+
+    if (codexMaxShapeConfigured(active.value)) {
+        return .{
+            .merged = false,
+            .backup_created = false,
+            .reason = "active_config_already_codex_max",
+        };
+    }
+
+    var candidate = try config.loadFromPath(allocator, candidate_path);
+    defer candidate.deinit();
+    try config.validate(candidate.value, std.io.null_writer);
+    if (!codexMaxShapeConfigured(candidate.value)) return error.ConfigValidationError;
+
+    var merged_buf = std.ArrayList(u8).init(allocator);
+    defer merged_buf.deinit();
+    try writeMergedCodexConfigJson(merged_buf.writer(), active.value, candidate.value);
+
+    const merged = try config.loadFromBytes(allocator, merged_buf.items);
+    defer merged.deinit();
+    try config.validate(merged.value, std.io.null_writer);
+    if (!codexMaxShapeConfigured(merged.value)) return error.ConfigValidationError;
+
+    if (fileExistsAbsolute(backup_path)) return error.PathAlreadyExists;
+    if (std.fs.path.dirname(active_config_path)) |dir| try std.fs.cwd().makePath(dir);
+
+    const tmp_path = try std.fmt.allocPrint(allocator, "{s}.tmp-{x}", .{ active_config_path, std.crypto.random.int(u64) });
+    defer allocator.free(tmp_path);
+
+    const tmp_file = try std.fs.createFileAbsolute(tmp_path, .{ .exclusive = true, .mode = 0o600 });
+    errdefer std.fs.deleteFileAbsolute(tmp_path) catch {};
+    {
+        defer tmp_file.close();
+        try tmp_file.writeAll(merged_buf.items);
+    }
+
+    try std.fs.renameAbsolute(active_config_path, backup_path);
+    std.fs.renameAbsolute(tmp_path, active_config_path) catch |e| {
+        std.fs.renameAbsolute(backup_path, active_config_path) catch {};
+        return e;
+    };
+
+    return .{
+        .merged = true,
+        .backup_created = true,
+        .reason = "merged_codex_max_candidate",
+    };
+}
+
+fn writeMergedCodexConfigJson(writer: anytype, active: config.Config, candidate: config.Config) !void {
+    const codex_provider = candidate.providers.map.get("codex") orelse return error.ConfigValidationError;
+    const codex_max_profile = candidate.profiles.map.get("codex-max") orelse return error.ConfigValidationError;
+    const codex_mini_profile = candidate.profiles.map.get("codex-mini") orelse return error.ConfigValidationError;
+    const health_weighted = candidate.strategies.map.get("health-weighted") orelse return error.ConfigValidationError;
+
+    try writer.writeAll("{\"version\":");
+    try writer.print("{d}", .{active.version});
+    try writer.writeAll(",\"defaults\":");
+    try std.json.stringify(active.defaults, .{}, writer);
+    try writer.writeAll(",\"provider_definitions\":");
+    try std.json.stringify(active.provider_definitions, .{}, writer);
+    try writer.writeAll(",\"providers\":{");
+
+    var first = true;
+    var wrote_codex = false;
+    var provider_it = active.providers.map.iterator();
+    while (provider_it.next()) |entry| {
+        if (!first) try writer.writeByte(',');
+        first = false;
+
+        const provider_name = entry.key_ptr.*;
+        try std.json.stringify(provider_name, .{}, writer);
+        try writer.writeByte(':');
+        if (std.mem.eql(u8, provider_name, "codex")) {
+            try writeMergedCodexProviderJson(writer, entry.value_ptr.*, codex_provider);
+            wrote_codex = true;
+        } else {
+            try std.json.stringify(entry.value_ptr.*, .{}, writer);
+        }
+    }
+    if (!wrote_codex) {
+        if (!first) try writer.writeByte(',');
+        try std.json.stringify("codex", .{}, writer);
+        try writer.writeByte(':');
+        try writeMergedCodexProviderJson(writer, null, codex_provider);
+    }
+
+    try writer.writeAll("},\"profiles\":{");
+    first = true;
+    var profile_it = active.profiles.map.iterator();
+    while (profile_it.next()) |entry| {
+        const profile_name = entry.key_ptr.*;
+        if (std.mem.eql(u8, profile_name, "codex-max") or std.mem.eql(u8, profile_name, "codex-mini")) continue;
+
+        if (!first) try writer.writeByte(',');
+        first = false;
+        try std.json.stringify(profile_name, .{}, writer);
+        try writer.writeByte(':');
+        try std.json.stringify(entry.value_ptr.*, .{}, writer);
+    }
+    if (!first) try writer.writeByte(',');
+    try std.json.stringify("codex-max", .{}, writer);
+    try writer.writeByte(':');
+    try std.json.stringify(codex_max_profile, .{}, writer);
+    try writer.writeByte(',');
+    try std.json.stringify("codex-mini", .{}, writer);
+    try writer.writeByte(':');
+    try std.json.stringify(codex_mini_profile, .{}, writer);
+
+    try writer.writeAll("},\"strategies\":{");
+    first = true;
+    var wrote_health_weighted = false;
+    var strategy_it = active.strategies.map.iterator();
+    while (strategy_it.next()) |entry| {
+        if (!first) try writer.writeByte(',');
+        first = false;
+
+        const strategy_name = entry.key_ptr.*;
+        try std.json.stringify(strategy_name, .{}, writer);
+        try writer.writeByte(':');
+        try std.json.stringify(entry.value_ptr.*, .{}, writer);
+        if (std.mem.eql(u8, strategy_name, "health-weighted")) wrote_health_weighted = true;
+    }
+
+    if (!wrote_health_weighted) {
+        if (!first) try writer.writeByte(',');
+        try std.json.stringify("health-weighted", .{}, writer);
+        try writer.writeByte(':');
+        try std.json.stringify(health_weighted, .{}, writer);
+    }
+
+    try writer.writeAll("}}\n");
+}
+
+fn writeMergedCodexProviderJson(
+    writer: anytype,
+    active_provider: ?config.ProviderConfig,
+    candidate_provider: config.ProviderConfig,
+) !void {
+    try writer.writeAll("{\"kind\":");
+    try std.json.stringify(candidate_provider.kind, .{}, writer);
+    try writer.writeAll(",\"config_dir_env\":");
+    if (candidate_provider.config_dir_env) |config_dir_env| {
+        try std.json.stringify(config_dir_env, .{}, writer);
+    } else if (active_provider) |provider_cfg| {
+        if (provider_cfg.config_dir_env) |config_dir_env| {
+            try std.json.stringify(config_dir_env, .{}, writer);
+        } else {
+            try writer.writeAll("null");
+        }
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"accounts\":{");
+
+    var first = true;
+    if (active_provider) |provider_cfg| {
+        var active_account_it = provider_cfg.accounts.map.iterator();
+        while (active_account_it.next()) |entry| {
+            const account_name = entry.key_ptr.*;
+            if (candidate_provider.accounts.map.get(account_name) != null) continue;
+
+            if (!first) try writer.writeByte(',');
+            first = false;
+            try std.json.stringify(account_name, .{}, writer);
+            try writer.writeByte(':');
+            try std.json.stringify(entry.value_ptr.*, .{}, writer);
+        }
+    }
+
+    var candidate_account_it = candidate_provider.accounts.map.iterator();
+    while (candidate_account_it.next()) |entry| {
+        if (!first) try writer.writeByte(',');
+        first = false;
+        try std.json.stringify(entry.key_ptr.*, .{}, writer);
+        try writer.writeByte(':');
+        try std.json.stringify(entry.value_ptr.*, .{}, writer);
+    }
+
+    try writer.writeAll("}}");
+}
+
+fn writeCodexConfigMergeResult(
+    writer: anytype,
+    active_config_path: []const u8,
+    candidate_path: []const u8,
+    backup_path: []const u8,
+    result: CodexConfigMergeResult,
+    json: bool,
+) !void {
+    if (json) {
+        try writer.writeAll("{\"merged\":");
+        try writer.writeAll(if (result.merged) "true" else "false");
+        try writer.writeAll(",\"reason\":");
+        try std.json.stringify(result.reason, .{}, writer);
+        try writer.writeAll(",\"active_config\":");
+        try std.json.stringify(active_config_path, .{}, writer);
+        try writer.writeAll(",\"candidate_config\":");
+        try std.json.stringify(candidate_path, .{}, writer);
+        try writer.writeAll(",\"backup_config\":");
+        if (result.backup_created) {
+            try std.json.stringify(backup_path, .{}, writer);
+        } else {
+            try writer.writeAll("null");
+        }
+        try writer.writeAll(",\"next_commands\":[");
+        try writeCommandJson(writer, "oauth-mux doctor --json");
+        try writer.writeByte(',');
+        try writeCommandJson(writer, "oauth-mux setup codex --status-only");
+        try writer.writeByte(',');
+        try writeCommandJson(writer, "oauth-mux codex canary");
+        try writer.writeAll("]}\n");
+        return;
+    }
+
+    try writer.writeAll("oauth-mux Codex Max config merge\n\n");
+    try writer.print("active config:    {s}\n", .{active_config_path});
+    try writer.print("candidate config: {s}\n", .{candidate_path});
+    if (result.backup_created) {
+        try writer.print("backup config:    {s}\n", .{backup_path});
+    } else {
+        try writer.writeAll("backup config:    not created\n");
+    }
+    try writer.print("merged:           {s}\n", .{if (result.merged) "yes" else "no"});
+    try writer.print("reason:           {s}\n\n", .{result.reason});
+    try writer.writeAll("next:\n");
+    try writer.writeAll("  oauth-mux doctor --json\n");
+    try writer.writeAll("  oauth-mux setup codex --status-only\n");
+    try writer.writeAll("  oauth-mux codex canary\n");
 }
 
 fn shellQuoteAlloc(allocator: std.mem.Allocator, value: []const u8) ![]const u8 {
@@ -3240,6 +3516,93 @@ test "doctor json recommends Codex Max candidate for single-account drift" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"codex_max_configured\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"severity\":\"warning\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux codex config-candidate --json") != null);
+}
+
+test "mergeCodexConfigCandidate preserves unrelated active providers" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+
+    const active_path = try std.fs.path.join(std.testing.allocator, &.{ root, "config.json" });
+    defer std.testing.allocator.free(active_path);
+    const candidate_path = try std.fs.path.join(std.testing.allocator, &.{ root, "codex-max.config.json" });
+    defer std.testing.allocator.free(candidate_path);
+    const backup_path = try std.fs.path.join(std.testing.allocator, &.{ root, "config.backup.json" });
+    defer std.testing.allocator.free(backup_path);
+
+    const active_json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "claude": {
+        \\      "kind": "claude",
+        \\      "accounts": {
+        \\        "personal": {
+        \\          "secret": { "backend": "env", "variable": "CLAUDE_TOKEN" }
+        \\        }
+        \\      }
+        \\    },
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "config_dir_env": "CODEX_HOME",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "CODEX_TOKEN" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "default": {
+        \\      "providers": ["claude:personal", "codex:default"],
+        \\      "strategy": "health-weighted"
+        \\    }
+        \\  },
+        \\  "strategies": {
+        \\    "health-weighted": {
+        \\      "kind": "health-weighted",
+        \\      "rate_limit_penalty": -10,
+        \\      "failure_penalty": -20,
+        \\      "success_bonus": 1
+        \\    }
+        \\  }
+        \\}
+    ;
+
+    {
+        const file = try std.fs.createFileAbsolute(active_path, .{ .mode = 0o600 });
+        defer file.close();
+        try file.writeAll(active_json);
+    }
+    {
+        const file = try std.fs.createFileAbsolute(candidate_path, .{ .mode = 0o600 });
+        defer file.close();
+        try writeCodexMaxStarterConfig(std.testing.allocator, file.writer(), "/tmp/omux-codex");
+    }
+
+    const result = try mergeCodexConfigCandidate(std.testing.allocator, active_path, candidate_path, backup_path);
+    try std.testing.expect(result.merged);
+    try std.testing.expect(result.backup_created);
+
+    const merged = try config.loadFromPath(std.testing.allocator, active_path);
+    defer merged.deinit();
+    try config.validate(merged.value, std.io.null_writer);
+    try std.testing.expect(codexMaxShapeConfigured(merged.value));
+    try std.testing.expect(merged.value.providers.map.get("claude") != null);
+    try std.testing.expect(merged.value.profiles.map.get("default") != null);
+
+    const backup = try config.loadFromPath(std.testing.allocator, backup_path);
+    defer backup.deinit();
+    try config.validate(backup.value, std.io.null_writer);
+    try std.testing.expect(!codexMaxShapeConfigured(backup.value));
+    try std.testing.expect(backup.value.providers.map.get("claude") != null);
+
+    const noop = try mergeCodexConfigCandidate(std.testing.allocator, active_path, candidate_path, backup_path);
+    try std.testing.expect(!noop.merged);
+    try std.testing.expect(!noop.backup_created);
+    try std.testing.expectEqualStrings("active_config_already_codex_max", noop.reason);
 }
 
 test "writeHealthJson includes redacted liveness" {


### PR DESCRIPTION
## Summary
- add oauth-mux codex config-merge to merge reviewed Codex Max candidates into the active config with backup
- preserve existing non-Codex providers, profiles, and the legacy codex:default account while adding Max routes
- include merge guidance in config-candidate output, docs, completions, just helpers, and first-run E2E

## Dogfood
- merged /Users/jess/.config/oauth-mux/codex-max.config.json into the real active config
- backup created at /Users/jess/.config/oauth-mux/config.json.backup-1777521367
- oauth-mux doctor --json now reports codex_max_configured=true
- oauth-mux codex canary passes non-live against the active config

## Validation
- zig build test
- ./scripts/first-run-e2e.sh
- ./zig-out/bin/oauth-mux codex canary
- just check
- just release