### PR TITLE
[codex] Track pending daemon handoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,12 @@ runs at most one admitted non-interactive action per tick, such as a
 `free_command` probe, then re-reads route state. Interactive reauth is never
 run silently; execute mode records a redacted `daemon_handoff` event with the
 user command to run. Inspect those queued user-mediated repairs with
-`oauth-mux daemon handoffs --json`. `daemon tick --loop --iterations <n>
---interval-ms <ms> --json` repeats the same portable foreground tick for
-dogfood and wrappers. No `systemctl`, `launchctl`, service manager, browser
-auth, provider spend, or secret mutation is assumed unless policy and CLI flags
-explicitly admit it.
+`oauth-mux daemon handoffs --json`; add `--all` to include historical handoff
+events after a later daemon tick has refreshed route evidence. `daemon tick
+--loop --iterations <n> --interval-ms <ms> --json` repeats the same portable
+foreground tick for dogfood and wrappers. No `systemctl`, `launchctl`, service
+manager, browser auth, provider spend, or secret mutation is assumed unless
+policy and CLI flags explicitly admit it.
 
 Secret read and writeback are also separate. Route and runtime JSON expose a
 `writeback` object with the secret backend capability and whether automatic

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -43,9 +43,10 @@ See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
   reads local state and does not require a daemon process. The same stream also
   carries redacted `token_refresh` events for refresh admission/writeback
   outcomes.
-- `oauth-mux daemon handoffs --json` for the filtered queue of user-mediated
-  daemon handoffs, such as upstream CLI login commands that must not run
-  silently in the background.
+- `oauth-mux daemon handoffs --json` for the filtered pending queue of
+  user-mediated daemon handoffs, such as upstream CLI login commands that must
+  not run silently in the background. `--all` keeps the historical handoff
+  events visible after later route evidence clears a pending prompt.
 - `oauth-mux daemon tick --once --json` for one portable, policy-gated
   daemon-shaped planning pass. Without `--execute`, it reports
   `executed:false` and does not run probes, repair commands, or mutation.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -198,6 +198,12 @@ reviewable user command. Agents and users can list those pending handoffs with:
 oauth-mux daemon handoffs --json
 ```
 
+The default handoff view is pending as of the daemon's last route evidence. Use
+`oauth-mux daemon handoffs --json --all` when you need the historical audit
+trail instead. After a user completes an upstream CLI login, another
+`daemon tick --once --execute ... --json` can refresh route evidence and clear
+the pending prompt.
+
 For a bounded foreground loop, use:
 
 ```bash

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -485,9 +485,11 @@ Tick JSON now includes `execution_mode`, `executions`, `handoff_queued`, and
 `next_tick_after` scheduling hints.
 
 Implementation note, 2026-04-30: `oauth-mux daemon handoffs --json` now exposes
-the filtered handoff queue from the same redacted local event stream. This gives
-users, wrappers, and agents a stable way to discover pending user-mediated
-repairs without scraping the full audit log.
+the filtered pending handoff queue from the same redacted local event stream.
+Later route-selectable or successful execution events clear matching pending
+handoffs; `--all` keeps the historical handoff events visible for audit. This
+gives users, wrappers, and agents a stable way to discover user-mediated repairs
+without scraping the full audit log.
 
 Implementation note, 2026-04-30: bounded foreground loop mode now exists through
 `oauth-mux daemon tick --loop --iterations <n> --interval-ms <ms> --json`. This

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -19,6 +19,7 @@ config="$tmp/config.json"
 state_dir="$tmp/state"
 exec_out="$tmp/exec.out"
 probe_cmd="$tmp/probe-harness.sh"
+reauth_probe_cmd="$tmp/reauth-probe-harness.sh"
 
 mkdir -p "$state_dir" "$tmp/a1-home" "$tmp/a2-home"
 
@@ -49,6 +50,26 @@ case "${capability}:${OMUX_ACTIVE_ACCOUNT:-}" in
 esac
 EOF
 chmod 0755 "$probe_cmd"
+
+cat >"$reauth_probe_cmd" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+
+if [ "${OMUX_ACTIVE_PROVIDER:-}" = "codex" ] && [ "${OMUX_ACTIVE_ACCOUNT:-}" = "max-1" ]; then
+  printf 'ok provider=%s account=%s capability=%s\n' \
+    "${OMUX_ACTIVE_PROVIDER:-}" \
+    "${OMUX_ACTIVE_ACCOUNT:-}" \
+    "${OMUX_ACTIVE_CAPABILITY:-}"
+  exit 0
+fi
+
+printf 'unexpected reauth probe route: provider=%s account=%s capability=%s\n' \
+  "${OMUX_ACTIVE_PROVIDER:-}" \
+  "${OMUX_ACTIVE_ACCOUNT:-}" \
+  "${OMUX_ACTIVE_CAPABILITY:-}" >&2
+exit 1
+EOF
+chmod 0755 "$reauth_probe_cmd"
 
 cat >"$config" <<EOF
 {
@@ -310,7 +331,27 @@ cat >"$reauth_config" <<EOF
       "runtime": {
         "writable_paths": ["CODEX_HOME"],
         "session_paths": ["CODEX_HOME/auth.json"]
-      }
+      },
+      "capabilities": [
+        {
+          "name": "codex-max",
+          "probe": {
+            "transport": "command",
+            "auth": "none",
+            "timeout_ms": 5000,
+            "budget": "free_command",
+            "command": ["$reauth_probe_cmd"]
+          }
+        }
+      ],
+      "failure_rules": [
+        {
+          "status": 400,
+          "class": {
+            "degraded": "unknown_4xx"
+          }
+        }
+      ]
     }
   },
   "providers": {
@@ -388,6 +429,16 @@ repair_reauth_confirmed="$(cat "$repair_reauth_confirmed_json")"
 expect_contains "$repair_reauth_confirmed" '"error":"interactive_json_unsupported"' "repair run json refuses interactive execution"
 expect_contains "$repair_reauth_confirmed" '"executed":false' "repair run json does not execute interactive repair"
 test ! -e "$tmp/reauth-home/auth.json"
+
+printf 'e2e: daemon handoffs clears after route evidence refresh\n'
+printf '%s\n' '{"access_token":"reauth-e2e"}' >"$tmp/reauth-home/auth.json"
+daemon_repaired="$(OMUX_CONFIG="$reauth_config" OMUX_STATE_DIR="$state_dir" "$bin" daemon tick --once --execute --profile needs-reauth --capability codex-max --json)"
+expect_contains "$daemon_repaired" '"executed":true' "daemon repaired tick runs probe after user-mediated login"
+expect_contains "$daemon_repaired" '"phase":"probe"' "daemon repaired tick records probe phase"
+daemon_handoffs_cleared="$(OMUX_STATE_DIR="$state_dir" "$bin" daemon handoffs --json)"
+expect_contains "$daemon_handoffs_cleared" '"handoffs":[]' "daemon handoffs clears resolved handoff"
+daemon_handoffs_all="$(OMUX_STATE_DIR="$state_dir" "$bin" daemon handoffs --json --all)"
+expect_contains "$daemon_handoffs_all" '"kind":"daemon_handoff"' "daemon handoffs --all preserves historical handoff events"
 
 printf 'e2e: daemon events exposes redacted repair run audit trail\n'
 repair_events="$(OMUX_STATE_DIR="$state_dir" "$bin" daemon events --json)"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -26,7 +26,7 @@ pub const Command = union(enum) {
     daemon_stop,
     daemon_status: DaemonStatusArgs,
     daemon_events: DaemonEventsArgs,
-    daemon_handoffs: DaemonEventsArgs,
+    daemon_handoffs: DaemonHandoffsArgs,
     daemon_tick: DaemonTickArgs,
     version_cmd,
     help,
@@ -176,6 +176,12 @@ pub const Command = union(enum) {
     pub const DaemonEventsArgs = struct {
         json: bool = false,
         limit: usize = 50,
+    };
+
+    pub const DaemonHandoffsArgs = struct {
+        json: bool = false,
+        limit: usize = 50,
+        all: bool = false,
     };
 
     pub const DaemonTickArgs = struct {
@@ -504,11 +510,13 @@ fn parseDaemonEvents(args: []const []const u8) Command {
 }
 
 fn parseDaemonHandoffs(args: []const []const u8) Command {
-    var result = Command.DaemonEventsArgs{};
+    var result = Command.DaemonHandoffsArgs{};
     var i: usize = 0;
     while (i < args.len) : (i += 1) {
         if (eql(args[i], "--json")) {
             result.json = true;
+        } else if (eql(args[i], "--all")) {
+            result.all = true;
         } else if (eql(args[i], "--limit")) {
             i += 1;
             if (i < args.len) {
@@ -742,8 +750,8 @@ pub fn printUsage(writer: anytype) !void {
         \\  daemon events [--json] [--limit <n>]
         \\      Show recent redacted repair events.
         \\
-        \\  daemon handoffs [--json] [--limit <n>]
-        \\      Show queued user-mediated daemon handoffs.
+        \\  daemon handoffs [--json] [--limit <n>] [--all]
+        \\      Show pending user-mediated daemon handoffs; --all includes history.
         \\
         \\  daemon tick [--once|--loop] [--execute] [--iterations <n>] [--interval-ms <ms>] [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
         \\      Plan daemon ticks; --execute runs at most one admitted non-interactive action per tick.
@@ -1159,12 +1167,13 @@ test "parse daemon events json limit" {
 }
 
 test "parse daemon handoffs json limit" {
-    const args = [_][]const u8{ "daemon", "handoffs", "--json", "--limit", "3" };
+    const args = [_][]const u8{ "daemon", "handoffs", "--json", "--limit", "3", "--all" };
     const cmd = parse(&args);
     switch (cmd) {
         .daemon_handoffs => |events| {
             try std.testing.expect(events.json);
             try std.testing.expectEqual(@as(usize, 3), events.limit);
+            try std.testing.expect(events.all);
         },
         else => return error.Unexpected,
     }
@@ -1263,6 +1272,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run start stop status events handoffs tick' -d 'Daemon subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l limit -d 'Limit event count' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l all -d 'Include historical handoff events'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l once -d 'Run one planning tick'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l loop -d 'Run bounded foreground planning ticks'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l execute -d 'Execute one admitted non-interactive tick action'

--- a/src/main.zig
+++ b/src/main.zig
@@ -163,7 +163,7 @@ pub fn main() !void {
             try repair_state.writeEvents(allocator, stdout, events_args.json, events_args.limit);
         },
         .daemon_handoffs => |events_args| {
-            try repair_state.writeHandoffs(allocator, stdout, events_args.json, events_args.limit);
+            try repair_state.writeHandoffs(allocator, stdout, events_args.json, events_args.limit, events_args.all);
         },
         .daemon_tick => |tick_args| {
             runDaemonTick(allocator, stdout, tick_args) catch |e| {
@@ -1593,7 +1593,10 @@ fn executeDaemonTickActions(
     selected_index: ?usize,
     executions: *std.ArrayList(DaemonTickExecution),
 ) !bool {
-    if (selected_index != null) return false;
+    if (selected_index) |idx| {
+        recordDaemonActionEvent(allocator, args, evaluations[idx], .none, "none", "route_selectable", "route_selectable", true, false, false);
+        return false;
+    }
 
     for (evaluations) |evaluation| {
         const decision = daemonTickDecision(cfg.policy.daemon, evaluation, std.time.timestamp());

--- a/src/repair_state.zig
+++ b/src/repair_state.zig
@@ -54,8 +54,12 @@ pub fn writeEvents(allocator: std.mem.Allocator, writer: anytype, json: bool, li
     try writeEventView(allocator, writer, json, limit, "events", null, "no repair events recorded");
 }
 
-pub fn writeHandoffs(allocator: std.mem.Allocator, writer: anytype, json: bool, limit: usize) !void {
-    try writeEventView(allocator, writer, json, limit, "handoffs", "daemon_handoff", "no daemon handoffs recorded");
+pub fn writeHandoffs(allocator: std.mem.Allocator, writer: anytype, json: bool, limit: usize, all: bool) !void {
+    if (all) {
+        try writeEventView(allocator, writer, json, limit, "handoffs", "daemon_handoff", "no daemon handoffs recorded");
+        return;
+    }
+    try writePendingHandoffView(allocator, writer, json, limit);
 }
 
 fn writeEventView(
@@ -118,6 +122,63 @@ fn writeEmptyJsonView(writer: anytype, root_key: []const u8) !void {
     try writer.print("{{\"{s}\":[]}}\n", .{root_key});
 }
 
+fn writePendingHandoffView(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    json: bool,
+    limit: usize,
+) !void {
+    const path = try eventsPath(allocator);
+    defer allocator.free(path);
+
+    const file = std.fs.openFileAbsolute(path, .{}) catch |e| switch (e) {
+        error.FileNotFound => {
+            if (json) {
+                try writeEmptyJsonView(writer, "handoffs");
+            } else {
+                try writer.writeAll("no pending daemon handoffs recorded\n");
+            }
+            return;
+        },
+        else => return e,
+    };
+    defer file.close();
+
+    const bytes = try file.readToEndAlloc(allocator, 1024 * 1024);
+    defer allocator.free(bytes);
+
+    var pending = std.ArrayList([]const u8).init(allocator);
+    defer pending.deinit();
+    var it = std.mem.splitScalar(u8, bytes, '\n');
+    while (it.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (trimmed.len == 0) continue;
+        if (isQueuedHandoffEvent(trimmed)) {
+            try upsertPendingHandoff(&pending, trimmed);
+        } else {
+            removeResolvedHandoffs(&pending, trimmed);
+        }
+    }
+
+    if (pending.items.len == 0 and !json) {
+        try writer.writeAll("no pending daemon handoffs recorded\n");
+        return;
+    }
+
+    const start = if (limit != 0 and pending.items.len > limit) pending.items.len - limit else 0;
+    if (!json) {
+        try writeTextLines(writer, pending.items[start..]);
+        return;
+    }
+
+    try writer.writeAll("{\"handoffs\":[");
+    for (pending.items[start..], 0..) |line, idx| {
+        if (idx > 0) try writer.writeByte(',');
+        try writer.writeAll(line);
+    }
+    try writer.writeAll("]}\n");
+}
+
 fn eventLineMatchesKind(line: []const u8, filter_kind: ?[]const u8) bool {
     const kind = filter_kind orelse return true;
     const marker = "\"kind\":\"";
@@ -125,6 +186,101 @@ fn eventLineMatchesKind(line: []const u8, filter_kind: ?[]const u8) bool {
     const value_start = pos + marker.len;
     const value_end_delta = std.mem.indexOfScalar(u8, line[value_start..], '"') orelse return false;
     return std.mem.eql(u8, line[value_start .. value_start + value_end_delta], kind);
+}
+
+fn isQueuedHandoffEvent(line: []const u8) bool {
+    return eventLineMatchesKind(line, "daemon_handoff") and eventFieldEquals(line, "outcome", "handoff_queued");
+}
+
+fn upsertPendingHandoff(pending: *std.ArrayList([]const u8), line: []const u8) !void {
+    var idx: usize = 0;
+    while (idx < pending.items.len) {
+        if (eventRouteKeyMatches(pending.items[idx], line)) {
+            _ = pending.orderedRemove(idx);
+            continue;
+        }
+        idx += 1;
+    }
+    try pending.append(line);
+}
+
+fn removeResolvedHandoffs(pending: *std.ArrayList([]const u8), event_line: []const u8) void {
+    if (!eventResolvesHandoff(event_line)) return;
+    var idx: usize = 0;
+    while (idx < pending.items.len) {
+        if (eventRouteKeyMatches(pending.items[idx], event_line)) {
+            _ = pending.orderedRemove(idx);
+            continue;
+        }
+        idx += 1;
+    }
+}
+
+fn eventResolvesHandoff(line: []const u8) bool {
+    if (eventFieldEquals(line, "outcome", "route_selectable")) return true;
+    if (eventFieldBool(line, "ok") == true and eventFieldEquals(line, "outcome", "executed")) return true;
+    if (eventFieldBool(line, "ok") == true and eventFieldEquals(line, "outcome", "noop")) return true;
+    return false;
+}
+
+fn eventRouteKeyMatches(a: []const u8, b: []const u8) bool {
+    return eventOptionalFieldEquals(a, b, "profile") and
+        eventOptionalFieldEquals(a, b, "provider") and
+        eventOptionalFieldEquals(a, b, "account") and
+        eventOptionalFieldEquals(a, b, "capability");
+}
+
+fn eventOptionalFieldEquals(a: []const u8, b: []const u8, field: []const u8) bool {
+    const av = eventFieldString(a, field);
+    const bv = eventFieldString(b, field);
+    if (av == null and bv == null) return true;
+    if (av == null or bv == null) return false;
+    return std.mem.eql(u8, av.?, bv.?);
+}
+
+fn eventFieldEquals(line: []const u8, field: []const u8, expected: []const u8) bool {
+    const value = eventFieldString(line, field) orelse return false;
+    return std.mem.eql(u8, value, expected);
+}
+
+fn eventFieldBool(line: []const u8, field: []const u8) ?bool {
+    const start = eventFieldValueStart(line, field) orelse return null;
+    if (std.mem.startsWith(u8, line[start..], "true")) return true;
+    if (std.mem.startsWith(u8, line[start..], "false")) return false;
+    return null;
+}
+
+fn eventFieldString(line: []const u8, field: []const u8) ?[]const u8 {
+    var idx = eventFieldValueStart(line, field) orelse return null;
+    if (std.mem.startsWith(u8, line[idx..], "null")) return null;
+    if (idx >= line.len or line[idx] != '"') return null;
+    idx += 1;
+    const start = idx;
+    while (idx < line.len) : (idx += 1) {
+        if (line[idx] == '\\') {
+            idx += 1;
+            continue;
+        }
+        if (line[idx] == '"') return line[start..idx];
+    }
+    return null;
+}
+
+fn eventFieldValueStart(line: []const u8, field: []const u8) ?usize {
+    var search_start: usize = 0;
+    while (search_start < line.len) {
+        const quote_delta = std.mem.indexOfScalar(u8, line[search_start..], '"') orelse return null;
+        const key_start = search_start + quote_delta + 1;
+        if (key_start + field.len + 2 <= line.len and
+            std.mem.eql(u8, line[key_start .. key_start + field.len], field) and
+            line[key_start + field.len] == '"' and
+            line[key_start + field.len + 1] == ':')
+        {
+            return key_start + field.len + 2;
+        }
+        search_start = key_start;
+    }
+    return null;
 }
 
 pub fn acquireRepairLock(
@@ -345,6 +501,25 @@ test "event kind filtering keeps daemon handoffs only" {
     try std.testing.expect(!eventLineMatchesKind("{\"kind\":\"repair_run\"}", "daemon_handoff"));
     try std.testing.expect(!eventLineMatchesKind("{\"kind\":\"repair_run\",\"reason\":\"daemon_handoff\"}", "daemon_handoff"));
     try std.testing.expect(eventLineMatchesKind("{\"kind\":\"repair_run\"}", null));
+}
+
+test "pending handoff queue resolves by later route event" {
+    var pending = std.ArrayList([]const u8).init(std.testing.allocator);
+    defer pending.deinit();
+
+    const handoff =
+        "{\"kind\":\"daemon_handoff\",\"profile\":\"codex-max\",\"provider\":\"codex\",\"account\":\"max-1\",\"capability\":\"codex-max\",\"outcome\":\"handoff_queued\",\"ok\":false}";
+    const unrelated =
+        "{\"kind\":\"daemon_action\",\"profile\":\"codex-max\",\"provider\":\"codex\",\"account\":\"max-2\",\"capability\":\"codex-max\",\"outcome\":\"route_selectable\",\"ok\":true}";
+    const resolved =
+        "{\"kind\":\"daemon_action\",\"profile\":\"codex-max\",\"provider\":\"codex\",\"account\":\"max-1\",\"capability\":\"codex-max\",\"outcome\":\"route_selectable\",\"ok\":true}";
+
+    try upsertPendingHandoff(&pending, handoff);
+    try std.testing.expectEqual(@as(usize, 1), pending.items.len);
+    removeResolvedHandoffs(&pending, unrelated);
+    try std.testing.expectEqual(@as(usize, 1), pending.items.len);
+    removeResolvedHandoffs(&pending, resolved);
+    try std.testing.expectEqual(@as(usize, 0), pending.items.len);
 }
 
 test "refresh event json carries redacted writeback evidence" {


### PR DESCRIPTION
## Summary
- make `oauth-mux daemon handoffs` default to the pending handoff queue
- add `--all` for historical handoff audit events
- record route-selectable daemon evidence during execute ticks so completed user-mediated logins can clear stale prompts
- extend e2e coverage for queue, clear, and history behavior

## Why
PR #57 exposed handoff events, but the onboarding surface needs pending/resolved semantics so users and agents do not keep seeing stale login prompts after an account has recovered.

## Validation
- `nix develop --command just check-local`
- `git diff --check`
- empty-state smoke for `daemon handoffs --json` and `daemon handoffs --json --all`