### PR TITLE
[codex] Gate refresh by writeback admission

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ Secret read and writeback are also separate. Route and runtime JSON expose a
 `writeback` object with the secret backend capability and whether automatic
 refresh writeback is admitted. CLI-owned stores such as Codex can be readable
 file stores while still refusing oauth-mux refresh mutation because repair is
-owned by the upstream CLI.
+owned by the upstream CLI. Automatic OAuth refresh is gated by that same
+admission plan: today only `oauth_mux_refresh` providers with `replace_file`
+secret backends can persist refreshed credentials.
 
 First-run Codex subscription path:
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -85,7 +85,9 @@ Route, runtime, repair-plan, and daemon tick JSON also report `writeback`. Use
 that field when deciding whether a future repair loop can refresh in place:
 `replace_file` means the backend has a provider-neutral file write surface, but
 `automatic_refresh_admitted` can still be false when the provider owns repair
-through its upstream CLI.
+through its upstream CLI. Current automatic refresh follows that contract: it
+will not call a token endpoint unless writeback is admitted, and admitted file
+backends are replaced atomically.
 
 ## Provider Author Experience
 

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -57,6 +57,9 @@ See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
   tells operators whether a route is `readonly`, `replace_file`,
   `command_write`, `keychain_write`, `sops_write`, or `unsupported`, and whether
   oauth-mux automatic refresh writeback is admitted for that provider/account.
+- Atomic file replacement for admitted `replace_file` OAuth refresh backends.
+  This is provider-ownership-gated and does not apply to Codex or other
+  upstream-CLI-owned stores.
 - Future manual QA where daemon activity is bounded and visible.
 
 ## Not Allowed Yet

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -194,6 +194,11 @@ Codex and Claude-style CLI-owned stores: a file-backed credential can be
 readable and writable by the current user, while oauth-mux still refuses to
 rewrite it because upstream login owns the session.
 
+The refresh path now uses that same admission gate. File-backed credentials can
+be replaced atomically, but automatic refresh only runs for providers whose
+definition declares `repair.owner = "oauth_mux_refresh"` and whose backend
+reports `automatic_refresh_admitted: true`. Codex remains upstream-CLI-owned.
+
 If `repair-plan --profile codex-max` reports a config validation error, the
 active config is not the three-account Codex Max shape. That usually means the
 machine still has an older generic config with only `codex:default`. Generate a

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -489,14 +489,21 @@ policy still refuses provider spend, interactive auth, and mutation.
 - Refuse refresh when a backend is read-only or token age semantics are
   ambiguous.
 
-Implementation note, 2026-04-30: the first writeback matrix now exists, but it
-does not yet persist refreshed tokens. Route, runtime, repair-plan, and daemon
-tick JSON expose `writeback.capability`, `writeback.automatic_refresh_admitted`,
-and `writeback.reason` for each account. This deliberately separates "oauth-mux
-can read the local credential" from "oauth-mux is allowed to rewrite this
-credential during automatic refresh." CLI-owned stores such as Codex may resolve
-to a writable file backend while still refusing automatic oauth-mux mutation
-because repair ownership remains with the upstream CLI login flow.
+Implementation note, 2026-04-30: the first writeback matrix now exists. Route,
+runtime, repair-plan, and daemon tick JSON expose `writeback.capability`,
+`writeback.automatic_refresh_admitted`, and `writeback.reason` for each account.
+This deliberately separates "oauth-mux can read the local credential" from
+"oauth-mux is allowed to rewrite this credential during automatic refresh."
+CLI-owned stores such as Codex may resolve to a writable file backend while
+still refusing automatic oauth-mux mutation because repair ownership remains
+with the upstream CLI login flow.
+
+Implementation note, 2026-04-30: provider-neutral `replace_file` writeback is
+implemented as atomic same-path replacement, and the pipeline refresh path is
+now gated by the writeback plan before it calls a token endpoint. That means
+automatic refresh requires both `repair.owner = "oauth_mux_refresh"` and an
+admitted backend. Read-only, command, keychain, SOPS, unsupported, and
+upstream-owned backends fail closed.
 
 ### M4: Daemon Beta
 

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -520,6 +520,7 @@ fn buildProbeEnv(
 fn attemptRefresh(ctx: *Context, rt: []const u8) PipelineError!void {
     const prov = ctx.provider_name orelse return error.ProviderNotFound;
     const def = config_mod.resolveProviderDefinition(ctx.cfg, prov);
+    const backend = try refreshWritebackBackend(ctx, def);
     const url = def.auth.token_endpoint orelse fallbackRefreshUrl(ctx) orelse {
         log.warn("token: no refresh URL for {s}", .{prov});
         return error.TokenRefreshFailed;
@@ -527,6 +528,37 @@ fn attemptRefresh(ctx: *Context, rt: []const u8) PipelineError!void {
 
     const result = oauth.refreshToken(ctx.allocator, url, rt, def.auth.client_id) catch |e| {
         log.err("token: refresh failed: {s}", .{@errorName(e)});
+        return error.TokenRefreshFailed;
+    };
+    errdefer ctx.allocator.free(result.access_token);
+    errdefer if (result.refresh_token) |new_rt| ctx.allocator.free(new_rt);
+
+    const expires_at = if (result.expires_in) |ei| std.time.timestamp() + ei else null;
+    var retained_refresh_token: ?[]const u8 = null;
+    var retained_refresh_token_from_old = false;
+    if (result.refresh_token) |new_rt| {
+        retained_refresh_token = new_rt;
+    } else {
+        retained_refresh_token = ctx.allocator.dupe(u8, rt) catch return error.OutOfMemory;
+        retained_refresh_token_from_old = true;
+    }
+    errdefer if (retained_refresh_token_from_old) {
+        if (retained_refresh_token) |old_rt| ctx.allocator.free(old_rt);
+    };
+
+    const credential = provider_schema.buildCredentialGeneric(
+        def,
+        .{
+            .access_token = result.access_token,
+            .refresh_token = retained_refresh_token,
+            .expires_at = expires_at,
+        },
+        ctx.allocator,
+    ) catch return error.TokenRefreshFailed;
+    defer ctx.allocator.free(credential);
+
+    secret.writeReplace(backend, credential, ctx.allocator) catch |e| {
+        log.err("token: refresh writeback failed for {s}: {s}", .{ prov, @errorName(e) });
         return error.TokenRefreshFailed;
     };
 
@@ -537,11 +569,28 @@ fn attemptRefresh(ctx: *Context, rt: []const u8) PipelineError!void {
     }
     ctx.token = .{
         .access_token = result.access_token,
-        .refresh_token = result.refresh_token,
-        .expires_at = if (result.expires_in) |ei| std.time.timestamp() + ei else null,
+        .refresh_token = retained_refresh_token,
+        .expires_at = expires_at,
     };
 
     log.info("token: refreshed successfully", .{});
+}
+
+fn refreshWritebackBackend(
+    ctx: *Context,
+    def: provider_schema.ProviderDefinition,
+) PipelineError!types.SecretBackend {
+    const prov = ctx.provider_name orelse return error.ProviderNotFound;
+    const acct = ctx.account_name orelse return error.AccountNotFound;
+    const prov_cfg = ctx.cfg.providers.map.get(prov) orelse return error.ProviderNotFound;
+    const acct_cfg = prov_cfg.accounts.map.get(acct) orelse return error.AccountNotFound;
+    const backend = config_mod.resolveSecretBackend(acct_cfg.secret) catch return error.ConfigValidationError;
+    const plan = secret.writebackPlan(backend, def.repair.owner);
+    if (!plan.automatic_refresh_admitted) {
+        log.warn("token: refresh writeback not admitted for {s}:{s}: {s}", .{ prov, acct, plan.reason });
+        return error.TokenRefreshFailed;
+    }
+    return backend;
 }
 
 fn fallbackRefreshUrl(ctx: *Context) ?[]const u8 {
@@ -734,6 +783,130 @@ test "runEnv uses configured provider definition" {
     try expectEnvPair(ctx.env_pairs.items, "TOY_TOKEN", "toy-at");
     try expectEnvPair(ctx.env_pairs.items, "OMUX_ACTIVE_PROVIDER", "toy");
     try expectEnvPair(ctx.env_pairs.items, "OMUX_ACTIVE_ACCOUNT", "default");
+}
+
+test "refreshWritebackBackend admits only oauth-mux owned file writeback" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const auth_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/auth.json", .{root_path});
+    defer std.testing.allocator.free(auth_path);
+
+    const admitted_json = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "provider_definitions": {{
+        \\    "toy": {{
+        \\      "name": "toy",
+        \\      "repair": {{ "owner": "oauth_mux_refresh" }},
+        \\      "auth": {{ "token_endpoint": "https://example.invalid/token" }}
+        \\    }}
+        \\  }},
+        \\  "providers": {{
+        \\    "toy": {{
+        \\      "kind": "toy",
+        \\      "accounts": {{
+        \\        "default": {{ "secret": {{ "backend": "file", "path": "{s}" }} }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{}},
+        \\  "strategies": {{}}
+        \\}}
+    ,
+        .{auth_path},
+    );
+    defer std.testing.allocator.free(admitted_json);
+
+    const admitted = try config_mod.loadFromBytes(std.testing.allocator, admitted_json);
+    defer admitted.deinit();
+    var admitted_store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer admitted_store.deinit();
+    var admitted_ctx = Context.init(std.testing.allocator, admitted.value, &admitted_store);
+    defer admitted_ctx.deinit();
+    admitted_ctx.provider_name = "toy";
+    admitted_ctx.account_name = "default";
+    const admitted_backend = try refreshWritebackBackend(&admitted_ctx, config_mod.resolveProviderDefinition(admitted.value, "toy"));
+    switch (admitted_backend) {
+        .file => |ref| try std.testing.expectEqualStrings(auth_path, ref.path),
+        else => return error.TestUnexpectedResult,
+    }
+
+    const upstream_json = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "provider_definitions": {{
+        \\    "toy": {{
+        \\      "name": "toy",
+        \\      "repair": {{ "owner": "upstream_cli_login" }}
+        \\    }}
+        \\  }},
+        \\  "providers": {{
+        \\    "toy": {{
+        \\      "kind": "toy",
+        \\      "accounts": {{
+        \\        "default": {{ "secret": {{ "backend": "file", "path": "{s}" }} }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{}},
+        \\  "strategies": {{}}
+        \\}}
+    ,
+        .{auth_path},
+    );
+    defer std.testing.allocator.free(upstream_json);
+
+    const upstream = try config_mod.loadFromBytes(std.testing.allocator, upstream_json);
+    defer upstream.deinit();
+    var upstream_store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer upstream_store.deinit();
+    var upstream_ctx = Context.init(std.testing.allocator, upstream.value, &upstream_store);
+    defer upstream_ctx.deinit();
+    upstream_ctx.provider_name = "toy";
+    upstream_ctx.account_name = "default";
+    try std.testing.expectError(
+        error.TokenRefreshFailed,
+        refreshWritebackBackend(&upstream_ctx, config_mod.resolveProviderDefinition(upstream.value, "toy")),
+    );
+
+    const readonly_json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "repair": { "owner": "oauth_mux_refresh" }
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": { "secret": { "backend": "env", "variable": "TOY_AUTH" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const readonly = try config_mod.loadFromBytes(std.testing.allocator, readonly_json);
+    defer readonly.deinit();
+    var readonly_store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer readonly_store.deinit();
+    var readonly_ctx = Context.init(std.testing.allocator, readonly.value, &readonly_store);
+    defer readonly_ctx.deinit();
+    readonly_ctx.provider_name = "toy";
+    readonly_ctx.account_name = "default";
+    try std.testing.expectError(
+        error.TokenRefreshFailed,
+        refreshWritebackBackend(&readonly_ctx, config_mod.resolveProviderDefinition(readonly.value, "toy")),
+    );
 }
 
 test "runEnv honors capability route health from profile" {

--- a/src/secret.zig
+++ b/src/secret.zig
@@ -16,6 +16,13 @@ pub const ReadError = error{
     IoError,
 };
 
+pub const WriteError = error{
+    UnsupportedBackend,
+    AccessDenied,
+    IoError,
+    OutOfMemory,
+};
+
 pub const WritebackPlan = struct {
     capability: types.SecretWriteCapability,
     automatic_refresh_admitted: bool,
@@ -94,6 +101,13 @@ pub fn writebackPlan(backend: types.SecretBackend, owner: types.RepairOwner) Wri
     };
 }
 
+pub fn writeReplace(backend: types.SecretBackend, bytes: []const u8, allocator: std.mem.Allocator) WriteError!void {
+    return switch (backend) {
+        .file => |ref| writeFileReplace(ref, bytes, allocator),
+        .keychain, .sops, .age, .env, .command, .stdin => error.UnsupportedBackend,
+    };
+}
+
 fn readEnv(ref: types.SecretBackend.EnvRef, allocator: std.mem.Allocator) ReadError![]const u8 {
     const val = env.get(allocator, ref.variable) catch return error.OutOfMemory;
     return val orelse {
@@ -117,6 +131,38 @@ fn readFile(ref: types.SecretBackend.FileRef, allocator: std.mem.Allocator) Read
     defer file.close();
 
     return file.readToEndAlloc(allocator, 4 * 1024 * 1024) catch return error.IoError;
+}
+
+fn writeFileReplace(ref: types.SecretBackend.FileRef, bytes: []const u8, allocator: std.mem.Allocator) WriteError!void {
+    const expanded = paths.expandTilde(allocator, ref.path) catch return error.OutOfMemory;
+    defer allocator.free(expanded);
+
+    if (std.fs.path.dirname(expanded)) |dir| {
+        std.fs.cwd().makePath(dir) catch |e| switch (e) {
+            error.AccessDenied => return error.AccessDenied,
+            else => return error.IoError,
+        };
+    }
+
+    const tmp_path = std.fmt.allocPrint(allocator, "{s}.tmp-{x}", .{ expanded, std.crypto.random.int(u64) }) catch return error.OutOfMemory;
+    defer allocator.free(tmp_path);
+
+    const file = std.fs.createFileAbsolute(tmp_path, .{ .exclusive = true, .mode = 0o600 }) catch |e| switch (e) {
+        error.AccessDenied => return error.AccessDenied,
+        else => return error.IoError,
+    };
+    errdefer std.fs.deleteFileAbsolute(tmp_path) catch {};
+
+    {
+        defer file.close();
+        file.writeAll(bytes) catch return error.IoError;
+        file.sync() catch return error.IoError;
+    }
+
+    std.fs.renameAbsolute(tmp_path, expanded) catch |e| switch (e) {
+        error.AccessDenied => return error.AccessDenied,
+        else => return error.IoError,
+    };
 }
 
 fn readKeychain(ref: types.SecretBackend.KeychainRef, allocator: std.mem.Allocator) ReadError![]const u8 {
@@ -332,6 +378,31 @@ test "readEnv not found" {
 test "readFile not found" {
     const result = readFile(.{ .path = "/tmp/omux-test-nonexistent-file" }, std.testing.allocator);
     try std.testing.expectError(error.NotFound, result);
+}
+
+test "writeReplace atomically replaces file backend bytes" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const target_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(target_path);
+    const auth_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/auth.json", .{target_path});
+    defer std.testing.allocator.free(auth_path);
+
+    const backend = types.SecretBackend{ .file = .{ .path = auth_path } };
+    try writeReplace(backend, "first", std.testing.allocator);
+    {
+        const read_back = try readFile(.{ .path = auth_path }, std.testing.allocator);
+        defer std.testing.allocator.free(read_back);
+        try std.testing.expectEqualStrings("first", read_back);
+    }
+
+    try writeReplace(backend, "second", std.testing.allocator);
+    {
+        const read_back = try readFile(.{ .path = auth_path }, std.testing.allocator);
+        defer std.testing.allocator.free(read_back);
+        try std.testing.expectEqualStrings("second", read_back);
+    }
 }
 
 test "writeCapability classifies secret backend write surfaces" {


### PR DESCRIPTION
## Summary

Tightens the stay-afloat refresh boundary so OAuth refresh cannot run unless writeback is explicitly admitted.

- adds provider-neutral atomic file replacement for `file` secret backends
- gates pipeline refresh before token endpoint calls using provider repair ownership plus backend writeback admission
- preserves the previous refresh token when a refresh response rotates only the access token
- documents that Codex and other upstream-CLI-owned stores remain non-mutating even when file-backed

## Why

The previous pipeline could attempt in-memory refresh for expired OAuth credentials without proving that oauth-mux was allowed to persist the result. That is not good enough for daemon/stay-afloat work: automatic refresh must fail closed unless provider ownership and backend writeback are both explicit.

## Validation

- `just test`
- `nix develop --command zig fmt src/secret.zig src/pipeline.zig`
- `nix develop --command just check-local`