### PR TITLE
[codex] Add secret writeback capability matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ wrappers. It re-reads health/runtime state each iteration, still emits
 `executed:false`, and remains portable: no `systemctl`, `launchctl`, service
 manager, browser auth, provider spend, or secret mutation is assumed.
 
+Secret read and writeback are also separate. Route and runtime JSON expose a
+`writeback` object with the secret backend capability and whether automatic
+refresh writeback is admitted. CLI-owned stores such as Codex can be readable
+file stores while still refusing oauth-mux refresh mutation because repair is
+owned by the upstream CLI.
+
 First-run Codex subscription path:
 
 ```bash

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -81,6 +81,12 @@ useful for support bundles and full-machine cleanup.
 also safe without confirmation. It will not open a browser, run `codex login`,
 or mutate credential stores unless the user supplies `--confirm-repair`.
 
+Route, runtime, repair-plan, and daemon tick JSON also report `writeback`. Use
+that field when deciding whether a future repair loop can refresh in place:
+`replace_file` means the backend has a provider-neutral file write surface, but
+`automatic_refresh_admitted` can still be false when the provider owns repair
+through its upstream CLI.
+
 ## Provider Author Experience
 
 A new provider should usually start as data, not Zig:

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -53,6 +53,10 @@ See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
   only `free_local` and `free_command` budgets; provider calls, provider-spend,
   interactive auth, and mutation remain refused unless explicitly configured.
 - Local experimentation with daemon socket/status behavior.
+- Secret-backend writeback classification in route/runtime/repair JSON. This
+  tells operators whether a route is `readonly`, `replace_file`,
+  `command_write`, `keychain_write`, `sops_write`, or `unsupported`, and whether
+  oauth-mux automatic refresh writeback is admitted for that provider/account.
 - Future manual QA where daemon activity is bounded and visible.
 
 ## Not Allowed Yet

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -186,6 +186,14 @@ re-reads local health and runtime state, but it remains planning-only and does
 not require launchd, systemd, Homebrew services, cron, or a platform-specific
 daemon manager.
 
+Route, runtime, repair-plan, and daemon tick JSON include a `writeback` object.
+That object separates the secret backend surface (`readonly`, `replace_file`,
+`command_write`, `keychain_write`, `sops_write`, or `unsupported`) from whether
+automatic refresh writeback is admitted for this provider. This matters for
+Codex and Claude-style CLI-owned stores: a file-backed credential can be
+readable and writable by the current user, while oauth-mux still refuses to
+rewrite it because upstream login owns the session.
+
 If `repair-plan --profile codex-max` reports a config validation error, the
 active config is not the three-account Codex Max shape. That usually means the
 machine still has an older generic config with only `codex:default`. Generate a

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -489,6 +489,15 @@ policy still refuses provider spend, interactive auth, and mutation.
 - Refuse refresh when a backend is read-only or token age semantics are
   ambiguous.
 
+Implementation note, 2026-04-30: the first writeback matrix now exists, but it
+does not yet persist refreshed tokens. Route, runtime, repair-plan, and daemon
+tick JSON expose `writeback.capability`, `writeback.automatic_refresh_admitted`,
+and `writeback.reason` for each account. This deliberately separates "oauth-mux
+can read the local credential" from "oauth-mux is allowed to rewrite this
+credential during automatic refresh." CLI-owned stores such as Codex may resolve
+to a writable file backend while still refusing automatic oauth-mux mutation
+because repair ownership remains with the upstream CLI login flow.
+
 ### M4: Daemon Beta
 
 - Promote daemon to opt-in beta.

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -250,6 +250,7 @@ expect_contains "$route_explain" '"ok":true' "route explain reports available se
 expect_contains "$route_explain" '"selected":{"provider":"toy","account":"a2"' "route explain selects fallback account a2"
 expect_contains "$route_explain" '"skip_reason":"quota_exhausted"' "route explain keeps exhausted reason"
 expect_contains "$route_explain" '"skip_reason":"available"' "route explain marks available selected route"
+expect_contains "$route_explain" '"writeback":{"capability":"readonly","automatic_refresh_admitted":false,"reason":"provider_repair_is_manual_only"}' "route explain reports readonly writeback boundary"
 
 printf 'e2e: route select chooses selected fallback without probing\n'
 route_select="$(omux route select --profile expensive --capability expensive --json)"
@@ -308,8 +309,8 @@ cat >"$reauth_config" <<EOF
         "max-1": {
           "config_dir": "$tmp/reauth-home",
           "secret": {
-            "backend": "env",
-            "variable": "OMUX_E2E_REAUTH"
+            "backend": "file",
+            "path": "$tmp/reauth-home/auth.json"
           }
         }
       }
@@ -340,6 +341,7 @@ expect_contains "$repair_reauth" '"confirmation_required":true' "repair run requ
 expect_contains "$repair_reauth" '"requires":"--confirm-repair"' "repair run reports required flag"
 expect_contains "$repair_reauth" '"command":"oauth-mux codex login-device max-1"' "repair run reports upstream command"
 expect_contains "$repair_reauth" '"daemon_repair":{"admitted":false,"reason":"interactive_not_allowed","budget":"interactive"}' "repair run reports daemon policy refusal"
+expect_contains "$repair_reauth" '"writeback":{"capability":"replace_file","automatic_refresh_admitted":false,"reason":"provider_repair_owned_by_upstream_cli"}' "repair run reports upstream-owned file writeback boundary"
 test ! -e "$tmp/reauth-home/auth.json"
 
 repair_reauth_confirmed_json="$tmp/repair-run-reauth-confirmed.json"

--- a/src/main.zig
+++ b/src/main.zig
@@ -12,6 +12,7 @@ const provider = @import("provider.zig");
 const provider_schema = @import("provider_schema.zig");
 const daemon = @import("daemon.zig");
 const repair_state = @import("repair_state.zig");
+const secret_mod = @import("secret.zig");
 
 pub fn main() !void {
     log.init();
@@ -1040,6 +1041,8 @@ fn writeRepairPlanRouteJson(
     try std.json.stringify(@tagName(def.extension_mode), .{}, writer);
     try writer.writeAll(",\"repair_owner\":");
     try std.json.stringify(@tagName(def.repair.owner), .{}, writer);
+    try writer.writeAll(",\"writeback\":");
+    try writeRouteWritebackJson(writer, cfg, route, def);
     try writer.writeAll(",\"probe_budget\":");
     if (budget) |probe_budget| {
         try std.json.stringify(@tagName(probe_budget), .{}, writer);
@@ -1154,6 +1157,46 @@ fn writeAdmissionDecisionJson(writer: anytype, decision: AdmissionDecision) !voi
     try writer.writeAll(",\"budget\":");
     if (decision.budget) |budget| try std.json.stringify(@tagName(budget), .{}, writer) else try writer.writeAll("null");
     try writer.writeByte('}');
+}
+
+fn writeRouteWritebackJson(
+    writer: anytype,
+    cfg: config.Config,
+    route: RepairPlanRoute,
+    def: provider_schema.ProviderDefinition,
+) !void {
+    const plan = routeWritebackPlan(cfg, route, def);
+    try writer.writeByte('{');
+    try writer.writeAll("\"capability\":");
+    try std.json.stringify(@tagName(plan.capability), .{}, writer);
+    try writer.writeAll(",\"automatic_refresh_admitted\":");
+    try writer.writeAll(if (plan.automatic_refresh_admitted) "true" else "false");
+    try writer.writeAll(",\"reason\":");
+    try std.json.stringify(plan.reason, .{}, writer);
+    try writer.writeByte('}');
+}
+
+fn routeWritebackPlan(
+    cfg: config.Config,
+    route: RepairPlanRoute,
+    def: provider_schema.ProviderDefinition,
+) secret_mod.WritebackPlan {
+    const prov = cfg.providers.map.get(route.provider) orelse return .{
+        .capability = .unsupported,
+        .automatic_refresh_admitted = false,
+        .reason = "provider_not_configured",
+    };
+    const account = prov.accounts.map.get(route.account) orelse return .{
+        .capability = .unsupported,
+        .automatic_refresh_admitted = false,
+        .reason = "account_not_configured",
+    };
+    const backend = config.resolveSecretBackend(account.secret) catch return .{
+        .capability = .unsupported,
+        .automatic_refresh_admitted = false,
+        .reason = "secret_backend_invalid",
+    };
+    return secret_mod.writebackPlan(backend, def.repair.owner);
 }
 
 fn daemonProbeAdmission(policy: config.DaemonPolicyConfig, budget: ?types.ActionBudget) AdmissionDecision {
@@ -1697,6 +1740,8 @@ fn writeRouteEvaluationJson(
     try std.json.stringify(@tagName(def.extension_mode), .{}, writer);
     try writer.writeAll(",\"repair_owner\":");
     try std.json.stringify(@tagName(def.repair.owner), .{}, writer);
+    try writer.writeAll(",\"writeback\":");
+    try writeRouteWritebackJson(writer, cfg, evaluation.route, def);
     try writer.writeAll(",\"probe_budget\":");
     if (evaluation.budget) |budget| try std.json.stringify(@tagName(budget), .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"admission\":");
@@ -2660,6 +2705,8 @@ fn writeRuntimeAccountJson(
     try writer.writeAll(if (info.ready()) "true" else "false");
     try writer.writeAll(",\"runtime\":");
     try writeRuntimeReadinessRedactedJson(writer, info.readiness);
+    try writer.writeAll(",\"writeback\":");
+    try writeAccountWritebackJson(writer, account, def);
     try writer.writeAll(",\"config_dir_env\":");
     if (env_var) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"config_dir_set\":");
@@ -2721,6 +2768,34 @@ fn writeRuntimeReadinessRedactedJson(writer: anytype, readiness: types.RuntimeRe
         },
     }
     try writer.writeByte('}');
+}
+
+fn writeAccountWritebackJson(
+    writer: anytype,
+    account: config.AccountConfig,
+    def: provider_schema.ProviderDefinition,
+) !void {
+    const plan = accountWritebackPlan(account, def);
+    try writer.writeByte('{');
+    try writer.writeAll("\"capability\":");
+    try std.json.stringify(@tagName(plan.capability), .{}, writer);
+    try writer.writeAll(",\"automatic_refresh_admitted\":");
+    try writer.writeAll(if (plan.automatic_refresh_admitted) "true" else "false");
+    try writer.writeAll(",\"reason\":");
+    try std.json.stringify(plan.reason, .{}, writer);
+    try writer.writeByte('}');
+}
+
+fn accountWritebackPlan(
+    account: config.AccountConfig,
+    def: provider_schema.ProviderDefinition,
+) secret_mod.WritebackPlan {
+    const backend = config.resolveSecretBackend(account.secret) catch return .{
+        .capability = .unsupported,
+        .automatic_refresh_admitted = false,
+        .reason = "secret_backend_invalid",
+    };
+    return secret_mod.writebackPlan(backend, def.repair.owner);
 }
 
 fn runtimeAccountInfo(

--- a/src/secret.zig
+++ b/src/secret.zig
@@ -16,6 +16,12 @@ pub const ReadError = error{
     IoError,
 };
 
+pub const WritebackPlan = struct {
+    capability: types.SecretWriteCapability,
+    automatic_refresh_admitted: bool,
+    reason: []const u8,
+};
+
 pub fn read(backend: types.SecretBackend, allocator: std.mem.Allocator) ReadError![]const u8 {
     return switch (backend) {
         .keychain => |ref| readKeychain(ref, allocator),
@@ -25,6 +31,66 @@ pub fn read(backend: types.SecretBackend, allocator: std.mem.Allocator) ReadErro
         .sops => |ref| readSops(ref, allocator),
         .age => |ref| readAge(ref, allocator),
         .stdin => readStdin(allocator),
+    };
+}
+
+pub fn writeCapability(backend: types.SecretBackend) types.SecretWriteCapability {
+    return switch (backend) {
+        .file => .replace_file,
+        .command => .command_write,
+        .keychain => .keychain_write,
+        .sops => .sops_write,
+        .env, .stdin => .readonly,
+        .age => .unsupported,
+    };
+}
+
+pub fn writebackPlan(backend: types.SecretBackend, owner: types.RepairOwner) WritebackPlan {
+    const capability = writeCapability(backend);
+    if (owner != .oauth_mux_refresh) {
+        return .{
+            .capability = capability,
+            .automatic_refresh_admitted = false,
+            .reason = switch (owner) {
+                .upstream_cli_login => "provider_repair_owned_by_upstream_cli",
+                .external_secret_owner => "provider_repair_owned_by_external_secret",
+                .manual_only => "provider_repair_is_manual_only",
+                .oauth_mux_refresh => unreachable,
+            },
+        };
+    }
+
+    return switch (capability) {
+        .replace_file => .{
+            .capability = capability,
+            .automatic_refresh_admitted = true,
+            .reason = "replace_file_writeback_available",
+        },
+        .readonly => .{
+            .capability = capability,
+            .automatic_refresh_admitted = false,
+            .reason = "secret_backend_is_readonly",
+        },
+        .command_write => .{
+            .capability = capability,
+            .automatic_refresh_admitted = false,
+            .reason = "command_write_contract_missing",
+        },
+        .keychain_write => .{
+            .capability = capability,
+            .automatic_refresh_admitted = false,
+            .reason = "keychain_write_not_implemented",
+        },
+        .sops_write => .{
+            .capability = capability,
+            .automatic_refresh_admitted = false,
+            .reason = "sops_write_not_implemented",
+        },
+        .unsupported => .{
+            .capability = capability,
+            .automatic_refresh_admitted = false,
+            .reason = "secret_backend_writeback_unsupported",
+        },
     };
 }
 
@@ -266,4 +332,32 @@ test "readEnv not found" {
 test "readFile not found" {
     const result = readFile(.{ .path = "/tmp/omux-test-nonexistent-file" }, std.testing.allocator);
     try std.testing.expectError(error.NotFound, result);
+}
+
+test "writeCapability classifies secret backend write surfaces" {
+    try std.testing.expect(writeCapability(.{ .file = .{ .path = "/tmp/omux-auth.json" } }) == .replace_file);
+    try std.testing.expect(writeCapability(.{ .env = .{ .variable = "OMUX_AUTH" } }) == .readonly);
+    try std.testing.expect(writeCapability(.{ .command = .{ .argv = &.{"omux-secret"} } }) == .command_write);
+    try std.testing.expect(writeCapability(.{ .keychain = .{ .service = "oauth-mux", .account = "work" } }) == .keychain_write);
+    try std.testing.expect(writeCapability(.{ .sops = .{ .path = "/tmp/secrets.yaml" } }) == .sops_write);
+    try std.testing.expect(writeCapability(.{ .age = .{ .path = "/tmp/secret.age", .identity = "/tmp/key.txt" } }) == .unsupported);
+    try std.testing.expect(writeCapability(.stdin) == .readonly);
+}
+
+test "writebackPlan requires oauth-mux refresh ownership" {
+    const file_backend = types.SecretBackend{ .file = .{ .path = "/tmp/omux-auth.json" } };
+    const admitted = writebackPlan(file_backend, .oauth_mux_refresh);
+    try std.testing.expect(admitted.automatic_refresh_admitted);
+    try std.testing.expect(admitted.capability == .replace_file);
+    try std.testing.expectEqualStrings("replace_file_writeback_available", admitted.reason);
+
+    const upstream_owned = writebackPlan(file_backend, .upstream_cli_login);
+    try std.testing.expect(!upstream_owned.automatic_refresh_admitted);
+    try std.testing.expect(upstream_owned.capability == .replace_file);
+    try std.testing.expectEqualStrings("provider_repair_owned_by_upstream_cli", upstream_owned.reason);
+
+    const env_owned = writebackPlan(.{ .env = .{ .variable = "OMUX_AUTH" } }, .oauth_mux_refresh);
+    try std.testing.expect(!env_owned.automatic_refresh_admitted);
+    try std.testing.expect(env_owned.capability == .readonly);
+    try std.testing.expectEqualStrings("secret_backend_is_readonly", env_owned.reason);
 }

--- a/src/types.zig
+++ b/src/types.zig
@@ -283,6 +283,22 @@ pub const RepairOwner = enum {
     manual_only,
 };
 
+pub const SecretWriteCapability = enum {
+    readonly,
+    replace_file,
+    command_write,
+    keychain_write,
+    sops_write,
+    unsupported,
+
+    pub fn providerNeutralWriteback(self: SecretWriteCapability) bool {
+        return switch (self) {
+            .replace_file => true,
+            .readonly, .command_write, .keychain_write, .sops_write, .unsupported => false,
+        };
+    }
+};
+
 pub const RuntimeReadiness = union(enum) {
     ready,
     missing_binary: []const u8,


### PR DESCRIPTION
## Summary

Adds a typed secret writeback capability matrix and surfaces it in the stay-afloat JSON paths before any automatic refresh mutation exists.

- classifies secret backends as readonly, replace_file, command_write, keychain_write, sops_write, or unsupported
- separates provider-neutral backend write capability from provider repair ownership
- reports writeback in repair-plan, route explain/select, doctor runtime, and daemon tick route JSON
- documents that CLI-owned stores such as Codex can be readable file stores while still refusing oauth-mux refresh mutation

## Why

The stay-afloat loop needs to know whether a credential can be read, whether it can be written, and whether oauth-mux is actually allowed to perform automatic refresh. This prevents the daemon arc from silently rewriting upstream-owned sessions.

## Validation

- just build
- ./scripts/e2e-local.sh
- nix develop --command just check-local