### PR TITLE
Update install matrix for 0.1.5

### DIFF
--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -10,15 +10,15 @@ files, SOPS plaintext, or token-shaped values here.
 
 | Surface | Version | Host | Source | Result | Caveat |
 | --- | --- | --- | --- | --- | --- |
-| npm global install | 0.1.4 | macOS arm64 | public npm registry | Pass | Public registry reports `oauth-mux@0.1.4` plus all six platform packages. |
-| npm one-shot | 0.1.4 | macOS arm64 | public npm registry | Pass | `npx -y oauth-mux@0.1.4 version` returns `oauth-mux 0.1.4`. |
-| GitHub release tarball | 0.1.4 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Release workflow `25166266397` published all tarballs, packages, checksums, formula, and installer. |
-| `curl | sh` installer | 0.1.4 | macOS arm64 and `../lab` | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass | Default installer repo is canonical; no `REPO=...` override needed. |
+| npm global install | 0.1.5 | macOS arm64 | public npm registry | Pass | Public registry reports `oauth-mux@0.1.5` plus all six platform packages. |
+| npm one-shot | 0.1.5 | macOS arm64 | public npm registry | Pass | `npx -y oauth-mux@0.1.5 version` returns `oauth-mux 0.1.5`. |
+| GitHub release tarball | 0.1.5 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Release workflow `25171997189` published all tarballs, packages, checksums, formula, and installer. |
+| `curl | sh` installer | 0.1.5 | macOS arm64 and `../lab` | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass | Default installer repo is canonical; no `REPO=...` override needed. |
 | Homebrew formula | 0.1.3 | macOS arm64 | `tinyland/tools` tap | Pass | `just homebrew-qa 0.1.3` installs from the private `tinyland-inc/homebrew-tools` tap, runs `brew audit`, `brew test`, `oauth-mux version`, and `oauth-mux doctor --json`. |
-| deb package | 0.1.4 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25166924387` installed package and ran `/usr/bin/oauth-mux version`. |
-| rpm package | 0.1.4 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25166924387` installed package and ran `/usr/bin/oauth-mux version`. |
-| Codex live dogfood | 0.1.4 | macOS arm64 | public npm one-shot | Pass with degraded route | Published npm binary reported `max-1#codex-max` quota exhausted while `max-2` and `max-3` covered `codex-max`; `codex-mini` remained covered. |
-| lab dogfood | 0.1.4 | macOS arm64 | public npm one-shot | Pass | Installed `oauth-mux doctor --json` reports `ok: true` against local config/state. |
+| deb package | 0.1.5 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25172711458` installed package and ran `/usr/bin/oauth-mux version`. |
+| rpm package | 0.1.5 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25172711458` installed package and ran `/usr/bin/oauth-mux version`. |
+| Codex live dogfood | 0.1.5 | macOS arm64 | public npm one-shot | Pass with degraded route | Published npm binary reported `max-1#codex-max` quota exhausted while `max-2` and `max-3` covered `codex-max`; `codex-mini` remained covered. |
+| lab dogfood | 0.1.5 | macOS arm64 | public npm one-shot | Pass | Installed `oauth-mux doctor --json` reports `ok: true` against local config/state. |
 | first-run source e2e | main | macOS arm64 | source checkout | Pass | `just first-run-e2e` runs with temporary HOME/XDG roots and proves no-config `init --codex-max`, JSON diagnostics, redacted report, and non-mutating Codex help. |
 
 ## Evidence Commands
@@ -28,7 +28,7 @@ npm clean install:
 ```bash
 tmp="$(mktemp -d)"
 npm_config_cache="$tmp/cache" \
-  npm install --prefix "$tmp/app" --install-strategy=shallow oauth-mux@0.1.4 \
+  npm install --prefix "$tmp/app" --install-strategy=shallow oauth-mux@0.1.5 \
   --ignore-scripts=false --no-audit --no-fund
 "$tmp/app/node_modules/.bin/oauth-mux" version
 rm -rf "$tmp"
@@ -37,7 +37,7 @@ rm -rf "$tmp"
 Expected output includes:
 
 ```text
-oauth-mux 0.1.4
+oauth-mux 0.1.5
 ```
 
 Raw release tarball:
@@ -45,9 +45,9 @@ Raw release tarball:
 ```bash
 tmp="$(mktemp -d)"
 curl -fsSL -o "$tmp/oauth-mux-aarch64-macos.tar.gz" \
-  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.4/oauth-mux-aarch64-macos.tar.gz
+  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.5/oauth-mux-aarch64-macos.tar.gz
 curl -fsSL -o "$tmp/SHA256SUMS" \
-  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.4/SHA256SUMS
+  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.5/SHA256SUMS
 (cd "$tmp" && shasum -a 256 -c --ignore-missing SHA256SUMS)
 tar -xzf "$tmp/oauth-mux-aarch64-macos.tar.gz" -C "$tmp"
 "$tmp/oauth-mux" version
@@ -58,16 +58,16 @@ Expected output includes:
 
 ```text
 oauth-mux-aarch64-macos.tar.gz: OK
-oauth-mux 0.1.4
+oauth-mux 0.1.5
 ```
 
-Public installer for v0.1.4:
+Public installer for v0.1.5:
 
 ```bash
 tmp="$(mktemp -d)"
-VERSION=0.1.4 \
+VERSION=0.1.5 \
 INSTALL_DIR="$tmp/bin" \
-  sh -c 'curl -fsSL https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.4/install.sh | sh'
+  sh -c 'curl -fsSL https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.5/install.sh | sh'
 "$tmp/bin/oauth-mux" version
 rm -rf "$tmp"
 ```
@@ -75,7 +75,7 @@ rm -rf "$tmp"
 Expected output includes:
 
 ```text
-oauth-mux 0.1.4
+oauth-mux 0.1.5
 ```
 
 Homebrew tap install:
@@ -136,10 +136,16 @@ Homebrew-installed oauth-mux codex live-qa --confirm-spend with examples/codex-m
 Latest public npm dogfood proof:
 
 ```text
-npx -y oauth-mux@0.1.4 version: oauth-mux 0.1.4
-npx -y oauth-mux@0.1.4 doctor --json: ok
-npx -y oauth-mux@0.1.4 codex live-qa --json: confirmation_required without --confirm-spend
+npx -y oauth-mux@0.1.5 version: oauth-mux 0.1.5
+npx -y oauth-mux@0.1.5 doctor --json: ok
+npx -y oauth-mux@0.1.5 codex live-qa --json: confirmation_required without --confirm-spend
 confirmed live QA:
+  routes_total: 6
+  routes_available: 5
+  routes_unavailable: 1
+  probe_errors: 0
+  capabilities_covered: 2
+  capabilities_uncovered: 0
   max-1#codex-mini: available
   max-1#codex-max: quota_exhausted reset@1777987200
   max-2#codex-mini: available
@@ -151,20 +157,20 @@ confirmed live QA:
 System package install QA after GitHub Release publication:
 
 ```bash
-gh workflow run system-package-install-qa.yml -f version=0.1.4
+gh workflow run system-package-install-qa.yml -f version=0.1.5
 ```
 
 Latest hosted proof:
 
 ```text
-System Package Install QA run 25166924387: pass
-job 73775458655: deb/rpm install from published release assets
+System Package Install QA run 25172711458: pass
+job 73796295655: deb/rpm install from published release assets
 ```
 
 Local reproduction on a host with healthy Docker:
 
 ```bash
-just system-package-qa 0.1.4
+just system-package-qa 0.1.5
 ```
 
 ## Next Proof


### PR DESCRIPTION
## Summary

Updates the install beta matrix after the 0.1.5 release and npm publication.

- records 0.1.5 npm, npx, GitHub release, curl installer, deb, and rpm proof
- records the confirmed 0.1.5 public npm Codex live-QA coverage result
- keeps Homebrew tap evidence at 0.1.3 because the tap has not been mutated in this release path

## Validation

- npm temp-prefix install of oauth-mux@0.1.5 returned oauth-mux 0.1.5
- raw v0.1.5 aarch64-macos tarball checksum/install returned oauth-mux 0.1.5
- v0.1.5 curl installer temp install returned oauth-mux 0.1.5
- hosted System Package Install QA run 25172711458 passed