### PR TITLE
[codex] Add scoped runtime doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ mutating auth state:
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux route explain --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux route select --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair-plan --profile codex-max --capability codex-max --json
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 ```
 
 `route select` and `route explain` are no-spend stay-afloat commands. They use
@@ -100,6 +101,9 @@ as `probe_needed` instead of being treated as available.
 `doctor runtime --json` is also no-spend. It checks local runtime prerequisites
 such as upstream binaries, configured account store directories, write access,
 and expected session files without reading token values or contacting providers.
+Use `doctor runtime --profile <name> --capability <name> --json` when a user or
+agent needs profile-level truth without letting a stale unrelated account poison
+the stay-afloat decision.
 
 First-run Codex subscription path:
 
@@ -110,6 +114,7 @@ oauth-mux doctor runtime --json
 oauth-mux setup codex
 oauth-mux codex canary
 oauth-mux codex live-qa
+oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 oauth-mux route explain --profile codex-max --capability codex-max --json
 oauth-mux repair-plan --profile codex-max --capability codex-max --json
 ```

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -67,7 +67,10 @@ oauth-mux codex probe-all --capability codex-mini --json
 `doctor runtime`, `route explain`, and `route select` are no-spend surfaces.
 They only use local runtime checks plus recorded liveness, so they are safe for
 agents to run before deciding whether a live probe or user-driven reauth is
-warranted.
+warranted. Prefer scoped runtime checks such as
+`oauth-mux doctor runtime --profile codex-max --capability codex-max --json`
+when dogfooding a specific stay-afloat route; global runtime doctor is still
+useful for support bundles and full-machine cleanup.
 
 ## Provider Author Experience
 

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -28,7 +28,8 @@ See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
 ## Allowed Now
 
 - `oauth-mux daemon run` as the foreground primitive for any future wrapper.
-- `oauth-mux doctor runtime` for no-spend local runtime/session diagnostics.
+- `oauth-mux doctor runtime` for no-spend local runtime/session diagnostics,
+  including profile-scoped route readiness checks.
 - `oauth-mux route explain` for no-spend route-state explanation.
 - `oauth-mux route select` for no-spend route choice from recorded evidence.
 - `oauth-mux repair-plan` for non-mutating stay-afloat action planning.
@@ -71,6 +72,7 @@ Until then, user and agent onboarding should use one-shot commands:
 oauth-mux discover --json
 oauth-mux codex canary
 oauth-mux doctor runtime --json
+oauth-mux doctor runtime --profile <profile> --capability <capability> --json
 oauth-mux route explain --profile <profile> --capability <capability> --json
 oauth-mux route select --profile <profile> --capability <capability> --json
 oauth-mux probe --profile <profile> --capability <capability> --json

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -50,6 +50,7 @@ oauth-mux doctor runtime --json
 oauth-mux setup codex
 oauth-mux codex canary
 oauth-mux codex live-qa
+oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 oauth-mux route explain --profile codex-max --capability codex-max --json
 oauth-mux repair-plan --profile codex-max --capability codex-max --json
 ```
@@ -64,6 +65,11 @@ upstream binary availability, configured account store directories, local write
 access via a temporary marker file, and expected session-file presence. It does
 not read token values, run live probes, open auth flows, or create missing
 account stores.
+
+For profile-level stay-afloat checks, scope the runtime report:
+`oauth-mux doctor runtime --profile codex-max --capability codex-max --json`.
+That reports only the route set the user or agent intends to use, so unrelated
+legacy accounts can be cleaned up separately without hiding a usable mux path.
 
 `oauth-mux setup codex` is the user-facing alias for
 `oauth-mux codex onboard` / `oauth-mux codex setup`. It creates the expected
@@ -216,6 +222,7 @@ oauth-mux discover --json
 oauth-mux status --json
 oauth-mux health --json
 oauth-mux doctor runtime --json
+oauth-mux doctor runtime --profile <profile> --capability <capability> --json
 oauth-mux route explain --profile <profile> --capability <capability> --json
 ```
 

--- a/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
+++ b/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
@@ -38,7 +38,7 @@ OAuth and muxing surfaces:
 | Codex three-account stores | `max-1`, `max-2`, and `max-3` are isolated by `CODEX_HOME` and report logged-in ChatGPT status. |
 | Codex route liveness | Hosted and local installed-binary live canaries have proven all three accounts across `codex-mini` and `codex-max`. Earlier proof also preserved the distinction between quota exhaustion and auth death. |
 | Typed liveness | Unit and e2e tests cover `live`, `degraded`, `dead`, route-scoped `provider:account#capability`, and fallback decisions. |
-| Agent-safe discovery | `doctor --json`, `doctor runtime --json`, `report --redacted --json`, `providers list --json`, `discover --json`, `status --json`, `health --json`, `route explain --json`, and `route select --json` exist and are documented. |
+| Agent-safe discovery | `doctor --json`, `doctor runtime --json`, scoped `doctor runtime`, `report --redacted --json`, `providers list --json`, `discover --json`, `status --json`, `health --json`, `route explain --json`, and `route select --json` exist and are documented. |
 | Non-mutating help | `oauth-mux codex canary --help`, `oauth-mux codex probe-all --help`, and `oauth-mux setup codex --help` print help without creating stores or probing. |
 
 ## Not Yet Proven
@@ -97,6 +97,7 @@ oauth-mux doctor --json
 oauth-mux init --codex-max
 oauth-mux config validate
 oauth-mux doctor runtime --json
+oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 oauth-mux discover --json
 oauth-mux report --redacted --json
 oauth-mux route explain --profile codex-max --capability codex-max --json

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -424,6 +424,12 @@ process while their session files were present. `route explain` now consumes the
 same account runtime readiness, so an otherwise `live.available` Codex account
 is not selected when the current process cannot write its account store.
 
+Implementation note, 2026-04-30: `doctor runtime` now accepts the same
+`--profile`, `--provider`, `--account`, and `--capability` selectors as
+`repair-plan` and `route`. Scoped runtime doctor reports route-level readiness,
+which lets a user or agent prove that a specific stay-afloat profile is usable
+even when unrelated configured accounts still need cleanup.
+
 ### M2: Repair Plan
 
 - Add `needs_reauth` state.

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -205,6 +205,13 @@ expect_contains "$runtime_json" '"ok":true' "runtime doctor reports ready"
 expect_contains "$runtime_json" '"ready_accounts":2' "runtime doctor counts ready accounts"
 expect_contains "$runtime_json" '"config_dir_writable":true' "runtime doctor verifies writable config dirs"
 
+printf 'e2e: scoped runtime doctor reports route readiness\n'
+runtime_scoped_json="$(omux doctor runtime --profile expensive --capability expensive --json)"
+expect_contains "$runtime_scoped_json" '"ok":true' "scoped runtime doctor reports ready profile"
+expect_contains "$runtime_scoped_json" '"scope":{"profile":"expensive"' "scoped runtime doctor reports profile scope"
+expect_contains "$runtime_scoped_json" '"route_reports":[' "scoped runtime doctor reports routes"
+expect_contains "$runtime_scoped_json" '"ready_accounts":2' "scoped runtime doctor counts profile routes"
+
 printf 'e2e: redacted report does not expose secret values\n'
 report_json="$(omux report --redacted --json)"
 expect_contains "$report_json" '"redacted":true' "report is redacted"

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -153,6 +153,24 @@ expect_not_contains "$(cat "$runtime_doctor")" "$store_root/max-1" "runtime doct
 test ! -e "$store_root"
 test ! -e "$legacy_store_root"
 
+printf 'first-run e2e: scoped runtime doctor reports Codex Max route readiness\n'
+runtime_doctor_scoped="$tmp/doctor-runtime-codex-max.json"
+run_json "$runtime_doctor_scoped" doctor runtime --profile codex-max --capability codex-max --json
+jq -e '
+  .configured == true
+  and .config_valid == true
+  and .ok == false
+  and .scope.profile == "codex-max"
+  and .scope.capability == "codex-max"
+  and .accounts == 3
+  and .action_needed_accounts == 3
+  and (.route_reports | length) == 3
+  and all(.route_reports[]; .provider == "codex" and .capability == "codex-max" and .ready == false)
+' "$runtime_doctor_scoped" >/dev/null
+expect_not_contains "$(cat "$runtime_doctor_scoped")" "$store_root/max-1" "scoped runtime doctor does not print concrete Codex store paths"
+test ! -e "$store_root"
+test ! -e "$legacy_store_root"
+
 printf 'first-run e2e: discovery is redacted and agent-usable\n'
 discover_json="$tmp/discover.json"
 run_json "$discover_json" discover --json

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -59,6 +59,10 @@ pub const Command = union(enum) {
     pub const DoctorArgs = struct {
         mode: DoctorMode = .summary,
         json: bool = false,
+        profile: ?[]const u8 = null,
+        provider: ?[]const u8 = null,
+        account: ?[]const u8 = null,
+        capability: ?[]const u8 = null,
     };
 
     pub const ReportArgs = struct {
@@ -267,10 +271,23 @@ fn parseProbe(args: []const []const u8) Command {
 
 fn parseDoctor(args: []const []const u8) Command {
     var result = Command.DoctorArgs{};
-    for (args) |arg| {
-        if (eql(arg, "runtime")) {
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        if (eql(args[i], "runtime")) {
             result.mode = .runtime;
-        } else if (eql(arg, "--json")) {
+        } else if (eql(args[i], "--profile") or eql(args[i], "-p")) {
+            i += 1;
+            if (i < args.len) result.profile = args[i];
+        } else if (eql(args[i], "--provider")) {
+            i += 1;
+            if (i < args.len) result.provider = args[i];
+        } else if (eql(args[i], "--account")) {
+            i += 1;
+            if (i < args.len) result.account = args[i];
+        } else if (eql(args[i], "--capability")) {
+            i += 1;
+            if (i < args.len) result.capability = args[i];
+        } else if (eql(args[i], "--json")) {
             result.json = true;
         }
     }
@@ -532,8 +549,11 @@ pub fn printUsage(writer: anytype) !void {
         \\  probe [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
         \\      Validate a selected account and run its capability probe when configured.
         \\
-        \\  doctor [runtime] [--json]
-        \\      Run no-spend readiness checks and print first-run next commands.
+        \\  doctor [--json]
+        \\      Run no-spend config readiness checks and print first-run next commands.
+        \\
+        \\  doctor runtime [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
+        \\      Check local runtime readiness without reading token values.
         \\
         \\  report [--redacted] [--json] [--include-paths]
         \\      Print a redacted support bundle without reading credential values.
@@ -902,6 +922,20 @@ test "parse repair plan with profile" {
     }
 }
 
+test "parse runtime doctor with route scope" {
+    const args = [_][]const u8{ "doctor", "runtime", "--profile", "codex-max", "--capability", "codex-max", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .doctor => |doctor| {
+            try std.testing.expect(doctor.mode == .runtime);
+            try std.testing.expectEqualStrings("codex-max", doctor.profile.?);
+            try std.testing.expectEqualStrings("codex-max", doctor.capability.?);
+            try std.testing.expect(doctor.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 test "parse daemon repair plan alias" {
     const args = [_][]const u8{ "daemon", "repair-plan", "--provider", "codex", "--account", "max-1", "--capability", "codex-max" };
     const cmd = parse(&args);
@@ -963,6 +997,10 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from probe' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -a runtime -d 'Runtime readiness checks'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -l json -d 'JSON output'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -l profile -s p -d 'Profile name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -l provider -d 'Provider name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -l account -d 'Account name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -l capability -d 'Route capability' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from report providers' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from report' -l redacted -d 'Redact credential paths and values'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from report' -l include-paths -d 'Include non-token paths'

--- a/src/main.zig
+++ b/src/main.zig
@@ -1465,12 +1465,38 @@ fn runDoctorRuntime(allocator: std.mem.Allocator, writer: anytype, args: cli.Com
         break :blk true;
     };
 
+    if (doctorRuntimeScoped(args)) {
+        var routes = try collectRepairPlanRoutes(allocator, parsed.value, doctorArgsToRepairPlanArgs(args));
+        defer routes.deinit();
+        const stats = try collectRuntimeDoctorRouteStats(allocator, parsed.value, config_valid, routes.items);
+        if (args.json) {
+            try writeDoctorRuntimeScopedJson(writer, allocator, parsed.value, stats, config_path, validation_messages.items, routes.items, args);
+        } else {
+            try writeDoctorRuntimeScopedText(writer, allocator, parsed.value, stats, config_path, validation_messages.items, routes.items, args);
+        }
+        return;
+    }
+
     const stats = try collectRuntimeDoctorStats(allocator, parsed.value, config_valid);
     if (args.json) {
         try writeDoctorRuntimeJson(writer, allocator, parsed.value, stats, config_path, validation_messages.items);
     } else {
         try writeDoctorRuntimeText(writer, allocator, parsed.value, stats, config_path, validation_messages.items);
     }
+}
+
+fn doctorRuntimeScoped(args: cli.Command.DoctorArgs) bool {
+    return args.profile != null or args.provider != null or args.account != null or args.capability != null;
+}
+
+fn doctorArgsToRepairPlanArgs(args: cli.Command.DoctorArgs) cli.Command.RepairPlanArgs {
+    return .{
+        .profile = args.profile,
+        .provider = args.provider,
+        .account = args.account,
+        .capability = args.capability,
+        .json = args.json,
+    };
 }
 
 fn collectRuntimeDoctorStats(allocator: std.mem.Allocator, cfg: config.Config, config_valid: bool) !RuntimeDoctorStats {
@@ -1495,6 +1521,43 @@ fn collectRuntimeDoctorStats(allocator: std.mem.Allocator, cfg: config.Config, c
                 stats.ready_accounts += 1;
             } else {
                 stats.action_needed_accounts += 1;
+            }
+        }
+    }
+
+    return stats;
+}
+
+fn collectRuntimeDoctorRouteStats(
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    config_valid: bool,
+    routes: []const RepairPlanRoute,
+) !RuntimeDoctorStats {
+    var stats = RuntimeDoctorStats{
+        .configured = true,
+        .config_valid = config_valid,
+    };
+
+    var seen_providers = std.StringHashMap(void).init(allocator);
+    defer seen_providers.deinit();
+
+    for (routes) |route| {
+        if (!seen_providers.contains(route.provider)) {
+            try seen_providers.put(route.provider, {});
+            stats.providers += 1;
+        }
+
+        stats.accounts += 1;
+        const def = config.resolveProviderDefinition(cfg, route.provider);
+        const readiness = try routeRuntimeReadiness(allocator, cfg, route, def);
+        if (readiness.isReady()) {
+            stats.ready_accounts += 1;
+        } else {
+            stats.action_needed_accounts += 1;
+            switch (readiness) {
+                .missing_binary => stats.missing_binaries += 1,
+                else => {},
             }
         }
     }
@@ -1583,6 +1646,49 @@ fn writeDoctorRuntimeText(
     }
 }
 
+fn writeDoctorRuntimeScopedText(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    stats: RuntimeDoctorStats,
+    config_path: []const u8,
+    validation_messages: []const u8,
+    routes: []const RepairPlanRoute,
+    args: cli.Command.DoctorArgs,
+) !void {
+    try writer.writeAll("oauth-mux doctor runtime\n\n");
+    try writer.print("  config: {s}\n", .{config_path});
+    try writer.print("  readiness: {s}\n", .{if (stats.ok()) "ready" else "action_needed"});
+    try writer.print("  scope: {s}\n", .{if (doctorRuntimeScoped(args)) "route" else "all"});
+    if (args.profile) |profile_name| try writer.print("    profile: {s}\n", .{profile_name});
+    if (args.provider) |provider_name| try writer.print("    provider: {s}\n", .{provider_name});
+    if (args.account) |account_name| try writer.print("    account: {s}\n", .{account_name});
+    if (args.capability) |capability| try writer.print("    capability: {s}\n", .{capability});
+    try writer.print("  providers: {d}  routes: {d}  ready: {d}  action_needed: {d}\n", .{
+        stats.providers,
+        stats.accounts,
+        stats.ready_accounts,
+        stats.action_needed_accounts,
+    });
+    if (validation_messages.len != 0) {
+        try writer.writeAll("\n  validation:\n");
+        var lines = std.mem.splitScalar(u8, validation_messages, '\n');
+        while (lines.next()) |line| {
+            if (line.len == 0) continue;
+            try writer.print("    {s}\n", .{line});
+        }
+    }
+
+    try writer.writeAll("\n  routes:\n");
+    for (routes) |route| {
+        const def = config.resolveProviderDefinition(cfg, route.provider);
+        const runtime = try routeRuntimeReadiness(allocator, cfg, route, def);
+        try writer.print("    {s}:{s}", .{ route.provider, route.account });
+        if (route.capability) |capability| try writer.print("#{s}", .{capability});
+        try writer.print(" runtime={s}\n", .{runtimeReadinessSummary(runtime)});
+    }
+}
+
 fn writeDoctorRuntimeJson(
     writer: anytype,
     allocator: std.mem.Allocator,
@@ -1622,6 +1728,87 @@ fn writeDoctorRuntimeJson(
     try writer.writeByte(',');
     try writeCommandJson(writer, "oauth-mux repair-plan --profile <profile> --capability <capability> --json");
     try writer.writeAll("]}\n");
+}
+
+fn writeDoctorRuntimeScopedJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    stats: RuntimeDoctorStats,
+    config_path: []const u8,
+    validation_messages: []const u8,
+    routes: []const RepairPlanRoute,
+    args: cli.Command.DoctorArgs,
+) !void {
+    try writer.writeByte('{');
+    try writer.writeAll("\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"ok\":");
+    try writer.writeAll(if (stats.ok()) "true" else "false");
+    try writer.writeAll(",\"configured\":true,\"config_valid\":");
+    try writer.writeAll(if (stats.config_valid) "true" else "false");
+    try writer.writeAll(",\"config_path\":");
+    try std.json.stringify(config_path, .{}, writer);
+    try writer.writeAll(",\"scope\":");
+    try writeDoctorRuntimeScopeJson(writer, args);
+    try writer.writeAll(",\"validation_messages\":");
+    try std.json.stringify(validation_messages, .{}, writer);
+    try writer.print(",\"providers\":{d},\"accounts\":{d},\"ready_accounts\":{d},\"action_needed_accounts\":{d},\"missing_binaries\":{d}", .{
+        stats.providers,
+        stats.accounts,
+        stats.ready_accounts,
+        stats.action_needed_accounts,
+        stats.missing_binaries,
+    });
+    try writer.writeAll(",\"route_reports\":[");
+    for (routes, 0..) |route, idx| {
+        if (idx > 0) try writer.writeByte(',');
+        try writeRuntimeRouteJson(writer, allocator, cfg, route);
+    }
+    try writer.writeAll("],\"provider_reports\":[],\"next_commands\":[");
+    try writeCommandJson(writer, "oauth-mux route explain --profile <profile> --capability <capability> --json");
+    try writer.writeByte(',');
+    try writeCommandJson(writer, "oauth-mux repair-plan --profile <profile> --capability <capability> --json");
+    try writer.writeAll("]}\n");
+}
+
+fn writeDoctorRuntimeScopeJson(writer: anytype, args: cli.Command.DoctorArgs) !void {
+    try writer.writeByte('{');
+    try writer.writeAll("\"profile\":");
+    if (args.profile) |profile_name| try std.json.stringify(profile_name, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"provider\":");
+    if (args.provider) |provider_name| try std.json.stringify(provider_name, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"account\":");
+    if (args.account) |account_name| try std.json.stringify(account_name, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"capability\":");
+    if (args.capability) |capability| try std.json.stringify(capability, .{}, writer) else try writer.writeAll("null");
+    try writer.writeByte('}');
+}
+
+fn writeRuntimeRouteJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    route: RepairPlanRoute,
+) !void {
+    const def = config.resolveProviderDefinition(cfg, route.provider);
+    const runtime = try routeRuntimeReadiness(allocator, cfg, route, def);
+    try writer.writeByte('{');
+    try writer.writeAll("\"provider\":");
+    try std.json.stringify(route.provider, .{}, writer);
+    try writer.writeAll(",\"account\":");
+    try std.json.stringify(route.account, .{}, writer);
+    try writer.writeAll(",\"capability\":");
+    if (route.capability) |capability| {
+        try std.json.stringify(capability, .{}, writer);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"ready\":");
+    try writer.writeAll(if (runtime.isReady()) "true" else "false");
+    try writer.writeAll(",\"runtime\":");
+    try writeRuntimeReadinessRedactedJson(writer, runtime);
+    try writer.writeByte('}');
 }
 
 fn writeRuntimeProviderJson(
@@ -4774,6 +4961,63 @@ test "collectRepairPlanRoutes expands profile capability routes" {
     try std.testing.expectEqualStrings("max-1", routes.items[0].account);
     try std.testing.expectEqualStrings("codex-max", routes.items[0].capability.?);
     try std.testing.expectEqualStrings("max-2", routes.items[1].account);
+}
+
+test "runtime doctor route scope reports only requested profile routes" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": { "name": "toy", "display_name": "Toy Provider" }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "a1": { "secret": { "backend": "env", "variable": "TOY_A1" } },
+        \\        "a2": { "secret": { "backend": "env", "variable": "TOY_A2" } }
+        \\      }
+        \\    },
+        \\    "stale": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "unused": { "secret": { "backend": "env", "variable": "TOY_UNUSED" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "work": {
+        \\      "providers": ["toy:a1#chat", "toy:a2#chat"]
+        \\    }
+        \\  },
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try config.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var routes = try collectRepairPlanRoutes(std.testing.allocator, parsed.value, .{ .profile = "work", .capability = "chat" });
+    defer routes.deinit();
+    const stats = try collectRuntimeDoctorRouteStats(std.testing.allocator, parsed.value, true, routes.items);
+
+    try std.testing.expect(stats.ok());
+    try std.testing.expectEqual(@as(usize, 1), stats.providers);
+    try std.testing.expectEqual(@as(usize, 2), stats.accounts);
+    try std.testing.expectEqual(@as(usize, 2), stats.ready_accounts);
+
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+    try writeDoctorRuntimeScopedJson(buf.writer(), std.testing.allocator, parsed.value, stats, "/tmp/oauth-mux/config.json", "", routes.items, .{
+        .mode = .runtime,
+        .profile = "work",
+        .capability = "chat",
+        .json = true,
+    });
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"ok\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"scope\":{\"profile\":\"work\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"route_reports\":[{\"provider\":\"toy\",\"account\":\"a1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"provider\":\"stale\"") == null);
 }
 
 test "repairActionFor warns before spending provider quota without health evidence" {


### PR DESCRIPTION
## Summary

- add `doctor runtime` route selectors for profile/provider/account/capability scoped checks
- report scoped route readiness separately from global provider inventory
- cover scoped runtime doctor in unit tests, local E2E, first-run E2E, and docs

## Why

Global runtime doctor is useful for full-machine cleanup, but stay-afloat decisions need profile-level truth. A stale unrelated account such as `codex:default` should not make `codex-max` look unusable when all mux routes are ready.

## Validation

- `just test`
- `just check-local`
- dogfood: `oauth-mux doctor runtime --profile codex-max --capability codex-max --json` => `ok: true`, 3/3 Codex Max routes ready
- dogfood: `oauth-mux route select --profile codex-max --capability codex-max --json` selects `codex:max-2` while `max-1` waits for quota reset
