### PR TITLE
[codex] Add daemon handoff listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,12 @@ that policy. By default it is planning-only and reports `executed:false`.
 runs at most one admitted non-interactive action per tick, such as a
 `free_command` probe, then re-reads route state. Interactive reauth is never
 run silently; execute mode records a redacted `daemon_handoff` event with the
-user command to run. `daemon tick --loop --iterations <n> --interval-ms <ms>
---json` repeats the same portable foreground tick for dogfood and wrappers. No
-`systemctl`, `launchctl`, service manager, browser auth, provider spend, or
-secret mutation is assumed unless policy and CLI flags explicitly admit it.
+user command to run. Inspect those queued user-mediated repairs with
+`oauth-mux daemon handoffs --json`. `daemon tick --loop --iterations <n>
+--interval-ms <ms> --json` repeats the same portable foreground tick for
+dogfood and wrappers. No `systemctl`, `launchctl`, service manager, browser
+auth, provider spend, or secret mutation is assumed unless policy and CLI flags
+explicitly admit it.
 
 Secret read and writeback are also separate. Route and runtime JSON expose a
 `writeback` object with the secret backend capability and whether automatic

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -43,6 +43,9 @@ See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
   reads local state and does not require a daemon process. The same stream also
   carries redacted `token_refresh` events for refresh admission/writeback
   outcomes.
+- `oauth-mux daemon handoffs --json` for the filtered queue of user-mediated
+  daemon handoffs, such as upstream CLI login commands that must not run
+  silently in the background.
 - `oauth-mux daemon tick --once --json` for one portable, policy-gated
   daemon-shaped planning pass. Without `--execute`, it reports
   `executed:false` and does not run probes, repair commands, or mutation.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -192,7 +192,11 @@ recorded route state without requiring a service manager. Provider-spending
 probes, interactive browser/device auth, and credential mutation remain refused
 unless policy explicitly admits them. Interactive reauth is not run in the
 background; execute mode records a redacted `daemon_handoff` event with the
-reviewable user command.
+reviewable user command. Agents and users can list those pending handoffs with:
+
+```bash
+oauth-mux daemon handoffs --json
+```
 
 For a bounded foreground loop, use:
 

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -484,6 +484,11 @@ probes require explicit policy, and interactive reauth becomes a redacted
 Tick JSON now includes `execution_mode`, `executions`, `handoff_queued`, and
 `next_tick_after` scheduling hints.
 
+Implementation note, 2026-04-30: `oauth-mux daemon handoffs --json` now exposes
+the filtered handoff queue from the same redacted local event stream. This gives
+users, wrappers, and agents a stable way to discover pending user-mediated
+repairs without scraping the full audit log.
+
 Implementation note, 2026-04-30: bounded foreground loop mode now exists through
 `oauth-mux daemon tick --loop --iterations <n> --interval-ms <ms> --json`. This
 keeps the daemon beta portable and wrapper-friendly: no system service manager

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -365,6 +365,13 @@ expect_contains "$daemon_handoff" '"admitted":false' "daemon handoff preserves d
 expect_contains "$daemon_handoff" '"command":"oauth-mux codex login-device max-1"' "daemon handoff reports upstream login command"
 test ! -e "$tmp/reauth-home/auth.json"
 
+printf 'e2e: daemon handoffs exposes queued user-mediated repair actions\n'
+daemon_handoffs="$(OMUX_STATE_DIR="$state_dir" "$bin" daemon handoffs --json)"
+expect_contains "$daemon_handoffs" '"handoffs":[' "daemon handoffs returns json handoff list"
+expect_contains "$daemon_handoffs" '"kind":"daemon_handoff"' "daemon handoffs includes handoff events"
+expect_contains "$daemon_handoffs" '"outcome":"handoff_queued"' "daemon handoffs includes queued outcome"
+expect_contains "$daemon_handoffs" '"command":"oauth-mux codex login-device max-1"' "daemon handoffs includes upstream command"
+
 repair_reauth_confirmed_json="$tmp/repair-run-reauth-confirmed.json"
 set +e
 OMUX_CONFIG="$reauth_config" \

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -26,6 +26,7 @@ pub const Command = union(enum) {
     daemon_stop,
     daemon_status: DaemonStatusArgs,
     daemon_events: DaemonEventsArgs,
+    daemon_handoffs: DaemonEventsArgs,
     daemon_tick: DaemonTickArgs,
     version_cmd,
     help,
@@ -221,6 +222,7 @@ pub fn parse(args: []const []const u8) Command {
             if (eql(rest[0], "stop")) return .daemon_stop;
             if (eql(rest[0], "status")) return parseDaemonStatus(rest[1..]);
             if (eql(rest[0], "events")) return parseDaemonEvents(rest[1..]);
+            if (eql(rest[0], "handoffs")) return parseDaemonHandoffs(rest[1..]);
             if (eql(rest[0], "tick")) return parseDaemonTick(rest[1..]);
         }
         return .{ .daemon_status = .{} };
@@ -501,6 +503,22 @@ fn parseDaemonEvents(args: []const []const u8) Command {
     return .{ .daemon_events = result };
 }
 
+fn parseDaemonHandoffs(args: []const []const u8) Command {
+    var result = Command.DaemonEventsArgs{};
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        if (eql(args[i], "--json")) {
+            result.json = true;
+        } else if (eql(args[i], "--limit")) {
+            i += 1;
+            if (i < args.len) {
+                result.limit = std.fmt.parseInt(usize, args[i], 10) catch result.limit;
+            }
+        }
+    }
+    return .{ .daemon_handoffs = result };
+}
+
 fn parseDaemonTick(args: []const []const u8) Command {
     var result = Command.DaemonTickArgs{};
     var i: usize = 0;
@@ -723,6 +741,9 @@ pub fn printUsage(writer: anytype) !void {
         \\
         \\  daemon events [--json] [--limit <n>]
         \\      Show recent redacted repair events.
+        \\
+        \\  daemon handoffs [--json] [--limit <n>]
+        \\      Show queued user-mediated daemon handoffs.
         \\
         \\  daemon tick [--once|--loop] [--execute] [--iterations <n>] [--interval-ms <ms>] [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
         \\      Plan daemon ticks; --execute runs at most one admitted non-interactive action per tick.
@@ -1137,6 +1158,18 @@ test "parse daemon events json limit" {
     }
 }
 
+test "parse daemon handoffs json limit" {
+    const args = [_][]const u8{ "daemon", "handoffs", "--json", "--limit", "3" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .daemon_handoffs => |events| {
+            try std.testing.expect(events.json);
+            try std.testing.expectEqual(@as(usize, 3), events.limit);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 test "parse daemon tick once json selector" {
     const args = [_][]const u8{ "daemon", "tick", "--once", "--profile", "codex-max", "--capability", "codex-max", "--json" };
     const cmd = parse(&args);
@@ -1227,7 +1260,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary live-qa probe-all config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run start stop status events tick' -d 'Daemon subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run start stop status events handoffs tick' -d 'Daemon subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l limit -d 'Limit event count' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l once -d 'Run one planning tick'

--- a/src/main.zig
+++ b/src/main.zig
@@ -162,6 +162,9 @@ pub fn main() !void {
         .daemon_events => |events_args| {
             try repair_state.writeEvents(allocator, stdout, events_args.json, events_args.limit);
         },
+        .daemon_handoffs => |events_args| {
+            try repair_state.writeHandoffs(allocator, stdout, events_args.json, events_args.limit);
+        },
         .daemon_tick => |tick_args| {
             runDaemonTick(allocator, stdout, tick_args) catch |e| {
                 log.err("daemon tick: {s}", .{@errorName(e)});

--- a/src/repair_state.zig
+++ b/src/repair_state.zig
@@ -51,15 +51,31 @@ pub fn appendEvent(allocator: std.mem.Allocator, event: RepairEvent) !void {
 }
 
 pub fn writeEvents(allocator: std.mem.Allocator, writer: anytype, json: bool, limit: usize) !void {
+    try writeEventView(allocator, writer, json, limit, "events", null, "no repair events recorded");
+}
+
+pub fn writeHandoffs(allocator: std.mem.Allocator, writer: anytype, json: bool, limit: usize) !void {
+    try writeEventView(allocator, writer, json, limit, "handoffs", "daemon_handoff", "no daemon handoffs recorded");
+}
+
+fn writeEventView(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    json: bool,
+    limit: usize,
+    root_key: []const u8,
+    filter_kind: ?[]const u8,
+    empty_text: []const u8,
+) !void {
     const path = try eventsPath(allocator);
     defer allocator.free(path);
 
     const file = std.fs.openFileAbsolute(path, .{}) catch |e| switch (e) {
         error.FileNotFound => {
             if (json) {
-                try writer.writeAll("{\"events\":[]}\n");
+                try writeEmptyJsonView(writer, root_key);
             } else {
-                try writer.writeAll("no repair events recorded\n");
+                try writer.print("{s}\n", .{empty_text});
             }
             return;
         },
@@ -70,26 +86,45 @@ pub fn writeEvents(allocator: std.mem.Allocator, writer: anytype, json: bool, li
     const bytes = try file.readToEndAlloc(allocator, 1024 * 1024);
     defer allocator.free(bytes);
 
-    if (!json) {
-        try writeLastTextLines(writer, bytes, limit);
-        return;
-    }
-
-    try writer.writeAll("{\"events\":[");
     var lines = std.ArrayList([]const u8).init(allocator);
     defer lines.deinit();
     var it = std.mem.splitScalar(u8, bytes, '\n');
     while (it.next()) |line| {
         const trimmed = std.mem.trim(u8, line, " \t\r");
-        if (trimmed.len != 0) try lines.append(trimmed);
+        if (trimmed.len != 0 and eventLineMatchesKind(trimmed, filter_kind)) try lines.append(trimmed);
+    }
+
+    if (lines.items.len == 0 and !json) {
+        try writer.print("{s}\n", .{empty_text});
+        return;
     }
 
     const start = if (limit != 0 and lines.items.len > limit) lines.items.len - limit else 0;
+
+    if (!json) {
+        try writeTextLines(writer, lines.items[start..]);
+        return;
+    }
+
+    try writer.print("{{\"{s}\":[", .{root_key});
     for (lines.items[start..], 0..) |line, idx| {
         if (idx > 0) try writer.writeByte(',');
         try writer.writeAll(line);
     }
     try writer.writeAll("]}\n");
+}
+
+fn writeEmptyJsonView(writer: anytype, root_key: []const u8) !void {
+    try writer.print("{{\"{s}\":[]}}\n", .{root_key});
+}
+
+fn eventLineMatchesKind(line: []const u8, filter_kind: ?[]const u8) bool {
+    const kind = filter_kind orelse return true;
+    const marker = "\"kind\":\"";
+    const pos = std.mem.indexOf(u8, line, marker) orelse return false;
+    const value_start = pos + marker.len;
+    const value_end_delta = std.mem.indexOfScalar(u8, line[value_start..], '"') orelse return false;
+    return std.mem.eql(u8, line[value_start .. value_start + value_end_delta], kind);
 }
 
 pub fn acquireRepairLock(
@@ -265,24 +300,10 @@ fn writeEventJson(writer: anytype, event: RepairEvent) !void {
     try writer.writeByte('}');
 }
 
-fn writeLastTextLines(writer: anytype, bytes: []const u8, limit: usize) !void {
-    var count: usize = 0;
-    var it_count = std.mem.splitScalar(u8, bytes, '\n');
-    while (it_count.next()) |line| {
-        if (std.mem.trim(u8, line, " \t\r").len != 0) count += 1;
-    }
-
-    const skip = if (limit != 0 and count > limit) count - limit else 0;
-    var seen: usize = 0;
-    var it = std.mem.splitScalar(u8, bytes, '\n');
-    while (it.next()) |line| {
-        const trimmed = std.mem.trim(u8, line, " \t\r");
-        if (trimmed.len == 0) continue;
-        if (seen >= skip) {
-            try writer.writeAll(trimmed);
-            try writer.writeByte('\n');
-        }
-        seen += 1;
+fn writeTextLines(writer: anytype, lines: []const []const u8) !void {
+    for (lines) |line| {
+        try writer.writeAll(line);
+        try writer.writeByte('\n');
     }
 }
 
@@ -317,6 +338,13 @@ test "repair event json is redacted and structured" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"profile\":\"codex-max\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"account\":\"max-1\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "token") == null);
+}
+
+test "event kind filtering keeps daemon handoffs only" {
+    try std.testing.expect(eventLineMatchesKind("{\"kind\":\"daemon_handoff\"}", "daemon_handoff"));
+    try std.testing.expect(!eventLineMatchesKind("{\"kind\":\"repair_run\"}", "daemon_handoff"));
+    try std.testing.expect(!eventLineMatchesKind("{\"kind\":\"repair_run\",\"reason\":\"daemon_handoff\"}", "daemon_handoff"));
+    try std.testing.expect(eventLineMatchesKind("{\"kind\":\"repair_run\"}", null));
 }
 
 test "refresh event json carries redacted writeback evidence" {


### PR DESCRIPTION
## Summary
- add `oauth-mux daemon handoffs [--json] [--limit <n>]` as a filtered view of queued user-mediated daemon handoffs
- reuse the redacted repair event stream instead of adding new state
- document the handoff queue and cover it in local e2e dogfood

## Why
Daemon tick execution can now queue interactive reauth handoffs, but users and agents needed a first-class way to discover those pending actions without scraping the full audit log.

## Validation
- `nix develop --command just check-local`
- `git diff --check`
- empty-state smoke: `OMUX_STATE_DIR=... ./zig-out/bin/oauth-mux daemon handoffs --json` -> `{"handoffs":[]}`