### PR TITLE
[codex] Harden repair run JSON boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ the stay-afloat decision.
 `repair run` is the explicit mutation boundary. Without `--confirm-repair`, it
 will not open auth flows or run upstream CLI repair commands; it only reports
 whether a route is already selectable, whether no admitted repair exists, or
-which command would require confirmation.
+which command would require confirmation. Confirmed interactive repairs should
+be run without `--json` so upstream CLI login output cannot corrupt machine
+readable output.
 
 First-run Codex subscription path:
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -147,7 +147,9 @@ exits nonzero when no route has enough evidence to be selected.
 mutation unless `--confirm-repair` is present. Without confirmation, it is safe
 for agents to run because it only reports that a route is already selectable,
 that no admitted repair exists, or that a specific upstream CLI command would
-need user approval.
+need user approval. Confirmed interactive repair is a human foreground flow and
+should be run without `--json`; JSON mode refuses interactive repair execution
+so upstream CLI output cannot corrupt machine-readable output.
 
 If `repair-plan --profile codex-max` reports a config validation error, the
 active config is not the three-account Codex Max shape. That usually means the

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -448,6 +448,8 @@ foreground admission gate for mutating repair. It does not change
 `repair-plan`; it reuses the same typed action model, refuses mutation without
 `--confirm-repair`, no-ops when a profile is already afloat, and only runs
 provider-owned repair commands that are represented as first-class actions.
+Confirmed interactive repair is intentionally rejected in `--json` mode because
+upstream CLIs can write browser/device auth output to stdout or stderr.
 
 ### M3: Refresh Writeback
 

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -323,6 +323,23 @@ expect_contains "$repair_reauth" '"requires":"--confirm-repair"' "repair run rep
 expect_contains "$repair_reauth" '"command":"oauth-mux codex login-device max-1"' "repair run reports upstream command"
 test ! -e "$tmp/reauth-home/auth.json"
 
+repair_reauth_confirmed_json="$tmp/repair-run-reauth-confirmed.json"
+set +e
+OMUX_CONFIG="$reauth_config" \
+  OMUX_STATE_DIR="$state_dir" \
+  OMUX_E2E_REAUTH='{}' \
+  "$bin" repair run --profile needs-reauth --capability codex-max --confirm-repair --json >"$repair_reauth_confirmed_json" 2>"$tmp/repair-run-reauth-confirmed.stderr"
+repair_reauth_confirmed_status=$?
+set -e
+if [ "$repair_reauth_confirmed_status" -eq 0 ]; then
+  printf 'e2e assertion failed: repair run --json should refuse confirmed interactive repair\n' >&2
+  exit 1
+fi
+repair_reauth_confirmed="$(cat "$repair_reauth_confirmed_json")"
+expect_contains "$repair_reauth_confirmed" '"error":"interactive_json_unsupported"' "repair run json refuses interactive execution"
+expect_contains "$repair_reauth_confirmed" '"executed":false' "repair run json does not execute interactive repair"
+test ! -e "$tmp/reauth-home/auth.json"
+
 printf 'e2e: route health does not poison unrelated capability\n'
 cheap_after_quota="$(omux env --profile cheap --capability cheap --shell bash)"
 expect_contains "$cheap_after_quota" "export OMUX_ACTIVE_ACCOUNT='a1'" "cheap route still uses a1 after expensive quota"

--- a/src/main.zig
+++ b/src/main.zig
@@ -548,6 +548,11 @@ fn runRepairRun(allocator: std.mem.Allocator, writer: anytype, args: cli.Command
         return error.RepairConfirmationRequired;
     }
 
+    if (args.json and evaluation.action.interactive) {
+        try writeRepairRunJsonInteractiveUnsupported(writer, allocator, parsed.value, evaluation, args);
+        return error.RepairConfirmationRequired;
+    }
+
     const command = try repairCommandAlloc(allocator, evaluation.action.command, evaluation.route);
     defer if (command) |value| allocator.free(value);
 
@@ -656,6 +661,24 @@ fn writeRepairRunConfirmationJson(
     try writer.writeAll("{\"version\":");
     try std.json.stringify(cli.version, .{}, writer);
     try writer.writeAll(",\"ok\":false,\"executed\":false,\"confirmation_required\":true,\"requires\":\"--confirm-repair\",\"profile\":");
+    if (args.profile) |profile_name| try std.json.stringify(profile_name, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"capability\":");
+    if (args.capability) |capability| try std.json.stringify(capability, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"route\":");
+    try writeRouteEvaluationJson(writer, allocator, cfg, evaluation, false);
+    try writer.writeAll("}\n");
+}
+
+fn writeRepairRunJsonInteractiveUnsupported(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluation: RouteEvaluation,
+    args: cli.Command.RepairRunArgs,
+) !void {
+    try writer.writeAll("{\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"ok\":false,\"executed\":false,\"confirmation_required\":false,\"error\":\"interactive_json_unsupported\",\"message\":\"interactive repair may write upstream CLI output; rerun without --json after reviewing repair-plan\",\"profile\":");
     if (args.profile) |profile_name| try std.json.stringify(profile_name, .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"capability\":");
     if (args.capability) |capability| try std.json.stringify(capability, .{}, writer) else try writer.writeAll("null");
@@ -5414,6 +5437,53 @@ test "repair run confirmation json refuses mutating reauth by default" {
 
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"confirmation_required\":true") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"requires\":\"--confirm-repair\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"command\":\"oauth-mux codex login-device max-1\"") != null);
+}
+
+test "repair run json refuses confirmed interactive repair execution" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": {
+        \\          "config_dir": "/tmp/oauth-mux-test/max-1",
+        \\          "secret": { "backend": "file", "path": "/tmp/oauth-mux-test/max-1/auth.json" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try config.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    const route = RepairPlanRoute{ .provider = "codex", .account = "max-1", .capability = "codex-max" };
+    const evaluation = RouteEvaluation{
+        .route = route,
+        .runtime = .{ .needs_reauth = .{ .methods = &.{"upstream_cli_login"}, .reason = "session_file_missing" } },
+        .health = null,
+        .budget = .spend_provider,
+        .action = reauthAction(route, provider_schema.codex_def),
+        .selectable = false,
+        .skip_reason = "needs_reauth",
+    };
+
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+    try writeRepairRunJsonInteractiveUnsupported(buf.writer(), std.testing.allocator, parsed.value, evaluation, .{
+        .provider = "codex",
+        .account = "max-1",
+        .capability = "codex-max",
+        .confirm_repair = true,
+        .json = true,
+    });
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"error\":\"interactive_json_unsupported\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"executed\":false") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"command\":\"oauth-mux codex login-device max-1\"") != null);
 }
 


### PR DESCRIPTION
## Summary

- refuse confirmed interactive repair execution when `--json` is set
- keep JSON mode safe for agents and inspection-only flows
- document that confirmed upstream CLI repair should run in foreground text mode
- cover the refusal in unit tests and local E2E

## Why

Interactive upstream login commands can write browser/device auth output to stdout/stderr. Running those while promising JSON output risks corrupting machine-readable output, so JSON mode now reports `interactive_json_unsupported` instead of executing.

## Validation

- `just check-local`
