### PR TITLE
Add guarded Codex live QA command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ Run the no-spend Codex Max canary:
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex canary
 ```
 
+Run guarded live route QA only when real Codex calls are intended:
+
+```bash
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex live-qa
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex live-qa --confirm-spend
+```
+
 Explain current Codex Max stay-afloat actions without running probes or
 mutating auth state:
 
@@ -84,6 +91,7 @@ oauth-mux init --codex-max
 oauth-mux doctor
 oauth-mux setup codex
 oauth-mux codex canary
+oauth-mux codex live-qa
 oauth-mux repair-plan --profile codex-max --capability codex-max --json
 ```
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -54,7 +54,8 @@ with `--store-root <path>`.
 Live probes remain explicit because they can spend subscription calls:
 
 ```bash
-oauth-mux codex canary --live
+oauth-mux codex live-qa
+oauth-mux codex live-qa --confirm-spend
 oauth-mux codex probe-all --capability codex-mini --json
 ```
 

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -128,7 +128,7 @@ brew install tinyland/tools/oauth-mux: pass
 brew audit --formula --strict tinyland/tools/oauth-mux: pass
 brew test tinyland/tools/oauth-mux: pass
 /opt/homebrew/bin/oauth-mux doctor --json: ok
-Homebrew-installed oauth-mux codex canary --live with examples/codex-max.config.json:
+Homebrew-installed oauth-mux codex live-qa --confirm-spend with examples/codex-max.config.json:
   max-1, max-2, max-3 available for codex-mini and codex-max
 ```
 

--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -48,8 +48,13 @@ OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex canary
 ```
 
 That command validates config, prints discovery/status evidence, and checks
-`codex login status` for each account without running probes. Add `--live` only
-when the canary should also invoke this live QA matrix.
+`codex login status` for each account without running probes. Use the guarded
+live QA command when the installed CLI should also invoke this live matrix:
+
+```bash
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex live-qa
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex live-qa --confirm-spend
+```
 
 For a focused account matrix on one route class:
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -47,6 +47,7 @@ oauth-mux init --codex-max
 oauth-mux doctor
 oauth-mux setup codex
 oauth-mux codex canary
+oauth-mux codex live-qa
 oauth-mux repair-plan --profile codex-max --capability codex-max --json
 ```
 
@@ -89,10 +90,20 @@ health has already been recorded. It also prints the current non-mutating
 repair plan for the configured Codex route profiles, so a user or agent can see
 whether the next action is to fix runtime setup, run an explicit probe, wait for
 quota, or reauthenticate through the upstream Codex CLI. It does not run live
-probes by default. To include bounded route probes:
+probes by default.
+
+For guarded live route QA, start with:
 
 ```bash
-oauth-mux codex canary --live
+oauth-mux codex live-qa
+```
+
+That command explains the quota-spending confirmation requirement and exits
+before creating stores or running provider calls. When real Codex calls are
+intended, confirm explicitly:
+
+```bash
+oauth-mux codex live-qa --confirm-spend
 ```
 
 To probe one route class across every expected Codex account:
@@ -143,6 +154,7 @@ creating `CODEX_HOME` directories, checking login status, or running probes:
 
 ```bash
 oauth-mux codex canary --help
+oauth-mux codex live-qa --help
 oauth-mux codex probe-all --help
 oauth-mux setup codex --help
 ```
@@ -151,8 +163,9 @@ Source checkouts keep `just codex-max-onboard` and `just codex-max-canary` as
 thin aliases for installed commands. `just codex-max-setup` is a thin alias for
 `oauth-mux setup codex`, `just codex-max-repair-plan` is a thin alias for
 `oauth-mux repair-plan --profile codex-max --capability codex-max --json`, and
-`just codex-max-probe-all` is likewise a thin alias for
-`oauth-mux codex probe-all`.
+`just codex-max-live-qa` / `just codex-max-live-qa-confirmed` wrap the guarded
+installed live QA command. `just codex-max-probe-all` is likewise a thin alias
+for `oauth-mux codex probe-all`.
 
 The clean no-config first-run path is covered by:
 
@@ -164,7 +177,8 @@ That harness runs with a temporary `HOME`, XDG config/state/data/runtime roots,
 and no inherited `OMUX_*` overrides. It proves `init --codex-max`, JSON
 diagnostics, redacted support output, repair-plan route explanation,
 non-clobbering config-candidate generation, config-merge backup behavior, and
-non-mutating Codex help without touching the operator's real OAuth stores.
+non-mutating Codex help plus the unconfirmed live-QA spend gate without touching
+the operator's real OAuth stores.
 
 ## Agent Discovery Contract
 
@@ -183,22 +197,26 @@ Agents may run:
 
 ```bash
 oauth-mux probe --profile <profile> --capability <capability> --json
+oauth-mux codex live-qa --json
 oauth-mux codex probe-all --capability <capability> --json
 oauth-mux env --profile <profile> --capability <capability> --shell <shell>
 oauth-mux exec --profile <profile> --capability <capability> -- <command>
 ```
 
 Probe JSON includes `ok`, `error`, and `exit_code` alongside typed
-`liveness`. Agents should use `liveness` to distinguish `rate_limited`,
-`quota_exhausted`, `degraded`, and `dead` instead of treating every nonzero
-probe exit as the same failure class.
+`liveness`. `codex live-qa --json` is safe without confirmation: it exits
+nonzero with `confirmation_required` and `spends_provider_calls: true` before
+running provider calls. Agents should use `liveness` to distinguish
+`rate_limited`, `quota_exhausted`, `degraded`, and `dead` instead of treating
+every nonzero probe exit as the same failure class.
 
 Agents must not:
 
 - read files referenced by `secret.path`;
 - print token-shaped values;
 - copy OAuth stores between accounts;
-- run live probes unless the user explicitly authorized spend.
+- run live probes or pass `--confirm-spend` unless the user explicitly
+  authorized spend.
 
 `discover --json` is intentionally redacted. It reports config path, state path,
 providers, account names, secret backend names, tags, profiles, and safe command

--- a/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
+++ b/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
@@ -128,7 +128,8 @@ Required path:
 ```bash
 oauth-mux setup codex
 oauth-mux codex canary
-OMUX_LIVE_QA_CONFIRM=spend-real-calls oauth-mux codex canary --live
+oauth-mux codex live-qa
+OMUX_LIVE_QA_CONFIRM=spend-real-calls oauth-mux codex live-qa
 oauth-mux codex probe-all --capability codex-mini --json
 oauth-mux codex probe-all --capability codex-max --json
 oauth-mux health --json

--- a/justfile
+++ b/justfile
@@ -79,6 +79,12 @@ codex-max-setup: build
 codex-max-canary: build
     OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux codex canary
 
+codex-max-live-qa: build
+    OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux codex live-qa
+
+codex-max-live-qa-confirmed: build
+    OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux codex live-qa --confirm-spend
+
 codex-max-repair-plan CAPABILITY="codex-max": build
     OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux repair-plan --profile {{CAPABILITY}} --capability {{CAPABILITY}} --json
 

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -276,6 +276,22 @@ jq -e '
 expect_not_contains "$(cat "$report_json")" "auth.json" "redacted report omits credential file paths"
 expect_not_contains "$(cat "$report_json")" "$operator_home" "redacted report does not reference operator home"
 
+printf 'first-run e2e: Codex live-qa requires explicit spend confirmation\n'
+live_qa_json="$tmp/live-qa-unconfirmed.json"
+set +e
+omux codex live-qa --json >"$live_qa_json" 2>"$tmp/live-qa-unconfirmed.stderr"
+live_qa_status=$?
+set -e
+if [ "$live_qa_status" -eq 0 ]; then
+  printf 'first-run e2e assertion failed: live-qa without confirmation should fail\n' >&2
+  exit 1
+fi
+jq -e '
+  .ok == false
+  and .error == "confirmation_required"
+  and .spends_provider_calls == true
+' "$live_qa_json" >/dev/null
+
 printf 'first-run e2e: Codex help remains non-mutating\n'
 help_out="$(omux codex canary --help)"
 expect_contains "$help_out" "non-mutating" "Codex help declares non-mutating behavior"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -105,6 +105,7 @@ pub const Command = union(enum) {
         login_status_all,
         onboard,
         canary,
+        live_qa,
         probe_all,
         config_candidate,
         config_merge,
@@ -119,6 +120,7 @@ pub const Command = union(enum) {
         device: bool = false,
         status_only: bool = false,
         live: bool = false,
+        confirm_spend: bool = false,
         json: bool = false,
         output: ?[]const u8 = null,
         candidate: ?[]const u8 = null,
@@ -385,6 +387,8 @@ fn parseCodex(args: []const []const u8) Command {
             result.action = .onboard;
         } else if (eql(args[0], "canary")) {
             result.action = .canary;
+        } else if (eql(args[0], "live-qa")) {
+            result.action = .live_qa;
         } else if (eql(args[0], "probe-all")) {
             result.action = .probe_all;
         } else if (eql(args[0], "config-candidate")) {
@@ -433,6 +437,8 @@ fn parseCodexOptions(result: *Command.CodexArgs, args: []const []const u8, optio
             result.status_only = true;
         } else if (eql(args[i], "--live")) {
             result.live = true;
+        } else if (eql(args[i], "--confirm-spend")) {
+            result.confirm_spend = true;
         } else if (eql(args[i], "--json")) {
             result.json = true;
         } else if (result.account == null and !std.mem.startsWith(u8, args[i], "-")) {
@@ -509,6 +515,9 @@ pub fn printUsage(writer: anytype) !void {
         \\  codex canary [--accounts a,b,c] [--capabilities c1,c2] [--live]
         \\      Run a no-spend Codex Max readiness check; --live runs probes.
         \\
+        \\  codex live-qa [--accounts a,b,c] [--capabilities c1,c2] [--confirm-spend] [--json]
+        \\      Run confirmed Codex route probes and record route evidence.
+        \\
         \\  codex probe-all [--accounts a,b,c] [--capabilities c1,c2] [--json]
         \\      Probe every selected Codex account/capability route.
         \\
@@ -548,6 +557,7 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\  oauth-mux setup codex [--accounts a,b,c] [--device|--status-only] [--live]
         \\  oauth-mux codex setup|onboard [--accounts a,b,c] [--device|--status-only] [--live]
         \\  oauth-mux codex canary [--accounts a,b,c] [--capabilities c1,c2] [--live]
+        \\  oauth-mux codex live-qa [--accounts a,b,c] [--capabilities c1,c2] [--confirm-spend] [--json]
         \\  oauth-mux codex probe-all [--accounts a,b,c] [--capability c] [--json]
         \\  oauth-mux codex config-candidate [--output path] [--store-root path] [--json]
         \\  oauth-mux codex config-merge [--candidate path] [--backup path] [--json]
@@ -559,7 +569,8 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\
         \\Safety:
         \\  canary is no-spend unless --live is provided.
-        \\  probe-all and canary --live run real provider probes.
+        \\  live-qa, probe-all, and canary --live run real provider probes.
+        \\  live-qa requires --confirm-spend or OMUX_LIVE_QA_CONFIRM=spend-real-calls.
         \\  --help and -h are non-mutating for every Codex subcommand.
         \\
         \\Defaults:
@@ -672,6 +683,21 @@ test "parse codex canary" {
             try std.testing.expectEqualStrings("max-1,max-2", codex.accounts);
             try std.testing.expectEqualStrings("codex-mini", codex.capabilities);
             try std.testing.expect(codex.live);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse codex live qa confirmation" {
+    const args = [_][]const u8{ "codex", "live-qa", "--accounts", "max-1,max-3", "--capabilities", "codex-mini", "--confirm-spend", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex => |codex| {
+            try std.testing.expect(codex.action == .live_qa);
+            try std.testing.expectEqualStrings("max-1,max-3", codex.accounts);
+            try std.testing.expectEqualStrings("codex-mini", codex.capabilities);
+            try std.testing.expect(codex.confirm_spend);
+            try std.testing.expect(codex.json);
         },
         else => return error.Unexpected,
     }
@@ -860,7 +886,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary probe-all config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary live-qa probe-all config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run start stop status' -d 'Daemon subcommand'
             \\
         );

--- a/src/main.zig
+++ b/src/main.zig
@@ -1110,7 +1110,7 @@ fn writeDoctorNextCommandsText(writer: anytype, stats: DoctorStats) !void {
         }
         try writer.writeAll("    oauth-mux setup codex\n");
         try writer.writeAll("    oauth-mux codex canary\n");
-        try writer.writeAll("    oauth-mux codex canary --live\n");
+        try writer.writeAll("    oauth-mux codex live-qa\n");
     }
 }
 
@@ -1141,7 +1141,7 @@ fn writeDoctorNextCommandsJson(writer: anytype, stats: DoctorStats) !void {
         }
         try writeDoctorCommandJson(writer, &first, "oauth-mux setup codex");
         try writeDoctorCommandJson(writer, &first, "oauth-mux codex canary");
-        try writeDoctorCommandJson(writer, &first, "oauth-mux codex canary --live");
+        try writeDoctorCommandJson(writer, &first, "oauth-mux codex live-qa");
     }
 }
 
@@ -2775,6 +2775,7 @@ fn runCodex(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Cod
         .login_status_all => try runCodexLoginStatusAll(allocator, writer, args, root),
         .onboard => try runCodexOnboard(allocator, writer, args, root),
         .canary => try runCodexCanary(allocator, writer, args, root),
+        .live_qa => try runCodexLiveQa(allocator, writer, args, root),
         .probe_all => try runCodexProbeAll(allocator, writer, args),
         .config_candidate => try runCodexConfigCandidate(allocator, writer, args, root),
         .config_merge => try runCodexConfigMerge(allocator, writer, args),
@@ -2871,6 +2872,131 @@ fn runCodexProbeAll(allocator: std.mem.Allocator, writer: anytype, args: cli.Com
         try writer.writeAll("\n=== live probes ===\n");
     }
     try runCodexLiveProbes(allocator, writer, args, !args.json);
+}
+
+fn runCodexLiveQa(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs, root: []const u8) !void {
+    if (!codexLiveQaConfirmed(args)) {
+        if (args.json) {
+            try writer.writeAll("{\"ok\":false,\"error\":\"confirmation_required\",\"required\":\"--confirm-spend or OMUX_LIVE_QA_CONFIRM=spend-real-calls\",\"spends_provider_calls\":true}\n");
+        } else {
+            try writer.writeAll("oauth-mux Codex live QA is disabled.\n\n");
+            try writer.writeAll("This command runs real Codex provider probes and can spend subscription quota.\n");
+            try writer.writeAll("Re-run with --confirm-spend or OMUX_LIVE_QA_CONFIRM=spend-real-calls.\n");
+        }
+        return error.CodexLiveQaConfirmationRequired;
+    }
+
+    if (args.json) {
+        try bootstrapCodexDirs(allocator, std.io.null_writer, args, root);
+    } else {
+        try bootstrapCodexDirs(allocator, writer, args, root);
+    }
+
+    if (args.json) {
+        try writer.writeAll("{\"version\":");
+        try std.json.stringify(cli.version, .{}, writer);
+        try writer.writeAll(",\"ok\":");
+
+        var route_buf = std.ArrayList(u8).init(allocator);
+        defer route_buf.deinit();
+        var failures: usize = 0;
+        var total: usize = 0;
+        try collectCodexLiveQaRoutesJson(allocator, &route_buf, args, &total, &failures);
+
+        try writer.writeAll(if (failures == 0) "true" else "false");
+        try writer.writeAll(",\"spends_provider_calls\":true,\"accounts\":");
+        try std.json.stringify(args.accounts, .{}, writer);
+        try writer.writeAll(",\"capabilities\":");
+        try std.json.stringify(args.capabilities, .{}, writer);
+        try writer.print(",\"routes_total\":{d},\"failures\":{d},\"routes\":[", .{ total, failures });
+        try writer.writeAll(route_buf.items);
+        try writer.writeAll("]}\n");
+        if (failures != 0) return error.CodexRouteProbeFailed;
+        return;
+    }
+
+    try writer.writeAll("oauth-mux Codex live QA\n\n");
+    try writer.print("store root:   {s}\n", .{root});
+    try writer.print("accounts:     {s}\n", .{args.accounts});
+    try writer.print("capabilities: {s}\n", .{args.capabilities});
+    try writer.writeAll("confirmed:    yes, real provider probes may spend quota\n\n");
+
+    try writer.writeAll("=== config validate ===\n");
+    try validateCurrentConfig(allocator, writer);
+
+    try writer.writeAll("\n=== codex login status ===\n");
+    try runCodexLoginStatusAll(allocator, writer, args, root);
+
+    try writer.writeAll("\n=== live probes ===\n");
+    const failures = try runCodexLiveProbesCount(allocator, writer, args, true);
+
+    try writer.writeAll("\n=== route liveness snapshot ===\n");
+    try writeCodexRouteSnapshot(allocator, writer, args);
+
+    try writer.writeAll("\n=== repair plan ===\n");
+    try writeCodexRepairPlanSnapshot(allocator, writer, args);
+
+    if (failures != 0) return error.CodexRouteProbeFailed;
+}
+
+fn codexLiveQaConfirmed(args: cli.Command.CodexArgs) bool {
+    if (args.confirm_spend) return true;
+    const confirm = std.process.getEnvVarOwned(std.heap.page_allocator, "OMUX_LIVE_QA_CONFIRM") catch return false;
+    defer std.heap.page_allocator.free(confirm);
+    return std.mem.eql(u8, confirm, "spend-real-calls");
+}
+
+fn collectCodexLiveQaRoutesJson(
+    allocator: std.mem.Allocator,
+    routes: *std.ArrayList(u8),
+    args: cli.Command.CodexArgs,
+    total: *usize,
+    failures: *usize,
+) !void {
+    var first = true;
+    var account_it = std.mem.splitScalar(u8, args.accounts, ',');
+    while (account_it.next()) |raw_account| {
+        const account = std.mem.trim(u8, raw_account, " \t\r\n");
+        if (account.len == 0) continue;
+        var capability_it = std.mem.splitScalar(u8, args.capabilities, ',');
+        while (capability_it.next()) |raw_capability| {
+            const capability = std.mem.trim(u8, raw_capability, " \t\r\n");
+            if (capability.len == 0) continue;
+            total.* += 1;
+
+            var probe_buf = std.ArrayList(u8).init(allocator);
+            defer probe_buf.deinit();
+            const probe_error = runProbe(allocator, probe_buf.writer(), .{
+                .provider = "codex",
+                .account = account,
+                .capability = capability,
+                .json = true,
+            });
+
+            const route_failed = if (probe_error) |_| false else |e| !liveQaErrorIsRecordedEvidence(e);
+            if (route_failed) failures.* += 1;
+
+            if (!first) try routes.append(',');
+            first = false;
+            const route_json = std.mem.trim(u8, probe_buf.items, " \t\r\n");
+            if (route_json.len == 0) {
+                try routes.appendSlice("{\"provider\":\"codex\",\"account\":");
+                try std.json.stringify(account, .{}, routes.writer());
+                try routes.appendSlice(",\"capability\":");
+                try std.json.stringify(capability, .{}, routes.writer());
+                try routes.appendSlice(",\"ok\":false,\"error\":\"ProbeDidNotProduceJson\"}");
+            } else {
+                try routes.appendSlice(route_json);
+            }
+        }
+    }
+}
+
+fn liveQaErrorIsRecordedEvidence(e: anyerror) bool {
+    return switch (e) {
+        error.AllAccountsExhausted => true,
+        else => false,
+    };
 }
 
 fn runCodexConfigCandidate(
@@ -3291,6 +3417,12 @@ fn runCodexLoginStatusAll(allocator: std.mem.Allocator, writer: anytype, args: c
 }
 
 fn runCodexLiveProbes(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs, emit_headers: bool) !void {
+    const failures = try runCodexLiveProbesCount(allocator, writer, args, emit_headers);
+    if (failures != 0) return error.CodexRouteProbeFailed;
+}
+
+fn runCodexLiveProbesCount(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs, emit_headers: bool) !usize {
+    var failures: usize = 0;
     var account_it = std.mem.splitScalar(u8, args.accounts, ',');
     while (account_it.next()) |raw_account| {
         const account = std.mem.trim(u8, raw_account, " \t\r\n");
@@ -3307,10 +3439,11 @@ fn runCodexLiveProbes(allocator: std.mem.Allocator, writer: anytype, args: cli.C
                 .json = args.json,
             }) catch |e| switch (e) {
                 error.AllAccountsExhausted => {},
-                else => return e,
+                else => failures += 1,
             };
         }
     }
+    return failures;
 }
 
 fn writeCodexRouteSnapshot(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs) !void {


### PR DESCRIPTION
Adds an installed codex live-qa command with explicit spend confirmation. Updates first-run docs, just aliases, and e2e coverage so users and agents see a guarded path before real provider probes. Validated with just check, just release, unconfirmed live-qa JSON gate, and confirmed max-3 codex-mini and codex-max live probes.