### PR TITLE
Add one-shot daemon tick

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux route select --profile
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair-plan --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair run --profile codex-max --capability codex-max --json
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux daemon tick --once --profile codex-max --capability codex-max --json
 oauth-mux daemon events --json
 ```
 
@@ -126,7 +127,10 @@ only `free_local` and `free_command` work; `cheap_provider`, `spend_provider`,
 `interactive`, and `mutating` actions are reported as refused until the config
 explicitly allows them. `route explain --json` and `repair-plan --json` include
 the effective policy plus per-route admission decisions so agents can back off
-without guessing.
+without guessing. `daemon tick --once --json` is the first daemon-shaped
+dogfood primitive: it evaluates the same routes under that policy and reports
+`executed:false`; it does not run live probes, repair commands, or background
+mutation.
 
 First-run Codex subscription path:
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -31,6 +31,7 @@ oauth-mux config validate
 oauth-mux discover --json
 oauth-mux doctor runtime --json
 oauth-mux route explain --profile <profile> --capability <capability> --json
+oauth-mux daemon tick --once --profile <profile> --capability <capability> --json
 ```
 
 Source checkouts prove this path without touching real operator state:
@@ -49,6 +50,7 @@ oauth-mux setup codex
 oauth-mux codex canary
 oauth-mux route explain --profile codex-max --capability codex-max --json
 oauth-mux route select --profile codex-max --capability codex-max --json
+oauth-mux daemon tick --once --profile codex-max --capability codex-max --json
 ```
 
 Those commands are installed CLI surface, not source-checkout-only helpers.
@@ -64,10 +66,10 @@ oauth-mux codex live-qa --confirm-spend
 oauth-mux codex probe-all --capability codex-mini --json
 ```
 
-`doctor runtime`, `route explain`, and `route select` are no-spend surfaces.
-They only use local runtime checks plus recorded liveness, so they are safe for
-agents to run before deciding whether a live probe or user-driven reauth is
-warranted. Prefer scoped runtime checks such as
+`doctor runtime`, `route explain`, `route select`, and `daemon tick --once` are
+no-spend surfaces. They only use local runtime checks plus recorded liveness, so
+they are safe for agents to run before deciding whether a live probe or
+user-driven reauth is warranted. Prefer scoped runtime checks such as
 `oauth-mux doctor runtime --profile codex-max --capability codex-max --json`
 when dogfooding a specific stay-afloat route; global runtime doctor is still
 useful for support bundles and full-machine cleanup.

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -41,6 +41,9 @@ See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
 - `oauth-mux daemon status --json` for local inspection.
 - `oauth-mux daemon events --json` for the redacted repair-run event log. This
   reads local state and does not require a daemon process.
+- `oauth-mux daemon tick --once --json` for one portable, policy-gated
+  daemon-shaped planning pass. It reports `executed:false` and does not run
+  probes, repair commands, or mutation.
 - Account-scoped advisory locks during confirmed `repair run`, reported back as
   `repair_in_progress` by runtime-aware route planning.
 - Config-level daemon admission policy for route planning. The default admits

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -169,6 +169,12 @@ are refused in the admission report unless `policy.daemon` explicitly allows
 them. `repair-plan --json` and `route explain --json` include both the effective
 policy and per-route `daemon_probe` / `daemon_repair` decisions.
 
+`oauth-mux daemon tick --once --json` is the portable daemon dogfood surface. It
+loads the same route/runtime/liveness state, applies the daemon policy, and
+prints what a future background loop would be allowed to do. It always reports
+`executed:false` today: no provider probes, browser/device auth, repair
+commands, or secret mutation are run by the tick.
+
 If `repair-plan --profile codex-max` reports a config validation error, the
 active config is not the three-account Codex Max shape. That usually means the
 machine still has an older generic config with only `codex:default`. Generate a

--- a/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
+++ b/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
@@ -38,7 +38,7 @@ OAuth and muxing surfaces:
 | Codex three-account stores | `max-1`, `max-2`, and `max-3` are isolated by `CODEX_HOME` and report logged-in ChatGPT status. |
 | Codex route liveness | Hosted and local installed-binary live canaries have proven all three accounts across `codex-mini` and `codex-max`. Earlier proof also preserved the distinction between quota exhaustion and auth death. |
 | Typed liveness | Unit and e2e tests cover `live`, `degraded`, `dead`, route-scoped `provider:account#capability`, and fallback decisions. |
-| Agent-safe discovery | `doctor --json`, `doctor runtime --json`, scoped `doctor runtime`, `report --redacted --json`, `providers list --json`, `discover --json`, `status --json`, `health --json`, `route explain --json`, and `route select --json` exist and are documented. |
+| Agent-safe discovery | `doctor --json`, `doctor runtime --json`, scoped `doctor runtime`, `report --redacted --json`, `providers list --json`, `discover --json`, `status --json`, `health --json`, `route explain --json`, `route select --json`, and `daemon tick --once --json` exist and are documented. |
 | Non-mutating help | `oauth-mux codex canary --help`, `oauth-mux codex probe-all --help`, and `oauth-mux setup codex --help` print help without creating stores or probing. |
 
 ## Not Yet Proven

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -468,6 +468,13 @@ daemon loop policy-driven while preserving the current product boundary: no
 provider calls, quota-spending probes, browser/device auth, or credential
 mutation in background mode unless an operator opts in explicitly.
 
+Implementation note, 2026-04-30: `oauth-mux daemon tick --once --json` now
+provides the first daemon-shaped dogfood primitive. It loads route runtime,
+recorded liveness, repair actions, and daemon admission policy, then reports
+what a future daemon loop would be allowed to consider. The tick is explicitly
+planning-only and emits `executed:false`; it does not run provider probes,
+repair commands, browser/device auth, or secret mutation.
+
 ### M3: Refresh Writeback
 
 - Implement backend write capabilities.

--- a/justfile
+++ b/justfile
@@ -217,6 +217,9 @@ daemon-status: build
 daemon-events: build
     ./zig-out/bin/oauth-mux daemon events --json
 
+daemon-tick PROFILE="codex-max" CAPABILITY="codex-max": build
+    ./zig-out/bin/oauth-mux daemon tick --once --profile {{PROFILE}} --capability {{CAPABILITY}} --json
+
 # ── Shell integration ──
 
 completions-fish: build

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -257,6 +257,15 @@ expect_contains "$route_select" '"action":"select"' "route select reports action
 expect_contains "$route_select" '"ok":true' "route select reports available selection"
 expect_contains "$route_select" '"selected":{"provider":"toy","account":"a2"' "route select selects fallback account a2"
 
+printf 'e2e: daemon tick plans stay-afloat without executing work\n'
+daemon_tick="$(omux daemon tick --once --profile expensive --capability expensive --json)"
+expect_contains "$daemon_tick" '"mode":"once"' "daemon tick reports one-shot mode"
+expect_contains "$daemon_tick" '"executed":false' "daemon tick does not execute probes or repair"
+expect_contains "$daemon_tick" '"afloat":true' "daemon tick reports profile afloat"
+expect_contains "$daemon_tick" '"selected":{"provider":"toy","account":"a2"' "daemon tick selects fallback account a2"
+expect_contains "$daemon_tick" '"action":"wait_for_quota"' "daemon tick includes wait action for exhausted route"
+expect_contains "$daemon_tick" '"reason":"route_selectable"' "daemon tick marks selectable route as no-op"
+
 printf 'e2e: repair run no-ops when fallback route is selectable\n'
 repair_run="$(omux repair run --profile expensive --capability expensive --json)"
 expect_contains "$repair_run" '"ok":true' "repair run reports ok when afloat"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -26,6 +26,7 @@ pub const Command = union(enum) {
     daemon_stop,
     daemon_status: DaemonStatusArgs,
     daemon_events: DaemonEventsArgs,
+    daemon_tick: DaemonTickArgs,
     version_cmd,
     help,
     codex_help,
@@ -175,6 +176,15 @@ pub const Command = union(enum) {
         json: bool = false,
         limit: usize = 50,
     };
+
+    pub const DaemonTickArgs = struct {
+        profile: ?[]const u8 = null,
+        provider: ?[]const u8 = null,
+        account: ?[]const u8 = null,
+        capability: ?[]const u8 = null,
+        once: bool = true,
+        json: bool = false,
+    };
 };
 
 pub fn parse(args: []const []const u8) Command {
@@ -208,6 +218,7 @@ pub fn parse(args: []const []const u8) Command {
             if (eql(rest[0], "stop")) return .daemon_stop;
             if (eql(rest[0], "status")) return parseDaemonStatus(rest[1..]);
             if (eql(rest[0], "events")) return parseDaemonEvents(rest[1..]);
+            if (eql(rest[0], "tick")) return parseDaemonTick(rest[1..]);
         }
         return .{ .daemon_status = .{} };
     }
@@ -487,6 +498,31 @@ fn parseDaemonEvents(args: []const []const u8) Command {
     return .{ .daemon_events = result };
 }
 
+fn parseDaemonTick(args: []const []const u8) Command {
+    var result = Command.DaemonTickArgs{};
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        if (eql(args[i], "--profile") or eql(args[i], "-p")) {
+            i += 1;
+            if (i < args.len) result.profile = args[i];
+        } else if (eql(args[i], "--provider")) {
+            i += 1;
+            if (i < args.len) result.provider = args[i];
+        } else if (eql(args[i], "--account")) {
+            i += 1;
+            if (i < args.len) result.account = args[i];
+        } else if (eql(args[i], "--capability")) {
+            i += 1;
+            if (i < args.len) result.capability = args[i];
+        } else if (eql(args[i], "--json")) {
+            result.json = true;
+        } else if (eql(args[i], "--once")) {
+            result.once = true;
+        }
+    }
+    return .{ .daemon_tick = result };
+}
+
 fn parseConfig(args: []const []const u8) Command {
     if (args.len == 0) return .config_path;
     if (eql(args[0], "validate")) return .config_validate;
@@ -668,6 +704,9 @@ pub fn printUsage(writer: anytype) !void {
         \\
         \\  daemon events [--json] [--limit <n>]
         \\      Show recent redacted repair events.
+        \\
+        \\  daemon tick [--once] [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
+        \\      Plan one policy-gated daemon tick without executing probes or repair.
         \\
         \\  init [--interactive] [--codex-max]
         \\      Generate a starter config file.
@@ -1079,6 +1118,20 @@ test "parse daemon events json limit" {
     }
 }
 
+test "parse daemon tick once json selector" {
+    const args = [_][]const u8{ "daemon", "tick", "--once", "--profile", "codex-max", "--capability", "codex-max", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .daemon_tick => |tick| {
+            try std.testing.expect(tick.once);
+            try std.testing.expect(tick.json);
+            try std.testing.expectEqualStrings("codex-max", tick.profile.?);
+            try std.testing.expectEqualStrings("codex-max", tick.capability.?);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
     if (eql(shell_name, "fish")) {
         try writer.writeAll(
@@ -1138,9 +1191,14 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary live-qa probe-all config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run start stop status events' -d 'Daemon subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run start stop status events tick' -d 'Daemon subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l limit -d 'Limit event count' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l once -d 'Run one planning tick'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l profile -s p -d 'Profile name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l provider -d 'Provider name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l account -d 'Account name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l capability -d 'Route capability' -r
             \\
         );
     } else if (eql(shell_name, "zsh")) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -161,6 +161,12 @@ pub fn main() !void {
         .daemon_events => |events_args| {
             try repair_state.writeEvents(allocator, stdout, events_args.json, events_args.limit);
         },
+        .daemon_tick => |tick_args| {
+            runDaemonTick(allocator, stdout, tick_args) catch |e| {
+                log.err("daemon tick: {s}", .{@errorName(e)});
+                std.process.exit(exitCodeFromPipelineError(e));
+            };
+        },
     }
 }
 
@@ -346,6 +352,7 @@ fn writeDiscoverText(writer: anytype, cfg: config.Config, config_path: []const u
     try writer.writeAll("    oauth-mux route explain --profile <profile> --capability <capability> --json\n");
     try writer.writeAll("    oauth-mux route select --profile <profile> --capability <capability> --json\n");
     try writer.writeAll("    oauth-mux repair-plan --profile <profile> --capability <capability> --json\n");
+    try writer.writeAll("    oauth-mux daemon tick --once --profile <profile> --capability <capability> --json\n");
     try writer.writeAll("    oauth-mux repair run --profile <profile> --capability <capability> --json\n");
     if (codex_configured and !codex_max_configured) {
         try writer.writeAll("    oauth-mux codex config-candidate --json\n");
@@ -451,6 +458,7 @@ fn writeDiscoverJson(writer: anytype, cfg: config.Config, config_path: []const u
         "oauth-mux route explain --profile <profile> --capability <capability> --json",
         "oauth-mux route select --profile <profile> --capability <capability> --json",
         "oauth-mux repair-plan --profile <profile> --capability <capability> --json",
+        "oauth-mux daemon tick --once --profile <profile> --capability <capability> --json",
         "oauth-mux repair run --profile <profile> --capability <capability> --json",
         "oauth-mux env --profile <profile> --capability <capability> --shell <shell>",
         "oauth-mux exec --profile <profile> --capability <capability> -- <command>",
@@ -1427,6 +1435,42 @@ fn runRoute(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Rou
     if (args.action == .select and selected_index == null) return error.AllAccountsExhausted;
 }
 
+fn runDaemonTick(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.DaemonTickArgs) !void {
+    const parsed = try config.load(allocator);
+    defer parsed.deinit();
+
+    var validation_messages = std.ArrayList(u8).init(allocator);
+    defer validation_messages.deinit();
+    try config.validate(parsed.value, validation_messages.writer());
+
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+
+    var routes = try collectRepairPlanRoutes(allocator, parsed.value, daemonTickArgsToPlanArgs(args));
+    defer routes.deinit();
+
+    var evaluations = std.ArrayList(RouteEvaluation).init(allocator);
+    defer evaluations.deinit();
+    try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &evaluations);
+
+    const selected_index = firstSelectableRoute(evaluations.items);
+    if (args.json) {
+        try writeDaemonTickJson(writer, allocator, parsed.value, evaluations.items, selected_index, args);
+    } else {
+        try writeDaemonTickText(writer, allocator, parsed.value, evaluations.items, selected_index, args);
+    }
+}
+
+fn daemonTickArgsToPlanArgs(args: cli.Command.DaemonTickArgs) cli.Command.RepairPlanArgs {
+    return .{
+        .profile = args.profile,
+        .provider = args.provider,
+        .account = args.account,
+        .capability = args.capability,
+        .json = args.json,
+    };
+}
+
 fn collectRouteEvaluations(
     allocator: std.mem.Allocator,
     cfg: config.Config,
@@ -1623,6 +1667,210 @@ fn writeRouteEvaluationJson(
     try writer.writeAll(",\"action\":");
     try writeRepairActionJson(writer, allocator, evaluation.action, evaluation.route);
     try writer.writeByte('}');
+}
+
+const DaemonTickDecision = struct {
+    phase: []const u8,
+    action: []const u8,
+    admitted: bool,
+    reason: []const u8,
+    budget: ?types.ActionBudget = null,
+    executed: bool = false,
+};
+
+const DaemonTickStats = struct {
+    routes: usize = 0,
+    selectable: usize = 0,
+    admitted_probes: usize = 0,
+    blocked_probes: usize = 0,
+    admitted_repairs: usize = 0,
+    blocked_repairs: usize = 0,
+    no_action: usize = 0,
+};
+
+fn writeDaemonTickText(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+    args: cli.Command.DaemonTickArgs,
+) !void {
+    try writer.writeAll("oauth-mux daemon tick\n\n");
+    try writer.print("  mode: {s}\n", .{if (args.once) "once" else "loop"});
+    try writer.writeAll("  executed: no\n");
+    try writer.writeAll("  boundary: planning only; no probes or repair commands executed\n");
+    if (args.profile) |profile_name| try writer.print("  profile: {s}\n", .{profile_name});
+    if (args.capability) |capability| try writer.print("  capability: {s}\n", .{capability});
+    if (selected_index) |idx| {
+        const selected = evaluations[idx].route;
+        try writer.print("  selected: {s}:{s}", .{ selected.provider, selected.account });
+        if (selected.capability) |capability| try writer.print("#{s}", .{capability});
+        try writer.writeByte('\n');
+    } else {
+        try writer.writeAll("  selected: none\n");
+    }
+
+    if (evaluations.len == 0) {
+        try writer.writeAll("  no matching configured routes\n");
+        return;
+    }
+
+    try writer.writeAll("\n  routes:\n");
+    for (evaluations) |evaluation| {
+        const decision = daemonTickDecision(cfg.policy.daemon, evaluation);
+        try writer.print("    {s}:{s}", .{ evaluation.route.provider, evaluation.route.account });
+        if (evaluation.route.capability) |capability| try writer.print("#{s}", .{capability});
+        try writer.print(" selectable={s} runtime={s} tick={s} admitted={s} reason={s}", .{
+            if (evaluation.selectable) "true" else "false",
+            runtimeReadinessSummary(evaluation.runtime),
+            decision.action,
+            if (decision.admitted) "true" else "false",
+            decision.reason,
+        });
+        if (decision.budget) |budget| try writer.print(" budget={s}", .{@tagName(budget)});
+        if (try repairCommandAlloc(allocator, evaluation.action.command, evaluation.route)) |command| {
+            defer allocator.free(command);
+            try writer.print(" command={s}", .{command});
+        }
+        try writer.writeByte('\n');
+    }
+}
+
+fn writeDaemonTickJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+    args: cli.Command.DaemonTickArgs,
+) !void {
+    const stats = daemonTickStats(cfg.policy.daemon, evaluations);
+
+    try writer.writeAll("{\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"mode\":");
+    try std.json.stringify(if (args.once) "once" else "loop", .{}, writer);
+    try writer.writeAll(",\"executed\":false");
+    try writer.writeAll(",\"message\":\"planning only; no probes or repair commands executed\"");
+    try writer.writeAll(",\"policy\":");
+    try writePolicyJson(writer, cfg.policy);
+    try writer.writeAll(",\"profile\":");
+    if (args.profile) |profile_name| try std.json.stringify(profile_name, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"capability\":");
+    if (args.capability) |capability| try std.json.stringify(capability, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"afloat\":");
+    try writer.writeAll(if (selected_index != null) "true" else "false");
+    try writer.writeAll(",\"selected\":");
+    if (selected_index) |idx| {
+        try writeRouteSelectionJson(writer, evaluations[idx].route);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"summary\":");
+    try writeDaemonTickStatsJson(writer, stats);
+    try writer.writeAll(",\"routes\":[");
+    for (evaluations, 0..) |evaluation, idx| {
+        if (idx > 0) try writer.writeByte(',');
+        const selected = if (selected_index) |selected| idx == selected else false;
+        try writer.writeByte('{');
+        try writer.writeAll("\"route\":");
+        try writeRouteEvaluationJson(writer, allocator, cfg, evaluation, selected);
+        try writer.writeAll(",\"tick\":");
+        try writeDaemonTickDecisionJson(writer, daemonTickDecision(cfg.policy.daemon, evaluation));
+        try writer.writeByte('}');
+    }
+    try writer.writeAll("]}\n");
+}
+
+fn writeDaemonTickStatsJson(writer: anytype, stats: DaemonTickStats) !void {
+    try writer.print(
+        "{{\"routes\":{d},\"selectable\":{d},\"admitted_probes\":{d},\"blocked_probes\":{d},\"admitted_repairs\":{d},\"blocked_repairs\":{d},\"no_action\":{d}}}",
+        .{
+            stats.routes,
+            stats.selectable,
+            stats.admitted_probes,
+            stats.blocked_probes,
+            stats.admitted_repairs,
+            stats.blocked_repairs,
+            stats.no_action,
+        },
+    );
+}
+
+fn writeDaemonTickDecisionJson(writer: anytype, decision: DaemonTickDecision) !void {
+    try writer.writeByte('{');
+    try writer.writeAll("\"phase\":");
+    try std.json.stringify(decision.phase, .{}, writer);
+    try writer.writeAll(",\"action\":");
+    try std.json.stringify(decision.action, .{}, writer);
+    try writer.writeAll(",\"admitted\":");
+    try writer.writeAll(if (decision.admitted) "true" else "false");
+    try writer.writeAll(",\"reason\":");
+    try std.json.stringify(decision.reason, .{}, writer);
+    try writer.writeAll(",\"budget\":");
+    if (decision.budget) |budget| try std.json.stringify(@tagName(budget), .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"executed\":");
+    try writer.writeAll(if (decision.executed) "true" else "false");
+    try writer.writeByte('}');
+}
+
+fn daemonTickStats(policy: config.DaemonPolicyConfig, evaluations: []const RouteEvaluation) DaemonTickStats {
+    var stats = DaemonTickStats{ .routes = evaluations.len };
+    for (evaluations) |evaluation| {
+        if (evaluation.selectable) stats.selectable += 1;
+        const decision = daemonTickDecision(policy, evaluation);
+        if (std.mem.eql(u8, decision.phase, "probe")) {
+            if (decision.admitted) stats.admitted_probes += 1 else stats.blocked_probes += 1;
+        } else if (std.mem.eql(u8, decision.phase, "repair")) {
+            if (decision.admitted) stats.admitted_repairs += 1 else stats.blocked_repairs += 1;
+        } else if (std.mem.eql(u8, decision.phase, "none") or std.mem.eql(u8, decision.phase, "observe")) {
+            stats.no_action += 1;
+        }
+    }
+    return stats;
+}
+
+fn daemonTickDecision(policy: config.DaemonPolicyConfig, evaluation: RouteEvaluation) DaemonTickDecision {
+    if (evaluation.selectable) {
+        return .{
+            .phase = "none",
+            .action = "none",
+            .admitted = true,
+            .reason = "route_selectable",
+        };
+    }
+
+    if (evaluation.action.command == .probe) {
+        const admission = daemonProbeAdmission(policy, evaluation.budget);
+        return .{
+            .phase = "probe",
+            .action = "probe",
+            .admitted = admission.admitted,
+            .reason = admission.reason,
+            .budget = admission.budget,
+        };
+    }
+
+    if (evaluation.action.command != .none or evaluation.action.mutating or evaluation.action.interactive) {
+        const admission = daemonRepairAdmission(policy, evaluation.action);
+        return .{
+            .phase = "repair",
+            .action = evaluation.action.kind,
+            .admitted = admission.admitted,
+            .reason = admission.reason,
+            .budget = admission.budget,
+        };
+    }
+
+    const admission = daemonRepairAdmission(policy, evaluation.action);
+    return .{
+        .phase = "observe",
+        .action = evaluation.action.kind,
+        .admitted = admission.admitted,
+        .reason = if (admission.admitted) "observe_only" else admission.reason,
+        .budget = admission.budget,
+    };
 }
 
 const DoctorStats = struct {
@@ -1849,6 +2097,7 @@ fn writeDoctorNextCommandsText(writer: anytype, stats: DoctorStats) !void {
     try writer.writeAll("    oauth-mux doctor runtime --json\n");
     try writer.writeAll("    oauth-mux route explain --profile <profile> --capability <capability> --json\n");
     try writer.writeAll("    oauth-mux route select --profile <profile> --capability <capability> --json\n");
+    try writer.writeAll("    oauth-mux daemon tick --once --profile <profile> --capability <capability> --json\n");
     try writer.writeAll("    oauth-mux repair run --profile <profile> --capability <capability> --json\n");
     if (stats.codex_configured) {
         if (!stats.codex_max_configured) {
@@ -1884,6 +2133,7 @@ fn writeDoctorNextCommandsJson(writer: anytype, stats: DoctorStats) !void {
     try writeDoctorCommandJson(writer, &first, "oauth-mux route explain --profile <profile> --capability <capability> --json");
     try writeDoctorCommandJson(writer, &first, "oauth-mux route select --profile <profile> --capability <capability> --json");
     try writeDoctorCommandJson(writer, &first, "oauth-mux repair-plan --json");
+    try writeDoctorCommandJson(writer, &first, "oauth-mux daemon tick --once --profile <profile> --capability <capability> --json");
     try writeDoctorCommandJson(writer, &first, "oauth-mux repair run --profile <profile> --capability <capability> --json");
     if (stats.codex_configured) {
         if (!stats.codex_max_configured) {
@@ -2216,6 +2466,8 @@ fn writeDoctorRuntimeJson(
     try writeCommandJson(writer, "oauth-mux route explain --profile <profile> --capability <capability> --json");
     try writer.writeByte(',');
     try writeCommandJson(writer, "oauth-mux repair-plan --profile <profile> --capability <capability> --json");
+    try writer.writeByte(',');
+    try writeCommandJson(writer, "oauth-mux daemon tick --once --profile <profile> --capability <capability> --json");
     try writer.writeAll("]}\n");
 }
 
@@ -2258,6 +2510,8 @@ fn writeDoctorRuntimeScopedJson(
     try writeCommandJson(writer, "oauth-mux route explain --profile <profile> --capability <capability> --json");
     try writer.writeByte(',');
     try writeCommandJson(writer, "oauth-mux repair-plan --profile <profile> --capability <capability> --json");
+    try writer.writeByte(',');
+    try writeCommandJson(writer, "oauth-mux daemon tick --once --profile <profile> --capability <capability> --json");
     try writer.writeAll("]}\n");
 }
 
@@ -5400,6 +5654,7 @@ test "writeDiscoverJson includes stay-afloat agent-safe commands" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux route explain --profile <profile> --capability <capability> --json") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux route select --profile <profile> --capability <capability> --json") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux repair-plan --profile <profile> --capability <capability> --json") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux daemon tick --once --profile <profile> --capability <capability> --json") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux repair run --profile <profile> --capability <capability> --json") != null);
 }
 
@@ -5608,6 +5863,54 @@ test "writePolicyJson exposes effective daemon admission policy" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"allowed_budgets\":[\"free_local\",\"free_command\"]") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"allow_interactive\":false") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"allow_mutating\":false") != null);
+}
+
+test "daemon tick refuses spend provider probe by default" {
+    const decision = daemonTickDecision((config.PolicyConfig{}).daemon, .{
+        .route = .{ .provider = "codex", .account = "max-1", .capability = "codex-max" },
+        .runtime = .ready,
+        .health = null,
+        .budget = .spend_provider,
+        .action = .{
+            .kind = "probe_needed",
+            .severity = "warning",
+            .message = "probe would spend",
+            .command = .probe,
+            .budget = .spend_provider,
+        },
+        .selectable = false,
+        .skip_reason = "unrecorded",
+    });
+
+    try std.testing.expectEqualStrings("probe", decision.phase);
+    try std.testing.expect(!decision.admitted);
+    try std.testing.expectEqualStrings("budget_not_allowed", decision.reason);
+    try std.testing.expectEqual(types.ActionBudget.spend_provider, decision.budget.?);
+    try std.testing.expect(!decision.executed);
+}
+
+test "daemon tick reports selectable route as no-op" {
+    const health = health_mod.AccountHealth{
+        .liveness = .{ .live = .{ .availability = .available } },
+    };
+    const decision = daemonTickDecision((config.PolicyConfig{}).daemon, .{
+        .route = .{ .provider = "codex", .account = "max-2", .capability = "codex-max" },
+        .runtime = .ready,
+        .health = health,
+        .budget = .spend_provider,
+        .action = .{
+            .kind = "none",
+            .severity = "ok",
+            .message = "route is selectable",
+        },
+        .selectable = true,
+        .skip_reason = "available",
+    });
+
+    try std.testing.expectEqualStrings("none", decision.phase);
+    try std.testing.expect(decision.admitted);
+    try std.testing.expectEqualStrings("route_selectable", decision.reason);
+    try std.testing.expect(!decision.executed);
 }
 
 test "repairActionFor classifies quota exhaustion as wait action" {


### PR DESCRIPTION
## Summary

Adds a portable one-shot daemon planning primitive:

- `oauth-mux daemon tick --once --json`
- selector support for profile/provider/account/capability
- JSON/text output that includes route state, selected fallback, daemon policy, per-route tick decisions, and `executed:false`
- `just daemon-tick` dogfood helper
- README/onboarding/daemon-boundary/stay-afloat spec updates
- local E2E coverage for the no-execution stay-afloat tick

This keeps the daemon arc honest: users and agents can inspect what a future loop would be allowed to do without running provider probes, opening auth flows, or mutating credential stores.

## Validation

- `just test`
- `just build && ./scripts/e2e-local.sh`
- `just check-local`
- `just daemon-tick` against the real local Codex Max state: selected `codex:max-2#codex-max`, observed `max-1` quota wait, kept `executed:false`, and kept provider-spend probes blocked by daemon policy.

Linear: TIN-738
