### PR TITLE
Add bounded daemon tick loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair-plan --profile 
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair run --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux daemon tick --once --profile codex-max --capability codex-max --json
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux daemon tick --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
 oauth-mux daemon events --json
 ```
 
@@ -133,7 +134,11 @@ the effective policy plus per-route admission decisions so agents can back off
 without guessing. `daemon tick --once --json` is the first daemon-shaped
 dogfood primitive: it evaluates the same routes under that policy and reports
 `executed:false`; it does not run live probes, repair commands, or background
-mutation.
+mutation. `daemon tick --loop --iterations <n> --interval-ms <ms> --json`
+runs the same planning tick as a bounded foreground loop for dogfood and
+wrappers. It re-reads health/runtime state each iteration, still emits
+`executed:false`, and remains portable: no `systemctl`, `launchctl`, service
+manager, browser auth, provider spend, or secret mutation is assumed.
 
 First-run Codex subscription path:
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -32,6 +32,7 @@ oauth-mux discover --json
 oauth-mux doctor runtime --json
 oauth-mux route explain --profile <profile> --capability <capability> --json
 oauth-mux daemon tick --once --profile <profile> --capability <capability> --json
+oauth-mux daemon tick --loop --iterations 2 --interval-ms 0 --profile <profile> --capability <capability> --json
 ```
 
 Source checkouts prove this path without touching real operator state:
@@ -51,6 +52,7 @@ oauth-mux codex canary
 oauth-mux route explain --profile codex-max --capability codex-max --json
 oauth-mux route select --profile codex-max --capability codex-max --json
 oauth-mux daemon tick --once --profile codex-max --capability codex-max --json
+oauth-mux daemon tick --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
 ```
 
 Those commands are installed CLI surface, not source-checkout-only helpers.
@@ -66,10 +68,11 @@ oauth-mux codex live-qa --confirm-spend
 oauth-mux codex probe-all --capability codex-mini --json
 ```
 
-`doctor runtime`, `route explain`, `route select`, and `daemon tick --once` are
-no-spend surfaces. They only use local runtime checks plus recorded liveness, so
-they are safe for agents to run before deciding whether a live probe or
-user-driven reauth is warranted. Prefer scoped runtime checks such as
+`doctor runtime`, `route explain`, `route select`, `daemon tick --once`, and
+bounded `daemon tick --loop` are no-spend surfaces. They only use local runtime
+checks plus recorded liveness, so they are safe for agents to run before
+deciding whether a live probe or user-driven reauth is warranted. Prefer scoped
+runtime checks such as
 `oauth-mux doctor runtime --profile codex-max --capability codex-max --json`
 when dogfooding a specific stay-afloat route; global runtime doctor is still
 useful for support bundles and full-machine cleanup.

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -44,6 +44,9 @@ See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
 - `oauth-mux daemon tick --once --json` for one portable, policy-gated
   daemon-shaped planning pass. It reports `executed:false` and does not run
   probes, repair commands, or mutation.
+- `oauth-mux daemon tick --loop --iterations <n> --interval-ms <ms> --json`
+  for a bounded foreground planning loop. It re-reads local health/runtime
+  state each tick and remains service-manager agnostic.
 - Account-scoped advisory locks during confirmed `repair run`, reported back as
   `repair_in_progress` by runtime-aware route planning.
 - Config-level daemon admission policy for route planning. The default admits
@@ -92,6 +95,7 @@ oauth-mux route select --profile <profile> --capability <capability> --json
 oauth-mux probe --profile <profile> --capability <capability> --json
 oauth-mux repair-plan --profile <profile> --capability <capability> --json
 oauth-mux repair run --profile <profile> --capability <capability> --json
+oauth-mux daemon tick --loop --iterations 2 --interval-ms 0 --profile <profile> --capability <capability> --json
 oauth-mux daemon events --json
 oauth-mux exec --profile <profile> --capability <capability> -- <command>
 ```

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -175,6 +175,17 @@ prints what a future background loop would be allowed to do. It always reports
 `executed:false` today: no provider probes, browser/device auth, repair
 commands, or secret mutation are run by the tick.
 
+For a bounded foreground loop, use:
+
+```bash
+oauth-mux daemon tick --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
+```
+
+Loop mode emits one JSON envelope containing repeated tick snapshots. Each tick
+re-reads local health and runtime state, but it remains planning-only and does
+not require launchd, systemd, Homebrew services, cron, or a platform-specific
+daemon manager.
+
 If `repair-plan --profile codex-max` reports a config validation error, the
 active config is not the three-account Codex Max shape. That usually means the
 machine still has an older generic config with only `codex:default`. Generate a

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -475,6 +475,12 @@ what a future daemon loop would be allowed to consider. The tick is explicitly
 planning-only and emits `executed:false`; it does not run provider probes,
 repair commands, browser/device auth, or secret mutation.
 
+Implementation note, 2026-04-30: bounded foreground loop mode now exists through
+`oauth-mux daemon tick --loop --iterations <n> --interval-ms <ms> --json`. This
+keeps the daemon beta portable and wrapper-friendly: no system service manager
+is assumed, each iteration re-reads local health/runtime state, and the default
+policy still refuses provider spend, interactive auth, and mutation.
+
 ### M3: Refresh Writeback
 
 - Implement backend write capabilities.

--- a/justfile
+++ b/justfile
@@ -220,6 +220,9 @@ daemon-events: build
 daemon-tick PROFILE="codex-max" CAPABILITY="codex-max": build
     ./zig-out/bin/oauth-mux daemon tick --once --profile {{PROFILE}} --capability {{CAPABILITY}} --json
 
+daemon-loop PROFILE="codex-max" CAPABILITY="codex-max" ITERATIONS="2" INTERVAL_MS="0": build
+    ./zig-out/bin/oauth-mux daemon tick --loop --iterations {{ITERATIONS}} --interval-ms {{INTERVAL_MS}} --profile {{PROFILE}} --capability {{CAPABILITY}} --json
+
 # ── Shell integration ──
 
 completions-fish: build

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -266,6 +266,15 @@ expect_contains "$daemon_tick" '"selected":{"provider":"toy","account":"a2"' "da
 expect_contains "$daemon_tick" '"action":"wait_for_quota"' "daemon tick includes wait action for exhausted route"
 expect_contains "$daemon_tick" '"reason":"route_selectable"' "daemon tick marks selectable route as no-op"
 
+printf 'e2e: bounded daemon tick loop emits repeated planning snapshots\n'
+daemon_loop="$(omux daemon tick --loop --iterations 2 --interval-ms 0 --profile expensive --capability expensive --json)"
+expect_contains "$daemon_loop" '"mode":"loop"' "daemon tick loop reports loop mode"
+expect_contains "$daemon_loop" '"iterations_requested":2' "daemon tick loop reports requested iterations"
+expect_contains "$daemon_loop" '"ticks":[' "daemon tick loop returns tick array"
+expect_contains "$daemon_loop" '"tick_index":0' "daemon tick loop includes first tick"
+expect_contains "$daemon_loop" '"tick_index":1' "daemon tick loop includes second tick"
+expect_contains "$daemon_loop" '"executed":false' "daemon tick loop remains planning-only"
+
 printf 'e2e: repair run no-ops when fallback route is selectable\n'
 repair_run="$(omux repair run --profile expensive --capability expensive --json)"
 expect_contains "$repair_run" '"ok":true' "repair run reports ok when afloat"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -183,6 +183,8 @@ pub const Command = union(enum) {
         account: ?[]const u8 = null,
         capability: ?[]const u8 = null,
         once: bool = true,
+        iterations: u32 = 1,
+        interval_ms: u64 = 60_000,
         json: bool = false,
     };
 };
@@ -518,6 +520,20 @@ fn parseDaemonTick(args: []const []const u8) Command {
             result.json = true;
         } else if (eql(args[i], "--once")) {
             result.once = true;
+            result.iterations = 1;
+        } else if (eql(args[i], "--loop")) {
+            result.once = false;
+        } else if (eql(args[i], "--iterations")) {
+            i += 1;
+            if (i < args.len) {
+                result.iterations = std.fmt.parseInt(u32, args[i], 10) catch result.iterations;
+                if (result.iterations > 1) result.once = false;
+            }
+        } else if (eql(args[i], "--interval-ms")) {
+            i += 1;
+            if (i < args.len) {
+                result.interval_ms = std.fmt.parseInt(u64, args[i], 10) catch result.interval_ms;
+            }
         }
     }
     return .{ .daemon_tick = result };
@@ -705,8 +721,8 @@ pub fn printUsage(writer: anytype) !void {
         \\  daemon events [--json] [--limit <n>]
         \\      Show recent redacted repair events.
         \\
-        \\  daemon tick [--once] [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
-        \\      Plan one policy-gated daemon tick without executing probes or repair.
+        \\  daemon tick [--once|--loop] [--iterations <n>] [--interval-ms <ms>] [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
+        \\      Plan one or more policy-gated daemon ticks without executing probes or repair.
         \\
         \\  init [--interactive] [--codex-max]
         \\      Generate a starter config file.
@@ -1132,6 +1148,22 @@ test "parse daemon tick once json selector" {
     }
 }
 
+test "parse daemon tick bounded loop" {
+    const args = [_][]const u8{ "daemon", "tick", "--loop", "--iterations", "3", "--interval-ms", "250", "--profile", "codex-max", "--capability", "codex-max", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .daemon_tick => |tick| {
+            try std.testing.expect(!tick.once);
+            try std.testing.expectEqual(@as(u32, 3), tick.iterations);
+            try std.testing.expectEqual(@as(u64, 250), tick.interval_ms);
+            try std.testing.expect(tick.json);
+            try std.testing.expectEqualStrings("codex-max", tick.profile.?);
+            try std.testing.expectEqualStrings("codex-max", tick.capability.?);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
     if (eql(shell_name, "fish")) {
         try writer.writeAll(
@@ -1195,6 +1227,9 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l limit -d 'Limit event count' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l once -d 'Run one planning tick'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l loop -d 'Run bounded foreground planning ticks'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l iterations -d 'Number of planning ticks' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l interval-ms -d 'Milliseconds between ticks' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l profile -s p -d 'Profile name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l provider -d 'Provider name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l account -d 'Account name' -r

--- a/src/main.zig
+++ b/src/main.zig
@@ -1443,21 +1443,51 @@ fn runDaemonTick(allocator: std.mem.Allocator, writer: anytype, args: cli.Comman
     defer validation_messages.deinit();
     try config.validate(parsed.value, validation_messages.writer());
 
-    var store = health_mod.HealthStore.load(allocator, .{});
-    defer store.deinit();
-
     var routes = try collectRepairPlanRoutes(allocator, parsed.value, daemonTickArgsToPlanArgs(args));
     defer routes.deinit();
 
-    var evaluations = std.ArrayList(RouteEvaluation).init(allocator);
-    defer evaluations.deinit();
-    try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &evaluations);
+    const iterations = normalizedDaemonTickIterations(args);
+    if (args.json and iterations > 1) {
+        try writer.writeAll("{\"version\":");
+        try std.json.stringify(cli.version, .{}, writer);
+        try writer.writeAll(",\"mode\":\"loop\",\"executed\":false,\"message\":\"bounded foreground planning loop; no probes or repair commands executed\",\"iterations_requested\":");
+        try writer.print("{d}", .{iterations});
+        try writer.writeAll(",\"interval_ms\":");
+        try writer.print("{d}", .{args.interval_ms});
+        try writer.writeAll(",\"ticks\":[");
+    }
 
-    const selected_index = firstSelectableRoute(evaluations.items);
-    if (args.json) {
-        try writeDaemonTickJson(writer, allocator, parsed.value, evaluations.items, selected_index, args);
-    } else {
-        try writeDaemonTickText(writer, allocator, parsed.value, evaluations.items, selected_index, args);
+    var idx: u32 = 0;
+    while (idx < iterations) : (idx += 1) {
+        var store = health_mod.HealthStore.load(allocator, .{});
+        defer store.deinit();
+
+        var evaluations = std.ArrayList(RouteEvaluation).init(allocator);
+        defer evaluations.deinit();
+        try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &evaluations);
+
+        const selected_index = firstSelectableRoute(evaluations.items);
+        const observed_at = std.time.timestamp();
+
+        if (args.json) {
+            if (iterations > 1) {
+                if (idx > 0) try writer.writeByte(',');
+                try writeDaemonTickJsonObject(writer, allocator, parsed.value, evaluations.items, selected_index, args, idx, observed_at, false);
+            } else {
+                try writeDaemonTickJsonObject(writer, allocator, parsed.value, evaluations.items, selected_index, args, idx, observed_at, true);
+                try writer.writeByte('\n');
+            }
+        } else {
+            if (iterations > 1) try writer.print("tick {d}/{d}\n", .{ idx + 1, iterations });
+            try writeDaemonTickText(writer, allocator, parsed.value, evaluations.items, selected_index, args);
+            if (iterations > 1 and idx + 1 < iterations) try writer.writeByte('\n');
+        }
+
+        sleepBetweenDaemonTicks(args, idx, iterations);
+    }
+
+    if (args.json and iterations > 1) {
+        try writer.writeAll("]}\n");
     }
 }
 
@@ -1469,6 +1499,19 @@ fn daemonTickArgsToPlanArgs(args: cli.Command.DaemonTickArgs) cli.Command.Repair
         .capability = args.capability,
         .json = args.json,
     };
+}
+
+fn normalizedDaemonTickIterations(args: cli.Command.DaemonTickArgs) u32 {
+    if (args.once) return 1;
+    return @max(args.iterations, 1);
+}
+
+fn sleepBetweenDaemonTicks(args: cli.Command.DaemonTickArgs, idx: u32, iterations: u32) void {
+    if (idx + 1 >= iterations) return;
+    if (args.interval_ms == 0) return;
+    const max_ms = std.math.maxInt(u64) / std.time.ns_per_ms;
+    const bounded_ms = @min(args.interval_ms, max_ms);
+    std.time.sleep(bounded_ms * std.time.ns_per_ms);
 }
 
 fn collectRouteEvaluations(
@@ -1737,18 +1780,29 @@ fn writeDaemonTickText(
     }
 }
 
-fn writeDaemonTickJson(
+fn writeDaemonTickJsonObject(
     writer: anytype,
     allocator: std.mem.Allocator,
     cfg: config.Config,
     evaluations: []const RouteEvaluation,
     selected_index: ?usize,
     args: cli.Command.DaemonTickArgs,
+    tick_index: u32,
+    observed_at: i64,
+    include_version: bool,
 ) !void {
     const stats = daemonTickStats(cfg.policy.daemon, evaluations);
 
-    try writer.writeAll("{\"version\":");
-    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeByte('{');
+    if (include_version) {
+        try writer.writeAll("\"version\":");
+        try std.json.stringify(cli.version, .{}, writer);
+        try writer.writeByte(',');
+    }
+    try writer.writeAll("\"tick_index\":");
+    try writer.print("{d}", .{tick_index});
+    try writer.writeAll(",\"observed_at\":");
+    try writer.print("{d}", .{observed_at});
     try writer.writeAll(",\"mode\":");
     try std.json.stringify(if (args.once) "once" else "loop", .{}, writer);
     try writer.writeAll(",\"executed\":false");
@@ -1780,7 +1834,7 @@ fn writeDaemonTickJson(
         try writeDaemonTickDecisionJson(writer, daemonTickDecision(cfg.policy.daemon, evaluation));
         try writer.writeByte('}');
     }
-    try writer.writeAll("]}\n");
+    try writer.writeAll("]}");
 }
 
 fn writeDaemonTickStatsJson(writer: anytype, stats: DaemonTickStats) !void {


### PR DESCRIPTION
## Summary

Adds a bounded foreground loop mode to the existing daemon tick planner:

- `oauth-mux daemon tick --loop --iterations <n> --interval-ms <ms> --json`
- `just daemon-loop` for source checkout dogfood
- JSON loop envelope with repeated tick snapshots
- local e2e coverage proving loop mode remains planning-only
- README/onboarding/adoption/daemon-boundary/spec updates

The loop re-reads local health/runtime state each tick and still reports `executed:false`; it does not run provider probes, browser/device auth, repair commands, or secret mutation.

## Why

This is the next safe step toward stay-afloat daemon beta work without introducing platform-specific service assumptions. It gives users, wrappers, and agents a repeatable foreground primitive before we consider automatic repair or background packaging.

## Validation

- `just test`
- `just build`
- `./scripts/e2e-local.sh`
- `nix develop --command just check-local`
- `just daemon-loop codex-max codex-max 2 0`
