### PR TITLE
[codex] Add repair run admission gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux route explain --profil
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux route select --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair-plan --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux doctor runtime --profile codex-max --capability codex-max --json
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair run --profile codex-max --capability codex-max --json
 ```
 
 `route select` and `route explain` are no-spend stay-afloat commands. They use
@@ -105,6 +106,11 @@ Use `doctor runtime --profile <name> --capability <name> --json` when a user or
 agent needs profile-level truth without letting a stale unrelated account poison
 the stay-afloat decision.
 
+`repair run` is the explicit mutation boundary. Without `--confirm-repair`, it
+will not open auth flows or run upstream CLI repair commands; it only reports
+whether a route is already selectable, whether no admitted repair exists, or
+which command would require confirmation.
+
 First-run Codex subscription path:
 
 ```bash
@@ -117,6 +123,7 @@ oauth-mux codex live-qa
 oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 oauth-mux route explain --profile codex-max --capability codex-max --json
 oauth-mux repair-plan --profile codex-max --capability codex-max --json
+oauth-mux repair run --profile codex-max --capability codex-max --json
 ```
 
 If an existing config only has a single `codex:default` account, create a safe

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -72,6 +72,10 @@ warranted. Prefer scoped runtime checks such as
 when dogfooding a specific stay-afloat route; global runtime doctor is still
 useful for support bundles and full-machine cleanup.
 
+`oauth-mux repair run --profile <profile> --capability <capability> --json` is
+also safe without confirmation. It will not open a browser, run `codex login`,
+or mutate credential stores unless the user supplies `--confirm-repair`.
+
 ## Provider Author Experience
 
 A new provider should usually start as data, not Zig:

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -15,10 +15,12 @@ permission/session ownership and automatic reauth are not solved by the current
 daemon.
 
 `oauth-mux doctor runtime`, `oauth-mux route explain`, `oauth-mux route
-select`, and `oauth-mux repair-plan` are the current bridge between dogfooding
-evidence and future daemon work. They read local runtime readiness and recorded
-liveness, then either diagnose account stores, explain the route set, select
-the first currently usable route, or print the next non-mutating repair actions.
+select`, `oauth-mux repair-plan`, and `oauth-mux repair run` are the current
+bridge between dogfooding evidence and future daemon work. They read local
+runtime readiness and recorded liveness, then either diagnose account stores,
+explain the route set, select the first currently usable route, print the next
+non-mutating repair actions, or run one admitted repair action only after an
+explicit confirmation flag.
 `oauth-mux daemon repair-plan` is only a namespace alias for that same one-shot
 planner; it does not start a background service, run probes, open browsers,
 refresh credentials, or rewrite secret stores.
@@ -33,6 +35,7 @@ See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
 - `oauth-mux route explain` for no-spend route-state explanation.
 - `oauth-mux route select` for no-spend route choice from recorded evidence.
 - `oauth-mux repair-plan` for non-mutating stay-afloat action planning.
+- `oauth-mux repair run` for one explicit, confirmed repair command.
 - `oauth-mux daemon repair-plan` as a compatibility alias for the same
   one-shot planner.
 - `oauth-mux daemon status` for local inspection.
@@ -45,7 +48,8 @@ See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
 - Automatic subscription-spending checks.
 - Silent token refresh for providers whose refresh semantics are owned by an
   upstream CLI.
-- Automatic execution of repair-plan commands.
+- Automatic execution of repair-plan commands without an explicit foreground
+  user command and confirmation flag.
 - Any release gate that depends on a long-running daemon.
 - Treating `systemctl`, `launchctl`, Homebrew services, cron, or Windows
   Services as part of the core product contract.
@@ -77,5 +81,6 @@ oauth-mux route explain --profile <profile> --capability <capability> --json
 oauth-mux route select --profile <profile> --capability <capability> --json
 oauth-mux probe --profile <profile> --capability <capability> --json
 oauth-mux repair-plan --profile <profile> --capability <capability> --json
+oauth-mux repair run --profile <profile> --capability <capability> --json
 oauth-mux exec --profile <profile> --capability <capability> -- <command>
 ```

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -53,6 +53,7 @@ oauth-mux codex live-qa
 oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 oauth-mux route explain --profile codex-max --capability codex-max --json
 oauth-mux repair-plan --profile codex-max --capability codex-max --json
+oauth-mux repair run --profile codex-max --capability codex-max --json
 ```
 
 `oauth-mux doctor` is the no-spend readiness report. It checks whether config is
@@ -142,6 +143,12 @@ readiness plus recorded route liveness and do not probe providers or mutate auth
 state. Unrecorded routes are reported as `probe_needed`, and `route select`
 exits nonzero when no route has enough evidence to be selected.
 
+`oauth-mux repair run` is the explicit repair execution gate. It refuses
+mutation unless `--confirm-repair` is present. Without confirmation, it is safe
+for agents to run because it only reports that a route is already selectable,
+that no admitted repair exists, or that a specific upstream CLI command would
+need user approval.
+
 If `repair-plan --profile codex-max` reports a config validation error, the
 active config is not the three-account Codex Max shape. That usually means the
 machine still has an older generic config with only `codex:default`. Generate a
@@ -225,6 +232,7 @@ oauth-mux health --json
 oauth-mux doctor runtime --json
 oauth-mux doctor runtime --profile <profile> --capability <capability> --json
 oauth-mux route explain --profile <profile> --capability <capability> --json
+oauth-mux repair run --profile <profile> --capability <capability> --json
 ```
 
 Agents may run:

--- a/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
+++ b/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
@@ -103,6 +103,7 @@ oauth-mux report --redacted --json
 oauth-mux codex canary
 oauth-mux route explain --profile codex-max --capability codex-max --json
 oauth-mux route select --profile codex-max --capability codex-max --json
+oauth-mux repair run --profile codex-max --capability codex-max --json
 oauth-mux codex canary --help
 ```
 

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -443,6 +443,12 @@ runtime readiness plus recorded liveness, emits typed action JSON, and suggests
 copy-pastable commands. The `daemon repair-plan` spelling is an alias for that
 one-shot planner, not daemon automation.
 
+Implementation note, 2026-04-30: `oauth-mux repair run` is the first explicit
+foreground admission gate for mutating repair. It does not change
+`repair-plan`; it reuses the same typed action model, refuses mutation without
+`--confirm-repair`, no-ops when a profile is already afloat, and only runs
+provider-owned repair commands that are represented as first-class actions.
+
 ### M3: Refresh Writeback
 
 - Implement backend write capabilities.

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -257,6 +257,72 @@ expect_contains "$route_select" '"action":"select"' "route select reports action
 expect_contains "$route_select" '"ok":true' "route select reports available selection"
 expect_contains "$route_select" '"selected":{"provider":"toy","account":"a2"' "route select selects fallback account a2"
 
+printf 'e2e: repair run no-ops when fallback route is selectable\n'
+repair_run="$(omux repair run --profile expensive --capability expensive --json)"
+expect_contains "$repair_run" '"ok":true' "repair run reports ok when afloat"
+expect_contains "$repair_run" '"executed":false' "repair run does not execute while route is selectable"
+expect_contains "$repair_run" '"reason":"route_selectable"' "repair run reports selectable route reason"
+
+printf 'e2e: repair run requires confirmation before upstream reauth\n'
+reauth_config="$tmp/reauth-config.json"
+mkdir -p "$tmp/reauth-home"
+cat >"$reauth_config" <<EOF
+{
+  "version": 1,
+  "provider_definitions": {
+    "codex": {
+      "name": "codex",
+      "display_name": "Codex Test Harness",
+      "repair": {
+        "owner": "upstream_cli_login"
+      },
+      "runtime": {
+        "writable_paths": ["CODEX_HOME"],
+        "session_paths": ["CODEX_HOME/auth.json"]
+      }
+    }
+  },
+  "providers": {
+    "codex": {
+      "kind": "codex",
+      "config_dir_env": "CODEX_HOME",
+      "accounts": {
+        "max-1": {
+          "config_dir": "$tmp/reauth-home",
+          "secret": {
+            "backend": "env",
+            "variable": "OMUX_E2E_REAUTH"
+          }
+        }
+      }
+    }
+  },
+  "profiles": {
+    "needs-reauth": {
+      "providers": ["codex:max-1#codex-max"]
+    }
+  },
+  "strategies": {}
+}
+EOF
+repair_reauth_json="$tmp/repair-run-reauth.json"
+set +e
+OMUX_CONFIG="$reauth_config" \
+  OMUX_STATE_DIR="$state_dir" \
+  OMUX_E2E_REAUTH='{}' \
+  "$bin" repair run --profile needs-reauth --capability codex-max --json >"$repair_reauth_json" 2>"$tmp/repair-run-reauth.stderr"
+repair_reauth_status=$?
+set -e
+if [ "$repair_reauth_status" -eq 0 ]; then
+  printf 'e2e assertion failed: repair run should require confirmation before reauth\n' >&2
+  exit 1
+fi
+repair_reauth="$(cat "$repair_reauth_json")"
+expect_contains "$repair_reauth" '"confirmation_required":true' "repair run requires confirmation"
+expect_contains "$repair_reauth" '"requires":"--confirm-repair"' "repair run reports required flag"
+expect_contains "$repair_reauth" '"command":"oauth-mux codex login-device max-1"' "repair run reports upstream command"
+test ! -e "$tmp/reauth-home/auth.json"
+
 printf 'e2e: route health does not poison unrelated capability\n'
 cheap_after_quota="$(omux env --profile cheap --capability cheap --shell bash)"
 expect_contains "$cheap_after_quota" "export OMUX_ACTIVE_ACCOUNT='a1'" "cheap route still uses a1 after expensive quota"

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -183,6 +183,7 @@ jq -e '
   and (.agent_safe_commands | index("oauth-mux route explain --profile <profile> --capability <capability> --json") != null)
   and (.agent_safe_commands | index("oauth-mux route select --profile <profile> --capability <capability> --json") != null)
   and (.agent_safe_commands | index("oauth-mux repair-plan --profile <profile> --capability <capability> --json") != null)
+  and (.agent_safe_commands | index("oauth-mux repair run --profile <profile> --capability <capability> --json") != null)
   and (.agent_safe_commands | index("oauth-mux codex config-candidate --json") == null)
 ' "$discover_json" >/dev/null
 
@@ -226,6 +227,18 @@ jq -e '
   and .selected == null
   and (.routes | length) == 3
 ' "$route_select_json" >/dev/null
+
+printf 'first-run e2e: repair run refuses to mutate without admitted repair\n'
+repair_run_json="$tmp/repair-run-codex-max.json"
+run_json "$repair_run_json" repair run --profile codex-max --capability codex-max --json
+jq -e '
+  .ok == true
+  and .executed == false
+  and .confirmation_required == false
+  and .reason == "no_admitted_repair"
+' "$repair_run_json" >/dev/null
+test ! -e "$store_root"
+test ! -e "$legacy_store_root"
 
 printf 'first-run e2e: config-candidate writes sidecar without clobbering active config\n'
 config_before="$(cat "$config_path")"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -14,6 +14,7 @@ pub const Command = union(enum) {
     health: HealthArgs,
     discover: DiscoverArgs,
     repair_plan: RepairPlanArgs,
+    repair_run: RepairRunArgs,
     route: RouteArgs,
     config_validate,
     config_path,
@@ -103,6 +104,15 @@ pub const Command = union(enum) {
         json: bool = false,
     };
 
+    pub const RepairRunArgs = struct {
+        profile: ?[]const u8 = null,
+        provider: ?[]const u8 = null,
+        account: ?[]const u8 = null,
+        capability: ?[]const u8 = null,
+        json: bool = false,
+        confirm_repair: bool = false,
+    };
+
     pub const RouteAction = enum {
         select,
         explain,
@@ -172,6 +182,7 @@ pub fn parse(args: []const []const u8) Command {
     if (eql(cmd, "status")) return parseStatus(rest);
     if (eql(cmd, "health")) return parseHealth(rest);
     if (eql(cmd, "discover")) return parseDiscover(rest);
+    if (eql(cmd, "repair")) return parseRepair(rest);
     if (eql(cmd, "repair-plan")) return parseRepairPlan(rest);
     if (eql(cmd, "route")) return parseRoute(rest);
     if (eql(cmd, "config")) return parseConfig(rest);
@@ -377,6 +388,38 @@ fn parseRepairPlan(args: []const []const u8) Command {
     return .{ .repair_plan = result };
 }
 
+fn parseRepair(args: []const []const u8) Command {
+    if (args.len > 0 and eql(args[0], "run")) {
+        return parseRepairRun(args[1..]);
+    }
+    return .help;
+}
+
+fn parseRepairRun(args: []const []const u8) Command {
+    var result = Command.RepairRunArgs{};
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        if (eql(args[i], "--profile") or eql(args[i], "-p")) {
+            i += 1;
+            if (i < args.len) result.profile = args[i];
+        } else if (eql(args[i], "--provider")) {
+            i += 1;
+            if (i < args.len) result.provider = args[i];
+        } else if (eql(args[i], "--account")) {
+            i += 1;
+            if (i < args.len) result.account = args[i];
+        } else if (eql(args[i], "--capability")) {
+            i += 1;
+            if (i < args.len) result.capability = args[i];
+        } else if (eql(args[i], "--json")) {
+            result.json = true;
+        } else if (eql(args[i], "--confirm-repair")) {
+            result.confirm_repair = true;
+        }
+    }
+    return .{ .repair_run = result };
+}
+
 fn parseRoute(args: []const []const u8) Command {
     var result = Command.RouteArgs{};
     var i: usize = 0;
@@ -572,6 +615,9 @@ pub fn printUsage(writer: anytype) !void {
         \\
         \\  repair-plan [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
         \\      Explain non-mutating repair actions from runtime and liveness state.
+        \\
+        \\  repair run [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--confirm-repair] [--json]
+        \\      Run one admitted repair action; refuses mutation without confirmation.
         \\
         \\  route select|explain [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
         \\      Select or explain a route from recorded liveness without probing.
@@ -936,6 +982,20 @@ test "parse runtime doctor with route scope" {
     }
 }
 
+test "parse repair run requires explicit confirmation flag" {
+    const args = [_][]const u8{ "repair", "run", "--profile", "codex-max", "--capability", "codex-max", "--confirm-repair", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .repair_run => |repair| {
+            try std.testing.expectEqualStrings("codex-max", repair.profile.?);
+            try std.testing.expectEqualStrings("codex-max", repair.capability.?);
+            try std.testing.expect(repair.confirm_repair);
+            try std.testing.expect(repair.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 test "parse daemon repair plan alias" {
     const args = [_][]const u8{ "daemon", "repair-plan", "--provider", "codex", "--account", "max-1", "--capability", "codex-max" };
     const cmd = parse(&args);
@@ -982,6 +1042,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n __fish_use_subcommand -a health -d 'Show health data'
             \\complete -c oauth-mux -n __fish_use_subcommand -a discover -d 'Show agent-safe inventory'
             \\complete -c oauth-mux -n __fish_use_subcommand -a repair-plan -d 'Show non-mutating repair plan'
+            \\complete -c oauth-mux -n __fish_use_subcommand -a repair -d 'Run admitted repair actions'
             \\complete -c oauth-mux -n __fish_use_subcommand -a route -d 'Select or explain routes'
             \\complete -c oauth-mux -n __fish_use_subcommand -a config -d 'Config operations'
             \\complete -c oauth-mux -n __fish_use_subcommand -a init -d 'Generate config'
@@ -1013,6 +1074,13 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from repair-plan' -l provider -d 'Provider name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from repair-plan' -l account -d 'Account name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from repair-plan' -l capability -d 'Route capability' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from repair' -a 'run' -d 'Repair subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from repair' -l json -d 'JSON output'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from repair' -l profile -s p -d 'Profile name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from repair' -l provider -d 'Provider name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from repair' -l account -d 'Account name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from repair' -l capability -d 'Route capability' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from repair' -l confirm-repair -d 'Confirm mutating repair'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from route' -a 'select explain' -d 'Route subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from route' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'

--- a/src/main.zig
+++ b/src/main.zig
@@ -118,6 +118,13 @@ pub fn main() !void {
             };
         },
 
+        .repair_run => |repair_args| {
+            runRepairRun(allocator, stdout, repair_args) catch |e| {
+                log.err("repair run: {s}", .{@errorName(e)});
+                std.process.exit(exitCodeFromPipelineError(e));
+            };
+        },
+
         .route => |route_args| {
             runRoute(allocator, stdout, route_args) catch |e| {
                 log.err("route: {s}", .{@errorName(e)});
@@ -335,6 +342,7 @@ fn writeDiscoverText(writer: anytype, cfg: config.Config, config_path: []const u
     try writer.writeAll("    oauth-mux route explain --profile <profile> --capability <capability> --json\n");
     try writer.writeAll("    oauth-mux route select --profile <profile> --capability <capability> --json\n");
     try writer.writeAll("    oauth-mux repair-plan --profile <profile> --capability <capability> --json\n");
+    try writer.writeAll("    oauth-mux repair run --profile <profile> --capability <capability> --json\n");
     if (codex_configured and !codex_max_configured) {
         try writer.writeAll("    oauth-mux codex config-candidate --json\n");
     }
@@ -439,6 +447,7 @@ fn writeDiscoverJson(writer: anytype, cfg: config.Config, config_path: []const u
         "oauth-mux route explain --profile <profile> --capability <capability> --json",
         "oauth-mux route select --profile <profile> --capability <capability> --json",
         "oauth-mux repair-plan --profile <profile> --capability <capability> --json",
+        "oauth-mux repair run --profile <profile> --capability <capability> --json",
         "oauth-mux env --profile <profile> --capability <capability> --shell <shell>",
         "oauth-mux exec --profile <profile> --capability <capability> -- <command>",
     };
@@ -497,6 +506,219 @@ fn runRepairPlan(allocator: std.mem.Allocator, writer: anytype, args: cli.Comman
     } else {
         try writeRepairPlanText(writer, allocator, parsed.value, &store, routes.items, args);
     }
+}
+
+fn runRepairRun(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.RepairRunArgs) !void {
+    const parsed = try config.load(allocator);
+    defer parsed.deinit();
+
+    var validation_messages = std.ArrayList(u8).init(allocator);
+    defer validation_messages.deinit();
+    try config.validate(parsed.value, validation_messages.writer());
+
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+
+    var routes = try collectRepairPlanRoutes(allocator, parsed.value, repairRunArgsToPlanArgs(args));
+    defer routes.deinit();
+
+    var evaluations = std.ArrayList(RouteEvaluation).init(allocator);
+    defer evaluations.deinit();
+    try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &evaluations);
+
+    const selected_index = firstSelectableRoute(evaluations.items);
+    const candidate_index = repairRunCandidate(evaluations.items, selected_index, args);
+
+    if (candidate_index == null) {
+        if (args.json) {
+            try writeRepairRunNoopJson(writer, evaluations.items, selected_index, args);
+        } else {
+            try writeRepairRunNoopText(writer, evaluations.items, selected_index, args);
+        }
+        return;
+    }
+
+    const evaluation = evaluations.items[candidate_index.?];
+    if (!args.confirm_repair) {
+        if (args.json) {
+            try writeRepairRunConfirmationJson(writer, allocator, parsed.value, evaluation, args);
+        } else {
+            try writeRepairRunConfirmationText(writer, allocator, evaluation);
+        }
+        return error.RepairConfirmationRequired;
+    }
+
+    const command = try repairCommandAlloc(allocator, evaluation.action.command, evaluation.route);
+    defer if (command) |value| allocator.free(value);
+
+    const ok = try executeRepairCommand(allocator, parsed.value, evaluation);
+    if (args.json) {
+        try writeRepairRunExecutedJson(writer, allocator, parsed.value, evaluation, command, ok);
+    } else {
+        try writeRepairRunExecutedText(writer, evaluation, command, ok);
+    }
+    if (!ok) return error.CodexCommandFailed;
+}
+
+fn repairRunArgsToPlanArgs(args: cli.Command.RepairRunArgs) cli.Command.RepairPlanArgs {
+    return .{
+        .profile = args.profile,
+        .provider = args.provider,
+        .account = args.account,
+        .capability = args.capability,
+        .json = args.json,
+    };
+}
+
+fn repairRunCandidate(
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+    args: cli.Command.RepairRunArgs,
+) ?usize {
+    if (args.account == null and selected_index != null) return null;
+
+    for (evaluations, 0..) |evaluation, idx| {
+        if (evaluation.action.mutating and evaluation.action.command != .none) return idx;
+    }
+    return null;
+}
+
+fn writeRepairRunNoopText(
+    writer: anytype,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+    args: cli.Command.RepairRunArgs,
+) !void {
+    try writer.writeAll("oauth-mux repair run\n\n");
+    if (args.profile) |profile_name| try writer.print("  profile: {s}\n", .{profile_name});
+    if (args.capability) |capability| try writer.print("  capability: {s}\n", .{capability});
+    if (selected_index) |idx| {
+        const route = evaluations[idx].route;
+        try writer.print("  selected: {s}:{s}", .{ route.provider, route.account });
+        if (route.capability) |capability| try writer.print("#{s}", .{capability});
+        try writer.writeAll("\n  executed: no\n  reason: route is already selectable; no repair needed for stay-afloat\n");
+    } else {
+        try writer.writeAll("  executed: no\n  reason: no admitted mutating repair action found\n");
+    }
+}
+
+fn writeRepairRunNoopJson(
+    writer: anytype,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+    args: cli.Command.RepairRunArgs,
+) !void {
+    try writer.writeAll("{\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"ok\":true,\"executed\":false,\"confirmation_required\":false,\"profile\":");
+    if (args.profile) |profile_name| try std.json.stringify(profile_name, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"capability\":");
+    if (args.capability) |capability| try std.json.stringify(capability, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"reason\":");
+    if (selected_index != null) {
+        try std.json.stringify("route_selectable", .{}, writer);
+    } else {
+        try std.json.stringify("no_admitted_repair", .{}, writer);
+    }
+    try writer.writeAll(",\"selected\":");
+    if (selected_index) |idx| {
+        try writeRouteSelectionJson(writer, evaluations[idx].route);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll("}\n");
+}
+
+fn writeRepairRunConfirmationText(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    evaluation: RouteEvaluation,
+) !void {
+    try writer.writeAll("oauth-mux repair run\n\n");
+    try writer.writeAll("  executed: no\n");
+    try writer.writeAll("  confirmation_required: --confirm-repair\n");
+    try writer.print("  route: {s}:{s}", .{ evaluation.route.provider, evaluation.route.account });
+    if (evaluation.route.capability) |capability| try writer.print("#{s}", .{capability});
+    try writer.print("\n  action: {s}\n", .{evaluation.action.kind});
+    if (try repairCommandAlloc(allocator, evaluation.action.command, evaluation.route)) |command| {
+        defer allocator.free(command);
+        try writer.print("  command: {s}\n", .{command});
+    }
+}
+
+fn writeRepairRunConfirmationJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluation: RouteEvaluation,
+    args: cli.Command.RepairRunArgs,
+) !void {
+    try writer.writeAll("{\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"ok\":false,\"executed\":false,\"confirmation_required\":true,\"requires\":\"--confirm-repair\",\"profile\":");
+    if (args.profile) |profile_name| try std.json.stringify(profile_name, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"capability\":");
+    if (args.capability) |capability| try std.json.stringify(capability, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"route\":");
+    try writeRouteEvaluationJson(writer, allocator, cfg, evaluation, false);
+    try writer.writeAll("}\n");
+}
+
+fn writeRepairRunExecutedText(
+    writer: anytype,
+    evaluation: RouteEvaluation,
+    command: ?[]const u8,
+    ok: bool,
+) !void {
+    try writer.writeAll("oauth-mux repair run\n\n");
+    try writer.print("  executed: {s}\n", .{if (ok) "yes" else "failed"});
+    try writer.print("  route: {s}:{s}", .{ evaluation.route.provider, evaluation.route.account });
+    if (evaluation.route.capability) |capability| try writer.print("#{s}", .{capability});
+    try writer.print("\n  action: {s}\n", .{evaluation.action.kind});
+    if (command) |value| try writer.print("  command: {s}\n", .{value});
+}
+
+fn writeRepairRunExecutedJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluation: RouteEvaluation,
+    command: ?[]const u8,
+    ok: bool,
+) !void {
+    try writer.writeAll("{\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"ok\":");
+    try writer.writeAll(if (ok) "true" else "false");
+    try writer.writeAll(",\"executed\":true,\"confirmation_required\":false,\"command\":");
+    if (command) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"route\":");
+    try writeRouteEvaluationJson(writer, allocator, cfg, evaluation, false);
+    try writer.writeAll("}\n");
+}
+
+fn executeRepairCommand(
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluation: RouteEvaluation,
+) !bool {
+    return switch (evaluation.action.command) {
+        .none, .probe => false,
+        .codex_login_device => try executeCodexLoginDeviceRepair(allocator, cfg, evaluation.route),
+    };
+}
+
+fn executeCodexLoginDeviceRepair(
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    route: RepairPlanRoute,
+) !bool {
+    const prov = cfg.providers.map.get(route.provider) orelse return false;
+    const account = prov.accounts.map.get(route.account) orelse return false;
+    const config_dir = account.config_dir orelse return false;
+    const expanded = try paths.expandTilde(allocator, config_dir);
+    defer allocator.free(expanded);
+    return try runCodexCli(allocator, expanded, &.{ "codex", "login", "--device-auth" });
 }
 
 fn collectRepairPlanRoutes(
@@ -1362,6 +1584,7 @@ fn writeDoctorNextCommandsText(writer: anytype, stats: DoctorStats) !void {
     try writer.writeAll("    oauth-mux doctor runtime --json\n");
     try writer.writeAll("    oauth-mux route explain --profile <profile> --capability <capability> --json\n");
     try writer.writeAll("    oauth-mux route select --profile <profile> --capability <capability> --json\n");
+    try writer.writeAll("    oauth-mux repair run --profile <profile> --capability <capability> --json\n");
     if (stats.codex_configured) {
         if (!stats.codex_max_configured) {
             try writer.writeAll("    oauth-mux codex config-candidate\n");
@@ -1396,6 +1619,7 @@ fn writeDoctorNextCommandsJson(writer: anytype, stats: DoctorStats) !void {
     try writeDoctorCommandJson(writer, &first, "oauth-mux route explain --profile <profile> --capability <capability> --json");
     try writeDoctorCommandJson(writer, &first, "oauth-mux route select --profile <profile> --capability <capability> --json");
     try writeDoctorCommandJson(writer, &first, "oauth-mux repair-plan --json");
+    try writeDoctorCommandJson(writer, &first, "oauth-mux repair run --profile <profile> --capability <capability> --json");
     if (stats.codex_configured) {
         if (!stats.codex_max_configured) {
             try writeDoctorCommandJson(writer, &first, "oauth-mux codex config-candidate --json");
@@ -4908,6 +5132,7 @@ test "writeDiscoverJson includes stay-afloat agent-safe commands" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux route explain --profile <profile> --capability <capability> --json") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux route select --profile <profile> --capability <capability> --json") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux repair-plan --profile <profile> --capability <capability> --json") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux repair run --profile <profile> --capability <capability> --json") != null);
 }
 
 test "writeDiscoverJson exposes Codex Max drift command" {
@@ -5115,6 +5340,80 @@ test "writeRepairActionJson emits codex reauth command without running it" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"kind\":\"reauth\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"interactive\":true") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"mutating\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"command\":\"oauth-mux codex login-device max-1\"") != null);
+}
+
+test "repairRunCandidate skips repair when profile already has selectable route" {
+    const dead_route = RepairPlanRoute{ .provider = "codex", .account = "max-1", .capability = "codex-max" };
+    const live_route = RepairPlanRoute{ .provider = "codex", .account = "max-2", .capability = "codex-max" };
+    const evaluations = [_]RouteEvaluation{
+        .{
+            .route = dead_route,
+            .runtime = .{ .needs_reauth = .{ .methods = &.{"upstream_cli_login"}, .reason = "session_file_missing" } },
+            .health = null,
+            .budget = .spend_provider,
+            .action = reauthAction(dead_route, provider_schema.codex_def),
+            .selectable = false,
+            .skip_reason = "needs_reauth",
+        },
+        .{
+            .route = live_route,
+            .runtime = .ready,
+            .health = health_mod.AccountHealth{ .liveness = .{ .live = .{ .availability = .available } } },
+            .budget = .spend_provider,
+            .action = .{ .kind = "none", .severity = "ok", .message = "route is selectable" },
+            .selectable = true,
+            .skip_reason = "available",
+        },
+    };
+
+    try std.testing.expect(repairRunCandidate(&evaluations, 1, .{ .profile = "codex-max" }) == null);
+    try std.testing.expectEqual(@as(?usize, 0), repairRunCandidate(&evaluations, null, .{ .profile = "codex-max" }));
+}
+
+test "repair run confirmation json refuses mutating reauth by default" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": {
+        \\          "config_dir": "/tmp/oauth-mux-test/max-1",
+        \\          "secret": { "backend": "file", "path": "/tmp/oauth-mux-test/max-1/auth.json" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try config.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    const route = RepairPlanRoute{ .provider = "codex", .account = "max-1", .capability = "codex-max" };
+    const evaluation = RouteEvaluation{
+        .route = route,
+        .runtime = .{ .needs_reauth = .{ .methods = &.{"upstream_cli_login"}, .reason = "session_file_missing" } },
+        .health = null,
+        .budget = .spend_provider,
+        .action = reauthAction(route, provider_schema.codex_def),
+        .selectable = false,
+        .skip_reason = "needs_reauth",
+    };
+
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+    try writeRepairRunConfirmationJson(buf.writer(), std.testing.allocator, parsed.value, evaluation, .{
+        .provider = "codex",
+        .account = "max-1",
+        .capability = "codex-max",
+        .json = true,
+    });
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"confirmation_required\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"requires\":\"--confirm-repair\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"command\":\"oauth-mux codex login-device max-1\"") != null);
 }
 


### PR DESCRIPTION
## Summary

- add `oauth-mux repair run` as the explicit foreground gate for admitted mutating repair actions
- keep `repair-plan` non-mutating and require `--confirm-repair` before running upstream CLI repair
- no-op when a profile already has a selectable fallback route or when no admitted repair exists
- add unit coverage, local E2E, first-run E2E, docs, and agent-safe discovery wiring

## Why

Stay-afloat now knows route truth and can inject the selected account, but repair execution still needed a clean boundary. This command gives users and agents a safe next step that never opens auth or mutates credential stores unless explicitly confirmed.

## Validation

- `zig build test`
- `just check-local`
- dogfood: `oauth-mux repair run --profile codex-max --capability codex-max --json` no-ops because `codex:max-2` is selectable
- dogfood: `oauth-mux repair run --provider codex --account max-1 --capability codex-max --json` no-ops because quota exhaustion is a wait state, not reauth
