### PR TITLE
[codex] Add runtime doctor diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ oauth-mux doctor
 oauth-mux report --redacted
 oauth-mux providers list
 oauth-mux discover --json
+oauth-mux doctor runtime --json
 ```
 
 Validate an example:
@@ -96,11 +97,16 @@ OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair-plan --profile 
 recorded route liveness plus runtime readiness; unrecorded routes are reported
 as `probe_needed` instead of being treated as available.
 
+`doctor runtime --json` is also no-spend. It checks local runtime prerequisites
+such as upstream binaries, configured account store directories, write access,
+and expected session files without reading token values or contacting providers.
+
 First-run Codex subscription path:
 
 ```bash
 oauth-mux init --codex-max
 oauth-mux doctor
+oauth-mux doctor runtime --json
 oauth-mux setup codex
 oauth-mux codex canary
 oauth-mux codex live-qa

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -29,6 +29,7 @@ oauth-mux report --redacted
 oauth-mux providers list
 oauth-mux config validate
 oauth-mux discover --json
+oauth-mux doctor runtime --json
 oauth-mux route explain --profile <profile> --capability <capability> --json
 ```
 
@@ -43,6 +44,7 @@ For Codex subscription users working from a source checkout today:
 ```bash
 oauth-mux init --codex-max
 oauth-mux doctor
+oauth-mux doctor runtime --json
 oauth-mux setup codex
 oauth-mux codex canary
 oauth-mux route explain --profile codex-max --capability codex-max --json
@@ -62,9 +64,10 @@ oauth-mux codex live-qa --confirm-spend
 oauth-mux codex probe-all --capability codex-mini --json
 ```
 
-`route explain` and `route select` are no-spend surfaces. They only use
-recorded liveness and runtime readiness, so they are safe for agents to run
-before deciding whether a live probe or user-driven reauth is warranted.
+`doctor runtime`, `route explain`, and `route select` are no-spend surfaces.
+They only use local runtime checks plus recorded liveness, so they are safe for
+agents to run before deciding whether a live probe or user-driven reauth is
+warranted.
 
 ## Provider Author Experience
 

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -14,20 +14,21 @@ exhaustion to `codex:max-2#codex-max`, but it also exposed that runtime
 permission/session ownership and automatic reauth are not solved by the current
 daemon.
 
-`oauth-mux route explain`, `oauth-mux route select`, and `oauth-mux
-repair-plan` are the current bridge between dogfooding evidence and future
-daemon work. They read runtime readiness and recorded liveness, then either
-explain the route set, select the first currently usable route, or print the
-next non-mutating repair actions. `oauth-mux daemon repair-plan` is only a
-namespace alias for that same one-shot planner; it does not start a background
-service, run probes, open browsers, refresh credentials, or rewrite secret
-stores.
+`oauth-mux doctor runtime`, `oauth-mux route explain`, `oauth-mux route
+select`, and `oauth-mux repair-plan` are the current bridge between dogfooding
+evidence and future daemon work. They read local runtime readiness and recorded
+liveness, then either diagnose account stores, explain the route set, select
+the first currently usable route, or print the next non-mutating repair actions.
+`oauth-mux daemon repair-plan` is only a namespace alias for that same one-shot
+planner; it does not start a background service, run probes, open browsers,
+refresh credentials, or rewrite secret stores.
 
 See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
 
 ## Allowed Now
 
 - `oauth-mux daemon run` as the foreground primitive for any future wrapper.
+- `oauth-mux doctor runtime` for no-spend local runtime/session diagnostics.
 - `oauth-mux route explain` for no-spend route-state explanation.
 - `oauth-mux route select` for no-spend route choice from recorded evidence.
 - `oauth-mux repair-plan` for non-mutating stay-afloat action planning.
@@ -69,6 +70,7 @@ Until then, user and agent onboarding should use one-shot commands:
 ```bash
 oauth-mux discover --json
 oauth-mux codex canary
+oauth-mux doctor runtime --json
 oauth-mux route explain --profile <profile> --capability <capability> --json
 oauth-mux route select --profile <profile> --capability <capability> --json
 oauth-mux probe --profile <profile> --capability <capability> --json

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -19,7 +19,7 @@ files, SOPS plaintext, or token-shaped values here.
 | rpm package | 0.1.5 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25172711458` installed package and ran `/usr/bin/oauth-mux version`. |
 | Codex live dogfood | 0.1.5 | macOS arm64 | public npm one-shot | Pass with degraded route | Published npm binary reported `max-1#codex-max` quota exhausted while `max-2` and `max-3` covered `codex-max`; `codex-mini` remained covered. |
 | lab dogfood | 0.1.5 | macOS arm64 | public npm one-shot | Pass | Installed `oauth-mux doctor --json` reports `ok: true` against local config/state. |
-| first-run source e2e | main | macOS arm64 | source checkout | Pass | `just first-run-e2e` runs with temporary HOME/XDG roots and proves no-config `init --codex-max`, JSON diagnostics, redacted report, no-spend route explanation/select refusal, and non-mutating Codex help. |
+| first-run source e2e | main | macOS arm64 | source checkout | Pass | `just first-run-e2e` runs with temporary HOME/XDG roots and proves no-config `init --codex-max`, JSON diagnostics, runtime diagnostics, redacted report, no-spend route explanation/select refusal, and non-mutating Codex help. |
 
 ## Evidence Commands
 
@@ -101,6 +101,7 @@ Expected output includes:
 ```text
 first-run e2e: route explain reports no recorded health without mutation
 first-run e2e: route select refuses unrecorded health evidence
+first-run e2e: runtime doctor classifies unbootstrapped stores without mutation
 first-run e2e passed
 ```
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -36,6 +36,7 @@ Generic starter:
 ```bash
 oauth-mux init
 oauth-mux doctor
+oauth-mux doctor runtime --json
 oauth-mux config validate
 oauth-mux discover
 ```
@@ -45,6 +46,7 @@ Codex Max three-account starter:
 ```bash
 oauth-mux init --codex-max
 oauth-mux doctor
+oauth-mux doctor runtime --json
 oauth-mux setup codex
 oauth-mux codex canary
 oauth-mux codex live-qa
@@ -56,6 +58,12 @@ oauth-mux repair-plan --profile codex-max --capability codex-max --json
 present and valid, counts configured providers/accounts/profiles, reports
 whether health state exists, and prints the next safe commands for the current
 state.
+
+`oauth-mux doctor runtime --json` is the no-spend runtime report. It checks
+upstream binary availability, configured account store directories, local write
+access via a temporary marker file, and expected session-file presence. It does
+not read token values, run live probes, open auth flows, or create missing
+account stores.
 
 `oauth-mux setup codex` is the user-facing alias for
 `oauth-mux codex onboard` / `oauth-mux codex setup`. It creates the expected
@@ -190,7 +198,8 @@ just first-run-e2e
 That harness runs with a temporary `HOME`, XDG config/state/data/runtime roots,
 and no inherited `OMUX_*` overrides. It proves `init --codex-max`, JSON
 diagnostics, redacted support output, repair-plan route explanation,
-no-spend route explanation and route-select refusal without health evidence,
+runtime diagnostics, no-spend route explanation and route-select refusal without
+health evidence,
 non-clobbering config-candidate generation, config-merge backup behavior, and
 non-mutating Codex help plus the unconfirmed live-QA spend gate without touching
 the operator's real OAuth stores.
@@ -206,6 +215,7 @@ oauth-mux providers list --json
 oauth-mux discover --json
 oauth-mux status --json
 oauth-mux health --json
+oauth-mux doctor runtime --json
 oauth-mux route explain --profile <profile> --capability <capability> --json
 ```
 

--- a/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
+++ b/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
@@ -38,7 +38,7 @@ OAuth and muxing surfaces:
 | Codex three-account stores | `max-1`, `max-2`, and `max-3` are isolated by `CODEX_HOME` and report logged-in ChatGPT status. |
 | Codex route liveness | Hosted and local installed-binary live canaries have proven all three accounts across `codex-mini` and `codex-max`. Earlier proof also preserved the distinction between quota exhaustion and auth death. |
 | Typed liveness | Unit and e2e tests cover `live`, `degraded`, `dead`, route-scoped `provider:account#capability`, and fallback decisions. |
-| Agent-safe discovery | `doctor --json`, `report --redacted --json`, `providers list --json`, `discover --json`, `status --json`, `health --json`, `route explain --json`, and `route select --json` exist and are documented. |
+| Agent-safe discovery | `doctor --json`, `doctor runtime --json`, `report --redacted --json`, `providers list --json`, `discover --json`, `status --json`, `health --json`, `route explain --json`, and `route select --json` exist and are documented. |
 | Non-mutating help | `oauth-mux codex canary --help`, `oauth-mux codex probe-all --help`, and `oauth-mux setup codex --help` print help without creating stores or probing. |
 
 ## Not Yet Proven
@@ -96,6 +96,7 @@ oauth-mux version
 oauth-mux doctor --json
 oauth-mux init --codex-max
 oauth-mux config validate
+oauth-mux doctor runtime --json
 oauth-mux discover --json
 oauth-mux report --redacted --json
 oauth-mux route explain --profile codex-max --capability codex-max --json
@@ -108,6 +109,8 @@ Acceptance:
 - no credential values are read or printed;
 - help is non-mutating;
 - diagnostics point to the next safe command;
+- runtime diagnostics classify unbootstrapped account stores without creating
+  them;
 - route explanation does not probe or mutate;
 - route selection refuses to select unrecorded health optimistically;
 - generated config validates from a clean state.
@@ -174,6 +177,7 @@ oauth-mux providers list --json
 oauth-mux discover --json
 oauth-mux status --json
 oauth-mux health --json
+oauth-mux doctor runtime --json
 oauth-mux route explain --profile <profile> --capability <capability> --json
 oauth-mux route select --profile <profile> --capability <capability> --json
 ```
@@ -272,8 +276,8 @@ Do not call a provider "supported" without also exposing whether it is
 
 1. Land M1 one-shot stay-afloat route selection and explanation.
 2. Keep the clean first-run e2e script proving Story A without touching
-   existing credentials, including route explanation and route-select refusal
-   before health evidence exists.
+   existing credentials, including runtime diagnostics, route explanation, and
+   route-select refusal before health evidence exists.
 3. Extend the live-provider QA harness to accept provider-specific lanes for
    GitHub, Vercel, and Claude.
 4. Run and record Wave 1 live proof, then update provider proof status only for

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -412,6 +412,18 @@ providers, open browsers, run repair commands, or mutate secret stores.
 Unrecorded routes surface as `probe_needed`; `route select` exits nonzero when
 there is no `live.available` route with ready runtime state.
 
+Implementation note, 2026-04-30: `doctor runtime --json` now checks local
+runtime prerequisites without provider calls. It reports missing upstream
+binaries, configured account store presence, local write access via a temporary
+marker file, and expected session-file presence. It does not read token values
+or create missing account stores.
+
+Dogfood note, 2026-04-30: running the runtime doctor from the current Codex
+sandbox classified configured Codex account stores as not writable from this
+process while their session files were present. `route explain` now consumes the
+same account runtime readiness, so an otherwise `live.available` Codex account
+is not selected when the current process cannot write its account store.
+
 ### M2: Repair Plan
 
 - Add `needs_reauth` state.

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -196,7 +196,14 @@ expect_contains "$doctor_json" '"ok":true' "doctor reports ready config"
 expect_contains "$doctor_json" '"providers":1' "doctor counts configured provider"
 expect_contains "$doctor_json" '"accounts":2' "doctor counts configured accounts"
 expect_contains "$doctor_json" '"oauth-mux discover --json"' "doctor recommends agent discovery"
+expect_contains "$doctor_json" '"oauth-mux doctor runtime --json"' "doctor recommends runtime diagnostics"
 expect_contains "$doctor_json" '"oauth-mux report --redacted --json"' "doctor recommends redacted report"
+
+printf 'e2e: runtime doctor reports local account stores ready\n'
+runtime_json="$(omux doctor runtime --json)"
+expect_contains "$runtime_json" '"ok":true' "runtime doctor reports ready"
+expect_contains "$runtime_json" '"ready_accounts":2' "runtime doctor counts ready accounts"
+expect_contains "$runtime_json" '"config_dir_writable":true' "runtime doctor verifies writable config dirs"
 
 printf 'e2e: redacted report does not expose secret values\n'
 report_json="$(omux report --redacted --json)"

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -131,10 +131,27 @@ jq -e '
   and .accounts == 3
   and (.next_commands | index("oauth-mux setup codex") != null)
   and (.next_commands | index("oauth-mux codex config-candidate --json") == null)
+  and (.next_commands | index("oauth-mux doctor runtime --json") != null)
   and (.next_commands | index("oauth-mux route explain --profile <profile> --capability <capability> --json") != null)
   and (.next_commands | index("oauth-mux route select --profile <profile> --capability <capability> --json") != null)
   and (.next_commands | index("oauth-mux repair-plan --json") != null)
 ' "$doctor_after" >/dev/null
+
+printf 'first-run e2e: runtime doctor classifies unbootstrapped stores without mutation\n'
+runtime_doctor="$tmp/doctor-runtime.json"
+run_json "$runtime_doctor" doctor runtime --json
+jq -e '
+  .configured == true
+  and .config_valid == true
+  and .ok == false
+  and .accounts == 3
+  and .action_needed_accounts == 3
+  and (.provider_reports[] | select(.name == "codex") | .accounts | length) == 3
+  and all(.provider_reports[] | select(.name == "codex") | .accounts[]; .ready == false)
+' "$runtime_doctor" >/dev/null
+expect_not_contains "$(cat "$runtime_doctor")" "$store_root/max-1" "runtime doctor does not print concrete Codex store paths"
+test ! -e "$store_root"
+test ! -e "$legacy_store_root"
 
 printf 'first-run e2e: discovery is redacted and agent-usable\n'
 discover_json="$tmp/discover.json"
@@ -144,6 +161,7 @@ jq -e '
   and .codex_max_configured == true
   and (.providers[] | select(.name == "codex") | .accounts | length) == 3
   and (.agent_safe_commands | index("oauth-mux report --redacted --json") != null)
+  and (.agent_safe_commands | index("oauth-mux doctor runtime --json") != null)
   and (.agent_safe_commands | index("oauth-mux route explain --profile <profile> --capability <capability> --json") != null)
   and (.agent_safe_commands | index("oauth-mux route select --profile <profile> --capability <capability> --json") != null)
   and (.agent_safe_commands | index("oauth-mux repair-plan --profile <profile> --capability <capability> --json") != null)

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -51,7 +51,13 @@ pub const Command = union(enum) {
         json: bool = false,
     };
 
+    pub const DoctorMode = enum {
+        summary,
+        runtime,
+    };
+
     pub const DoctorArgs = struct {
+        mode: DoctorMode = .summary,
         json: bool = false,
     };
 
@@ -262,7 +268,11 @@ fn parseProbe(args: []const []const u8) Command {
 fn parseDoctor(args: []const []const u8) Command {
     var result = Command.DoctorArgs{};
     for (args) |arg| {
-        if (eql(arg, "--json")) result.json = true;
+        if (eql(arg, "runtime")) {
+            result.mode = .runtime;
+        } else if (eql(arg, "--json")) {
+            result.json = true;
+        }
     }
     return .{ .doctor = result };
 }
@@ -522,7 +532,7 @@ pub fn printUsage(writer: anytype) !void {
         \\  probe [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
         \\      Validate a selected account and run its capability probe when configured.
         \\
-        \\  doctor [--json]
+        \\  doctor [runtime] [--json]
         \\      Run no-spend readiness checks and print first-run next commands.
         \\
         \\  report [--redacted] [--json] [--include-paths]
@@ -686,7 +696,22 @@ test "parse doctor json" {
     const args = [_][]const u8{ "doctor", "--json" };
     const cmd = parse(&args);
     switch (cmd) {
-        .doctor => |doctor| try std.testing.expect(doctor.json),
+        .doctor => |doctor| {
+            try std.testing.expect(doctor.mode == .summary);
+            try std.testing.expect(doctor.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse doctor runtime json" {
+    const args = [_][]const u8{ "doctor", "runtime", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .doctor => |doctor| {
+            try std.testing.expect(doctor.mode == .runtime);
+            try std.testing.expect(doctor.json);
+        },
         else => return error.Unexpected,
     }
 }
@@ -936,6 +961,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from probe route' -l account -d 'Account name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route' -l capability -d 'Route capability' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from probe' -l json -d 'JSON output'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -a runtime -d 'Runtime readiness checks'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from report providers' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from report' -l redacted -d 'Redact credential paths and values'

--- a/src/main.zig
+++ b/src/main.zig
@@ -70,7 +70,11 @@ pub fn main() !void {
         },
 
         .doctor => |doctor_args| {
-            try runDoctor(allocator, stdout, doctor_args);
+            if (doctor_args.mode == .runtime) {
+                try runDoctorRuntime(allocator, stdout, doctor_args);
+            } else {
+                try runDoctor(allocator, stdout, doctor_args);
+            }
         },
 
         .report => |report_args| {
@@ -326,6 +330,7 @@ fn writeDiscoverText(writer: anytype, cfg: config.Config, config_path: []const u
     try writer.writeAll("    oauth-mux providers list --json\n");
     try writer.writeAll("    oauth-mux status --json\n");
     try writer.writeAll("    oauth-mux health --json\n");
+    try writer.writeAll("    oauth-mux doctor runtime --json\n");
     try writer.writeAll("    oauth-mux probe --profile <profile> --capability <capability> --json\n");
     try writer.writeAll("    oauth-mux route explain --profile <profile> --capability <capability> --json\n");
     try writer.writeAll("    oauth-mux route select --profile <profile> --capability <capability> --json\n");
@@ -429,6 +434,7 @@ fn writeDiscoverJson(writer: anytype, cfg: config.Config, config_path: []const u
         "oauth-mux providers list --json",
         "oauth-mux status --json",
         "oauth-mux health --json",
+        "oauth-mux doctor runtime --json",
         "oauth-mux probe --profile <profile> --capability <capability> --json",
         "oauth-mux route explain --profile <profile> --capability <capability> --json",
         "oauth-mux route select --profile <profile> --capability <capability> --json",
@@ -591,7 +597,7 @@ fn writeRepairPlanText(
 
     for (routes) |route| {
         const def = config.resolveProviderDefinition(cfg, route.provider);
-        const runtime = try providerRuntimeReadiness(allocator, def, route.capability);
+        const runtime = try routeRuntimeReadiness(allocator, cfg, route, def);
         const health = routeHealth(store, route);
         const budget = routeProbeBudget(def, route.capability);
         const action = repairActionFor(route, def, runtime, health, budget);
@@ -649,7 +655,7 @@ fn writeRepairPlanRouteJson(
     route: RepairPlanRoute,
 ) !void {
     const def = config.resolveProviderDefinition(cfg, route.provider);
-    const runtime = try providerRuntimeReadiness(allocator, def, route.capability);
+    const runtime = try routeRuntimeReadiness(allocator, cfg, route, def);
     const health = routeHealth(store, route);
     const budget = routeProbeBudget(def, route.capability);
     const action = repairActionFor(route, def, runtime, health, budget);
@@ -947,7 +953,7 @@ fn collectRouteEvaluations(
 ) !void {
     for (routes) |route| {
         const def = config.resolveProviderDefinition(cfg, route.provider);
-        const runtime = try providerRuntimeReadiness(allocator, def, route.capability);
+        const runtime = try routeRuntimeReadiness(allocator, cfg, route, def);
         const health = routeHealth(store, route);
         const budget = routeProbeBudget(def, route.capability);
         const action = repairActionFor(route, def, runtime, health, budget);
@@ -1353,6 +1359,7 @@ fn writeDoctorNextCommandsText(writer: anytype, stats: DoctorStats) !void {
     try writer.writeAll("    oauth-mux providers list --json\n");
     try writer.writeAll("    oauth-mux status --json\n");
     try writer.writeAll("    oauth-mux health --json\n");
+    try writer.writeAll("    oauth-mux doctor runtime --json\n");
     try writer.writeAll("    oauth-mux route explain --profile <profile> --capability <capability> --json\n");
     try writer.writeAll("    oauth-mux route select --profile <profile> --capability <capability> --json\n");
     if (stats.codex_configured) {
@@ -1385,6 +1392,7 @@ fn writeDoctorNextCommandsJson(writer: anytype, stats: DoctorStats) !void {
     try writeDoctorCommandJson(writer, &first, "oauth-mux providers list --json");
     try writeDoctorCommandJson(writer, &first, "oauth-mux status --json");
     try writeDoctorCommandJson(writer, &first, "oauth-mux health --json");
+    try writeDoctorCommandJson(writer, &first, "oauth-mux doctor runtime --json");
     try writeDoctorCommandJson(writer, &first, "oauth-mux route explain --profile <profile> --capability <capability> --json");
     try writeDoctorCommandJson(writer, &first, "oauth-mux route select --profile <profile> --capability <capability> --json");
     try writeDoctorCommandJson(writer, &first, "oauth-mux repair-plan --json");
@@ -1402,6 +1410,531 @@ fn writeDoctorCommandJson(writer: anytype, first: *bool, command: []const u8) !v
     if (!first.*) try writer.writeByte(',');
     first.* = false;
     try writeCommandJson(writer, command);
+}
+
+const RuntimeDoctorStats = struct {
+    configured: bool = false,
+    config_valid: bool = false,
+    providers: usize = 0,
+    accounts: usize = 0,
+    ready_accounts: usize = 0,
+    action_needed_accounts: usize = 0,
+    missing_binaries: usize = 0,
+
+    fn ok(self: RuntimeDoctorStats) bool {
+        return self.configured and self.config_valid and self.accounts > 0 and self.action_needed_accounts == 0 and self.missing_binaries == 0;
+    }
+};
+
+const RuntimeAccountInfo = struct {
+    readiness: types.RuntimeReadiness = .ready,
+    config_dir_set: bool = false,
+    config_dir_exists: bool = false,
+    config_dir_writable: bool = false,
+    session_paths_total: usize = 0,
+    session_paths_present: usize = 0,
+
+    fn ready(self: RuntimeAccountInfo) bool {
+        return self.readiness.isReady();
+    }
+};
+
+fn runDoctorRuntime(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.DoctorArgs) !void {
+    const config_path = try paths.configFilePath(allocator);
+    defer allocator.free(config_path);
+
+    var validation_messages = std.ArrayList(u8).init(allocator);
+    defer validation_messages.deinit();
+
+    const parsed = config.load(allocator) catch |e| {
+        const stats = RuntimeDoctorStats{
+            .configured = false,
+            .config_valid = false,
+        };
+        if (args.json) {
+            try writeDoctorRuntimeJsonNoConfig(writer, stats, config_path, @errorName(e));
+        } else {
+            try writeDoctorRuntimeTextNoConfig(writer, config_path, @errorName(e));
+        }
+        return;
+    };
+    defer parsed.deinit();
+
+    const config_valid = blk: {
+        config.validate(parsed.value, validation_messages.writer()) catch break :blk false;
+        break :blk true;
+    };
+
+    const stats = try collectRuntimeDoctorStats(allocator, parsed.value, config_valid);
+    if (args.json) {
+        try writeDoctorRuntimeJson(writer, allocator, parsed.value, stats, config_path, validation_messages.items);
+    } else {
+        try writeDoctorRuntimeText(writer, allocator, parsed.value, stats, config_path, validation_messages.items);
+    }
+}
+
+fn collectRuntimeDoctorStats(allocator: std.mem.Allocator, cfg: config.Config, config_valid: bool) !RuntimeDoctorStats {
+    var stats = RuntimeDoctorStats{
+        .configured = true,
+        .config_valid = config_valid,
+        .providers = cfg.providers.map.count(),
+    };
+
+    var provider_it = cfg.providers.map.iterator();
+    while (provider_it.next()) |entry| {
+        const provider_name = entry.key_ptr.*;
+        const prov = entry.value_ptr.*;
+        const def = config.resolveProviderDefinition(cfg, provider_name);
+        stats.missing_binaries += try countMissingRuntimeBinaries(allocator, def);
+
+        var account_it = prov.accounts.map.iterator();
+        while (account_it.next()) |account_entry| {
+            stats.accounts += 1;
+            const info = try runtimeAccountInfo(allocator, prov, account_entry.value_ptr.*, def, config.resolveProviderKind(cfg, provider_name));
+            if (info.ready()) {
+                stats.ready_accounts += 1;
+            } else {
+                stats.action_needed_accounts += 1;
+            }
+        }
+    }
+
+    return stats;
+}
+
+fn writeDoctorRuntimeTextNoConfig(writer: anytype, config_path: []const u8, err: []const u8) !void {
+    try writer.writeAll("oauth-mux doctor runtime\n\n");
+    try writer.print("  config: {s}\n", .{config_path});
+    try writer.print("  readiness: action_needed ({s})\n\n", .{err});
+    try writer.writeAll("  next:\n");
+    try writer.writeAll("    oauth-mux init\n");
+    try writer.writeAll("    oauth-mux init --codex-max\n");
+}
+
+fn writeDoctorRuntimeJsonNoConfig(writer: anytype, stats: RuntimeDoctorStats, config_path: []const u8, err: []const u8) !void {
+    try writer.writeByte('{');
+    try writer.writeAll("\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"ok\":false,\"configured\":false,\"config_valid\":false,\"config_path\":");
+    try std.json.stringify(config_path, .{}, writer);
+    try writer.writeAll(",\"config_error\":");
+    try std.json.stringify(err, .{}, writer);
+    try writer.print(",\"providers\":{d},\"accounts\":{d},\"ready_accounts\":{d},\"action_needed_accounts\":{d},\"missing_binaries\":{d}", .{
+        stats.providers,
+        stats.accounts,
+        stats.ready_accounts,
+        stats.action_needed_accounts,
+        stats.missing_binaries,
+    });
+    try writer.writeAll(",\"provider_reports\":[],\"next_commands\":[");
+    try writeCommandJson(writer, "oauth-mux init --codex-max");
+    try writer.writeAll("]}\n");
+}
+
+fn writeDoctorRuntimeText(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    stats: RuntimeDoctorStats,
+    config_path: []const u8,
+    validation_messages: []const u8,
+) !void {
+    try writer.writeAll("oauth-mux doctor runtime\n\n");
+    try writer.print("  config: {s}\n", .{config_path});
+    try writer.print("  readiness: {s}\n", .{if (stats.ok()) "ready" else "action_needed"});
+    try writer.print("  providers: {d}  accounts: {d}  ready: {d}  action_needed: {d}\n", .{
+        stats.providers,
+        stats.accounts,
+        stats.ready_accounts,
+        stats.action_needed_accounts,
+    });
+    if (validation_messages.len != 0) {
+        try writer.writeAll("\n  validation:\n");
+        var lines = std.mem.splitScalar(u8, validation_messages, '\n');
+        while (lines.next()) |line| {
+            if (line.len == 0) continue;
+            try writer.print("    {s}\n", .{line});
+        }
+    }
+
+    try writer.writeAll("\n  runtime:\n");
+    var provider_it = cfg.providers.map.iterator();
+    while (provider_it.next()) |entry| {
+        const provider_name = entry.key_ptr.*;
+        const prov = entry.value_ptr.*;
+        const def = config.resolveProviderDefinition(cfg, provider_name);
+        try writer.print("    {s} kind={s}\n", .{ provider_name, prov.kind });
+        for (def.runtime.required_binaries) |binary_name| {
+            try writer.print("      binary {s}: {s}\n", .{ binary_name, if (try commandAvailable(allocator, binary_name)) "available" else "missing" });
+        }
+        var account_it = prov.accounts.map.iterator();
+        while (account_it.next()) |account_entry| {
+            const info = try runtimeAccountInfo(allocator, prov, account_entry.value_ptr.*, def, config.resolveProviderKind(cfg, provider_name));
+            try writer.print("      account {s}: {s} config_dir={s} exists={s} writable={s} sessions={d}/{d}\n", .{
+                account_entry.key_ptr.*,
+                runtimeReadinessSummary(info.readiness),
+                if (info.config_dir_set) "set" else "missing",
+                if (info.config_dir_exists) "true" else "false",
+                if (info.config_dir_writable) "true" else "false",
+                info.session_paths_present,
+                info.session_paths_total,
+            });
+        }
+    }
+}
+
+fn writeDoctorRuntimeJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    stats: RuntimeDoctorStats,
+    config_path: []const u8,
+    validation_messages: []const u8,
+) !void {
+    try writer.writeByte('{');
+    try writer.writeAll("\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"ok\":");
+    try writer.writeAll(if (stats.ok()) "true" else "false");
+    try writer.writeAll(",\"configured\":true,\"config_valid\":");
+    try writer.writeAll(if (stats.config_valid) "true" else "false");
+    try writer.writeAll(",\"config_path\":");
+    try std.json.stringify(config_path, .{}, writer);
+    try writer.writeAll(",\"validation_messages\":");
+    try std.json.stringify(validation_messages, .{}, writer);
+    try writer.print(",\"providers\":{d},\"accounts\":{d},\"ready_accounts\":{d},\"action_needed_accounts\":{d},\"missing_binaries\":{d}", .{
+        stats.providers,
+        stats.accounts,
+        stats.ready_accounts,
+        stats.action_needed_accounts,
+        stats.missing_binaries,
+    });
+    try writer.writeAll(",\"provider_reports\":[");
+    var first_provider = true;
+    var provider_it = cfg.providers.map.iterator();
+    while (provider_it.next()) |entry| {
+        if (!first_provider) try writer.writeByte(',');
+        first_provider = false;
+        try writeRuntimeProviderJson(writer, allocator, cfg, entry.key_ptr.*, entry.value_ptr.*);
+    }
+    try writer.writeAll("],\"next_commands\":[");
+    try writeCommandJson(writer, "oauth-mux route explain --profile <profile> --capability <capability> --json");
+    try writer.writeByte(',');
+    try writeCommandJson(writer, "oauth-mux repair-plan --profile <profile> --capability <capability> --json");
+    try writer.writeAll("]}\n");
+}
+
+fn writeRuntimeProviderJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    provider_name: []const u8,
+    prov: config.ProviderConfig,
+) !void {
+    const def = config.resolveProviderDefinition(cfg, provider_name);
+    const kind = config.resolveProviderKind(cfg, provider_name);
+    try writer.writeByte('{');
+    try writer.writeAll("\"name\":");
+    try std.json.stringify(provider_name, .{}, writer);
+    try writer.writeAll(",\"kind\":");
+    try std.json.stringify(prov.kind, .{}, writer);
+    try writer.writeAll(",\"required_binaries\":[");
+    for (def.runtime.required_binaries, 0..) |binary_name, idx| {
+        if (idx > 0) try writer.writeByte(',');
+        try writer.writeAll("{\"name\":");
+        try std.json.stringify(binary_name, .{}, writer);
+        try writer.writeAll(",\"available\":");
+        try writer.writeAll(if (try commandAvailable(allocator, binary_name)) "true" else "false");
+        try writer.writeByte('}');
+    }
+    try writer.writeAll("],\"accounts\":[");
+    var first_account = true;
+    var account_it = prov.accounts.map.iterator();
+    while (account_it.next()) |account_entry| {
+        if (!first_account) try writer.writeByte(',');
+        first_account = false;
+        try writeRuntimeAccountJson(writer, allocator, prov, account_entry.key_ptr.*, account_entry.value_ptr.*, def, kind);
+    }
+    try writer.writeAll("]}");
+}
+
+fn writeRuntimeAccountJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    prov: config.ProviderConfig,
+    account_name: []const u8,
+    account: config.AccountConfig,
+    def: provider_schema.ProviderDefinition,
+    kind: ?types.ProviderKind,
+) !void {
+    const info = try runtimeAccountInfo(allocator, prov, account, def, kind);
+    const env_var = runtimeConfigDirEnv(prov, def, kind);
+    try writer.writeByte('{');
+    try writer.writeAll("\"name\":");
+    try std.json.stringify(account_name, .{}, writer);
+    try writer.writeAll(",\"ready\":");
+    try writer.writeAll(if (info.ready()) "true" else "false");
+    try writer.writeAll(",\"runtime\":");
+    try writeRuntimeReadinessRedactedJson(writer, info.readiness);
+    try writer.writeAll(",\"config_dir_env\":");
+    if (env_var) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"config_dir_set\":");
+    try writer.writeAll(if (info.config_dir_set) "true" else "false");
+    try writer.writeAll(",\"config_dir_exists\":");
+    try writer.writeAll(if (info.config_dir_exists) "true" else "false");
+    try writer.writeAll(",\"config_dir_writable\":");
+    try writer.writeAll(if (info.config_dir_writable) "true" else "false");
+    try writer.writeAll(",\"session_paths\":[");
+    if (account.config_dir) |config_dir| {
+        const expanded = try paths.expandTilde(allocator, config_dir);
+        defer allocator.free(expanded);
+        for (def.runtime.session_paths, 0..) |session_spec, idx| {
+            if (idx > 0) try writer.writeByte(',');
+            try writer.writeAll("{\"name\":");
+            try std.json.stringify(session_spec, .{}, writer);
+            try writer.writeAll(",\"exists\":");
+            const exists = if (try resolveRuntimePath(allocator, session_spec, env_var, expanded)) |session_path| blk: {
+                defer allocator.free(session_path);
+                break :blk fileExists(session_path);
+            } else false;
+            try writer.writeAll(if (exists) "true" else "false");
+            try writer.writeByte('}');
+        }
+    }
+    try writer.writeAll("]}");
+}
+
+fn writeRuntimeReadinessRedactedJson(writer: anytype, readiness: types.RuntimeReadiness) !void {
+    try writer.writeByte('{');
+    try writer.writeAll("\"state\":");
+    try std.json.stringify(runtimeReadinessSummary(readiness), .{}, writer);
+    switch (readiness) {
+        .ready => {},
+        .missing_binary => |binary| {
+            try writer.writeAll(",\"binary\":");
+            try std.json.stringify(binary, .{}, writer);
+        },
+        .permission_denied => |info| {
+            try writer.writeAll(",\"path_ref\":");
+            try std.json.stringify(info.path, .{}, writer);
+            try writer.writeAll(",\"operation\":");
+            try std.json.stringify(info.operation, .{}, writer);
+        },
+        .unwritable_store, .session_unavailable, .sandbox_blocked => |detail| {
+            try writer.writeAll(",\"detail\":");
+            try std.json.stringify(detail, .{}, writer);
+        },
+        .needs_reauth => |info| {
+            try writer.writeAll(",\"reason\":");
+            try std.json.stringify(info.reason, .{}, writer);
+            try writer.writeAll(",\"methods\":");
+            try writeStringArrayJson(writer, info.methods);
+        },
+        .repair_in_progress => |info| {
+            try writer.writeAll(",\"account\":");
+            try std.json.stringify(info.account, .{}, writer);
+            try writer.print(",\"started_at\":{d}", .{info.started_at});
+        },
+    }
+    try writer.writeByte('}');
+}
+
+fn runtimeAccountInfo(
+    allocator: std.mem.Allocator,
+    prov: config.ProviderConfig,
+    account: config.AccountConfig,
+    def: provider_schema.ProviderDefinition,
+    kind: ?types.ProviderKind,
+) !RuntimeAccountInfo {
+    var info = RuntimeAccountInfo{
+        .config_dir_set = account.config_dir != null,
+        .session_paths_total = def.runtime.session_paths.len,
+    };
+
+    for (def.runtime.required_binaries) |binary_name| {
+        if (!try commandAvailable(allocator, binary_name)) {
+            info.readiness = .{ .missing_binary = binary_name };
+            return info;
+        }
+    }
+
+    const env_var = runtimeConfigDirEnv(prov, def, kind);
+    if (account.config_dir == null) {
+        if (env_var != null and (def.runtime.writable_paths.len != 0 or def.runtime.session_paths.len != 0)) {
+            info.readiness = .{ .session_unavailable = "account_config_dir_missing" };
+        }
+        return info;
+    }
+
+    const config_dir = try paths.expandTilde(allocator, account.config_dir.?);
+    defer allocator.free(config_dir);
+
+    const dir_state = checkDirectory(config_dir);
+    switch (dir_state) {
+        .ok => info.config_dir_exists = true,
+        .missing => {
+            info.readiness = .{ .session_unavailable = "config_dir_missing" };
+            return info;
+        },
+        .access_denied => {
+            info.readiness = .{ .permission_denied = .{ .path = "config_dir", .operation = "open" } };
+            return info;
+        },
+        .not_directory => {
+            info.readiness = .{ .session_unavailable = "config_dir_not_directory" };
+            return info;
+        },
+        .other_error => {
+            info.readiness = .{ .session_unavailable = "config_dir_unavailable" };
+            return info;
+        },
+    }
+
+    if (def.runtime.writable_paths.len != 0) {
+        for (def.runtime.writable_paths) |path_spec| {
+            const resolved = try resolveRuntimePath(allocator, path_spec, env_var, config_dir) orelse continue;
+            defer allocator.free(resolved);
+            if (!canWriteDirectoryMarker(allocator, resolved)) {
+                info.readiness = .{ .unwritable_store = "config_dir" };
+                return info;
+            }
+        }
+    } else {
+        info.config_dir_writable = true;
+    }
+
+    if (def.runtime.writable_paths.len != 0) info.config_dir_writable = true;
+
+    for (def.runtime.session_paths) |session_spec| {
+        const resolved = try resolveRuntimePath(allocator, session_spec, env_var, config_dir) orelse continue;
+        defer allocator.free(resolved);
+        switch (checkFile(resolved)) {
+            .exists => info.session_paths_present += 1,
+            .missing => {
+                info.readiness = .{ .needs_reauth = .{
+                    .methods = reauthMethodsFor(def),
+                    .reason = "session_file_missing",
+                } };
+                return info;
+            },
+            .access_denied => {
+                info.readiness = .{ .permission_denied = .{ .path = "session_file", .operation = "read" } };
+                return info;
+            },
+            .other_error => {
+                info.readiness = .{ .session_unavailable = "session_file_unavailable" };
+                return info;
+            },
+        }
+    }
+
+    info.readiness = .ready;
+    return info;
+}
+
+const DirectoryState = enum {
+    ok,
+    missing,
+    access_denied,
+    not_directory,
+    other_error,
+};
+
+const FileState = enum {
+    exists,
+    missing,
+    access_denied,
+    other_error,
+};
+
+fn checkDirectory(path_value: []const u8) DirectoryState {
+    var dir = openDirectory(path_value) catch |e| return switch (e) {
+        error.FileNotFound => .missing,
+        error.AccessDenied => .access_denied,
+        error.NotDir => .not_directory,
+        else => .other_error,
+    };
+    dir.close();
+    return .ok;
+}
+
+fn checkFile(path_value: []const u8) FileState {
+    const file = if (std.fs.path.isAbsolute(path_value))
+        std.fs.openFileAbsolute(path_value, .{}) catch |e| return switch (e) {
+            error.FileNotFound => .missing,
+            error.AccessDenied => .access_denied,
+            else => .other_error,
+        }
+    else
+        std.fs.cwd().openFile(path_value, .{}) catch |e| return switch (e) {
+            error.FileNotFound => .missing,
+            error.AccessDenied => .access_denied,
+            else => .other_error,
+        };
+    file.close();
+    return .exists;
+}
+
+fn openDirectory(path_value: []const u8) !std.fs.Dir {
+    if (std.fs.path.isAbsolute(path_value)) {
+        return std.fs.openDirAbsolute(path_value, .{});
+    }
+    return std.fs.cwd().openDir(path_value, .{});
+}
+
+fn canWriteDirectoryMarker(allocator: std.mem.Allocator, path_value: []const u8) bool {
+    var dir = openDirectory(path_value) catch return false;
+    defer dir.close();
+
+    const marker = std.fmt.allocPrint(allocator, ".oauth-mux-runtime-check-{d}", .{std.time.nanoTimestamp()}) catch return false;
+    defer allocator.free(marker);
+
+    const file = dir.createFile(marker, .{ .exclusive = true }) catch return false;
+    file.close();
+    dir.deleteFile(marker) catch {};
+    return true;
+}
+
+fn resolveRuntimePath(
+    allocator: std.mem.Allocator,
+    spec: []const u8,
+    env_var: ?[]const u8,
+    config_dir: []const u8,
+) !?[]const u8 {
+    if (env_var) |name| {
+        if (std.mem.eql(u8, spec, name)) return try allocator.dupe(u8, config_dir);
+        if (std.mem.startsWith(u8, spec, name) and spec.len > name.len and (spec[name.len] == '/' or spec[name.len] == '\\')) {
+            return try std.fs.path.join(allocator, &.{ config_dir, spec[name.len + 1 ..] });
+        }
+    }
+    if (std.fs.path.isAbsolute(spec) or (spec.len > 0 and spec[0] == '~')) {
+        return try paths.expandTilde(allocator, spec);
+    }
+    return null;
+}
+
+fn runtimeConfigDirEnv(prov: config.ProviderConfig, def: provider_schema.ProviderDefinition, kind: ?types.ProviderKind) ?[]const u8 {
+    if (prov.config_dir_env) |env_var| return env_var;
+    if (def.injection.config_dir_env) |env_var| return env_var;
+    if (kind) |provider_kind| return provider_kind.configDirEnv();
+    return null;
+}
+
+fn countMissingRuntimeBinaries(allocator: std.mem.Allocator, def: provider_schema.ProviderDefinition) !usize {
+    var missing: usize = 0;
+    for (def.runtime.required_binaries) |binary_name| {
+        if (!try commandAvailable(allocator, binary_name)) missing += 1;
+    }
+    return missing;
+}
+
+fn reauthMethodsFor(def: provider_schema.ProviderDefinition) []const []const u8 {
+    return switch (def.repair.owner) {
+        .upstream_cli_login => &.{"upstream_cli_login"},
+        .oauth_mux_refresh => &.{"oauth_mux_refresh"},
+        .external_secret_owner => &.{"external_secret_owner"},
+        .manual_only => &.{"manual"},
+    };
 }
 
 fn codexConfigured(cfg: config.Config) bool {
@@ -2175,6 +2708,21 @@ fn providerRuntimeReadiness(
     }
 
     return .ready;
+}
+
+fn routeRuntimeReadiness(
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    route: RepairPlanRoute,
+    def: provider_schema.ProviderDefinition,
+) !types.RuntimeReadiness {
+    const provider_runtime = try providerRuntimeReadiness(allocator, def, route.capability);
+    if (!provider_runtime.isReady()) return provider_runtime;
+
+    const prov = cfg.providers.map.get(route.provider) orelse return .{ .session_unavailable = "provider_config_missing" };
+    const account = prov.accounts.map.get(route.account) orelse return .{ .session_unavailable = "account_config_missing" };
+    const account_runtime = try runtimeAccountInfo(allocator, prov, account, def, config.resolveProviderKind(cfg, route.provider));
+    return account_runtime.readiness;
 }
 
 fn runtimeReadinessSummary(readiness: types.RuntimeReadiness) []const u8 {
@@ -4138,6 +4686,7 @@ test "writeDiscoverJson includes stay-afloat agent-safe commands" {
     defer buf.deinit();
 
     try writeDiscoverJson(buf.writer(), parsed.value, "/tmp/config.json", "/tmp/state");
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux doctor runtime --json") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux route explain --profile <profile> --capability <capability> --json") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux route select --profile <profile> --capability <capability> --json") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux repair-plan --profile <profile> --capability <capability> --json") != null);


### PR DESCRIPTION
## Summary

- add `oauth-mux doctor runtime --json` for no-spend runtime/session diagnostics
- classify missing binaries, missing account config dirs, unwritable stores, missing session files, and permission-denied session files without reading token values or contacting providers
- feed account runtime readiness into `route explain`, `route select`, and `repair-plan`, so live liveness alone is not enough when the current process cannot use the account store
- extend first-run and local e2e coverage plus onboarding/adoption/daemon-boundary docs

## Dogfood note

A local run from the current Codex process reported configured Codex session files present but account stores not writable from this process. That now prevents route selection and surfaces as a runtime fix instead of an OAuth or quota failure.

## Validation

- `just check`