### PR TITLE
[codex] Add daemon tick beta execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,14 +136,16 @@ only `free_local` and `free_command` work; `cheap_provider`, `spend_provider`,
 `interactive`, and `mutating` actions are reported as refused until the config
 explicitly allows them. `route explain --json` and `repair-plan --json` include
 the effective policy plus per-route admission decisions so agents can back off
-without guessing. `daemon tick --once --json` is the first daemon-shaped
-dogfood primitive: it evaluates the same routes under that policy and reports
-`executed:false`; it does not run live probes, repair commands, or background
-mutation. `daemon tick --loop --iterations <n> --interval-ms <ms> --json`
-runs the same planning tick as a bounded foreground loop for dogfood and
-wrappers. It re-reads health/runtime state each iteration, still emits
-`executed:false`, and remains portable: no `systemctl`, `launchctl`, service
-manager, browser auth, provider spend, or secret mutation is assumed.
+without guessing. `daemon tick --once --json` evaluates the same routes under
+that policy. By default it is planning-only and reports `executed:false`.
+`daemon tick --once --execute --json` is the opt-in beta execution boundary: it
+runs at most one admitted non-interactive action per tick, such as a
+`free_command` probe, then re-reads route state. Interactive reauth is never
+run silently; execute mode records a redacted `daemon_handoff` event with the
+user command to run. `daemon tick --loop --iterations <n> --interval-ms <ms>
+--json` repeats the same portable foreground tick for dogfood and wrappers. No
+`systemctl`, `launchctl`, service manager, browser auth, provider spend, or
+secret mutation is assumed unless policy and CLI flags explicitly admit it.
 
 Secret read and writeback are also separate. Route and runtime JSON expose a
 `writeback` object with the secret backend capability and whether automatic

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -69,10 +69,12 @@ oauth-mux codex probe-all --capability codex-mini --json
 ```
 
 `doctor runtime`, `route explain`, `route select`, `daemon tick --once`, and
-bounded `daemon tick --loop` are no-spend surfaces. They only use local runtime
-checks plus recorded liveness, so they are safe for agents to run before
-deciding whether a live probe or user-driven reauth is warranted. Prefer scoped
-runtime checks such as
+bounded `daemon tick --loop` are no-spend surfaces when run without
+`--execute`. They only use local runtime checks plus recorded liveness, so they
+are safe for agents to run before deciding whether a live probe or user-driven
+reauth is warranted. `daemon tick --execute` is the beta foreground execution
+boundary: it can run one admitted non-interactive action or queue an interactive
+handoff event. Prefer scoped runtime checks such as
 `oauth-mux doctor runtime --profile codex-max --capability codex-max --json`
 when dogfooding a specific stay-afloat route; global runtime doctor is still
 useful for support bundles and full-machine cleanup.

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -44,11 +44,15 @@ See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
   carries redacted `token_refresh` events for refresh admission/writeback
   outcomes.
 - `oauth-mux daemon tick --once --json` for one portable, policy-gated
-  daemon-shaped planning pass. It reports `executed:false` and does not run
-  probes, repair commands, or mutation.
+  daemon-shaped planning pass. Without `--execute`, it reports
+  `executed:false` and does not run probes, repair commands, or mutation.
+- `oauth-mux daemon tick --once --execute --json` as the beta execution
+  boundary. It runs at most one admitted non-interactive action per tick,
+  re-reads route state afterward, and queues interactive reauth as a redacted
+  `daemon_handoff` event instead of running it silently.
 - `oauth-mux daemon tick --loop --iterations <n> --interval-ms <ms> --json`
-  for a bounded foreground planning loop. It re-reads local health/runtime
-  state each tick and remains service-manager agnostic.
+  for a bounded foreground loop. It re-reads local health/runtime state each
+  tick and remains service-manager agnostic.
 - Account-scoped advisory locks during confirmed `repair run`, reported back as
   `repair_in_progress` by runtime-aware route planning.
 - Config-level daemon admission policy for route planning. The default admits
@@ -66,12 +70,11 @@ See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
 
 ## Not Allowed Yet
 
-- Background polling of live provider probes.
-- Automatic subscription-spending checks.
+- Unbounded background polling of live provider probes.
+- Automatic subscription-spending checks without explicit daemon policy.
 - Silent token refresh for providers whose refresh semantics are owned by an
   upstream CLI.
-- Automatic execution of repair-plan commands without an explicit foreground
-  user command and confirmation flag.
+- Silent execution of interactive repair-plan commands.
 - Any release gate that depends on a long-running daemon.
 - Treating `systemctl`, `launchctl`, Homebrew services, cron, or Windows
   Services as part of the core product contract.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -177,9 +177,22 @@ policy and per-route `daemon_probe` / `daemon_repair` decisions.
 
 `oauth-mux daemon tick --once --json` is the portable daemon dogfood surface. It
 loads the same route/runtime/liveness state, applies the daemon policy, and
-prints what a future background loop would be allowed to do. It always reports
-`executed:false` today: no provider probes, browser/device auth, repair
-commands, or secret mutation are run by the tick.
+prints what a future background loop would be allowed to do. Without
+`--execute` it remains planning-only and reports `executed:false`.
+
+Opt-in beta execution is explicit:
+
+```bash
+oauth-mux daemon tick --once --execute --profile codex-max --capability codex-max --json
+```
+
+Execute mode runs at most one admitted non-interactive action per tick. The
+default policy admits `free_command`, so command-backed probes can refresh
+recorded route state without requiring a service manager. Provider-spending
+probes, interactive browser/device auth, and credential mutation remain refused
+unless policy explicitly admits them. Interactive reauth is not run in the
+background; execute mode records a redacted `daemon_handoff` event with the
+reviewable user command.
 
 For a bounded foreground loop, use:
 
@@ -188,8 +201,8 @@ oauth-mux daemon tick --loop --iterations 2 --interval-ms 0 --profile codex-max 
 ```
 
 Loop mode emits one JSON envelope containing repeated tick snapshots. Each tick
-re-reads local health and runtime state, but it remains planning-only and does
-not require launchd, systemd, Homebrew services, cron, or a platform-specific
+re-reads local health and runtime state and does not require launchd, systemd,
+Homebrew services, cron, or a platform-specific
 daemon manager.
 
 Route, runtime, repair-plan, and daemon tick JSON include a `writeback` object.

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -475,6 +475,15 @@ what a future daemon loop would be allowed to consider. The tick is explicitly
 planning-only and emits `executed:false`; it does not run provider probes,
 repair commands, browser/device auth, or secret mutation.
 
+Implementation note, 2026-04-30: daemon tick beta execution now exists behind
+`--execute`. Execute mode runs at most one admitted non-interactive action per
+tick, then re-reads route state before rendering JSON. This is intentionally
+small: `free_command` probes can keep route evidence fresh, provider-spending
+probes require explicit policy, and interactive reauth becomes a redacted
+`daemon_handoff` event with a user command instead of silent background auth.
+Tick JSON now includes `execution_mode`, `executions`, `handoff_queued`, and
+`next_tick_after` scheduling hints.
+
 Implementation note, 2026-04-30: bounded foreground loop mode now exists through
 `oauth-mux daemon tick --loop --iterations <n> --interval-ms <ms> --json`. This
 keeps the daemon beta portable and wrapper-friendly: no system service manager

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -276,6 +276,18 @@ expect_contains "$daemon_loop" '"tick_index":0' "daemon tick loop includes first
 expect_contains "$daemon_loop" '"tick_index":1' "daemon tick loop includes second tick"
 expect_contains "$daemon_loop" '"executed":false' "daemon tick loop remains planning-only"
 
+printf 'e2e: daemon tick execute runs one admitted command probe\n'
+omux health --reset toy:a1 >/dev/null
+omux health --reset toy:a2 >/dev/null
+omux health --reset toy:a1#cheap >/dev/null
+omux health --reset toy:a2#cheap >/dev/null
+daemon_execute="$(omux daemon tick --once --execute --profile cheap --capability cheap --json)"
+expect_contains "$daemon_execute" '"execution_mode":"execute"' "daemon tick reports execute mode"
+expect_contains "$daemon_execute" '"executed":true' "daemon tick execute runs an admitted action"
+expect_contains "$daemon_execute" '"phase":"probe"' "daemon tick execute records probe phase"
+expect_contains "$daemon_execute" '"command":"oauth-mux probe --provider toy --account a1 --capability cheap --json"' "daemon tick execute reports redacted probe command"
+expect_contains "$daemon_execute" '"selected":{"provider":"toy","account":"a1"' "daemon tick execute reselects after probe"
+
 printf 'e2e: repair run no-ops when fallback route is selectable\n'
 repair_run="$(omux repair run --profile expensive --capability expensive --json)"
 expect_contains "$repair_run" '"ok":true' "repair run reports ok when afloat"
@@ -344,6 +356,15 @@ expect_contains "$repair_reauth" '"daemon_repair":{"admitted":false,"reason":"in
 expect_contains "$repair_reauth" '"writeback":{"capability":"replace_file","automatic_refresh_admitted":false,"reason":"provider_repair_owned_by_upstream_cli"}' "repair run reports upstream-owned file writeback boundary"
 test ! -e "$tmp/reauth-home/auth.json"
 
+printf 'e2e: daemon tick execute queues interactive reauth handoff\n'
+daemon_handoff="$(OMUX_CONFIG="$reauth_config" OMUX_STATE_DIR="$state_dir" "$bin" daemon tick --once --execute --profile needs-reauth --capability codex-max --json)"
+expect_contains "$daemon_handoff" '"execution_mode":"execute"' "daemon handoff reports execute mode"
+expect_contains "$daemon_handoff" '"handoff_queued":true' "daemon handoff queues user action"
+expect_contains "$daemon_handoff" '"phase":"handoff"' "daemon handoff reports handoff phase"
+expect_contains "$daemon_handoff" '"admitted":false' "daemon handoff preserves daemon policy refusal"
+expect_contains "$daemon_handoff" '"command":"oauth-mux codex login-device max-1"' "daemon handoff reports upstream login command"
+test ! -e "$tmp/reauth-home/auth.json"
+
 repair_reauth_confirmed_json="$tmp/repair-run-reauth-confirmed.json"
 set +e
 OMUX_CONFIG="$reauth_config" \
@@ -370,6 +391,8 @@ expect_contains "$repair_events" '"outcome":"interactive_json_unsupported"' "rep
 expect_contains "$repair_events" '"profile":"needs-reauth"' "repair events record profile"
 expect_contains "$repair_events" '"provider":"codex"' "repair events record provider"
 expect_contains "$repair_events" '"account":"max-1"' "repair events record account"
+expect_contains "$repair_events" '"kind":"daemon_handoff"' "repair events record daemon handoff"
+expect_contains "$repair_events" '"outcome":"handoff_queued"' "repair events record daemon handoff outcome"
 
 printf 'e2e: refresh admission refusal records redacted token_refresh event\n'
 refresh_config="$tmp/refresh-config.json"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -185,6 +185,7 @@ pub const Command = union(enum) {
         once: bool = true,
         iterations: u32 = 1,
         interval_ms: u64 = 60_000,
+        execute: bool = false,
         json: bool = false,
     };
 };
@@ -518,6 +519,8 @@ fn parseDaemonTick(args: []const []const u8) Command {
             if (i < args.len) result.capability = args[i];
         } else if (eql(args[i], "--json")) {
             result.json = true;
+        } else if (eql(args[i], "--execute")) {
+            result.execute = true;
         } else if (eql(args[i], "--once")) {
             result.once = true;
             result.iterations = 1;
@@ -721,8 +724,8 @@ pub fn printUsage(writer: anytype) !void {
         \\  daemon events [--json] [--limit <n>]
         \\      Show recent redacted repair events.
         \\
-        \\  daemon tick [--once|--loop] [--iterations <n>] [--interval-ms <ms>] [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
-        \\      Plan one or more policy-gated daemon ticks without executing probes or repair.
+        \\  daemon tick [--once|--loop] [--execute] [--iterations <n>] [--interval-ms <ms>] [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
+        \\      Plan daemon ticks; --execute runs at most one admitted non-interactive action per tick.
         \\
         \\  init [--interactive] [--codex-max]
         \\      Generate a starter config file.
@@ -1149,11 +1152,12 @@ test "parse daemon tick once json selector" {
 }
 
 test "parse daemon tick bounded loop" {
-    const args = [_][]const u8{ "daemon", "tick", "--loop", "--iterations", "3", "--interval-ms", "250", "--profile", "codex-max", "--capability", "codex-max", "--json" };
+    const args = [_][]const u8{ "daemon", "tick", "--loop", "--execute", "--iterations", "3", "--interval-ms", "250", "--profile", "codex-max", "--capability", "codex-max", "--json" };
     const cmd = parse(&args);
     switch (cmd) {
         .daemon_tick => |tick| {
             try std.testing.expect(!tick.once);
+            try std.testing.expect(tick.execute);
             try std.testing.expectEqual(@as(u32, 3), tick.iterations);
             try std.testing.expectEqual(@as(u64, 250), tick.interval_ms);
             try std.testing.expect(tick.json);
@@ -1228,6 +1232,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l limit -d 'Limit event count' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l once -d 'Run one planning tick'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l loop -d 'Run bounded foreground planning ticks'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l execute -d 'Execute one admitted non-interactive tick action'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l iterations -d 'Number of planning ticks' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l interval-ms -d 'Milliseconds between ticks' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l profile -s p -d 'Profile name' -r

--- a/src/main.zig
+++ b/src/main.zig
@@ -1493,7 +1493,11 @@ fn runDaemonTick(allocator: std.mem.Allocator, writer: anytype, args: cli.Comman
     if (args.json and iterations > 1) {
         try writer.writeAll("{\"version\":");
         try std.json.stringify(cli.version, .{}, writer);
-        try writer.writeAll(",\"mode\":\"loop\",\"executed\":false,\"message\":\"bounded foreground planning loop; no probes or repair commands executed\",\"iterations_requested\":");
+        try writer.writeAll(",\"mode\":\"loop\",\"execution_mode\":");
+        try std.json.stringify(if (args.execute) "execute" else "plan", .{}, writer);
+        try writer.writeAll(",\"executed\":false,\"message\":");
+        try std.json.stringify(daemonTickMessage(args), .{}, writer);
+        try writer.writeAll(",\"iterations_requested\":");
         try writer.print("{d}", .{iterations});
         try writer.writeAll(",\"interval_ms\":");
         try writer.print("{d}", .{args.interval_ms});
@@ -1509,20 +1513,34 @@ fn runDaemonTick(allocator: std.mem.Allocator, writer: anytype, args: cli.Comman
         defer evaluations.deinit();
         try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &evaluations);
 
-        const selected_index = firstSelectableRoute(evaluations.items);
+        var selected_index = firstSelectableRoute(evaluations.items);
         const observed_at = std.time.timestamp();
+        var executions = std.ArrayList(DaemonTickExecution).init(allocator);
+        defer executions.deinit();
+
+        const state_changed = if (args.execute)
+            try executeDaemonTickActions(allocator, parsed.value, args, evaluations.items, selected_index, &executions)
+        else
+            false;
+        if (state_changed) {
+            store.deinit();
+            store = health_mod.HealthStore.load(allocator, .{});
+            evaluations.clearRetainingCapacity();
+            try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &evaluations);
+            selected_index = firstSelectableRoute(evaluations.items);
+        }
 
         if (args.json) {
             if (iterations > 1) {
                 if (idx > 0) try writer.writeByte(',');
-                try writeDaemonTickJsonObject(writer, allocator, parsed.value, evaluations.items, selected_index, args, idx, observed_at, false);
+                try writeDaemonTickJsonObject(writer, allocator, parsed.value, evaluations.items, selected_index, executions.items, args, idx, observed_at, false);
             } else {
-                try writeDaemonTickJsonObject(writer, allocator, parsed.value, evaluations.items, selected_index, args, idx, observed_at, true);
+                try writeDaemonTickJsonObject(writer, allocator, parsed.value, evaluations.items, selected_index, executions.items, args, idx, observed_at, true);
                 try writer.writeByte('\n');
             }
         } else {
             if (iterations > 1) try writer.print("tick {d}/{d}\n", .{ idx + 1, iterations });
-            try writeDaemonTickText(writer, allocator, parsed.value, evaluations.items, selected_index, args);
+            try writeDaemonTickText(writer, allocator, parsed.value, evaluations.items, selected_index, executions.items, args, observed_at);
             if (iterations > 1 and idx + 1 < iterations) try writer.writeByte('\n');
         }
 
@@ -1555,6 +1573,180 @@ fn sleepBetweenDaemonTicks(args: cli.Command.DaemonTickArgs, idx: u32, iteration
     const max_ms = std.math.maxInt(u64) / std.time.ns_per_ms;
     const bounded_ms = @min(args.interval_ms, max_ms);
     std.time.sleep(bounded_ms * std.time.ns_per_ms);
+}
+
+fn daemonTickMessage(args: cli.Command.DaemonTickArgs) []const u8 {
+    return if (args.execute)
+        "execute mode; at most one admitted non-interactive action runs per tick"
+    else
+        "planning only; no probes or repair commands executed";
+}
+
+fn executeDaemonTickActions(
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    args: cli.Command.DaemonTickArgs,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+    executions: *std.ArrayList(DaemonTickExecution),
+) !bool {
+    if (selected_index != null) return false;
+
+    for (evaluations) |evaluation| {
+        const decision = daemonTickDecision(cfg.policy.daemon, evaluation, std.time.timestamp());
+        if (std.mem.eql(u8, decision.phase, "repair") and evaluation.action.interactive) {
+            try queueDaemonHandoff(allocator, args, evaluation, decision, executions);
+            return false;
+        }
+        if (!decision.admitted) continue;
+
+        if (std.mem.eql(u8, decision.phase, "probe")) {
+            return try executeDaemonProbe(allocator, args, evaluation, decision, executions);
+        }
+
+        if (std.mem.eql(u8, decision.phase, "repair") and
+            evaluation.action.command != .none and
+            !evaluation.action.interactive)
+        {
+            return try executeDaemonRepairCommand(allocator, cfg, args, evaluation, decision, executions);
+        }
+    }
+
+    return false;
+}
+
+fn executeDaemonProbe(
+    allocator: std.mem.Allocator,
+    args: cli.Command.DaemonTickArgs,
+    evaluation: RouteEvaluation,
+    decision: DaemonTickDecision,
+    executions: *std.ArrayList(DaemonTickExecution),
+) !bool {
+    var scratch = std.ArrayList(u8).init(allocator);
+    defer scratch.deinit();
+
+    var ok = true;
+    var reason: []const u8 = "probe_completed";
+    runProbe(allocator, scratch.writer(), .{
+        .provider = evaluation.route.provider,
+        .account = evaluation.route.account,
+        .capability = evaluation.route.capability,
+        .json = true,
+    }) catch |e| {
+        ok = false;
+        reason = @errorName(e);
+    };
+
+    try executions.append(.{
+        .route = evaluation.route,
+        .phase = "probe",
+        .action = "probe",
+        .admitted = true,
+        .executed = true,
+        .ok = ok,
+        .reason = reason,
+        .budget = decision.budget,
+        .command = .probe,
+    });
+    recordDaemonActionEvent(allocator, args, evaluation, .probe, "probe", if (ok) "executed" else "failed", reason, ok, true, false);
+    return true;
+}
+
+fn executeDaemonRepairCommand(
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    args: cli.Command.DaemonTickArgs,
+    evaluation: RouteEvaluation,
+    decision: DaemonTickDecision,
+    executions: *std.ArrayList(DaemonTickExecution),
+) !bool {
+    var lock = repair_state.acquireRepairLock(allocator, evaluation.route.provider, evaluation.route.account) catch |e| switch (e) {
+        error.RepairInProgress => {
+            try executions.append(.{
+                .route = evaluation.route,
+                .phase = "repair",
+                .action = evaluation.action.kind,
+                .admitted = true,
+                .executed = false,
+                .ok = false,
+                .reason = "repair_in_progress",
+                .budget = decision.budget,
+                .command = evaluation.action.command,
+            });
+            recordDaemonActionEvent(allocator, args, evaluation, evaluation.action.command, evaluation.action.kind, "repair_in_progress", "lock_busy", false, false, false);
+            return false;
+        },
+        else => return e,
+    };
+    defer lock.release();
+
+    const ok = try executeRepairCommand(allocator, cfg, evaluation);
+    try executions.append(.{
+        .route = evaluation.route,
+        .phase = "repair",
+        .action = evaluation.action.kind,
+        .admitted = true,
+        .executed = true,
+        .ok = ok,
+        .reason = if (ok) "command_success" else "command_failed",
+        .budget = decision.budget,
+        .command = evaluation.action.command,
+    });
+    recordDaemonActionEvent(allocator, args, evaluation, evaluation.action.command, evaluation.action.kind, if (ok) "executed" else "failed", if (ok) "command_success" else "command_failed", ok, true, false);
+    return ok;
+}
+
+fn queueDaemonHandoff(
+    allocator: std.mem.Allocator,
+    args: cli.Command.DaemonTickArgs,
+    evaluation: RouteEvaluation,
+    decision: DaemonTickDecision,
+    executions: *std.ArrayList(DaemonTickExecution),
+) !void {
+    try executions.append(.{
+        .route = evaluation.route,
+        .phase = "handoff",
+        .action = evaluation.action.kind,
+        .admitted = decision.admitted,
+        .executed = false,
+        .ok = false,
+        .handoff = true,
+        .reason = "interactive_user_handoff",
+        .budget = decision.budget,
+        .command = evaluation.action.command,
+    });
+    recordDaemonActionEvent(allocator, args, evaluation, evaluation.action.command, evaluation.action.kind, "handoff_queued", "interactive_user_handoff", false, false, true);
+}
+
+fn recordDaemonActionEvent(
+    allocator: std.mem.Allocator,
+    args: cli.Command.DaemonTickArgs,
+    evaluation: RouteEvaluation,
+    command_kind: RepairCommandKind,
+    action: []const u8,
+    outcome: []const u8,
+    reason: []const u8,
+    ok: bool,
+    executed: bool,
+    handoff: bool,
+) void {
+    const command = repairCommandAlloc(allocator, command_kind, evaluation.route) catch null;
+    defer if (command) |value| allocator.free(value);
+    repair_state.appendEvent(allocator, .{
+        .kind = if (handoff) "daemon_handoff" else "daemon_action",
+        .profile = args.profile,
+        .provider = evaluation.route.provider,
+        .account = evaluation.route.account,
+        .capability = evaluation.route.capability,
+        .action = action,
+        .command = command,
+        .outcome = outcome,
+        .reason = reason,
+        .ok = ok,
+        .executed = executed,
+        .interactive = evaluation.action.interactive,
+        .mutating = evaluation.action.mutating,
+    }) catch {};
 }
 
 fn collectRouteEvaluations(
@@ -1764,6 +1956,21 @@ const DaemonTickDecision = struct {
     reason: []const u8,
     budget: ?types.ActionBudget = null,
     executed: bool = false,
+    handoff: bool = false,
+    next_tick_after: ?i64 = null,
+};
+
+const DaemonTickExecution = struct {
+    route: RepairPlanRoute,
+    phase: []const u8,
+    action: []const u8,
+    admitted: bool,
+    executed: bool,
+    ok: bool,
+    handoff: bool = false,
+    reason: []const u8,
+    budget: ?types.ActionBudget = null,
+    command: RepairCommandKind = .none,
 };
 
 const DaemonTickStats = struct {
@@ -1774,6 +1981,7 @@ const DaemonTickStats = struct {
     admitted_repairs: usize = 0,
     blocked_repairs: usize = 0,
     no_action: usize = 0,
+    next_tick_after: ?i64 = null,
 };
 
 fn writeDaemonTickText(
@@ -1782,12 +1990,15 @@ fn writeDaemonTickText(
     cfg: config.Config,
     evaluations: []const RouteEvaluation,
     selected_index: ?usize,
+    executions: []const DaemonTickExecution,
     args: cli.Command.DaemonTickArgs,
+    observed_at: i64,
 ) !void {
     try writer.writeAll("oauth-mux daemon tick\n\n");
     try writer.print("  mode: {s}\n", .{if (args.once) "once" else "loop"});
-    try writer.writeAll("  executed: no\n");
-    try writer.writeAll("  boundary: planning only; no probes or repair commands executed\n");
+    try writer.print("  execution_mode: {s}\n", .{if (args.execute) "execute" else "plan"});
+    try writer.print("  executed: {s}\n", .{if (daemonTickExecutionsRan(executions)) "yes" else "no"});
+    try writer.print("  boundary: {s}\n", .{daemonTickMessage(args)});
     if (args.profile) |profile_name| try writer.print("  profile: {s}\n", .{profile_name});
     if (args.capability) |capability| try writer.print("  capability: {s}\n", .{capability});
     if (selected_index) |idx| {
@@ -1806,7 +2017,7 @@ fn writeDaemonTickText(
 
     try writer.writeAll("\n  routes:\n");
     for (evaluations) |evaluation| {
-        const decision = daemonTickDecision(cfg.policy.daemon, evaluation);
+        const decision = daemonTickDecision(cfg.policy.daemon, evaluation, observed_at);
         try writer.print("    {s}:{s}", .{ evaluation.route.provider, evaluation.route.account });
         if (evaluation.route.capability) |capability| try writer.print("#{s}", .{capability});
         try writer.print(" selectable={s} runtime={s} tick={s} admitted={s} reason={s}", .{
@@ -1823,6 +2034,23 @@ fn writeDaemonTickText(
         }
         try writer.writeByte('\n');
     }
+
+    if (executions.len != 0) {
+        try writer.writeAll("\n  executions:\n");
+        for (executions) |execution| {
+            try writer.print("    {s}:{s}", .{ execution.route.provider, execution.route.account });
+            if (execution.route.capability) |capability| try writer.print("#{s}", .{capability});
+            try writer.print(" phase={s} action={s} executed={s} ok={s} reason={s}", .{
+                execution.phase,
+                execution.action,
+                if (execution.executed) "true" else "false",
+                if (execution.ok) "true" else "false",
+                execution.reason,
+            });
+            if (execution.handoff) try writer.writeAll(" handoff=true");
+            try writer.writeByte('\n');
+        }
+    }
 }
 
 fn writeDaemonTickJsonObject(
@@ -1831,12 +2059,13 @@ fn writeDaemonTickJsonObject(
     cfg: config.Config,
     evaluations: []const RouteEvaluation,
     selected_index: ?usize,
+    executions: []const DaemonTickExecution,
     args: cli.Command.DaemonTickArgs,
     tick_index: u32,
     observed_at: i64,
     include_version: bool,
 ) !void {
-    const stats = daemonTickStats(cfg.policy.daemon, evaluations);
+    const stats = daemonTickStats(cfg.policy.daemon, evaluations, observed_at);
 
     try writer.writeByte('{');
     if (include_version) {
@@ -1850,8 +2079,14 @@ fn writeDaemonTickJsonObject(
     try writer.print("{d}", .{observed_at});
     try writer.writeAll(",\"mode\":");
     try std.json.stringify(if (args.once) "once" else "loop", .{}, writer);
-    try writer.writeAll(",\"executed\":false");
-    try writer.writeAll(",\"message\":\"planning only; no probes or repair commands executed\"");
+    try writer.writeAll(",\"execution_mode\":");
+    try std.json.stringify(if (args.execute) "execute" else "plan", .{}, writer);
+    try writer.writeAll(",\"executed\":");
+    try writer.writeAll(if (daemonTickExecutionsRan(executions)) "true" else "false");
+    try writer.writeAll(",\"handoff_queued\":");
+    try writer.writeAll(if (daemonTickHandoffQueued(executions)) "true" else "false");
+    try writer.writeAll(",\"message\":");
+    try std.json.stringify(daemonTickMessage(args), .{}, writer);
     try writer.writeAll(",\"policy\":");
     try writePolicyJson(writer, cfg.policy);
     try writer.writeAll(",\"profile\":");
@@ -1868,6 +2103,8 @@ fn writeDaemonTickJsonObject(
     }
     try writer.writeAll(",\"summary\":");
     try writeDaemonTickStatsJson(writer, stats);
+    try writer.writeAll(",\"executions\":");
+    try writeDaemonTickExecutionsJson(writer, allocator, executions);
     try writer.writeAll(",\"routes\":[");
     for (evaluations, 0..) |evaluation, idx| {
         if (idx > 0) try writer.writeByte(',');
@@ -1876,7 +2113,7 @@ fn writeDaemonTickJsonObject(
         try writer.writeAll("\"route\":");
         try writeRouteEvaluationJson(writer, allocator, cfg, evaluation, selected);
         try writer.writeAll(",\"tick\":");
-        try writeDaemonTickDecisionJson(writer, daemonTickDecision(cfg.policy.daemon, evaluation));
+        try writeDaemonTickDecisionJson(writer, daemonTickDecision(cfg.policy.daemon, evaluation, observed_at));
         try writer.writeByte('}');
     }
     try writer.writeAll("]}");
@@ -1884,7 +2121,7 @@ fn writeDaemonTickJsonObject(
 
 fn writeDaemonTickStatsJson(writer: anytype, stats: DaemonTickStats) !void {
     try writer.print(
-        "{{\"routes\":{d},\"selectable\":{d},\"admitted_probes\":{d},\"blocked_probes\":{d},\"admitted_repairs\":{d},\"blocked_repairs\":{d},\"no_action\":{d}}}",
+        "{{\"routes\":{d},\"selectable\":{d},\"admitted_probes\":{d},\"blocked_probes\":{d},\"admitted_repairs\":{d},\"blocked_repairs\":{d},\"no_action\":{d},\"next_tick_after\":",
         .{
             stats.routes,
             stats.selectable,
@@ -1895,6 +2132,69 @@ fn writeDaemonTickStatsJson(writer: anytype, stats: DaemonTickStats) !void {
             stats.no_action,
         },
     );
+    if (stats.next_tick_after) |next| {
+        try writer.print("{d}", .{next});
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeByte('}');
+}
+
+fn writeDaemonTickExecutionsJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    executions: []const DaemonTickExecution,
+) !void {
+    try writer.writeByte('[');
+    for (executions, 0..) |execution, idx| {
+        if (idx > 0) try writer.writeByte(',');
+        try writer.writeByte('{');
+        try writer.writeAll("\"provider\":");
+        try std.json.stringify(execution.route.provider, .{}, writer);
+        try writer.writeAll(",\"account\":");
+        try std.json.stringify(execution.route.account, .{}, writer);
+        try writer.writeAll(",\"capability\":");
+        if (execution.route.capability) |capability| try std.json.stringify(capability, .{}, writer) else try writer.writeAll("null");
+        try writer.writeAll(",\"phase\":");
+        try std.json.stringify(execution.phase, .{}, writer);
+        try writer.writeAll(",\"action\":");
+        try std.json.stringify(execution.action, .{}, writer);
+        try writer.writeAll(",\"admitted\":");
+        try writer.writeAll(if (execution.admitted) "true" else "false");
+        try writer.writeAll(",\"executed\":");
+        try writer.writeAll(if (execution.executed) "true" else "false");
+        try writer.writeAll(",\"ok\":");
+        try writer.writeAll(if (execution.ok) "true" else "false");
+        try writer.writeAll(",\"handoff\":");
+        try writer.writeAll(if (execution.handoff) "true" else "false");
+        try writer.writeAll(",\"reason\":");
+        try std.json.stringify(execution.reason, .{}, writer);
+        try writer.writeAll(",\"budget\":");
+        if (execution.budget) |budget| try std.json.stringify(@tagName(budget), .{}, writer) else try writer.writeAll("null");
+        try writer.writeAll(",\"command\":");
+        if (try repairCommandAlloc(allocator, execution.command, execution.route)) |command| {
+            defer allocator.free(command);
+            try std.json.stringify(command, .{}, writer);
+        } else {
+            try writer.writeAll("null");
+        }
+        try writer.writeByte('}');
+    }
+    try writer.writeByte(']');
+}
+
+fn daemonTickExecutionsRan(executions: []const DaemonTickExecution) bool {
+    for (executions) |execution| {
+        if (execution.executed) return true;
+    }
+    return false;
+}
+
+fn daemonTickHandoffQueued(executions: []const DaemonTickExecution) bool {
+    for (executions) |execution| {
+        if (execution.handoff) return true;
+    }
+    return false;
 }
 
 fn writeDaemonTickDecisionJson(writer: anytype, decision: DaemonTickDecision) !void {
@@ -1911,14 +2211,18 @@ fn writeDaemonTickDecisionJson(writer: anytype, decision: DaemonTickDecision) !v
     if (decision.budget) |budget| try std.json.stringify(@tagName(budget), .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"executed\":");
     try writer.writeAll(if (decision.executed) "true" else "false");
+    try writer.writeAll(",\"handoff\":");
+    try writer.writeAll(if (decision.handoff) "true" else "false");
+    try writer.writeAll(",\"next_tick_after\":");
+    if (decision.next_tick_after) |next| try writer.print("{d}", .{next}) else try writer.writeAll("null");
     try writer.writeByte('}');
 }
 
-fn daemonTickStats(policy: config.DaemonPolicyConfig, evaluations: []const RouteEvaluation) DaemonTickStats {
+fn daemonTickStats(policy: config.DaemonPolicyConfig, evaluations: []const RouteEvaluation, observed_at: i64) DaemonTickStats {
     var stats = DaemonTickStats{ .routes = evaluations.len };
     for (evaluations) |evaluation| {
         if (evaluation.selectable) stats.selectable += 1;
-        const decision = daemonTickDecision(policy, evaluation);
+        const decision = daemonTickDecision(policy, evaluation, observed_at);
         if (std.mem.eql(u8, decision.phase, "probe")) {
             if (decision.admitted) stats.admitted_probes += 1 else stats.blocked_probes += 1;
         } else if (std.mem.eql(u8, decision.phase, "repair")) {
@@ -1926,11 +2230,14 @@ fn daemonTickStats(policy: config.DaemonPolicyConfig, evaluations: []const Route
         } else if (std.mem.eql(u8, decision.phase, "none") or std.mem.eql(u8, decision.phase, "observe")) {
             stats.no_action += 1;
         }
+        if (decision.next_tick_after) |next| {
+            if (stats.next_tick_after == null or next < stats.next_tick_after.?) stats.next_tick_after = next;
+        }
     }
     return stats;
 }
 
-fn daemonTickDecision(policy: config.DaemonPolicyConfig, evaluation: RouteEvaluation) DaemonTickDecision {
+fn daemonTickDecision(policy: config.DaemonPolicyConfig, evaluation: RouteEvaluation, observed_at: i64) DaemonTickDecision {
     if (evaluation.selectable) {
         return .{
             .phase = "none",
@@ -1948,6 +2255,7 @@ fn daemonTickDecision(policy: config.DaemonPolicyConfig, evaluation: RouteEvalua
             .admitted = admission.admitted,
             .reason = admission.reason,
             .budget = admission.budget,
+            .next_tick_after = daemonTickNextAfter(evaluation.action, observed_at),
         };
     }
 
@@ -1959,6 +2267,8 @@ fn daemonTickDecision(policy: config.DaemonPolicyConfig, evaluation: RouteEvalua
             .admitted = admission.admitted,
             .reason = admission.reason,
             .budget = admission.budget,
+            .handoff = evaluation.action.interactive,
+            .next_tick_after = daemonTickNextAfter(evaluation.action, observed_at),
         };
     }
 
@@ -1969,7 +2279,17 @@ fn daemonTickDecision(policy: config.DaemonPolicyConfig, evaluation: RouteEvalua
         .admitted = admission.admitted,
         .reason = if (admission.admitted) "observe_only" else admission.reason,
         .budget = admission.budget,
+        .next_tick_after = daemonTickNextAfter(evaluation.action, observed_at),
     };
+}
+
+fn daemonTickNextAfter(action: RepairAction, observed_at: i64) ?i64 {
+    if (action.retry_after_s) |retry_after| return observed_at + @as(i64, retry_after);
+    if (action.wait_until) |wait_until| return wait_until;
+    if (std.mem.eql(u8, action.kind, "wait_for_repair")) return observed_at + 30;
+    if (std.mem.eql(u8, action.kind, "probe_needed")) return observed_at;
+    if (std.mem.eql(u8, action.kind, "reauth")) return observed_at;
+    return null;
 }
 
 const DoctorStats = struct {
@@ -6009,13 +6329,14 @@ test "daemon tick refuses spend provider probe by default" {
         },
         .selectable = false,
         .skip_reason = "unrecorded",
-    });
+    }, 1000);
 
     try std.testing.expectEqualStrings("probe", decision.phase);
     try std.testing.expect(!decision.admitted);
     try std.testing.expectEqualStrings("budget_not_allowed", decision.reason);
     try std.testing.expectEqual(types.ActionBudget.spend_provider, decision.budget.?);
     try std.testing.expect(!decision.executed);
+    try std.testing.expectEqual(@as(?i64, 1000), decision.next_tick_after);
 }
 
 test "daemon tick reports selectable route as no-op" {
@@ -6034,12 +6355,13 @@ test "daemon tick reports selectable route as no-op" {
         },
         .selectable = true,
         .skip_reason = "available",
-    });
+    }, 1000);
 
     try std.testing.expectEqualStrings("none", decision.phase);
     try std.testing.expect(decision.admitted);
     try std.testing.expectEqualStrings("route_selectable", decision.reason);
     try std.testing.expect(!decision.executed);
+    try std.testing.expect(decision.next_tick_after == null);
 }
 
 test "repairActionFor classifies quota exhaustion as wait action" {

--- a/src/repair_state.zig
+++ b/src/repair_state.zig
@@ -10,6 +10,7 @@ pub const RepairEvent = struct {
     account: ?[]const u8 = null,
     capability: ?[]const u8 = null,
     action: ?[]const u8 = null,
+    command: ?[]const u8 = null,
     writeback_capability: ?[]const u8 = null,
     automatic_refresh_admitted: ?bool = null,
     outcome: []const u8,
@@ -243,6 +244,8 @@ fn writeEventJson(writer: anytype, event: RepairEvent) !void {
     if (event.capability) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"action\":");
     if (event.action) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"command\":");
+    if (event.command) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"writeback_capability\":");
     if (event.writeback_capability) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"automatic_refresh_admitted\":");
@@ -299,6 +302,7 @@ test "repair event json is redacted and structured" {
         .account = "max-1",
         .capability = "codex-max",
         .action = "reauth",
+        .command = "oauth-mux codex login-device max-1",
         .outcome = "confirmation_required",
         .reason = "missing_session",
         .ok = false,
@@ -309,6 +313,7 @@ test "repair event json is redacted and structured" {
 
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"provider\":\"codex\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"kind\":\"repair_run\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"command\":\"oauth-mux codex login-device max-1\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"profile\":\"codex-max\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"account\":\"max-1\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "token") == null);


### PR DESCRIPTION
## Summary

- Add `oauth-mux daemon tick --execute` as the beta execution boundary.
- Execute at most one admitted non-interactive daemon action per tick, currently including admitted command-backed probes.
- Re-read route state after an executed probe so tick output reflects the new liveness evidence.
- Queue interactive reauth as a redacted `daemon_handoff` event instead of running upstream CLI auth silently.
- Add `execution_mode`, `executions`, `handoff_queued`, and `next_tick_after` scheduling hints to daemon tick JSON.
- Document the new boundary across README, onboarding, adoption, daemon boundary, and stay-afloat spec docs.

## Why

Stay-afloat had a real gap: we could plan around runtime/liveness state, but the daemon-shaped loop could not refresh local route evidence or hand a user a concrete reauth action. This keeps the default no-spend behavior intact while creating an explicit, portable foreground execution step that agents and wrappers can dogfood safely.

## Dogfood Evidence

- `OMUX_CONFIG=$PWD/examples/codex-max.config.json ./zig-out/bin/oauth-mux daemon tick --once --execute --profile codex-max --capability codex-max --json`
  - stayed afloat via `codex:max-2#codex-max`
  - did not execute because a selectable route already existed
  - reported `next_tick_after=1777987200` for the quota-exhausted `max-1` route
- `OMUX_CONFIG=$PWD/examples/codex-max.config.json ./zig-out/bin/oauth-mux route select --profile codex-max --capability codex-max --json`
  - selected `codex:max-2#codex-max`

## Validation

- `nix develop --command zig fmt src/main.zig src/cli.zig src/repair_state.zig`
- `nix develop --command just check-local`
- `./scripts/e2e-local.sh` via check-local covers:
  - planning-only daemon tick remains non-mutating
  - bounded loop remains planning-only by default
  - `daemon tick --execute` runs one admitted `free_command` probe
  - execute mode queues interactive Codex reauth as a redacted handoff event
