### PR TITLE
[codex] Use durable state for Codex dogfood helpers

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -251,8 +251,11 @@ thin aliases for installed commands. `just codex-max-setup` is a thin alias for
 `oauth-mux repair-plan --profile codex-max --capability codex-max --json`, and
 `just codex-max-live-qa` / `just codex-max-live-qa-confirmed` wrap the guarded
 installed live QA command. `just codex-max-probe-all` is likewise a thin alias
-for `oauth-mux codex probe-all`. Route selection and explanation should be run
-through the installed CLI directly:
+for `oauth-mux codex probe-all`. These source helpers intentionally share the
+default oauth-mux state directory so dogfood probes feed later route selection.
+Set `OMUX_STATE_DIR=/tmp/<dir>` explicitly when a run should be isolated for CI
+or artifact collection. Route selection and explanation should be run through
+the installed CLI directly:
 
 ```bash
 oauth-mux route explain --profile codex-max --capability codex-max --json

--- a/docs/spec/codex-max-operator-plan-2026-04-25.md
+++ b/docs/spec/codex-max-operator-plan-2026-04-25.md
@@ -183,12 +183,16 @@ OMUX_CONFIG=$PWD/examples/codex-max.config.json \
   oauth-mux probe --provider codex --account max-2 --capability codex-max --json
 ```
 
-Safer first-pass matrix probe, using the cheaper `codex-mini` route and a
-temporary health store:
+Safer first-pass matrix probe, using the cheaper `codex-mini` route and the
+default oauth-mux state store so later route selection can use the evidence:
 
 ```bash
 just codex-max-probe-all
 ```
+
+Use an explicit `OMUX_STATE_DIR=/tmp/<dir>` only when the probe evidence should
+be isolated from dogfood route selection, such as CI artifact collection or
+negative tests.
 
 Probe one account and route:
 

--- a/justfile
+++ b/justfile
@@ -50,7 +50,6 @@ probe *ARGS: build
 # ── Codex Max operator helpers ──
 
 codex_max_config := "examples/codex-max.config.json"
-codex_max_state := "/tmp/oauth-mux-codex-max-health"
 
 codex-max-bootstrap-dirs: build
     ./zig-out/bin/oauth-mux codex bootstrap-dirs
@@ -77,16 +76,16 @@ codex-max-setup: build
     OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux setup codex
 
 codex-max-canary: build
-    OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux codex canary
+    OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux codex canary
 
 codex-max-live-qa: build
-    OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux codex live-qa
+    OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux codex live-qa
 
 codex-max-live-qa-confirmed: build
-    OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux codex live-qa --confirm-spend
+    OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux codex live-qa --confirm-spend
 
 codex-max-repair-plan CAPABILITY="codex-max": build
-    OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux repair-plan --profile {{CAPABILITY}} --capability {{CAPABILITY}} --json
+    OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux repair-plan --profile {{CAPABILITY}} --capability {{CAPABILITY}} --json
 
 codex-max-config-candidate OUTPUT="/tmp/oauth-mux-codex-max.config.json": build
     ./zig-out/bin/oauth-mux codex config-candidate --output {{OUTPUT}}
@@ -95,10 +94,10 @@ codex-max-config-merge CANDIDATE="/tmp/oauth-mux-codex-max.config.json": build
     ./zig-out/bin/oauth-mux codex config-merge --candidate {{CANDIDATE}}
 
 codex-max-probe ACCOUNT CAPABILITY="codex-mini": build
-    OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux probe --provider codex --account {{ACCOUNT}} --capability {{CAPABILITY}} --json
+    OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux probe --provider codex --account {{ACCOUNT}} --capability {{CAPABILITY}} --json
 
 codex-max-probe-all CAPABILITY="codex-mini": build
-    OMUX_CONFIG=$PWD/{{codex_max_config}} OMUX_STATE_DIR={{codex_max_state}} ./zig-out/bin/oauth-mux codex probe-all --capability {{CAPABILITY}} --json
+    OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux codex probe-all --capability {{CAPABILITY}} --json
 
 # ── Cross-compilation ──
 

--- a/scripts/codex-max-canary.sh
+++ b/scripts/codex-max-canary.sh
@@ -8,7 +8,7 @@ config_path="${OMUX_CONFIG:-$repo_root/examples/codex-max.config.json}"
 accounts_csv="${OMUX_CODEX_ACCOUNTS:-max-1,max-2,max-3}"
 capabilities_csv="${OMUX_CODEX_CANARY_CAPABILITIES:-codex-mini,codex-max}"
 store_root="${OMUX_CODEX_STORE_ROOT:-${XDG_DATA_HOME:-$HOME/.local/share}/oauth-mux/codex}"
-state_dir="${OMUX_STATE_DIR:-/tmp/oauth-mux-codex-max-health}"
+state_dir="${OMUX_STATE_DIR:-}"
 bin="${OMUX_BIN:-$repo_root/zig-out/bin/oauth-mux}"
 
 if [ ! -x "$bin" ]; then
@@ -27,7 +27,11 @@ out_dir="${OMUX_CODEX_CANARY_OUT:-$repo_root/dist/codex-canary/$stamp}"
 mkdir -p "$out_dir"
 
 export OMUX_CONFIG="$config_path"
-export OMUX_STATE_DIR="$state_dir"
+if [ -n "$state_dir" ]; then
+  export OMUX_STATE_DIR="$state_dir"
+else
+  unset OMUX_STATE_DIR
+fi
 
 IFS=',' read -r -a accounts <<<"$accounts_csv"
 IFS=',' read -r -a capabilities <<<"$capabilities_csv"
@@ -43,7 +47,7 @@ summary="$out_dir/summary.txt"
 {
   printf 'oauth-mux Codex Max canary\n\n'
   printf 'config:       %s\n' "$config_path"
-  printf 'state:        %s\n' "$state_dir"
+  printf 'state:        %s\n' "${state_dir:-default oauth-mux state dir}"
   printf 'store root:   %s\n' "$store_root"
   printf 'accounts:     %s\n' "$accounts_csv"
   printf 'capabilities: %s\n' "$capabilities_csv"
@@ -87,13 +91,17 @@ done
 confirm="${OMUX_CODEX_CANARY_CONFIRM:-${OMUX_LIVE_QA_CONFIRM:-}}"
 if [ "$confirm" = "spend-real-calls" ]; then
   printf '\n=== live QA ===\n' | tee -a "$summary"
-  OMUX_CONFIG="$config_path" \
-    OMUX_STATE_DIR="$state_dir" \
-    OMUX_LIVE_QA_PROVIDER="${OMUX_LIVE_QA_PROVIDER:-codex}" \
-    OMUX_LIVE_QA_ACCOUNTS="$accounts_csv" \
-    OMUX_LIVE_QA_CAPABILITIES="$capabilities_csv" \
-    OMUX_LIVE_QA_CONFIRM=spend-real-calls \
-    "$repo_root/scripts/live-provider-qa.sh" 2>&1 | redact | tee "$out_dir/live-qa.txt"
+  live_env=(
+    "OMUX_CONFIG=$config_path"
+    "OMUX_LIVE_QA_PROVIDER=${OMUX_LIVE_QA_PROVIDER:-codex}"
+    "OMUX_LIVE_QA_ACCOUNTS=$accounts_csv"
+    "OMUX_LIVE_QA_CAPABILITIES=$capabilities_csv"
+    "OMUX_LIVE_QA_CONFIRM=spend-real-calls"
+  )
+  if [ -n "$state_dir" ]; then
+    live_env+=("OMUX_STATE_DIR=$state_dir")
+  fi
+  env "${live_env[@]}" "$repo_root/scripts/live-provider-qa.sh" 2>&1 | redact | tee "$out_dir/live-qa.txt"
 else
   {
     printf '\nLive probes not run.\n'


### PR DESCRIPTION
## Summary

- Remove the hidden `/tmp` state override from Codex source-checkout helpers in `justfile`.
- Make `scripts/codex-max-canary.sh` use the default oauth-mux state directory unless `OMUX_STATE_DIR` is explicitly provided.
- Document the intended split: durable default state for dogfooding, explicit temp state for CI/artifact isolation.

## Why

Dogfooding exposed a misleading split-brain state path: installed commands used the durable oauth-mux state store, while several source helpers forced `/tmp/oauth-mux-codex-max-health`. That made route selection look unrecorded even when the real dogfood state had current liveness evidence.

After this change, source helpers act like installed CLI commands by default. Operators can still set `OMUX_STATE_DIR=/tmp/<dir>` when they intentionally want isolated evidence.

## Dogfood Evidence

- Default route select correctly skipped `codex:max-1#codex-max` as quota-exhausted and selected `codex:max-2#codex-max`.
- `just codex-max-repair-plan codex-max` now reads the durable state and reports the same fallback state.
- `OMUX_CODEX_CANARY_OUT=/tmp/oauth-mux-canary-check ./scripts/codex-max-canary.sh` reported the default oauth-mux state dir and recorded liveness for all six Codex routes without running live probes.

## Validation

- `bash -n scripts/codex-max-canary.sh scripts/live-provider-qa.sh scripts/onboard-codex-max.sh`
- `just --list`
- `nix develop --command just check-local`
