### PR TITLE
[codex] Add runtime snapshot to Codex canary

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -100,12 +100,13 @@ oauth-mux codex canary
 ```
 
 The canary validates config, prints redacted discovery, checks
-`codex login status` for each expected account, and summarizes whether route
-health has already been recorded. It also prints the current non-mutating
-repair plan for the configured Codex route profiles, so a user or agent can see
-whether the next action is to fix runtime setup, run an explicit probe, wait for
-quota, or reauthenticate through the upstream Codex CLI. It does not run live
-probes by default.
+`codex login status` for each expected account, reports scoped runtime
+readiness for each Codex route profile, and summarizes whether route health has
+already been recorded. It also prints the current non-mutating repair plan for
+the configured Codex route profiles, so a user or agent can see whether the next
+action is to fix runtime setup, run an explicit probe, wait for quota, or
+reauthenticate through the upstream Codex CLI. It does not run live probes by
+default.
 
 For guarded live route QA, start with:
 

--- a/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
+++ b/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
@@ -100,6 +100,7 @@ oauth-mux doctor runtime --json
 oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 oauth-mux discover --json
 oauth-mux report --redacted --json
+oauth-mux codex canary
 oauth-mux route explain --profile codex-max --capability codex-max --json
 oauth-mux route select --profile codex-max --capability codex-max --json
 oauth-mux codex canary --help

--- a/src/main.zig
+++ b/src/main.zig
@@ -3838,6 +3838,10 @@ fn runCodexCanary(allocator: std.mem.Allocator, writer: anytype, args: cli.Comma
     try writer.writeAll("\n=== codex login status ===\n");
     try runCodexLoginStatusAll(allocator, writer, args, root);
 
+    try writer.writeAll("\n=== scoped runtime readiness ===\n");
+    try writer.writeAll("Local profile readiness without reading token values or probing providers.\n");
+    try writeCodexRuntimeDoctorSnapshot(allocator, writer, args);
+
     try writer.writeAll("\n=== route liveness snapshot ===\n");
     try writer.writeAll("Existing oauth-mux health state; add --live to refresh with real provider probes.\n");
     try writeCodexRouteSnapshot(allocator, writer, args);
@@ -4546,6 +4550,33 @@ fn writeCodexRouteSnapshot(allocator: std.mem.Allocator, writer: anytype, args: 
             }
             try writer.writeByte('\n');
         }
+    }
+}
+
+fn writeCodexRuntimeDoctorSnapshot(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs) !void {
+    var capability_it = std.mem.splitScalar(u8, args.capabilities, ',');
+    while (capability_it.next()) |raw_capability| {
+        const capability = std.mem.trim(u8, raw_capability, " \t\r\n");
+        if (capability.len == 0) continue;
+
+        if (!args.json) try writer.print("\n--- profile {s} ---\n", .{capability});
+        runDoctorRuntime(allocator, writer, .{
+            .mode = .runtime,
+            .profile = capability,
+            .capability = capability,
+            .json = args.json,
+        }) catch |e| switch (e) {
+            error.ConfigValidationError => {
+                if (args.json) {
+                    try writer.writeAll("{\"profile\":");
+                    try std.json.stringify(capability, .{}, writer);
+                    try writer.writeAll(",\"skipped\":true,\"error\":\"ConfigValidationError\"}\n");
+                } else {
+                    try writer.print("runtime doctor skipped for profile {s}: current config does not define that Codex profile\n", .{capability});
+                }
+            },
+            else => return e,
+        };
     }
 }
 


### PR DESCRIPTION
## Summary

- include scoped runtime doctor output in `oauth-mux codex canary`
- document that the no-spend canary now reports login status, profile runtime readiness, liveness, and repair actions
- add the canary to the dogfood E2E flow plan

## Why

Dogfooding stay-afloat needs one operator bundle that shows whether the current process can actually use each Codex route before looking at liveness and repair actions. This makes `codex canary` a better no-spend first check.

## Validation

- `just test`
- `just check-local`
- dogfood: `oauth-mux codex canary` shows scoped runtime readiness for `codex-mini` and `codex-max`, with 3/3 routes ready and no live probes run
