### PR TITLE
Bump version to 0.1.4

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 
-pub const version = "0.1.3";
+pub const version = "0.1.4";
 
 pub const Command = union(enum) {
     exec: ExecArgs,


### PR DESCRIPTION
Prepares the live-qa release by bumping the binary version to 0.1.4 and updating latest-version QA defaults. Local validation passed with just check, just release-proof 0.1.4, and non-publishing registry dry-run lanes for plan, GitHub, and system packages.