### PR TITLE
Fix live QA coverage semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex live-qa
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex live-qa --confirm-spend
 ```
 
+`codex live-qa --json` reports both per-route liveness and mux coverage.
+`routes_unavailable` can be nonzero while top-level `ok` remains true when
+another account still covers each requested capability. If an entire requested
+capability has no available account, `capabilities_uncovered` becomes nonzero
+and the command exits nonzero.
+
 Explain current Codex Max stay-afloat actions without running probes or
 mutating auth state:
 

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -10,14 +10,15 @@ files, SOPS plaintext, or token-shaped values here.
 
 | Surface | Version | Host | Source | Result | Caveat |
 | --- | --- | --- | --- | --- | --- |
-| npm global install | 0.1.3 | macOS arm64 | public npm registry | Pass | Clean temp-prefix global install returns `oauth-mux 0.1.3`. |
-| npm one-shot | 0.1.3 | `../lab` on macOS arm64 | public npm registry | Pass | `npx -y oauth-mux@0.1.3 version` returns `oauth-mux 0.1.3`. |
-| GitHub release tarball | 0.1.3 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Repo visibility must remain public for unauthenticated downloads. |
-| `curl | sh` installer | 0.1.3 | macOS arm64 and `../lab` | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass | Default installer repo is now canonical; no `REPO=...` override needed. |
+| npm global install | 0.1.4 | macOS arm64 | public npm registry | Pass | Public registry reports `oauth-mux@0.1.4` plus all six platform packages. |
+| npm one-shot | 0.1.4 | macOS arm64 | public npm registry | Pass | `npx -y oauth-mux@0.1.4 version` returns `oauth-mux 0.1.4`. |
+| GitHub release tarball | 0.1.4 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Release workflow `25166266397` published all tarballs, packages, checksums, formula, and installer. |
+| `curl | sh` installer | 0.1.4 | macOS arm64 and `../lab` | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass | Default installer repo is canonical; no `REPO=...` override needed. |
 | Homebrew formula | 0.1.3 | macOS arm64 | `tinyland/tools` tap | Pass | `just homebrew-qa 0.1.3` installs from the private `tinyland-inc/homebrew-tools` tap, runs `brew audit`, `brew test`, `oauth-mux version`, and `oauth-mux doctor --json`. |
-| deb package | 0.1.3 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25137323710` installed package and ran `/usr/bin/oauth-mux version`. |
-| rpm package | 0.1.3 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25137323710` installed package and ran `/usr/bin/oauth-mux version`. |
-| lab dogfood | 0.1.3 | `../lab` on macOS arm64 | installed `oauth-mux` CLI | Pass | Installed `oauth-mux doctor --json` reports `ok: true` against local config/state. |
+| deb package | 0.1.4 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25166924387` installed package and ran `/usr/bin/oauth-mux version`. |
+| rpm package | 0.1.4 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25166924387` installed package and ran `/usr/bin/oauth-mux version`. |
+| Codex live dogfood | 0.1.4 | macOS arm64 | public npm one-shot | Pass with degraded route | Published npm binary reported `max-1#codex-max` quota exhausted while `max-2` and `max-3` covered `codex-max`; `codex-mini` remained covered. |
+| lab dogfood | 0.1.4 | macOS arm64 | public npm one-shot | Pass | Installed `oauth-mux doctor --json` reports `ok: true` against local config/state. |
 | first-run source e2e | main | macOS arm64 | source checkout | Pass | `just first-run-e2e` runs with temporary HOME/XDG roots and proves no-config `init --codex-max`, JSON diagnostics, redacted report, and non-mutating Codex help. |
 
 ## Evidence Commands
@@ -27,7 +28,7 @@ npm clean install:
 ```bash
 tmp="$(mktemp -d)"
 npm_config_cache="$tmp/cache" \
-  npm install --prefix "$tmp/app" --install-strategy=shallow oauth-mux@0.1.3 \
+  npm install --prefix "$tmp/app" --install-strategy=shallow oauth-mux@0.1.4 \
   --ignore-scripts=false --no-audit --no-fund
 "$tmp/app/node_modules/.bin/oauth-mux" version
 rm -rf "$tmp"
@@ -36,7 +37,7 @@ rm -rf "$tmp"
 Expected output includes:
 
 ```text
-oauth-mux 0.1.3
+oauth-mux 0.1.4
 ```
 
 Raw release tarball:
@@ -44,9 +45,9 @@ Raw release tarball:
 ```bash
 tmp="$(mktemp -d)"
 curl -fsSL -o "$tmp/oauth-mux-aarch64-macos.tar.gz" \
-  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.3/oauth-mux-aarch64-macos.tar.gz
+  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.4/oauth-mux-aarch64-macos.tar.gz
 curl -fsSL -o "$tmp/SHA256SUMS" \
-  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.3/SHA256SUMS
+  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.4/SHA256SUMS
 (cd "$tmp" && shasum -a 256 -c --ignore-missing SHA256SUMS)
 tar -xzf "$tmp/oauth-mux-aarch64-macos.tar.gz" -C "$tmp"
 "$tmp/oauth-mux" version
@@ -57,16 +58,16 @@ Expected output includes:
 
 ```text
 oauth-mux-aarch64-macos.tar.gz: OK
-oauth-mux 0.1.3
+oauth-mux 0.1.4
 ```
 
-Public installer for v0.1.3:
+Public installer for v0.1.4:
 
 ```bash
 tmp="$(mktemp -d)"
-VERSION=0.1.3 \
+VERSION=0.1.4 \
 INSTALL_DIR="$tmp/bin" \
-  sh -c 'curl -fsSL https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.3/install.sh | sh'
+  sh -c 'curl -fsSL https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.4/install.sh | sh'
 "$tmp/bin/oauth-mux" version
 rm -rf "$tmp"
 ```
@@ -74,7 +75,7 @@ rm -rf "$tmp"
 Expected output includes:
 
 ```text
-oauth-mux 0.1.3
+oauth-mux 0.1.4
 ```
 
 Homebrew tap install:
@@ -132,23 +133,38 @@ Homebrew-installed oauth-mux codex live-qa --confirm-spend with examples/codex-m
   max-1, max-2, max-3 available for codex-mini and codex-max
 ```
 
+Latest public npm dogfood proof:
+
+```text
+npx -y oauth-mux@0.1.4 version: oauth-mux 0.1.4
+npx -y oauth-mux@0.1.4 doctor --json: ok
+npx -y oauth-mux@0.1.4 codex live-qa --json: confirmation_required without --confirm-spend
+confirmed live QA:
+  max-1#codex-mini: available
+  max-1#codex-max: quota_exhausted reset@1777987200
+  max-2#codex-mini: available
+  max-2#codex-max: available
+  max-3#codex-mini: available
+  max-3#codex-max: available
+```
+
 System package install QA after GitHub Release publication:
 
 ```bash
-gh workflow run system-package-install-qa.yml -f version=0.1.3
+gh workflow run system-package-install-qa.yml -f version=0.1.4
 ```
 
 Latest hosted proof:
 
 ```text
-System Package Install QA run 25137323710: pass
-job 73678810909: deb/rpm install from published release assets
+System Package Install QA run 25166924387: pass
+job 73775458655: deb/rpm install from published release assets
 ```
 
 Local reproduction on a host with healthy Docker:
 
 ```bash
-just system-package-qa 0.1.3
+just system-package-qa 0.1.4
 ```
 
 ## Next Proof

--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -56,6 +56,12 @@ OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex live-qa
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex live-qa --confirm-spend
 ```
 
+For `codex live-qa --json`, top-level `ok` is a mux coverage result: every
+requested capability must have at least one currently available account.
+Individual exhausted, limited, degraded, or dead routes remain visible through
+`routes_unavailable` and each route's typed `liveness`, so one spent account
+does not hide the fact that another account can still carry the capability.
+
 For a focused account matrix on one route class:
 
 ```bash

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -206,9 +206,13 @@ oauth-mux exec --profile <profile> --capability <capability> -- <command>
 Probe JSON includes `ok`, `error`, and `exit_code` alongside typed
 `liveness`. `codex live-qa --json` is safe without confirmation: it exits
 nonzero with `confirmation_required` and `spends_provider_calls: true` before
-running provider calls. Agents should use `liveness` to distinguish
-`rate_limited`, `quota_exhausted`, `degraded`, and `dead` instead of treating
-every nonzero probe exit as the same failure class.
+running provider calls. Once confirmed, its top-level `ok` means every
+requested capability has at least one available account, not that every account
+is currently available. Use `routes_available`, `routes_unavailable`,
+`probe_errors`, `capabilities_covered`, and `capabilities_uncovered` for
+automation. Agents should use route `liveness` to distinguish `rate_limited`,
+`quota_exhausted`, `degraded`, and `dead` instead of treating every nonzero
+probe exit as the same failure class.
 
 Agents must not:
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 
-pub const version = "0.1.4";
+pub const version = "0.1.5";
 
 pub const Command = union(enum) {
     exec: ExecArgs,

--- a/src/main.zig
+++ b/src/main.zig
@@ -2899,19 +2899,37 @@ fn runCodexLiveQa(allocator: std.mem.Allocator, writer: anytype, args: cli.Comma
 
         var route_buf = std.ArrayList(u8).init(allocator);
         defer route_buf.deinit();
-        var failures: usize = 0;
-        var total: usize = 0;
-        try collectCodexLiveQaRoutesJson(allocator, &route_buf, args, &total, &failures);
+        var capability_coverage = std.StringHashMap(bool).init(allocator);
+        defer freeLiveQaCoverage(allocator, &capability_coverage);
+        try seedLiveQaCapabilities(allocator, &capability_coverage, args.capabilities);
 
-        try writer.writeAll(if (failures == 0) "true" else "false");
+        var summary = LiveQaSummary{
+            .capabilities_total = capability_coverage.count(),
+        };
+        try collectCodexLiveQaRoutesJson(allocator, &route_buf, args, &capability_coverage, &summary);
+        summary.capabilities_covered = countLiveQaCoveredCapabilities(&capability_coverage);
+
+        try writer.writeAll(if (summary.ok()) "true" else "false");
         try writer.writeAll(",\"spends_provider_calls\":true,\"accounts\":");
         try std.json.stringify(args.accounts, .{}, writer);
         try writer.writeAll(",\"capabilities\":");
         try std.json.stringify(args.capabilities, .{}, writer);
-        try writer.print(",\"routes_total\":{d},\"failures\":{d},\"routes\":[", .{ total, failures });
+        try writer.print(
+            ",\"routes_total\":{d},\"routes_available\":{d},\"routes_unavailable\":{d},\"probe_errors\":{d},\"failures\":{d},\"capabilities_total\":{d},\"capabilities_covered\":{d},\"capabilities_uncovered\":{d},\"routes\":[",
+            .{
+                summary.routes_total,
+                summary.routes_available,
+                summary.routes_unavailable,
+                summary.probe_errors,
+                summary.failureCount(),
+                summary.capabilities_total,
+                summary.capabilities_covered,
+                summary.capabilitiesUncovered(),
+            },
+        );
         try writer.writeAll(route_buf.items);
         try writer.writeAll("]}\n");
-        if (failures != 0) return error.CodexRouteProbeFailed;
+        if (!summary.ok()) return error.CodexRouteProbeFailed;
         return;
     }
 
@@ -2939,6 +2957,31 @@ fn runCodexLiveQa(allocator: std.mem.Allocator, writer: anytype, args: cli.Comma
     if (failures != 0) return error.CodexRouteProbeFailed;
 }
 
+const LiveQaSummary = struct {
+    routes_total: usize = 0,
+    routes_available: usize = 0,
+    routes_unavailable: usize = 0,
+    probe_errors: usize = 0,
+    capabilities_total: usize = 0,
+    capabilities_covered: usize = 0,
+
+    fn capabilitiesUncovered(self: LiveQaSummary) usize {
+        if (self.capabilities_covered >= self.capabilities_total) return 0;
+        return self.capabilities_total - self.capabilities_covered;
+    }
+
+    fn ok(self: LiveQaSummary) bool {
+        return self.routes_total > 0 and
+            self.probe_errors == 0 and
+            self.capabilities_total > 0 and
+            self.capabilitiesUncovered() == 0;
+    }
+
+    fn failureCount(self: LiveQaSummary) usize {
+        return self.probe_errors + self.capabilitiesUncovered();
+    }
+};
+
 fn codexLiveQaConfirmed(args: cli.Command.CodexArgs) bool {
     if (args.confirm_spend) return true;
     const confirm = std.process.getEnvVarOwned(std.heap.page_allocator, "OMUX_LIVE_QA_CONFIRM") catch return false;
@@ -2946,12 +2989,44 @@ fn codexLiveQaConfirmed(args: cli.Command.CodexArgs) bool {
     return std.mem.eql(u8, confirm, "spend-real-calls");
 }
 
+fn seedLiveQaCapabilities(
+    allocator: std.mem.Allocator,
+    coverage: *std.StringHashMap(bool),
+    capabilities: []const u8,
+) !void {
+    var capability_it = std.mem.splitScalar(u8, capabilities, ',');
+    while (capability_it.next()) |raw_capability| {
+        const capability = std.mem.trim(u8, raw_capability, " \t\r\n");
+        if (capability.len == 0 or coverage.contains(capability)) continue;
+        const key = try allocator.dupe(u8, capability);
+        errdefer allocator.free(key);
+        try coverage.put(key, false);
+    }
+}
+
+fn countLiveQaCoveredCapabilities(coverage: *const std.StringHashMap(bool)) usize {
+    var covered: usize = 0;
+    var it = coverage.iterator();
+    while (it.next()) |entry| {
+        if (entry.value_ptr.*) covered += 1;
+    }
+    return covered;
+}
+
+fn freeLiveQaCoverage(allocator: std.mem.Allocator, coverage: *std.StringHashMap(bool)) void {
+    var it = coverage.iterator();
+    while (it.next()) |entry| {
+        allocator.free(entry.key_ptr.*);
+    }
+    coverage.deinit();
+}
+
 fn collectCodexLiveQaRoutesJson(
     allocator: std.mem.Allocator,
     routes: *std.ArrayList(u8),
     args: cli.Command.CodexArgs,
-    total: *usize,
-    failures: *usize,
+    capability_coverage: *std.StringHashMap(bool),
+    summary: *LiveQaSummary,
 ) !void {
     var first = true;
     var account_it = std.mem.splitScalar(u8, args.accounts, ',');
@@ -2962,7 +3037,7 @@ fn collectCodexLiveQaRoutesJson(
         while (capability_it.next()) |raw_capability| {
             const capability = std.mem.trim(u8, raw_capability, " \t\r\n");
             if (capability.len == 0) continue;
-            total.* += 1;
+            summary.routes_total += 1;
 
             var probe_buf = std.ArrayList(u8).init(allocator);
             defer probe_buf.deinit();
@@ -2973,8 +3048,16 @@ fn collectCodexLiveQaRoutesJson(
                 .json = true,
             });
 
-            const route_failed = if (probe_error) |_| false else |e| !liveQaErrorIsRecordedEvidence(e);
-            if (route_failed) failures.* += 1;
+            if (probe_error) |_| {
+                summary.routes_available += 1;
+                if (capability_coverage.getPtr(capability)) |covered| covered.* = true;
+            } else |e| {
+                if (liveQaErrorIsRecordedEvidence(e)) {
+                    summary.routes_unavailable += 1;
+                } else {
+                    summary.probe_errors += 1;
+                }
+            }
 
             if (!first) try routes.append(',');
             first = false;
@@ -3987,6 +4070,54 @@ test "writeProbeJson includes terminal pipeline error" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"health_key\":\"codex:max-1\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"state\":\"dead\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"hint_class\":\"auth_dead\"") != null);
+}
+
+test "LiveQaSummary ok is capability coverage not every route availability" {
+    const covered_with_unavailable_route = LiveQaSummary{
+        .routes_total = 3,
+        .routes_available = 2,
+        .routes_unavailable = 1,
+        .probe_errors = 0,
+        .capabilities_total = 2,
+        .capabilities_covered = 2,
+    };
+    try std.testing.expect(covered_with_unavailable_route.ok());
+    try std.testing.expectEqual(@as(usize, 0), covered_with_unavailable_route.capabilitiesUncovered());
+
+    const uncovered = LiveQaSummary{
+        .routes_total = 3,
+        .routes_available = 1,
+        .routes_unavailable = 2,
+        .probe_errors = 0,
+        .capabilities_total = 2,
+        .capabilities_covered = 1,
+    };
+    try std.testing.expect(!uncovered.ok());
+    try std.testing.expectEqual(@as(usize, 1), uncovered.capabilitiesUncovered());
+    try std.testing.expectEqual(@as(usize, 1), uncovered.failureCount());
+
+    const machinery_error = LiveQaSummary{
+        .routes_total = 2,
+        .routes_available = 2,
+        .probe_errors = 1,
+        .capabilities_total = 2,
+        .capabilities_covered = 2,
+    };
+    try std.testing.expect(!machinery_error.ok());
+    try std.testing.expectEqual(@as(usize, 1), machinery_error.failureCount());
+}
+
+test "seedLiveQaCapabilities deduplicates requested coverage keys" {
+    var coverage = std.StringHashMap(bool).init(std.testing.allocator);
+    defer freeLiveQaCoverage(std.testing.allocator, &coverage);
+
+    try seedLiveQaCapabilities(std.testing.allocator, &coverage, "codex-mini, codex-max,codex-mini");
+    try std.testing.expectEqual(@as(usize, 2), coverage.count());
+    try std.testing.expect(coverage.get("codex-mini").? == false);
+    try std.testing.expect(coverage.get("codex-max").? == false);
+
+    coverage.getPtr("codex-max").?.* = true;
+    try std.testing.expectEqual(@as(usize, 1), countLiveQaCoveredCapabilities(&coverage));
 }
 
 // Pull in all module tests


### PR DESCRIPTION
## Summary

This patch tightens Codex live-QA semantics after dogfooding the published 0.1.4 package against the real three-account setup.

- reports route availability separately from mux capability coverage
- keeps top-level ok focused on whether every requested capability has at least one available account
- exposes routes_available, routes_unavailable, probe_errors, capabilities_covered, and capabilities_uncovered in live-QA JSON
- bumps the candidate version to 0.1.5 and updates onboarding/live-provider/install evidence docs

## Root Cause

The 0.1.4 live-QA JSON treated AllAccountsExhausted as recorded evidence and therefore did not count it toward top-level health. That made a fully uncovered capability matrix look successful. The real dogfood case is subtler: max-1#codex-max is quota exhausted, but max-2 and max-3 still cover codex-max, so the mux is healthy while one route remains unavailable.

## Validation

- just check
- just release-proof 0.1.5
- OMUX_REGISTRY_DRY_RUN_CONFIRM=registry-dry-run OMUX_REGISTRY_LANES=plan,github,system just registry-dry-run 0.1.5
- local 0.1.5 live QA against real Codex stores: 6 routes total, 5 available, 1 unavailable, 0 probe errors, 2/2 capabilities covered
- public 0.1.4 install checks: npm temp-prefix install, npx one-shot, raw release tarball checksum/install, curl installer, hosted deb/rpm QA