### PR TITLE
[codex] Add repair event log and account locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux route select --profile
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair-plan --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair run --profile codex-max --capability codex-max --json
+oauth-mux daemon events --json
 ```
 
 `route select` and `route explain` are no-spend stay-afloat commands. They use
@@ -112,6 +113,13 @@ whether a route is already selectable, whether no admitted repair exists, or
 which command would require confirmation. Confirmed interactive repairs should
 be run without `--json` so upstream CLI login output cannot corrupt machine
 readable output.
+
+Every `repair run` invocation appends a redacted local event under the
+oauth-mux state directory. Confirmed repair uses an account-scoped advisory
+lock so concurrent repair attempts surface as `repair_in_progress` in runtime
+readiness instead of racing an upstream CLI login flow. Inspect recent events
+with `oauth-mux daemon events --json`; this does not require the daemon to be
+running.
 
 First-run Codex subscription path:
 

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -38,7 +38,11 @@ See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
 - `oauth-mux repair run` for one explicit, confirmed repair command.
 - `oauth-mux daemon repair-plan` as a compatibility alias for the same
   one-shot planner.
-- `oauth-mux daemon status` for local inspection.
+- `oauth-mux daemon status --json` for local inspection.
+- `oauth-mux daemon events --json` for the redacted repair-run event log. This
+  reads local state and does not require a daemon process.
+- Account-scoped advisory locks during confirmed `repair run`, reported back as
+  `repair_in_progress` by runtime-aware route planning.
 - Local experimentation with daemon socket/status behavior.
 - Future manual QA where daemon activity is bounded and visible.
 
@@ -82,5 +86,6 @@ oauth-mux route select --profile <profile> --capability <capability> --json
 oauth-mux probe --profile <profile> --capability <capability> --json
 oauth-mux repair-plan --profile <profile> --capability <capability> --json
 oauth-mux repair run --profile <profile> --capability <capability> --json
+oauth-mux daemon events --json
 oauth-mux exec --profile <profile> --capability <capability> -- <command>
 ```

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -151,6 +151,17 @@ need user approval. Confirmed interactive repair is a human foreground flow and
 should be run without `--json`; JSON mode refuses interactive repair execution
 so upstream CLI output cannot corrupt machine-readable output.
 
+Each `repair run` call records a redacted event. Confirmed repair also takes an
+account-scoped advisory lock before it launches an upstream repair command. A
+second process sees that lock as `repair_in_progress` through `doctor runtime`,
+`route explain`, `route select`, and `repair-plan`, so agents can back off
+without guessing whether OAuth, quota, or local runtime state failed. Inspect
+the audit trail with:
+
+```bash
+oauth-mux daemon events --json
+```
+
 If `repair-plan --profile codex-max` reports a config validation error, the
 active config is not the three-account Codex Max shape. That usually means the
 machine still has an older generic config with only `codex:default`. Generate a

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -451,6 +451,14 @@ provider-owned repair commands that are represented as first-class actions.
 Confirmed interactive repair is intentionally rejected in `--json` mode because
 upstream CLIs can write browser/device auth output to stdout or stderr.
 
+Implementation note, 2026-04-30: repair execution now has the first daemon-safe
+substrate. `repair run` appends redacted JSONL events, confirmed repair takes
+an account-scoped advisory lock, and route/runtime planning reports an active
+lock as `repair_in_progress`. `oauth-mux daemon events --json` reads the event
+log without requiring the daemon to be running. This is still one-shot
+foreground repair; it is the audit and concurrency layer needed before any
+background loop.
+
 ### M3: Refresh Writeback
 
 - Implement backend write capabilities.
@@ -462,7 +470,8 @@ upstream CLIs can write browser/device auth output to stdout or stderr.
 ### M4: Daemon Beta
 
 - Promote daemon to opt-in beta.
-- Add budgets, event log, lock files, and status JSON.
+- Add configurable budgets and status JSON beyond the current repair-run event
+  log and advisory lock substrate.
 - Keep live probes disabled by default.
 - Add Homebrew/systemd/launchd packaging notes only after stop/status behavior
   is proven.

--- a/justfile
+++ b/justfile
@@ -212,7 +212,10 @@ daemon-stop: build
     ./zig-out/bin/oauth-mux daemon stop
 
 daemon-status: build
-    ./zig-out/bin/oauth-mux daemon status
+    ./zig-out/bin/oauth-mux daemon status --json
+
+daemon-events: build
+    ./zig-out/bin/oauth-mux daemon events --json
 
 # ── Shell integration ──
 

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -340,6 +340,16 @@ expect_contains "$repair_reauth_confirmed" '"error":"interactive_json_unsupporte
 expect_contains "$repair_reauth_confirmed" '"executed":false' "repair run json does not execute interactive repair"
 test ! -e "$tmp/reauth-home/auth.json"
 
+printf 'e2e: daemon events exposes redacted repair run audit trail\n'
+repair_events="$(OMUX_STATE_DIR="$state_dir" "$bin" daemon events --json)"
+expect_contains "$repair_events" '"events":[' "daemon events returns json event list"
+expect_contains "$repair_events" '"outcome":"noop"' "repair events record selectable no-op"
+expect_contains "$repair_events" '"outcome":"confirmation_required"' "repair events record confirmation gate"
+expect_contains "$repair_events" '"outcome":"interactive_json_unsupported"' "repair events record json boundary refusal"
+expect_contains "$repair_events" '"profile":"needs-reauth"' "repair events record profile"
+expect_contains "$repair_events" '"provider":"codex"' "repair events record provider"
+expect_contains "$repair_events" '"account":"max-1"' "repair events record account"
+
 printf 'e2e: route health does not poison unrelated capability\n'
 cheap_after_quota="$(omux env --profile cheap --capability cheap --shell bash)"
 expect_contains "$cheap_after_quota" "export OMUX_ACTIVE_ACCOUNT='a1'" "cheap route still uses a1 after expensive quota"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -24,7 +24,8 @@ pub const Command = union(enum) {
     daemon_run,
     daemon_start,
     daemon_stop,
-    daemon_status,
+    daemon_status: DaemonStatusArgs,
+    daemon_events: DaemonEventsArgs,
     version_cmd,
     help,
     codex_help,
@@ -165,6 +166,15 @@ pub const Command = union(enum) {
     pub const CompletionsArgs = struct {
         shell: []const u8 = "fish",
     };
+
+    pub const DaemonStatusArgs = struct {
+        json: bool = false,
+    };
+
+    pub const DaemonEventsArgs = struct {
+        json: bool = false,
+        limit: usize = 50,
+    };
 };
 
 pub fn parse(args: []const []const u8) Command {
@@ -196,9 +206,10 @@ pub fn parse(args: []const []const u8) Command {
             if (eql(rest[0], "repair-plan")) return parseRepairPlan(rest[1..]);
             if (eql(rest[0], "start")) return .daemon_start;
             if (eql(rest[0], "stop")) return .daemon_stop;
-            if (eql(rest[0], "status")) return .daemon_status;
+            if (eql(rest[0], "status")) return parseDaemonStatus(rest[1..]);
+            if (eql(rest[0], "events")) return parseDaemonEvents(rest[1..]);
         }
-        return .daemon_status;
+        return .{ .daemon_status = .{} };
     }
     if (eql(cmd, "completions")) {
         if (rest.len > 0) return .{ .completions = .{ .shell = rest[0] } };
@@ -452,6 +463,30 @@ fn parseRoute(args: []const []const u8) Command {
     return .{ .route = result };
 }
 
+fn parseDaemonStatus(args: []const []const u8) Command {
+    var result = Command.DaemonStatusArgs{};
+    for (args) |arg| {
+        if (eql(arg, "--json")) result.json = true;
+    }
+    return .{ .daemon_status = result };
+}
+
+fn parseDaemonEvents(args: []const []const u8) Command {
+    var result = Command.DaemonEventsArgs{};
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        if (eql(args[i], "--json")) {
+            result.json = true;
+        } else if (eql(args[i], "--limit")) {
+            i += 1;
+            if (i < args.len) {
+                result.limit = std.fmt.parseInt(usize, args[i], 10) catch result.limit;
+            }
+        }
+    }
+    return .{ .daemon_events = result };
+}
+
 fn parseConfig(args: []const []const u8) Command {
     if (args.len == 0) return .config_path;
     if (eql(args[0], "validate")) return .config_validate;
@@ -628,7 +663,11 @@ pub fn printUsage(writer: anytype) !void {
         \\  daemon run         Run the daemon in the foreground.
         \\  daemon start       Start experimental daemon stub; no automatic repair.
         \\  daemon stop        Stop the daemon.
-        \\  daemon status      Show daemon status.
+        \\  daemon status [--json]
+        \\      Show daemon status.
+        \\
+        \\  daemon events [--json] [--limit <n>]
+        \\      Show recent redacted repair events.
         \\
         \\  init [--interactive] [--codex-max]
         \\      Generate a starter config file.
@@ -1028,6 +1067,18 @@ test "parse daemon run" {
     try std.testing.expect(parse(&args) == .daemon_run);
 }
 
+test "parse daemon events json limit" {
+    const args = [_][]const u8{ "daemon", "events", "--json", "--limit", "5" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .daemon_events => |events| {
+            try std.testing.expect(events.json);
+            try std.testing.expectEqual(@as(usize, 5), events.limit);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
     if (eql(shell_name, "fish")) {
         try writer.writeAll(
@@ -1087,7 +1138,9 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary live-qa probe-all config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run start stop status' -d 'Daemon subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run start stop status events' -d 'Daemon subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l json -d 'JSON output'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l limit -d 'Limit event count' -r
             \\
         );
     } else if (eql(shell_name, "zsh")) {
@@ -1106,6 +1159,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\    'health:Show health data'
             \\    'discover:Show agent-safe inventory'
             \\    'repair-plan:Show non-mutating repair plan'
+            \\    'repair:Run admitted repair actions'
             \\    'route:Select or explain routes'
             \\    'config:Config operations'
             \\    'init:Generate config'
@@ -1124,7 +1178,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
         try writer.writeAll(
             \\_oauth_mux_completions() {
             \\  local cur="${COMP_WORDS[COMP_CWORD]}"
-            \\  COMPREPLY=($(compgen -W "exec env probe doctor report providers status health discover repair-plan route config init setup codex daemon version completions" -- "$cur"))
+            \\  COMPREPLY=($(compgen -W "exec env probe doctor report providers status health discover repair-plan repair route config init setup codex daemon version completions" -- "$cur"))
             \\}
             \\complete -F _oauth_mux_completions oauth-mux
             \\

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -117,7 +117,7 @@ pub fn stop(allocator: std.mem.Allocator) !void {
     std.fs.deleteFileAbsolute(pid_path) catch {};
 }
 
-pub fn status(allocator: std.mem.Allocator, writer: anytype) !void {
+pub fn status(allocator: std.mem.Allocator, writer: anytype, json: bool) !void {
     const pid_path = try pidPath(allocator);
     defer allocator.free(pid_path);
 
@@ -125,9 +125,19 @@ pub fn status(allocator: std.mem.Allocator, writer: anytype) !void {
         const pid = readPidFile(allocator, pid_path) catch 0;
         const sock = try paths.socketPath(allocator);
         defer allocator.free(sock);
-        try writer.print("daemon: running (pid {d}, socket {s})\n", .{ pid, sock });
+        if (json) {
+            try writer.print("{{\"status\":\"running\",\"pid\":{d},\"socket\":", .{pid});
+            try std.json.stringify(sock, .{}, writer);
+            try writer.writeAll("}\n");
+        } else {
+            try writer.print("daemon: running (pid {d}, socket {s})\n", .{ pid, sock });
+        }
     } else {
-        try writer.writeAll("daemon: not running\n");
+        if (json) {
+            try writer.writeAll("{\"status\":\"not_running\"}\n");
+        } else {
+            try writer.writeAll("daemon: not running\n");
+        }
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -11,6 +11,7 @@ const health_mod = @import("health.zig");
 const provider = @import("provider.zig");
 const provider_schema = @import("provider_schema.zig");
 const daemon = @import("daemon.zig");
+const repair_state = @import("repair_state.zig");
 
 pub fn main() !void {
     log.init();
@@ -154,8 +155,11 @@ pub fn main() !void {
                 std.process.exit(types.ExitCode.general_error.int());
             };
         },
-        .daemon_status => {
-            try daemon.status(allocator, stdout);
+        .daemon_status => |daemon_args| {
+            try daemon.status(allocator, stdout, daemon_args.json);
+        },
+        .daemon_events => |events_args| {
+            try repair_state.writeEvents(allocator, stdout, events_args.json, events_args.limit);
         },
     }
 }
@@ -530,6 +534,11 @@ fn runRepairRun(allocator: std.mem.Allocator, writer: anytype, args: cli.Command
     const candidate_index = repairRunCandidate(evaluations.items, selected_index, args);
 
     if (candidate_index == null) {
+        if (selected_index) |idx| {
+            recordRepairRunEvent(allocator, args, evaluations.items[idx], "noop", "route_selectable", true, false);
+        } else {
+            recordRepairRunEvent(allocator, args, null, "no_admitted_repair", "no_admitted_repair", true, false);
+        }
         if (args.json) {
             try writeRepairRunNoopJson(writer, evaluations.items, selected_index, args);
         } else {
@@ -540,6 +549,7 @@ fn runRepairRun(allocator: std.mem.Allocator, writer: anytype, args: cli.Command
 
     const evaluation = evaluations.items[candidate_index.?];
     if (!args.confirm_repair) {
+        recordRepairRunEvent(allocator, args, evaluation, "confirmation_required", "missing_confirm_repair", false, false);
         if (args.json) {
             try writeRepairRunConfirmationJson(writer, allocator, parsed.value, evaluation, args);
         } else {
@@ -549,14 +559,31 @@ fn runRepairRun(allocator: std.mem.Allocator, writer: anytype, args: cli.Command
     }
 
     if (args.json and evaluation.action.interactive) {
+        recordRepairRunEvent(allocator, args, evaluation, "interactive_json_unsupported", "json_mode", false, false);
         try writeRepairRunJsonInteractiveUnsupported(writer, allocator, parsed.value, evaluation, args);
         return error.RepairConfirmationRequired;
     }
 
+    var lock = repair_state.acquireRepairLock(allocator, evaluation.route.provider, evaluation.route.account) catch |e| switch (e) {
+        error.RepairInProgress => {
+            recordRepairRunEvent(allocator, args, evaluation, "repair_in_progress", "lock_busy", false, false);
+            if (args.json) {
+                try writeRepairRunLockBusyJson(writer, allocator, parsed.value, evaluation, args);
+            } else {
+                try writeRepairRunLockBusyText(writer, evaluation);
+            }
+            return error.RepairAlreadyInProgress;
+        },
+        else => return e,
+    };
+    defer lock.release();
+
     const command = try repairCommandAlloc(allocator, evaluation.action.command, evaluation.route);
     defer if (command) |value| allocator.free(value);
 
+    try repair_state.appendEvent(allocator, repairRunEvent(evaluation, args.profile, "started", "confirmed_repair", false, false));
     const ok = try executeRepairCommand(allocator, parsed.value, evaluation);
+    recordRepairRunEvent(allocator, args, evaluation, if (ok) "executed" else "failed", if (ok) "command_success" else "command_failed", ok, true);
     if (args.json) {
         try writeRepairRunExecutedJson(writer, allocator, parsed.value, evaluation, command, ok);
     } else {
@@ -586,6 +613,52 @@ fn repairRunCandidate(
         if (evaluation.action.mutating and evaluation.action.command != .none) return idx;
     }
     return null;
+}
+
+fn recordRepairRunEvent(
+    allocator: std.mem.Allocator,
+    args: cli.Command.RepairRunArgs,
+    evaluation: ?RouteEvaluation,
+    outcome: []const u8,
+    reason: []const u8,
+    ok: bool,
+    executed: bool,
+) void {
+    const event = if (evaluation) |value|
+        repairRunEvent(value, args.profile, outcome, reason, ok, executed)
+    else
+        repair_state.RepairEvent{
+            .profile = args.profile,
+            .capability = args.capability,
+            .outcome = outcome,
+            .reason = reason,
+            .ok = ok,
+            .executed = executed,
+        };
+    repair_state.appendEvent(allocator, event) catch {};
+}
+
+fn repairRunEvent(
+    evaluation: RouteEvaluation,
+    profile: ?[]const u8,
+    outcome: []const u8,
+    reason: []const u8,
+    ok: bool,
+    executed: bool,
+) repair_state.RepairEvent {
+    return .{
+        .profile = profile,
+        .provider = evaluation.route.provider,
+        .account = evaluation.route.account,
+        .capability = evaluation.route.capability,
+        .action = evaluation.action.kind,
+        .outcome = outcome,
+        .reason = reason,
+        .ok = ok,
+        .executed = executed,
+        .interactive = evaluation.action.interactive,
+        .mutating = evaluation.action.mutating,
+    };
 }
 
 fn writeRepairRunNoopText(
@@ -679,6 +752,36 @@ fn writeRepairRunJsonInteractiveUnsupported(
     try writer.writeAll("{\"version\":");
     try std.json.stringify(cli.version, .{}, writer);
     try writer.writeAll(",\"ok\":false,\"executed\":false,\"confirmation_required\":false,\"error\":\"interactive_json_unsupported\",\"message\":\"interactive repair may write upstream CLI output; rerun without --json after reviewing repair-plan\",\"profile\":");
+    if (args.profile) |profile_name| try std.json.stringify(profile_name, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"capability\":");
+    if (args.capability) |capability| try std.json.stringify(capability, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"route\":");
+    try writeRouteEvaluationJson(writer, allocator, cfg, evaluation, false);
+    try writer.writeAll("}\n");
+}
+
+fn writeRepairRunLockBusyText(
+    writer: anytype,
+    evaluation: RouteEvaluation,
+) !void {
+    try writer.writeAll("oauth-mux repair run\n\n");
+    try writer.writeAll("  executed: no\n");
+    try writer.writeAll("  reason: repair already in progress for this account\n");
+    try writer.print("  route: {s}:{s}", .{ evaluation.route.provider, evaluation.route.account });
+    if (evaluation.route.capability) |capability| try writer.print("#{s}", .{capability});
+    try writer.writeByte('\n');
+}
+
+fn writeRepairRunLockBusyJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluation: RouteEvaluation,
+    args: cli.Command.RepairRunArgs,
+) !void {
+    try writer.writeAll("{\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"ok\":false,\"executed\":false,\"confirmation_required\":false,\"error\":\"repair_in_progress\",\"message\":\"another oauth-mux repair process holds this account lock\",\"profile\":");
     if (args.profile) |profile_name| try std.json.stringify(profile_name, .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"capability\":");
     if (args.capability) |capability| try std.json.stringify(capability, .{}, writer) else try writer.writeAll("null");
@@ -3155,6 +3258,9 @@ fn routeRuntimeReadiness(
 
     const prov = cfg.providers.map.get(route.provider) orelse return .{ .session_unavailable = "provider_config_missing" };
     const account = prov.accounts.map.get(route.account) orelse return .{ .session_unavailable = "account_config_missing" };
+    if (try repair_state.probeRepairLock(allocator, route.provider, route.account)) |progress| {
+        return .{ .repair_in_progress = progress };
+    }
     const account_runtime = try runtimeAccountInfo(allocator, prov, account, def, config.resolveProviderKind(cfg, route.provider));
     return account_runtime.readiness;
 }
@@ -5688,4 +5794,5 @@ comptime {
     _ = @import("daemon.zig");
     _ = @import("provider_schema.zig");
     _ = @import("fixture_redaction.zig");
+    _ = @import("repair_state.zig");
 }

--- a/src/repair_state.zig
+++ b/src/repair_state.zig
@@ -1,0 +1,312 @@
+const std = @import("std");
+const paths = @import("paths.zig");
+const types = @import("types.zig");
+
+pub const RepairEvent = struct {
+    ts: i64 = 0,
+    profile: ?[]const u8 = null,
+    provider: ?[]const u8 = null,
+    account: ?[]const u8 = null,
+    capability: ?[]const u8 = null,
+    action: ?[]const u8 = null,
+    outcome: []const u8,
+    reason: ?[]const u8 = null,
+    ok: bool = false,
+    executed: bool = false,
+    interactive: bool = false,
+    mutating: bool = false,
+};
+
+pub const RepairLock = struct {
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    file: std.fs.File,
+
+    pub fn release(self: *RepairLock) void {
+        self.file.close();
+        std.fs.deleteFileAbsolute(self.path) catch {};
+        self.allocator.free(self.path);
+    }
+};
+
+pub fn appendEvent(allocator: std.mem.Allocator, event: RepairEvent) !void {
+    const path = try eventsPath(allocator);
+    defer allocator.free(path);
+    try ensureParentDir(path);
+
+    const file = try std.fs.createFileAbsolute(path, .{
+        .truncate = false,
+        .mode = 0o600,
+        .lock = .exclusive,
+    });
+    defer file.close();
+
+    try file.seekFromEnd(0);
+    try writeEventJson(file.writer(), event);
+    try file.writeAll("\n");
+}
+
+pub fn writeEvents(allocator: std.mem.Allocator, writer: anytype, json: bool, limit: usize) !void {
+    const path = try eventsPath(allocator);
+    defer allocator.free(path);
+
+    const file = std.fs.openFileAbsolute(path, .{}) catch |e| switch (e) {
+        error.FileNotFound => {
+            if (json) {
+                try writer.writeAll("{\"events\":[]}\n");
+            } else {
+                try writer.writeAll("no repair events recorded\n");
+            }
+            return;
+        },
+        else => return e,
+    };
+    defer file.close();
+
+    const bytes = try file.readToEndAlloc(allocator, 1024 * 1024);
+    defer allocator.free(bytes);
+
+    if (!json) {
+        try writeLastTextLines(writer, bytes, limit);
+        return;
+    }
+
+    try writer.writeAll("{\"events\":[");
+    var lines = std.ArrayList([]const u8).init(allocator);
+    defer lines.deinit();
+    var it = std.mem.splitScalar(u8, bytes, '\n');
+    while (it.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (trimmed.len != 0) try lines.append(trimmed);
+    }
+
+    const start = if (limit != 0 and lines.items.len > limit) lines.items.len - limit else 0;
+    for (lines.items[start..], 0..) |line, idx| {
+        if (idx > 0) try writer.writeByte(',');
+        try writer.writeAll(line);
+    }
+    try writer.writeAll("]}\n");
+}
+
+pub fn acquireRepairLock(
+    allocator: std.mem.Allocator,
+    provider: []const u8,
+    account: []const u8,
+) !RepairLock {
+    const path = try lockPath(allocator, provider, account);
+    errdefer allocator.free(path);
+    try ensureParentDir(path);
+
+    const file = std.fs.createFileAbsolute(path, .{
+        .truncate = false,
+        .mode = 0o600,
+        .lock = .exclusive,
+        .lock_nonblocking = true,
+    }) catch |e| switch (e) {
+        error.WouldBlock => return error.RepairInProgress,
+        else => return e,
+    };
+    errdefer file.close();
+
+    const now = std.time.timestamp();
+    try file.setEndPos(0);
+    try file.seekTo(0);
+    const writer = file.writer();
+    try writer.writeAll("{\"provider\":");
+    try std.json.stringify(provider, .{}, writer);
+    try writer.writeAll(",\"account\":");
+    try std.json.stringify(account, .{}, writer);
+    try writer.print(",\"started_at\":{d}}}\n", .{now});
+
+    return .{
+        .allocator = allocator,
+        .path = path,
+        .file = file,
+    };
+}
+
+pub fn probeRepairLock(
+    allocator: std.mem.Allocator,
+    provider: []const u8,
+    account: []const u8,
+) !?types.RuntimeReadiness.RepairProgress {
+    const path = try lockPath(allocator, provider, account);
+    defer allocator.free(path);
+
+    const file = std.fs.openFileAbsolute(path, .{
+        .mode = .read_write,
+        .lock = .exclusive,
+        .lock_nonblocking = true,
+    }) catch |e| switch (e) {
+        error.FileNotFound => return null,
+        error.WouldBlock => return try readRepairProgress(allocator, path, account),
+        else => return e,
+    };
+    file.close();
+    return null;
+}
+
+fn eventsPath(allocator: std.mem.Allocator) ![]const u8 {
+    const dir = try paths.stateDir(allocator);
+    defer allocator.free(dir);
+    return std.fs.path.join(allocator, &.{ dir, "repair-events.jsonl" });
+}
+
+fn locksDir(allocator: std.mem.Allocator) ![]const u8 {
+    const dir = try paths.runtimeDir(allocator);
+    defer allocator.free(dir);
+    return std.fs.path.join(allocator, &.{ dir, "repair-locks" });
+}
+
+fn lockPath(allocator: std.mem.Allocator, provider: []const u8, account: []const u8) ![]const u8 {
+    const dir = try locksDir(allocator);
+    defer allocator.free(dir);
+    const file_name = try sanitizedLockFileName(allocator, provider, account);
+    defer allocator.free(file_name);
+    return std.fs.path.join(allocator, &.{ dir, file_name });
+}
+
+fn sanitizedLockFileName(allocator: std.mem.Allocator, provider: []const u8, account: []const u8) ![]const u8 {
+    var out = std.ArrayList(u8).init(allocator);
+    errdefer out.deinit();
+    try appendLockNamePart(&out, provider);
+    try out.append('-');
+    try appendLockNamePart(&out, account);
+    try out.appendSlice(".lock");
+    return try out.toOwnedSlice();
+}
+
+fn appendLockNamePart(out: *std.ArrayList(u8), value: []const u8) !void {
+    for (value) |c| {
+        const safe = std.ascii.isAlphanumeric(c) or c == '-' or c == '_' or c == '.';
+        try out.append(if (safe) c else '_');
+    }
+}
+
+fn readRepairProgress(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    fallback_account: []const u8,
+) !types.RuntimeReadiness.RepairProgress {
+    const file = std.fs.openFileAbsolute(path, .{}) catch return .{
+        .account = fallback_account,
+        .started_at = 0,
+    };
+    defer file.close();
+
+    const bytes = file.readToEndAlloc(allocator, 16 * 1024) catch return .{
+        .account = fallback_account,
+        .started_at = 0,
+    };
+    defer allocator.free(bytes);
+
+    return .{
+        .account = fallback_account,
+        .started_at = parseStartedAt(bytes) orelse 0,
+    };
+}
+
+fn parseStartedAt(bytes: []const u8) ?i64 {
+    const marker = "\"started_at\":";
+    const start = std.mem.indexOf(u8, bytes, marker) orelse return null;
+    var idx = start + marker.len;
+    while (idx < bytes.len and bytes[idx] == ' ') : (idx += 1) {}
+    const value_start = idx;
+    while (idx < bytes.len and std.ascii.isDigit(bytes[idx])) : (idx += 1) {}
+    if (idx == value_start) return null;
+    return std.fmt.parseInt(i64, bytes[value_start..idx], 10) catch null;
+}
+
+fn ensureParentDir(path: []const u8) !void {
+    if (std.fs.path.dirname(path)) |dir| {
+        std.fs.makeDirAbsolute(dir) catch |e| switch (e) {
+            error.PathAlreadyExists => {},
+            else => return e,
+        };
+    }
+}
+
+fn writeEventJson(writer: anytype, event: RepairEvent) !void {
+    const ts = if (event.ts == 0) std.time.timestamp() else event.ts;
+    try writer.print("{{\"ts\":{d},\"kind\":\"repair_run\"", .{ts});
+    try writer.writeAll(",\"profile\":");
+    if (event.profile) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"provider\":");
+    if (event.provider) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"account\":");
+    if (event.account) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"capability\":");
+    if (event.capability) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"action\":");
+    if (event.action) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"outcome\":");
+    try std.json.stringify(event.outcome, .{}, writer);
+    try writer.writeAll(",\"reason\":");
+    if (event.reason) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"ok\":");
+    try writer.writeAll(if (event.ok) "true" else "false");
+    try writer.writeAll(",\"executed\":");
+    try writer.writeAll(if (event.executed) "true" else "false");
+    try writer.writeAll(",\"interactive\":");
+    try writer.writeAll(if (event.interactive) "true" else "false");
+    try writer.writeAll(",\"mutating\":");
+    try writer.writeAll(if (event.mutating) "true" else "false");
+    try writer.writeByte('}');
+}
+
+fn writeLastTextLines(writer: anytype, bytes: []const u8, limit: usize) !void {
+    var count: usize = 0;
+    var it_count = std.mem.splitScalar(u8, bytes, '\n');
+    while (it_count.next()) |line| {
+        if (std.mem.trim(u8, line, " \t\r").len != 0) count += 1;
+    }
+
+    const skip = if (limit != 0 and count > limit) count - limit else 0;
+    var seen: usize = 0;
+    var it = std.mem.splitScalar(u8, bytes, '\n');
+    while (it.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (trimmed.len == 0) continue;
+        if (seen >= skip) {
+            try writer.writeAll(trimmed);
+            try writer.writeByte('\n');
+        }
+        seen += 1;
+    }
+}
+
+test "parseStartedAt reads lock metadata timestamp" {
+    try std.testing.expectEqual(@as(?i64, 42), parseStartedAt("{\"started_at\":42}\n"));
+    try std.testing.expectEqual(@as(?i64, null), parseStartedAt("{\"started_at\":\"42\"}\n"));
+}
+
+test "repair event json is redacted and structured" {
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+
+    try writeEventJson(buf.writer(), .{
+        .ts = 42,
+        .profile = "codex-max",
+        .provider = "codex",
+        .account = "max-1",
+        .capability = "codex-max",
+        .action = "reauth",
+        .outcome = "confirmation_required",
+        .reason = "missing_session",
+        .ok = false,
+        .executed = false,
+        .interactive = true,
+        .mutating = true,
+    });
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"provider\":\"codex\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"profile\":\"codex-max\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"account\":\"max-1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "token") == null);
+}
+
+test "sanitized lock file names do not preserve path separators" {
+    const name = try sanitizedLockFileName(std.testing.allocator, "co/dex", "max:1");
+    defer std.testing.allocator.free(name);
+    try std.testing.expectEqualStrings("co_dex-max_1.lock", name);
+}


### PR DESCRIPTION
## Summary

Adds the first daemon-safe substrate for stay-afloat repair without promoting the daemon to an automatic repair surface.

- records every `repair run` invocation to a redacted JSONL event log
- adds `oauth-mux daemon events --json [--limit n]` and `daemon status --json`
- takes an account-scoped advisory lock before confirmed repair execution
- reports active repair locks back as `repair_in_progress` through runtime-aware route planning
- updates onboarding/daemon docs and E2E coverage for the new audit trail

## Why

The one-shot repair path was explicit and safe, but repeated agent or future daemon use still needed durable evidence and concurrency control. This keeps the product boundary conservative: no background repair loop yet, but the audit and lock primitives are now real.

## Validation

- `just check-local`
- no-spend Codex dogfood: `codex canary`, `repair run --json`, `daemon events --json --limit 2`
