### PR TITLE
[codex] Add route select and explain

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,14 @@ Explain current Codex Max stay-afloat actions without running probes or
 mutating auth state:
 
 ```bash
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux route explain --profile codex-max --capability codex-max --json
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux route select --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair-plan --profile codex-max --capability codex-max --json
 ```
+
+`route select` and `route explain` are no-spend stay-afloat commands. They use
+recorded route liveness plus runtime readiness; unrecorded routes are reported
+as `probe_needed` instead of being treated as available.
 
 First-run Codex subscription path:
 
@@ -98,6 +104,7 @@ oauth-mux doctor
 oauth-mux setup codex
 oauth-mux codex canary
 oauth-mux codex live-qa
+oauth-mux route explain --profile codex-max --capability codex-max --json
 oauth-mux repair-plan --profile codex-max --capability codex-max --json
 ```
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -29,6 +29,7 @@ oauth-mux report --redacted
 oauth-mux providers list
 oauth-mux config validate
 oauth-mux discover --json
+oauth-mux route explain --profile <profile> --capability <capability> --json
 ```
 
 Source checkouts prove this path without touching real operator state:
@@ -44,6 +45,8 @@ oauth-mux init --codex-max
 oauth-mux doctor
 oauth-mux setup codex
 oauth-mux codex canary
+oauth-mux route explain --profile codex-max --capability codex-max --json
+oauth-mux route select --profile codex-max --capability codex-max --json
 ```
 
 Those commands are installed CLI surface, not source-checkout-only helpers.
@@ -58,6 +61,10 @@ oauth-mux codex live-qa
 oauth-mux codex live-qa --confirm-spend
 oauth-mux codex probe-all --capability codex-mini --json
 ```
+
+`route explain` and `route select` are no-spend surfaces. They only use
+recorded liveness and runtime readiness, so they are safe for agents to run
+before deciding whether a live probe or user-driven reauth is warranted.
 
 ## Provider Author Experience
 

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -14,18 +14,22 @@ exhaustion to `codex:max-2#codex-max`, but it also exposed that runtime
 permission/session ownership and automatic reauth are not solved by the current
 daemon.
 
-`oauth-mux repair-plan` is the current bridge between dogfooding evidence and
-future daemon work. It reads runtime readiness and recorded liveness, then
-prints the next non-mutating repair actions. `oauth-mux daemon repair-plan` is
-only a namespace alias for that same one-shot planner; it does not start a
-background service, run probes, open browsers, refresh credentials, or rewrite
-secret stores.
+`oauth-mux route explain`, `oauth-mux route select`, and `oauth-mux
+repair-plan` are the current bridge between dogfooding evidence and future
+daemon work. They read runtime readiness and recorded liveness, then either
+explain the route set, select the first currently usable route, or print the
+next non-mutating repair actions. `oauth-mux daemon repair-plan` is only a
+namespace alias for that same one-shot planner; it does not start a background
+service, run probes, open browsers, refresh credentials, or rewrite secret
+stores.
 
 See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
 
 ## Allowed Now
 
 - `oauth-mux daemon run` as the foreground primitive for any future wrapper.
+- `oauth-mux route explain` for no-spend route-state explanation.
+- `oauth-mux route select` for no-spend route choice from recorded evidence.
 - `oauth-mux repair-plan` for non-mutating stay-afloat action planning.
 - `oauth-mux daemon repair-plan` as a compatibility alias for the same
   one-shot planner.
@@ -65,6 +69,8 @@ Until then, user and agent onboarding should use one-shot commands:
 ```bash
 oauth-mux discover --json
 oauth-mux codex canary
+oauth-mux route explain --profile <profile> --capability <capability> --json
+oauth-mux route select --profile <profile> --capability <capability> --json
 oauth-mux probe --profile <profile> --capability <capability> --json
 oauth-mux repair-plan --profile <profile> --capability <capability> --json
 oauth-mux exec --profile <profile> --capability <capability> -- <command>

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -19,7 +19,7 @@ files, SOPS plaintext, or token-shaped values here.
 | rpm package | 0.1.5 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25172711458` installed package and ran `/usr/bin/oauth-mux version`. |
 | Codex live dogfood | 0.1.5 | macOS arm64 | public npm one-shot | Pass with degraded route | Published npm binary reported `max-1#codex-max` quota exhausted while `max-2` and `max-3` covered `codex-max`; `codex-mini` remained covered. |
 | lab dogfood | 0.1.5 | macOS arm64 | public npm one-shot | Pass | Installed `oauth-mux doctor --json` reports `ok: true` against local config/state. |
-| first-run source e2e | main | macOS arm64 | source checkout | Pass | `just first-run-e2e` runs with temporary HOME/XDG roots and proves no-config `init --codex-max`, JSON diagnostics, redacted report, and non-mutating Codex help. |
+| first-run source e2e | main | macOS arm64 | source checkout | Pass | `just first-run-e2e` runs with temporary HOME/XDG roots and proves no-config `init --codex-max`, JSON diagnostics, redacted report, no-spend route explanation/select refusal, and non-mutating Codex help. |
 
 ## Evidence Commands
 
@@ -99,6 +99,8 @@ just first-run-e2e
 Expected output includes:
 
 ```text
+first-run e2e: route explain reports no recorded health without mutation
+first-run e2e: route select refuses unrecorded health evidence
 first-run e2e passed
 ```
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -48,6 +48,7 @@ oauth-mux doctor
 oauth-mux setup codex
 oauth-mux codex canary
 oauth-mux codex live-qa
+oauth-mux route explain --profile codex-max --capability codex-max --json
 oauth-mux repair-plan --profile codex-max --capability codex-max --json
 ```
 
@@ -115,9 +116,16 @@ oauth-mux codex probe-all --capability codex-mini --json
 To inspect the stay-afloat decision loop without running a canary:
 
 ```bash
+oauth-mux route explain --profile codex-max --capability codex-max --json
+oauth-mux route select --profile codex-max --capability codex-max --json
 oauth-mux repair-plan --profile codex-max --capability codex-max --json
 oauth-mux repair-plan --profile codex-mini --capability codex-mini --json
 ```
+
+`route explain` and `route select` are no-spend commands. They read runtime
+readiness plus recorded route liveness and do not probe providers or mutate auth
+state. Unrecorded routes are reported as `probe_needed`, and `route select`
+exits nonzero when no route has enough evidence to be selected.
 
 If `repair-plan --profile codex-max` reports a config validation error, the
 active config is not the three-account Codex Max shape. That usually means the
@@ -165,7 +173,13 @@ thin aliases for installed commands. `just codex-max-setup` is a thin alias for
 `oauth-mux repair-plan --profile codex-max --capability codex-max --json`, and
 `just codex-max-live-qa` / `just codex-max-live-qa-confirmed` wrap the guarded
 installed live QA command. `just codex-max-probe-all` is likewise a thin alias
-for `oauth-mux codex probe-all`.
+for `oauth-mux codex probe-all`. Route selection and explanation should be run
+through the installed CLI directly:
+
+```bash
+oauth-mux route explain --profile codex-max --capability codex-max --json
+oauth-mux route select --profile codex-max --capability codex-max --json
+```
 
 The clean no-config first-run path is covered by:
 
@@ -176,6 +190,7 @@ just first-run-e2e
 That harness runs with a temporary `HOME`, XDG config/state/data/runtime roots,
 and no inherited `OMUX_*` overrides. It proves `init --codex-max`, JSON
 diagnostics, redacted support output, repair-plan route explanation,
+no-spend route explanation and route-select refusal without health evidence,
 non-clobbering config-candidate generation, config-merge backup behavior, and
 non-mutating Codex help plus the unconfirmed live-QA spend gate without touching
 the operator's real OAuth stores.
@@ -191,11 +206,13 @@ oauth-mux providers list --json
 oauth-mux discover --json
 oauth-mux status --json
 oauth-mux health --json
+oauth-mux route explain --profile <profile> --capability <capability> --json
 ```
 
 Agents may run:
 
 ```bash
+oauth-mux route select --profile <profile> --capability <capability> --json
 oauth-mux probe --profile <profile> --capability <capability> --json
 oauth-mux codex live-qa --json
 oauth-mux codex probe-all --capability <capability> --json
@@ -204,7 +221,9 @@ oauth-mux exec --profile <profile> --capability <capability> -- <command>
 ```
 
 Probe JSON includes `ok`, `error`, and `exit_code` alongside typed
-`liveness`. `codex live-qa --json` is safe without confirmation: it exits
+`liveness`. Route JSON includes `ok`, `selected`, `selectable`, `skip_reason`,
+runtime readiness, liveness, probe evidence, and the same action object used by
+`repair-plan`. `codex live-qa --json` is safe without confirmation: it exits
 nonzero with `confirmation_required` and `spends_provider_calls: true` before
 running provider calls. Once confirmed, its top-level `ok` means every
 requested capability has at least one available account, not that every account

--- a/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
+++ b/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
@@ -38,7 +38,7 @@ OAuth and muxing surfaces:
 | Codex three-account stores | `max-1`, `max-2`, and `max-3` are isolated by `CODEX_HOME` and report logged-in ChatGPT status. |
 | Codex route liveness | Hosted and local installed-binary live canaries have proven all three accounts across `codex-mini` and `codex-max`. Earlier proof also preserved the distinction between quota exhaustion and auth death. |
 | Typed liveness | Unit and e2e tests cover `live`, `degraded`, `dead`, route-scoped `provider:account#capability`, and fallback decisions. |
-| Agent-safe discovery | `doctor --json`, `report --redacted --json`, `providers list --json`, `discover --json`, `status --json`, and `health --json` exist and are documented. |
+| Agent-safe discovery | `doctor --json`, `report --redacted --json`, `providers list --json`, `discover --json`, `status --json`, `health --json`, `route explain --json`, and `route select --json` exist and are documented. |
 | Non-mutating help | `oauth-mux codex canary --help`, `oauth-mux codex probe-all --help`, and `oauth-mux setup codex --help` print help without creating stores or probing. |
 
 ## Not Yet Proven
@@ -98,6 +98,8 @@ oauth-mux init --codex-max
 oauth-mux config validate
 oauth-mux discover --json
 oauth-mux report --redacted --json
+oauth-mux route explain --profile codex-max --capability codex-max --json
+oauth-mux route select --profile codex-max --capability codex-max --json
 oauth-mux codex canary --help
 ```
 
@@ -106,6 +108,8 @@ Acceptance:
 - no credential values are read or printed;
 - help is non-mutating;
 - diagnostics point to the next safe command;
+- route explanation does not probe or mutate;
+- route selection refuses to select unrecorded health optimistically;
 - generated config validates from a clean state.
 
 Automated source-checkout proof:
@@ -133,6 +137,8 @@ OMUX_LIVE_QA_CONFIRM=spend-real-calls oauth-mux codex live-qa
 oauth-mux codex probe-all --capability codex-mini --json
 oauth-mux codex probe-all --capability codex-max --json
 oauth-mux health --json
+oauth-mux route explain --profile codex-max --capability codex-max --json
+oauth-mux route select --profile codex-max --capability codex-max --json
 ```
 
 Acceptance:
@@ -168,6 +174,8 @@ oauth-mux providers list --json
 oauth-mux discover --json
 oauth-mux status --json
 oauth-mux health --json
+oauth-mux route explain --profile <profile> --capability <capability> --json
+oauth-mux route select --profile <profile> --capability <capability> --json
 ```
 
 Acceptance:
@@ -222,6 +230,7 @@ Acceptance:
 - every route has a no-secret validation path;
 - each live route produces typed liveness evidence;
 - unavailable routes fall through without hiding the reason;
+- `route explain` reports skipped routes without spending provider calls;
 - command availability and missing upstream CLIs are reported as diagnostics,
   not silent failures.
 
@@ -261,9 +270,10 @@ Do not call a provider "supported" without also exposing whether it is
 
 ## Next Execution Order
 
-1. Keep `main` green and publish the non-mutating help fix in the next patch.
-2. Add a clean first-run e2e script that uses a temp home/config/state and
-   proves Story A without touching existing credentials.
+1. Land M1 one-shot stay-afloat route selection and explanation.
+2. Keep the clean first-run e2e script proving Story A without touching
+   existing credentials, including route explanation and route-select refusal
+   before health evidence exists.
 3. Extend the live-provider QA harness to accept provider-specific lanes for
    GitHub, Vercel, and Claude.
 4. Run and record Wave 1 live proof, then update provider proof status only for

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -284,10 +284,11 @@ RuntimeReadiness =
   | repair_in_progress(account, started_at)
 ```
 
-Selection should require both `CredentialLiveness` and `RuntimeReadiness`:
+Selection should require both `CredentialLiveness` and `RuntimeReadiness`.
+The current conservative product rule is:
 
 ```text
-SelectableRoute = live_or_degraded_auth_state + ready_runtime_state
+SelectableRoute = live.available + ready_runtime_state
 ```
 
 A denied session directory should not be reported as provider quota or OAuth
@@ -404,6 +405,12 @@ obvious and copy-pastable for humans and agents.
   - `max-1#codex-mini` available;
   - `max-1#codex-max` quota exhausted;
   - `max-2#codex-max` selected as fallback.
+
+Implementation note, 2026-04-30: `route select` and `route explain` now exist
+as one-shot, no-spend commands over recorded liveness. They do not probe live
+providers, open browsers, run repair commands, or mutate secret stores.
+Unrecorded routes surface as `probe_needed`; `route select` exits nonzero when
+there is no `live.available` route with ready runtime state.
 
 ### M2: Repair Plan
 

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -229,6 +229,20 @@ expect_contains "$health_json" '"key":"toy:a1#expensive"' "health includes faile
 expect_contains "$health_json" '"availability":"quota_exhausted"' "health records quota exhausted route availability"
 expect_contains "$health_json" '"decision":"try_next_account"' "health records fallback decision"
 
+printf 'e2e: route explain reports selected fallback without probing\n'
+route_explain="$(omux route explain --profile expensive --capability expensive --json)"
+expect_contains "$route_explain" '"action":"explain"' "route explain reports action"
+expect_contains "$route_explain" '"ok":true' "route explain reports available selection"
+expect_contains "$route_explain" '"selected":{"provider":"toy","account":"a2"' "route explain selects fallback account a2"
+expect_contains "$route_explain" '"skip_reason":"quota_exhausted"' "route explain keeps exhausted reason"
+expect_contains "$route_explain" '"skip_reason":"available"' "route explain marks available selected route"
+
+printf 'e2e: route select chooses selected fallback without probing\n'
+route_select="$(omux route select --profile expensive --capability expensive --json)"
+expect_contains "$route_select" '"action":"select"' "route select reports action"
+expect_contains "$route_select" '"ok":true' "route select reports available selection"
+expect_contains "$route_select" '"selected":{"provider":"toy","account":"a2"' "route select selects fallback account a2"
+
 printf 'e2e: route health does not poison unrelated capability\n'
 cheap_after_quota="$(omux env --profile cheap --capability cheap --shell bash)"
 expect_contains "$cheap_after_quota" "export OMUX_ACTIVE_ACCOUNT='a1'" "cheap route still uses a1 after expensive quota"

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -131,6 +131,8 @@ jq -e '
   and .accounts == 3
   and (.next_commands | index("oauth-mux setup codex") != null)
   and (.next_commands | index("oauth-mux codex config-candidate --json") == null)
+  and (.next_commands | index("oauth-mux route explain --profile <profile> --capability <capability> --json") != null)
+  and (.next_commands | index("oauth-mux route select --profile <profile> --capability <capability> --json") != null)
   and (.next_commands | index("oauth-mux repair-plan --json") != null)
 ' "$doctor_after" >/dev/null
 
@@ -142,6 +144,8 @@ jq -e '
   and .codex_max_configured == true
   and (.providers[] | select(.name == "codex") | .accounts | length) == 3
   and (.agent_safe_commands | index("oauth-mux report --redacted --json") != null)
+  and (.agent_safe_commands | index("oauth-mux route explain --profile <profile> --capability <capability> --json") != null)
+  and (.agent_safe_commands | index("oauth-mux route select --profile <profile> --capability <capability> --json") != null)
   and (.agent_safe_commands | index("oauth-mux repair-plan --profile <profile> --capability <capability> --json") != null)
   and (.agent_safe_commands | index("oauth-mux codex config-candidate --json") == null)
 ' "$discover_json" >/dev/null
@@ -155,6 +159,37 @@ jq -e '
   and all(.routes[]; .provider == "codex" and .capability == "codex-max" and .action.mutating == false)
   and all(.routes[]; .action.kind == "fix_runtime" or .action.kind == "probe_needed" or .action.kind == "none" or .action.kind == "wait_and_retry" or .action.kind == "wait_for_quota" or .action.kind == "wait_for_cooldown")
 ' "$repair_plan_json" >/dev/null
+
+printf 'first-run e2e: route explain reports no recorded health without mutation\n'
+route_explain_json="$tmp/route-explain-codex-max.json"
+run_json "$route_explain_json" route explain --profile codex-max --capability codex-max --json
+jq -e '
+  .action == "explain"
+  and .profile == "codex-max"
+  and .capability == "codex-max"
+  and .ok == false
+  and .selected == null
+  and (.routes | length) == 3
+  and all(.routes[]; .provider == "codex" and .capability == "codex-max" and .action.mutating == false)
+  and all(.routes[]; .action.kind == "fix_runtime" or .action.kind == "probe_needed")
+' "$route_explain_json" >/dev/null
+
+printf 'first-run e2e: route select refuses unrecorded health evidence\n'
+route_select_json="$tmp/route-select-codex-max.json"
+set +e
+omux route select --profile codex-max --capability codex-max --json >"$route_select_json" 2>"$tmp/route-select-codex-max.stderr"
+route_select_status=$?
+set -e
+if [ "$route_select_status" -eq 0 ]; then
+  printf 'first-run e2e assertion failed: route select should fail before health is recorded\n' >&2
+  exit 1
+fi
+jq -e '
+  .action == "select"
+  and .ok == false
+  and .selected == null
+  and (.routes | length) == 3
+' "$route_select_json" >/dev/null
 
 printf 'first-run e2e: config-candidate writes sidecar without clobbering active config\n'
 config_before="$(cat "$config_path")"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -14,6 +14,7 @@ pub const Command = union(enum) {
     health: HealthArgs,
     discover: DiscoverArgs,
     repair_plan: RepairPlanArgs,
+    route: RouteArgs,
     config_validate,
     config_path,
     init: InitArgs,
@@ -92,6 +93,20 @@ pub const Command = union(enum) {
         json: bool = false,
     };
 
+    pub const RouteAction = enum {
+        select,
+        explain,
+    };
+
+    pub const RouteArgs = struct {
+        action: RouteAction = .select,
+        profile: ?[]const u8 = null,
+        provider: ?[]const u8 = null,
+        account: ?[]const u8 = null,
+        capability: ?[]const u8 = null,
+        json: bool = false,
+    };
+
     pub const InitArgs = struct {
         interactive: bool = false,
         codex_max: bool = false,
@@ -148,6 +163,7 @@ pub fn parse(args: []const []const u8) Command {
     if (eql(cmd, "health")) return parseHealth(rest);
     if (eql(cmd, "discover")) return parseDiscover(rest);
     if (eql(cmd, "repair-plan")) return parseRepairPlan(rest);
+    if (eql(cmd, "route")) return parseRoute(rest);
     if (eql(cmd, "config")) return parseConfig(rest);
     if (eql(cmd, "init")) return parseInit(rest);
     if (eql(cmd, "setup")) return parseSetup(rest);
@@ -334,6 +350,38 @@ fn parseRepairPlan(args: []const []const u8) Command {
     return .{ .repair_plan = result };
 }
 
+fn parseRoute(args: []const []const u8) Command {
+    var result = Command.RouteArgs{};
+    var i: usize = 0;
+    if (args.len > 0) {
+        if (eql(args[0], "select")) {
+            result.action = .select;
+            i = 1;
+        } else if (eql(args[0], "explain")) {
+            result.action = .explain;
+            i = 1;
+        }
+    }
+    while (i < args.len) : (i += 1) {
+        if (eql(args[i], "--profile") or eql(args[i], "-p")) {
+            i += 1;
+            if (i < args.len) result.profile = args[i];
+        } else if (eql(args[i], "--provider")) {
+            i += 1;
+            if (i < args.len) result.provider = args[i];
+        } else if (eql(args[i], "--account")) {
+            i += 1;
+            if (i < args.len) result.account = args[i];
+        } else if (eql(args[i], "--capability")) {
+            i += 1;
+            if (i < args.len) result.capability = args[i];
+        } else if (eql(args[i], "--json")) {
+            result.json = true;
+        }
+    }
+    return .{ .route = result };
+}
+
 fn parseConfig(args: []const []const u8) Command {
     if (args.len == 0) return .config_path;
     if (eql(args[0], "validate")) return .config_validate;
@@ -494,6 +542,9 @@ pub fn printUsage(writer: anytype) !void {
         \\
         \\  repair-plan [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
         \\      Explain non-mutating repair actions from runtime and liveness state.
+        \\
+        \\  route select|explain [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
+        \\      Select or explain a route from recorded liveness without probing.
         \\
         \\  config validate    Validate the configuration file.
         \\  config path        Print the config file path.
@@ -839,6 +890,20 @@ test "parse daemon repair plan alias" {
     }
 }
 
+test "parse route explain with profile" {
+    const args = [_][]const u8{ "route", "explain", "--profile", "codex-max", "--capability", "codex-max", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .route => |route| {
+            try std.testing.expect(route.action == .explain);
+            try std.testing.expectEqualStrings("codex-max", route.profile.?);
+            try std.testing.expectEqualStrings("codex-max", route.capability.?);
+            try std.testing.expect(route.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 test "parse daemon run" {
     const args = [_][]const u8{ "daemon", "run" };
     try std.testing.expect(parse(&args) == .daemon_run);
@@ -858,6 +923,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n __fish_use_subcommand -a health -d 'Show health data'
             \\complete -c oauth-mux -n __fish_use_subcommand -a discover -d 'Show agent-safe inventory'
             \\complete -c oauth-mux -n __fish_use_subcommand -a repair-plan -d 'Show non-mutating repair plan'
+            \\complete -c oauth-mux -n __fish_use_subcommand -a route -d 'Select or explain routes'
             \\complete -c oauth-mux -n __fish_use_subcommand -a config -d 'Config operations'
             \\complete -c oauth-mux -n __fish_use_subcommand -a init -d 'Generate config'
             \\complete -c oauth-mux -n __fish_use_subcommand -a setup -d 'First-run setup'
@@ -865,10 +931,10 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n __fish_use_subcommand -a daemon -d 'Daemon operations'
             \\complete -c oauth-mux -n __fish_use_subcommand -a version -d 'Print version'
             \\complete -c oauth-mux -n __fish_use_subcommand -a completions -d 'Generate completions'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe' -l profile -s p -d 'Profile name' -r
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe' -l provider -d 'Provider name' -r
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from probe' -l account -d 'Account name' -r
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe' -l capability -d 'Route capability' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route' -l profile -s p -d 'Profile name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route' -l provider -d 'Provider name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from probe route' -l account -d 'Account name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route' -l capability -d 'Route capability' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from probe' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from report providers' -l json -d 'JSON output'
@@ -883,6 +949,8 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from repair-plan' -l provider -d 'Provider name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from repair-plan' -l account -d 'Account name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from repair-plan' -l capability -d 'Route capability' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from route' -a 'select explain' -d 'Route subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from route' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
@@ -906,6 +974,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\    'health:Show health data'
             \\    'discover:Show agent-safe inventory'
             \\    'repair-plan:Show non-mutating repair plan'
+            \\    'route:Select or explain routes'
             \\    'config:Config operations'
             \\    'init:Generate config'
             \\    'setup:First-run setup'
@@ -923,7 +992,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
         try writer.writeAll(
             \\_oauth_mux_completions() {
             \\  local cur="${COMP_WORDS[COMP_CWORD]}"
-            \\  COMPREPLY=($(compgen -W "exec env probe doctor report providers status health discover repair-plan config init setup codex daemon version completions" -- "$cur"))
+            \\  COMPREPLY=($(compgen -W "exec env probe doctor report providers status health discover repair-plan route config init setup codex daemon version completions" -- "$cur"))
             \\}
             \\complete -F _oauth_mux_completions oauth-mux
             \\

--- a/src/main.zig
+++ b/src/main.zig
@@ -114,6 +114,13 @@ pub fn main() !void {
             };
         },
 
+        .route => |route_args| {
+            runRoute(allocator, stdout, route_args) catch |e| {
+                log.err("route: {s}", .{@errorName(e)});
+                std.process.exit(exitCodeFromPipelineError(e));
+            };
+        },
+
         .completions => |comp_args| {
             try cli.printCompletions(stdout, comp_args.shell);
         },
@@ -320,6 +327,8 @@ fn writeDiscoverText(writer: anytype, cfg: config.Config, config_path: []const u
     try writer.writeAll("    oauth-mux status --json\n");
     try writer.writeAll("    oauth-mux health --json\n");
     try writer.writeAll("    oauth-mux probe --profile <profile> --capability <capability> --json\n");
+    try writer.writeAll("    oauth-mux route explain --profile <profile> --capability <capability> --json\n");
+    try writer.writeAll("    oauth-mux route select --profile <profile> --capability <capability> --json\n");
     try writer.writeAll("    oauth-mux repair-plan --profile <profile> --capability <capability> --json\n");
     if (codex_configured and !codex_max_configured) {
         try writer.writeAll("    oauth-mux codex config-candidate --json\n");
@@ -421,6 +430,8 @@ fn writeDiscoverJson(writer: anytype, cfg: config.Config, config_path: []const u
         "oauth-mux status --json",
         "oauth-mux health --json",
         "oauth-mux probe --profile <profile> --capability <capability> --json",
+        "oauth-mux route explain --profile <profile> --capability <capability> --json",
+        "oauth-mux route select --profile <profile> --capability <capability> --json",
         "oauth-mux repair-plan --profile <profile> --capability <capability> --json",
         "oauth-mux env --profile <profile> --capability <capability> --shell <shell>",
         "oauth-mux exec --profile <profile> --capability <capability> -- <command>",
@@ -883,6 +894,244 @@ fn repairCommandAlloc(
     };
 }
 
+const RouteEvaluation = struct {
+    route: RepairPlanRoute,
+    runtime: types.RuntimeReadiness,
+    health: ?health_mod.AccountHealth,
+    budget: ?types.ActionBudget,
+    action: RepairAction,
+    selectable: bool,
+    skip_reason: []const u8,
+};
+
+fn runRoute(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.RouteArgs) !void {
+    const parsed = try config.load(allocator);
+    defer parsed.deinit();
+
+    var validation_messages = std.ArrayList(u8).init(allocator);
+    defer validation_messages.deinit();
+    try config.validate(parsed.value, validation_messages.writer());
+
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+
+    var routes = try collectRepairPlanRoutes(allocator, parsed.value, .{
+        .profile = args.profile,
+        .provider = args.provider,
+        .account = args.account,
+        .capability = args.capability,
+    });
+    defer routes.deinit();
+
+    var evaluations = std.ArrayList(RouteEvaluation).init(allocator);
+    defer evaluations.deinit();
+    try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &evaluations);
+
+    const selected_index = firstSelectableRoute(evaluations.items);
+
+    if (args.json) {
+        try writeRouteJson(writer, allocator, parsed.value, evaluations.items, selected_index, args);
+    } else {
+        try writeRouteText(writer, allocator, evaluations.items, selected_index, args);
+    }
+
+    if (args.action == .select and selected_index == null) return error.AllAccountsExhausted;
+}
+
+fn collectRouteEvaluations(
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    store: *health_mod.HealthStore,
+    routes: []const RepairPlanRoute,
+    evaluations: *std.ArrayList(RouteEvaluation),
+) !void {
+    for (routes) |route| {
+        const def = config.resolveProviderDefinition(cfg, route.provider);
+        const runtime = try providerRuntimeReadiness(allocator, def, route.capability);
+        const health = routeHealth(store, route);
+        const budget = routeProbeBudget(def, route.capability);
+        const action = repairActionFor(route, def, runtime, health, budget);
+        const selectable = routeSelectable(runtime, health);
+        try evaluations.append(.{
+            .route = route,
+            .runtime = runtime,
+            .health = health,
+            .budget = budget,
+            .action = action,
+            .selectable = selectable,
+            .skip_reason = if (selectable) "available" else routeSkipReason(runtime, health),
+        });
+    }
+}
+
+fn firstSelectableRoute(evaluations: []const RouteEvaluation) ?usize {
+    for (evaluations, 0..) |evaluation, idx| {
+        if (evaluation.selectable) return idx;
+    }
+    return null;
+}
+
+fn routeSelectable(runtime: types.RuntimeReadiness, health: ?health_mod.AccountHealth) bool {
+    const current = health orelse return false;
+    return types.selectable(current.liveness, runtime);
+}
+
+fn routeSkipReason(runtime: types.RuntimeReadiness, health: ?health_mod.AccountHealth) []const u8 {
+    if (!runtime.isReady()) return runtimeReadinessSummary(runtime);
+    const current = health orelse return "unrecorded";
+    return switch (current.liveness) {
+        .live => |live| switch (live.availability) {
+            .available => "available",
+            .rate_limited => "rate_limited",
+            .quota_exhausted => "quota_exhausted",
+            .cooldown => "cooldown",
+        },
+        .degraded => |degraded| @tagName(degraded.reason),
+        .dead => |dead| @tagName(dead.reason),
+    };
+}
+
+fn writeRouteText(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+    args: cli.Command.RouteArgs,
+) !void {
+    try writer.print("oauth-mux route {s}\n\n", .{@tagName(args.action)});
+    if (args.profile) |profile_name| try writer.print("  profile: {s}\n", .{profile_name});
+    if (args.capability) |capability| try writer.print("  capability: {s}\n", .{capability});
+    if (selected_index) |idx| {
+        const selected = evaluations[idx].route;
+        try writer.print("  selected: {s}:{s}", .{ selected.provider, selected.account });
+        if (selected.capability) |capability| try writer.print("#{s}", .{capability});
+        try writer.writeByte('\n');
+    } else {
+        try writer.writeAll("  selected: none\n");
+    }
+
+    if (evaluations.len == 0) {
+        try writer.writeAll("  no matching configured routes\n");
+        return;
+    }
+
+    try writer.writeAll("\n  routes:\n");
+    for (evaluations) |evaluation| {
+        try writer.print("    {s}:{s}", .{ evaluation.route.provider, evaluation.route.account });
+        if (evaluation.route.capability) |capability| try writer.print("#{s}", .{capability});
+        try writer.print(" selectable={s} runtime={s}", .{
+            if (evaluation.selectable) "true" else "false",
+            runtimeReadinessSummary(evaluation.runtime),
+        });
+        if (evaluation.budget) |budget| try writer.print(" probe_budget={s}", .{@tagName(budget)});
+        try writer.writeAll(" liveness=");
+        if (evaluation.health) |health| {
+            try health_mod.writeLivenessSummary(writer, health.liveness);
+        } else {
+            try writer.writeAll("unrecorded");
+        }
+        try writer.print(" reason={s}", .{evaluation.skip_reason});
+        if (args.action == .explain) {
+            try writer.print(" action={s}", .{evaluation.action.kind});
+            if (try repairCommandAlloc(allocator, evaluation.action.command, evaluation.route)) |command| {
+                defer allocator.free(command);
+                try writer.print(" command={s}", .{command});
+            }
+        }
+        try writer.writeByte('\n');
+    }
+}
+
+fn writeRouteJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+    args: cli.Command.RouteArgs,
+) !void {
+    try writer.writeAll("{\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"action\":");
+    try std.json.stringify(@tagName(args.action), .{}, writer);
+    try writer.writeAll(",\"profile\":");
+    if (args.profile) |profile_name| try std.json.stringify(profile_name, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"capability\":");
+    if (args.capability) |capability| try std.json.stringify(capability, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"ok\":");
+    try writer.writeAll(if (selected_index != null) "true" else "false");
+    try writer.writeAll(",\"selected\":");
+    if (selected_index) |idx| {
+        try writeRouteSelectionJson(writer, evaluations[idx].route);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"routes\":[");
+    for (evaluations, 0..) |evaluation, idx| {
+        if (idx > 0) try writer.writeByte(',');
+        const selected = if (selected_index) |selected| idx == selected else false;
+        try writeRouteEvaluationJson(writer, allocator, cfg, evaluation, selected);
+    }
+    try writer.writeAll("]}\n");
+}
+
+fn writeRouteSelectionJson(writer: anytype, route: RepairPlanRoute) !void {
+    try writer.writeByte('{');
+    try writer.writeAll("\"provider\":");
+    try std.json.stringify(route.provider, .{}, writer);
+    try writer.writeAll(",\"account\":");
+    try std.json.stringify(route.account, .{}, writer);
+    try writer.writeAll(",\"capability\":");
+    if (route.capability) |capability| try std.json.stringify(capability, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"health_key\":");
+    if (route.capability) |capability| {
+        const key = health_mod.capabilityKey(route.provider, route.account, capability);
+        try std.json.stringify(key.slice(), .{}, writer);
+    } else {
+        const key = health_mod.accountKey(route.provider, route.account);
+        try std.json.stringify(key.slice(), .{}, writer);
+    }
+    try writer.writeByte('}');
+}
+
+fn writeRouteEvaluationJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluation: RouteEvaluation,
+    selected: bool,
+) !void {
+    const def = config.resolveProviderDefinition(cfg, evaluation.route.provider);
+    try writer.writeByte('{');
+    try writer.writeAll("\"provider\":");
+    try std.json.stringify(evaluation.route.provider, .{}, writer);
+    try writer.writeAll(",\"account\":");
+    try std.json.stringify(evaluation.route.account, .{}, writer);
+    try writer.writeAll(",\"capability\":");
+    if (evaluation.route.capability) |capability| try std.json.stringify(capability, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"selected\":");
+    try writer.writeAll(if (selected) "true" else "false");
+    try writer.writeAll(",\"selectable\":");
+    try writer.writeAll(if (evaluation.selectable) "true" else "false");
+    try writer.writeAll(",\"skip_reason\":");
+    try std.json.stringify(evaluation.skip_reason, .{}, writer);
+    try writer.writeAll(",\"extension_mode\":");
+    try std.json.stringify(@tagName(def.extension_mode), .{}, writer);
+    try writer.writeAll(",\"repair_owner\":");
+    try std.json.stringify(@tagName(def.repair.owner), .{}, writer);
+    try writer.writeAll(",\"probe_budget\":");
+    if (evaluation.budget) |budget| try std.json.stringify(@tagName(budget), .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"runtime\":");
+    try writeRuntimeReadinessJson(writer, evaluation.runtime);
+    try writer.writeAll(",\"liveness\":");
+    if (evaluation.health) |health| try writeLivenessJson(writer, health.liveness) else try writer.writeAll("null");
+    try writer.writeAll(",\"last_probe\":");
+    if (evaluation.health) |health| try writeProbeEvidenceJson(writer, health) else try writer.writeAll("null");
+    try writer.writeAll(",\"action\":");
+    try writeRepairActionJson(writer, allocator, evaluation.action, evaluation.route);
+    try writer.writeByte('}');
+}
+
 const DoctorStats = struct {
     configured: bool = false,
     config_valid: bool = false,
@@ -1104,6 +1353,8 @@ fn writeDoctorNextCommandsText(writer: anytype, stats: DoctorStats) !void {
     try writer.writeAll("    oauth-mux providers list --json\n");
     try writer.writeAll("    oauth-mux status --json\n");
     try writer.writeAll("    oauth-mux health --json\n");
+    try writer.writeAll("    oauth-mux route explain --profile <profile> --capability <capability> --json\n");
+    try writer.writeAll("    oauth-mux route select --profile <profile> --capability <capability> --json\n");
     if (stats.codex_configured) {
         if (!stats.codex_max_configured) {
             try writer.writeAll("    oauth-mux codex config-candidate\n");
@@ -1134,6 +1385,8 @@ fn writeDoctorNextCommandsJson(writer: anytype, stats: DoctorStats) !void {
     try writeDoctorCommandJson(writer, &first, "oauth-mux providers list --json");
     try writeDoctorCommandJson(writer, &first, "oauth-mux status --json");
     try writeDoctorCommandJson(writer, &first, "oauth-mux health --json");
+    try writeDoctorCommandJson(writer, &first, "oauth-mux route explain --profile <profile> --capability <capability> --json");
+    try writeDoctorCommandJson(writer, &first, "oauth-mux route select --profile <profile> --capability <capability> --json");
     try writeDoctorCommandJson(writer, &first, "oauth-mux repair-plan --json");
     if (stats.codex_configured) {
         if (!stats.codex_max_configured) {
@@ -1986,6 +2239,10 @@ fn circuitName(circuit: types.CircuitState) []const u8 {
 
 fn commandAvailable(allocator: std.mem.Allocator, binary_name: []const u8) !bool {
     if (binary_name.len == 0) return false;
+
+    if (std.mem.indexOfScalar(u8, binary_name, '/') != null or std.mem.indexOfScalar(u8, binary_name, '\\') != null) {
+        return fileExists(binary_name);
+    }
 
     const path_env = std.process.getEnvVarOwned(allocator, "PATH") catch return false;
     defer allocator.free(path_env);
@@ -3856,7 +4113,7 @@ test "writeHealthJson includes capability routes" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"availability\":\"quota_exhausted\"") != null);
 }
 
-test "writeDiscoverJson includes repair-plan as agent-safe command" {
+test "writeDiscoverJson includes stay-afloat agent-safe commands" {
     const json =
         \\{
         \\  "version": 1,
@@ -3881,6 +4138,8 @@ test "writeDiscoverJson includes repair-plan as agent-safe command" {
     defer buf.deinit();
 
     try writeDiscoverJson(buf.writer(), parsed.value, "/tmp/config.json", "/tmp/state");
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux route explain --profile <profile> --capability <capability> --json") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux route select --profile <profile> --capability <capability> --json") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux repair-plan --profile <profile> --capability <capability> --json") != null);
 }
 
@@ -4033,6 +4292,104 @@ test "writeRepairActionJson emits codex reauth command without running it" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"interactive\":true") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"mutating\":true") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"command\":\"oauth-mux codex login-device max-1\"") != null);
+}
+
+test "route select picks first ready live route and explains skipped quota route" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": { "name": "toy", "display_name": "Toy Provider" }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "a1": { "secret": { "backend": "env", "variable": "TOY_A1" } },
+        \\        "a2": { "secret": { "backend": "env", "variable": "TOY_A2" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "work": {
+        \\      "providers": ["toy:a1#chat", "toy:a2#chat"]
+        \\    }
+        \\  },
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try config.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    store.recordCapabilityHttpStatus("toy", "a1", "chat", 429, 7200);
+    _ = try store.getOrCreate("toy:a2#chat");
+
+    var routes = try collectRepairPlanRoutes(std.testing.allocator, parsed.value, .{ .profile = "work" });
+    defer routes.deinit();
+
+    var evaluations = std.ArrayList(RouteEvaluation).init(std.testing.allocator);
+    defer evaluations.deinit();
+    try collectRouteEvaluations(std.testing.allocator, parsed.value, &store, routes.items, &evaluations);
+
+    const selected = firstSelectableRoute(evaluations.items).?;
+    try std.testing.expectEqual(@as(usize, 1), selected);
+    try std.testing.expectEqualStrings("quota_exhausted", evaluations.items[0].skip_reason);
+    try std.testing.expect(evaluations.items[1].selectable);
+
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+    try writeRouteJson(buf.writer(), std.testing.allocator, parsed.value, evaluations.items, selected, .{
+        .action = .select,
+        .profile = "work",
+    });
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"ok\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"selected\":{\"provider\":\"toy\",\"account\":\"a2\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"skip_reason\":\"quota_exhausted\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"skip_reason\":\"available\"") != null);
+}
+
+test "route explain treats unrecorded health as probe needed" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": { "name": "toy", "display_name": "Toy Provider" }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "a1": { "secret": { "backend": "env", "variable": "TOY_A1" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "work": {
+        \\      "providers": ["toy:a1#chat"]
+        \\    }
+        \\  },
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try config.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+
+    var routes = try collectRepairPlanRoutes(std.testing.allocator, parsed.value, .{ .profile = "work" });
+    defer routes.deinit();
+
+    var evaluations = std.ArrayList(RouteEvaluation).init(std.testing.allocator);
+    defer evaluations.deinit();
+    try collectRouteEvaluations(std.testing.allocator, parsed.value, &store, routes.items, &evaluations);
+
+    try std.testing.expect(firstSelectableRoute(evaluations.items) == null);
+    try std.testing.expectEqualStrings("unrecorded", evaluations.items[0].skip_reason);
+    try std.testing.expectEqualStrings("probe_needed", evaluations.items[0].action.kind);
 }
 
 test "shellQuoteAlloc protects config paths with spaces" {


### PR DESCRIPTION
## Summary

- add `oauth-mux route explain` and `oauth-mux route select` as no-spend one-shot stay-afloat surfaces over recorded liveness and runtime readiness
- expose the new commands through doctor/discover, shell completions, README, onboarding, daemon-boundary, dogfood, and adoption docs
- extend local and first-run e2e coverage for fallback selection and conservative refusal when health evidence is unrecorded
- fix runtime command readiness for explicit command probe paths

## Validation

- `just check`

## Notes

`route select` only succeeds for routes with `live.available` liveness and ready runtime state. Unrecorded routes remain `probe_needed` rather than optimistic selections.