### PR TITLE
[codex] Record refresh writeback events

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ readiness instead of racing an upstream CLI login flow. Inspect recent events
 with `oauth-mux daemon events --json`; this does not require the daemon to be
 running.
 
+Refresh attempts use the same local event stream. `token_refresh` events record
+only route identity, writeback capability, admission, outcome, and redacted
+reason. They do not include access tokens, refresh tokens, credential paths, or
+provider response bodies.
+
 Daemon admission is policy-gated. By default, background/daemon planning admits
 only `free_local` and `free_command` work; `cheap_provider`, `spend_provider`,
 `interactive`, and `mutating` actions are reported as refused until the config

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -40,7 +40,9 @@ See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
   one-shot planner.
 - `oauth-mux daemon status --json` for local inspection.
 - `oauth-mux daemon events --json` for the redacted repair-run event log. This
-  reads local state and does not require a daemon process.
+  reads local state and does not require a daemon process. The same stream also
+  carries redacted `token_refresh` events for refresh admission/writeback
+  outcomes.
 - `oauth-mux daemon tick --once --json` for one portable, policy-gated
   daemon-shaped planning pass. It reports `executed:false` and does not run
   probes, repair commands, or mutation.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -162,6 +162,12 @@ the audit trail with:
 oauth-mux daemon events --json
 ```
 
+The same event log also records `token_refresh` outcomes from the pipeline.
+Those events include writeback capability and admission fields so dogfood runs
+can explain whether refresh was refused, attempted, persisted, or failed
+without exposing access tokens, refresh tokens, credential paths, or provider
+response bodies.
+
 Daemon policy is intentionally conservative. The default config admits only
 `free_local` and `free_command` budgets for daemon/background work. Provider
 calls, provider-spending probes, browser/device auth, and credential mutation

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -505,6 +505,13 @@ automatic refresh requires both `repair.owner = "oauth_mux_refresh"` and an
 admitted backend. Read-only, command, keychain, SOPS, unsupported, and
 upstream-owned backends fail closed.
 
+Implementation note, 2026-04-30: refresh admission and writeback outcomes are
+now written to the redacted local event stream as `token_refresh` events. Events
+include route identity, writeback capability, admission, outcome, and redacted
+reason; they intentionally omit tokens, credential paths, and provider response
+bodies. `oauth-mux daemon events --json` remains the single local evidence
+surface for both foreground repair and pipeline refresh behavior.
+
 ### M4: Daemon Beta
 
 - Promote daemon to opt-in beta.

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -371,6 +371,64 @@ expect_contains "$repair_events" '"profile":"needs-reauth"' "repair events recor
 expect_contains "$repair_events" '"provider":"codex"' "repair events record provider"
 expect_contains "$repair_events" '"account":"max-1"' "repair events record account"
 
+printf 'e2e: refresh admission refusal records redacted token_refresh event\n'
+refresh_config="$tmp/refresh-config.json"
+refresh_auth="$tmp/refresh-auth.json"
+cat >"$refresh_auth" <<'EOF'
+{"tokens":{"access_token":"expired-access-token","refresh_token":"expired-refresh-token","expires_at":1}}
+EOF
+cat >"$refresh_config" <<EOF
+{
+  "version": 1,
+  "provider_definitions": {
+    "toy": {
+      "name": "toy",
+      "repair": {
+        "owner": "upstream_cli_login"
+      },
+      "credential": {
+        "access_token_path": "tokens.access_token",
+        "refresh_token_path": "tokens.refresh_token",
+        "expires_at_path": "tokens.expires_at"
+      },
+      "injection": {
+        "direct_env": [["TOY_TOKEN", "access_token"]]
+      }
+    }
+  },
+  "providers": {
+    "toy": {
+      "kind": "toy",
+      "accounts": {
+        "expired": {
+          "secret": {
+            "backend": "file",
+            "path": "$refresh_auth"
+          }
+        }
+      }
+    }
+  },
+  "profiles": {
+    "refresh-refused": {
+      "providers": ["toy:expired"]
+    }
+  },
+  "strategies": {}
+}
+EOF
+refresh_refused_json="$tmp/refresh-refused.json"
+if OMUX_CONFIG="$refresh_config" OMUX_STATE_DIR="$state_dir" "$bin" env --profile refresh-refused --shell bash >"$refresh_refused_json" 2>"$tmp/refresh-refused.stderr"; then
+  printf 'e2e assertion failed: expired refresh route should fail closed before token endpoint\n' >&2
+  exit 1
+fi
+refresh_events="$(OMUX_STATE_DIR="$state_dir" "$bin" daemon events --json)"
+expect_contains "$refresh_events" '"kind":"token_refresh"' "refresh event records event kind"
+expect_contains "$refresh_events" '"outcome":"not_admitted"' "refresh event records admission refusal"
+expect_contains "$refresh_events" '"writeback_capability":"replace_file"' "refresh event records writeback capability"
+expect_contains "$refresh_events" '"automatic_refresh_admitted":false' "refresh event records admission boolean"
+expect_contains "$refresh_events" '"reason":"provider_repair_owned_by_upstream_cli"' "refresh event records redacted refusal reason"
+
 printf 'e2e: route health does not poison unrelated capability\n'
 cheap_after_quota="$(omux env --profile cheap --capability cheap --shell bash)"
 expect_contains "$cheap_after_quota" "export OMUX_ACTIVE_ACCOUNT='a1'" "cheap route still uses a1 after expensive quota"

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const types = @import("types.zig");
 const config_mod = @import("config.zig");
 const secret = @import("secret.zig");
@@ -11,6 +12,7 @@ const log = @import("log.zig");
 const oauth = @import("oauth.zig");
 const probe = @import("probe.zig");
 const env = @import("env.zig");
+const repair_state = @import("repair_state.zig");
 
 pub const Context = struct {
     allocator: std.mem.Allocator,
@@ -520,14 +522,16 @@ fn buildProbeEnv(
 fn attemptRefresh(ctx: *Context, rt: []const u8) PipelineError!void {
     const prov = ctx.provider_name orelse return error.ProviderNotFound;
     const def = config_mod.resolveProviderDefinition(ctx.cfg, prov);
-    const backend = try refreshWritebackBackend(ctx, def);
+    const writeback = try refreshWritebackBackend(ctx, def);
     const url = def.auth.token_endpoint orelse fallbackRefreshUrl(ctx) orelse {
         log.warn("token: no refresh URL for {s}", .{prov});
+        recordRefreshEvent(ctx, writeback.plan, "no_token_endpoint", "token_endpoint_missing", false, false);
         return error.TokenRefreshFailed;
     };
 
     const result = oauth.refreshToken(ctx.allocator, url, rt, def.auth.client_id) catch |e| {
         log.err("token: refresh failed: {s}", .{@errorName(e)});
+        recordRefreshEvent(ctx, writeback.plan, "token_endpoint_failed", @errorName(e), false, true);
         return error.TokenRefreshFailed;
     };
     errdefer ctx.allocator.free(result.access_token);
@@ -554,11 +558,15 @@ fn attemptRefresh(ctx: *Context, rt: []const u8) PipelineError!void {
             .expires_at = expires_at,
         },
         ctx.allocator,
-    ) catch return error.TokenRefreshFailed;
+    ) catch {
+        recordRefreshEvent(ctx, writeback.plan, "credential_build_failed", "credential_template_failed", false, true);
+        return error.TokenRefreshFailed;
+    };
     defer ctx.allocator.free(credential);
 
-    secret.writeReplace(backend, credential, ctx.allocator) catch |e| {
+    secret.writeReplace(writeback.backend, credential, ctx.allocator) catch |e| {
         log.err("token: refresh writeback failed for {s}: {s}", .{ prov, @errorName(e) });
+        recordRefreshEvent(ctx, writeback.plan, "writeback_failed", @errorName(e), false, true);
         return error.TokenRefreshFailed;
     };
 
@@ -573,13 +581,19 @@ fn attemptRefresh(ctx: *Context, rt: []const u8) PipelineError!void {
         .expires_at = expires_at,
     };
 
+    recordRefreshEvent(ctx, writeback.plan, "persisted", writeback.plan.reason, true, true);
     log.info("token: refreshed successfully", .{});
 }
+
+const RefreshWriteback = struct {
+    backend: types.SecretBackend,
+    plan: secret.WritebackPlan,
+};
 
 fn refreshWritebackBackend(
     ctx: *Context,
     def: provider_schema.ProviderDefinition,
-) PipelineError!types.SecretBackend {
+) PipelineError!RefreshWriteback {
     const prov = ctx.provider_name orelse return error.ProviderNotFound;
     const acct = ctx.account_name orelse return error.AccountNotFound;
     const prov_cfg = ctx.cfg.providers.map.get(prov) orelse return error.ProviderNotFound;
@@ -588,9 +602,40 @@ fn refreshWritebackBackend(
     const plan = secret.writebackPlan(backend, def.repair.owner);
     if (!plan.automatic_refresh_admitted) {
         log.warn("token: refresh writeback not admitted for {s}:{s}: {s}", .{ prov, acct, plan.reason });
+        recordRefreshEvent(ctx, plan, "not_admitted", plan.reason, false, false);
         return error.TokenRefreshFailed;
     }
-    return backend;
+    return .{
+        .backend = backend,
+        .plan = plan,
+    };
+}
+
+fn recordRefreshEvent(
+    ctx: *Context,
+    plan: secret.WritebackPlan,
+    outcome: []const u8,
+    reason: ?[]const u8,
+    ok: bool,
+    executed: bool,
+) void {
+    if (comptime builtin.is_test) return;
+    repair_state.appendEvent(ctx.allocator, .{
+        .kind = "token_refresh",
+        .profile = ctx.profile_name,
+        .provider = ctx.provider_name,
+        .account = ctx.account_name,
+        .capability = ctx.capability_name,
+        .action = "refresh",
+        .writeback_capability = @tagName(plan.capability),
+        .automatic_refresh_admitted = plan.automatic_refresh_admitted,
+        .outcome = outcome,
+        .reason = reason,
+        .ok = ok,
+        .executed = executed,
+        .interactive = false,
+        .mutating = true,
+    }) catch {};
 }
 
 fn fallbackRefreshUrl(ctx: *Context) ?[]const u8 {
@@ -829,8 +874,9 @@ test "refreshWritebackBackend admits only oauth-mux owned file writeback" {
     defer admitted_ctx.deinit();
     admitted_ctx.provider_name = "toy";
     admitted_ctx.account_name = "default";
-    const admitted_backend = try refreshWritebackBackend(&admitted_ctx, config_mod.resolveProviderDefinition(admitted.value, "toy"));
-    switch (admitted_backend) {
+    const admitted_writeback = try refreshWritebackBackend(&admitted_ctx, config_mod.resolveProviderDefinition(admitted.value, "toy"));
+    try std.testing.expect(admitted_writeback.plan.automatic_refresh_admitted);
+    switch (admitted_writeback.backend) {
         .file => |ref| try std.testing.expectEqualStrings(auth_path, ref.path),
         else => return error.TestUnexpectedResult,
     }

--- a/src/repair_state.zig
+++ b/src/repair_state.zig
@@ -4,11 +4,14 @@ const types = @import("types.zig");
 
 pub const RepairEvent = struct {
     ts: i64 = 0,
+    kind: []const u8 = "repair_run",
     profile: ?[]const u8 = null,
     provider: ?[]const u8 = null,
     account: ?[]const u8 = null,
     capability: ?[]const u8 = null,
     action: ?[]const u8 = null,
+    writeback_capability: ?[]const u8 = null,
+    automatic_refresh_admitted: ?bool = null,
     outcome: []const u8,
     reason: ?[]const u8 = null,
     ok: bool = false,
@@ -228,7 +231,8 @@ fn ensureParentDir(path: []const u8) !void {
 
 fn writeEventJson(writer: anytype, event: RepairEvent) !void {
     const ts = if (event.ts == 0) std.time.timestamp() else event.ts;
-    try writer.print("{{\"ts\":{d},\"kind\":\"repair_run\"", .{ts});
+    try writer.print("{{\"ts\":{d},\"kind\":", .{ts});
+    try std.json.stringify(event.kind, .{}, writer);
     try writer.writeAll(",\"profile\":");
     if (event.profile) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"provider\":");
@@ -239,6 +243,10 @@ fn writeEventJson(writer: anytype, event: RepairEvent) !void {
     if (event.capability) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"action\":");
     if (event.action) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"writeback_capability\":");
+    if (event.writeback_capability) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"automatic_refresh_admitted\":");
+    if (event.automatic_refresh_admitted) |value| try writer.writeAll(if (value) "true" else "false") else try writer.writeAll("null");
     try writer.writeAll(",\"outcome\":");
     try std.json.stringify(event.outcome, .{}, writer);
     try writer.writeAll(",\"reason\":");
@@ -300,9 +308,38 @@ test "repair event json is redacted and structured" {
     });
 
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"provider\":\"codex\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"kind\":\"repair_run\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"profile\":\"codex-max\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"account\":\"max-1\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "token") == null);
+}
+
+test "refresh event json carries redacted writeback evidence" {
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+
+    try writeEventJson(buf.writer(), .{
+        .ts = 43,
+        .kind = "token_refresh",
+        .profile = "work",
+        .provider = "figma",
+        .account = "design",
+        .action = "refresh",
+        .writeback_capability = "replace_file",
+        .automatic_refresh_admitted = true,
+        .outcome = "persisted",
+        .reason = "replace_file_writeback_available",
+        .ok = true,
+        .executed = true,
+        .mutating = true,
+    });
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"kind\":\"token_refresh\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"writeback_capability\":\"replace_file\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"automatic_refresh_admitted\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"outcome\":\"persisted\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "access_token") == null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "refresh_token") == null);
 }
 
 test "sanitized lock file names do not preserve path separators" {


### PR DESCRIPTION
## Summary

- Generalize repair-event JSON with a `kind` field plus writeback capability/admission evidence.
- Record redacted `token_refresh` events for refresh admission refusal, missing token endpoints, endpoint failure, credential build failure, writeback failure, and persisted refreshes.
- Add local e2e coverage proving an upstream-owned expired credential fails closed before provider mutation and leaves a redacted event trail.
- Update onboarding, README, daemon boundary, and stay-afloat spec docs with the new event surface.

## Why

Dogfooding showed a key stay-afloat gap: we could detect degraded runtime state, but foreground refresh attempts did not leave durable, redacted evidence about whether mutation was admitted, attempted, persisted, or refused. This PR makes refresh behavior visible without storing tokens, credential paths, or provider response bodies.

## Validation

- `nix develop --command zig fmt src/pipeline.zig src/repair_state.zig`
- `just test`
- `./scripts/e2e-local.sh`
- `nix develop --command just check-local`
