### PR TITLE
[codex] Add stay-afloat command

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux route select --profile
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair-plan --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair run --profile codex-max --capability codex-max --json
-OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux daemon tick --once --profile codex-max --capability codex-max --json
-OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux daemon tick --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux stay-afloat --once --profile codex-max --capability codex-max --json
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux stay-afloat --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
 oauth-mux daemon events --json
 ```
 
@@ -136,16 +136,16 @@ only `free_local` and `free_command` work; `cheap_provider`, `spend_provider`,
 `interactive`, and `mutating` actions are reported as refused until the config
 explicitly allows them. `route explain --json` and `repair-plan --json` include
 the effective policy plus per-route admission decisions so agents can back off
-without guessing. `daemon tick --once --json` evaluates the same routes under
+without guessing. `stay-afloat --once --json` evaluates the same routes under
 that policy. By default it is planning-only and reports `executed:false`.
-`daemon tick --once --execute --json` is the opt-in beta execution boundary: it
+`stay-afloat --once --execute --json` is the opt-in beta execution boundary: it
 runs at most one admitted non-interactive action per tick, such as a
-`free_command` probe, then re-reads route state. Interactive reauth is never
-run silently; execute mode records a redacted `daemon_handoff` event with the
-user command to run. Inspect those queued user-mediated repairs with
-`oauth-mux daemon handoffs --json`; add `--all` to include historical handoff
-events after a later daemon tick has refreshed route evidence. `daemon tick
---loop --iterations <n> --interval-ms <ms> --json` repeats the same portable
+`free_command` probe, then re-reads route state. Interactive reauth is never run
+silently; execute mode records a redacted `daemon_handoff` event with the user
+command to run. Inspect those queued user-mediated repairs with `oauth-mux
+daemon handoffs --json`; add `--all` to include historical handoff events after
+a later stay-afloat tick has refreshed route evidence. `stay-afloat --loop
+--iterations <n> --interval-ms <ms> --json` repeats the same portable
 foreground tick for dogfood and wrappers. No `systemctl`, `launchctl`, service
 manager, browser auth, provider spend, or secret mutation is assumed unless
 policy and CLI flags explicitly admit it.

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -31,8 +31,8 @@ oauth-mux config validate
 oauth-mux discover --json
 oauth-mux doctor runtime --json
 oauth-mux route explain --profile <profile> --capability <capability> --json
-oauth-mux daemon tick --once --profile <profile> --capability <capability> --json
-oauth-mux daemon tick --loop --iterations 2 --interval-ms 0 --profile <profile> --capability <capability> --json
+oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json
+oauth-mux stay-afloat --loop --iterations 2 --interval-ms 0 --profile <profile> --capability <capability> --json
 ```
 
 Source checkouts prove this path without touching real operator state:
@@ -51,8 +51,8 @@ oauth-mux setup codex
 oauth-mux codex canary
 oauth-mux route explain --profile codex-max --capability codex-max --json
 oauth-mux route select --profile codex-max --capability codex-max --json
-oauth-mux daemon tick --once --profile codex-max --capability codex-max --json
-oauth-mux daemon tick --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
+oauth-mux stay-afloat --once --profile codex-max --capability codex-max --json
+oauth-mux stay-afloat --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
 ```
 
 Those commands are installed CLI surface, not source-checkout-only helpers.
@@ -68,11 +68,11 @@ oauth-mux codex live-qa --confirm-spend
 oauth-mux codex probe-all --capability codex-mini --json
 ```
 
-`doctor runtime`, `route explain`, `route select`, `daemon tick --once`, and
-bounded `daemon tick --loop` are no-spend surfaces when run without
+`doctor runtime`, `route explain`, `route select`, `stay-afloat --once`, and
+bounded `stay-afloat --loop` are no-spend surfaces when run without
 `--execute`. They only use local runtime checks plus recorded liveness, so they
 are safe for agents to run before deciding whether a live probe or user-driven
-reauth is warranted. `daemon tick --execute` is the beta foreground execution
+reauth is warranted. `stay-afloat --execute` is the beta foreground execution
 boundary: it can run one admitted non-interactive action or queue an interactive
 handoff event. Prefer scoped runtime checks such as
 `oauth-mux doctor runtime --profile codex-max --capability codex-max --json`
@@ -83,7 +83,7 @@ useful for support bundles and full-machine cleanup.
 also safe without confirmation. It will not open a browser, run `codex login`,
 or mutate credential stores unless the user supplies `--confirm-repair`.
 
-Route, runtime, repair-plan, and daemon tick JSON also report `writeback`. Use
+Route, runtime, repair-plan, and stay-afloat JSON also report `writeback`. Use
 that field when deciding whether a future repair loop can refresh in place:
 `replace_file` means the backend has a provider-neutral file write surface, but
 `automatic_refresh_admitted` can still be false when the provider owns repair

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -47,14 +47,15 @@ See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
   user-mediated daemon handoffs, such as upstream CLI login commands that must
   not run silently in the background. `--all` keeps the historical handoff
   events visible after later route evidence clears a pending prompt.
-- `oauth-mux daemon tick --once --json` for one portable, policy-gated
-  daemon-shaped planning pass. Without `--execute`, it reports
-  `executed:false` and does not run probes, repair commands, or mutation.
-- `oauth-mux daemon tick --once --execute --json` as the beta execution
+- `oauth-mux stay-afloat --once --json` for one portable, policy-gated
+  daemon-shaped planning pass. `oauth-mux daemon tick --once --json` is the
+  lower-level alias. Without `--execute`, it reports `executed:false` and does
+  not run probes, repair commands, or mutation.
+- `oauth-mux stay-afloat --once --execute --json` as the beta execution
   boundary. It runs at most one admitted non-interactive action per tick,
   re-reads route state afterward, and queues interactive reauth as a redacted
   `daemon_handoff` event instead of running it silently.
-- `oauth-mux daemon tick --loop --iterations <n> --interval-ms <ms> --json`
+- `oauth-mux stay-afloat --loop --iterations <n> --interval-ms <ms> --json`
   for a bounded foreground loop. It re-reads local health/runtime state each
   tick and remains service-manager agnostic.
 - Account-scoped advisory locks during confirmed `repair run`, reported back as
@@ -111,7 +112,7 @@ oauth-mux route select --profile <profile> --capability <capability> --json
 oauth-mux probe --profile <profile> --capability <capability> --json
 oauth-mux repair-plan --profile <profile> --capability <capability> --json
 oauth-mux repair run --profile <profile> --capability <capability> --json
-oauth-mux daemon tick --loop --iterations 2 --interval-ms 0 --profile <profile> --capability <capability> --json
+oauth-mux stay-afloat --loop --iterations 2 --interval-ms 0 --profile <profile> --capability <capability> --json
 oauth-mux daemon events --json
 oauth-mux exec --profile <profile> --capability <capability> -- <command>
 ```

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -175,7 +175,7 @@ are refused in the admission report unless `policy.daemon` explicitly allows
 them. `repair-plan --json` and `route explain --json` include both the effective
 policy and per-route `daemon_probe` / `daemon_repair` decisions.
 
-`oauth-mux daemon tick --once --json` is the portable daemon dogfood surface. It
+`oauth-mux stay-afloat --once --json` is the portable stay-afloat dogfood surface. It
 loads the same route/runtime/liveness state, applies the daemon policy, and
 prints what a future background loop would be allowed to do. Without
 `--execute` it remains planning-only and reports `executed:false`.
@@ -183,7 +183,7 @@ prints what a future background loop would be allowed to do. Without
 Opt-in beta execution is explicit:
 
 ```bash
-oauth-mux daemon tick --once --execute --profile codex-max --capability codex-max --json
+oauth-mux stay-afloat --once --execute --profile codex-max --capability codex-max --json
 ```
 
 Execute mode runs at most one admitted non-interactive action per tick. The
@@ -201,13 +201,13 @@ oauth-mux daemon handoffs --json
 The default handoff view is pending as of the daemon's last route evidence. Use
 `oauth-mux daemon handoffs --json --all` when you need the historical audit
 trail instead. After a user completes an upstream CLI login, another
-`daemon tick --once --execute ... --json` can refresh route evidence and clear
+`stay-afloat --once --execute ... --json` can refresh route evidence and clear
 the pending prompt.
 
 For a bounded foreground loop, use:
 
 ```bash
-oauth-mux daemon tick --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
+oauth-mux stay-afloat --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
 ```
 
 Loop mode emits one JSON envelope containing repeated tick snapshots. Each tick
@@ -215,7 +215,7 @@ re-reads local health and runtime state and does not require launchd, systemd,
 Homebrew services, cron, or a platform-specific
 daemon manager.
 
-Route, runtime, repair-plan, and daemon tick JSON include a `writeback` object.
+Route, runtime, repair-plan, and stay-afloat JSON include a `writeback` object.
 That object separates the secret backend surface (`readonly`, `replace_file`,
 `command_write`, `keychain_write`, `sops_write`, or `unsupported`) from whether
 automatic refresh writeback is admitted for this provider. This matters for

--- a/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
+++ b/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
@@ -38,7 +38,7 @@ OAuth and muxing surfaces:
 | Codex three-account stores | `max-1`, `max-2`, and `max-3` are isolated by `CODEX_HOME` and report logged-in ChatGPT status. |
 | Codex route liveness | Hosted and local installed-binary live canaries have proven all three accounts across `codex-mini` and `codex-max`. Earlier proof also preserved the distinction between quota exhaustion and auth death. |
 | Typed liveness | Unit and e2e tests cover `live`, `degraded`, `dead`, route-scoped `provider:account#capability`, and fallback decisions. |
-| Agent-safe discovery | `doctor --json`, `doctor runtime --json`, scoped `doctor runtime`, `report --redacted --json`, `providers list --json`, `discover --json`, `status --json`, `health --json`, `route explain --json`, `route select --json`, and `daemon tick --once --json` exist and are documented. |
+| Agent-safe discovery | `doctor --json`, `doctor runtime --json`, scoped `doctor runtime`, `report --redacted --json`, `providers list --json`, `discover --json`, `status --json`, `health --json`, `route explain --json`, `route select --json`, and `stay-afloat --once --json` exist and are documented. |
 | Non-mutating help | `oauth-mux codex canary --help`, `oauth-mux codex probe-all --help`, and `oauth-mux setup codex --help` print help without creating stores or probing. |
 
 ## Not Yet Proven

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -497,6 +497,11 @@ keeps the daemon beta portable and wrapper-friendly: no system service manager
 is assumed, each iteration re-reads local health/runtime state, and the default
 policy still refuses provider spend, interactive auth, and mutation.
 
+Implementation note, 2026-04-30: `oauth-mux stay-afloat` is now the
+operator-facing alias for the same portable tick engine. `daemon tick` remains
+available as the lower-level implementation surface, but docs and onboarding
+should lead with `stay-afloat --once` and `stay-afloat --loop`.
+
 ### M3: Refresh Writeback
 
 - Implement backend write capabilities.

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -288,6 +288,13 @@ expect_contains "$daemon_tick" '"selected":{"provider":"toy","account":"a2"' "da
 expect_contains "$daemon_tick" '"action":"wait_for_quota"' "daemon tick includes wait action for exhausted route"
 expect_contains "$daemon_tick" '"reason":"route_selectable"' "daemon tick marks selectable route as no-op"
 
+printf 'e2e: stay-afloat aliases daemon tick planning\n'
+stay_afloat="$(omux stay-afloat --once --profile expensive --capability expensive --json)"
+expect_contains "$stay_afloat" '"mode":"once"' "stay-afloat reports one-shot mode"
+expect_contains "$stay_afloat" '"executed":false' "stay-afloat remains planning-only by default"
+expect_contains "$stay_afloat" '"afloat":true' "stay-afloat reports profile afloat"
+expect_contains "$stay_afloat" '"selected":{"provider":"toy","account":"a2"' "stay-afloat selects fallback account a2"
+
 printf 'e2e: bounded daemon tick loop emits repeated planning snapshots\n'
 daemon_loop="$(omux daemon tick --loop --iterations 2 --interval-ms 0 --profile expensive --capability expensive --json)"
 expect_contains "$daemon_loop" '"mode":"loop"' "daemon tick loop reports loop mode"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -16,6 +16,7 @@ pub const Command = union(enum) {
     repair_plan: RepairPlanArgs,
     repair_run: RepairRunArgs,
     route: RouteArgs,
+    stay_afloat: DaemonTickArgs,
     config_validate,
     config_path,
     init: InitArgs,
@@ -215,6 +216,7 @@ pub fn parse(args: []const []const u8) Command {
     if (eql(cmd, "repair")) return parseRepair(rest);
     if (eql(cmd, "repair-plan")) return parseRepairPlan(rest);
     if (eql(cmd, "route")) return parseRoute(rest);
+    if (eql(cmd, "stay-afloat")) return parseStayAfloat(rest);
     if (eql(cmd, "config")) return parseConfig(rest);
     if (eql(cmd, "init")) return parseInit(rest);
     if (eql(cmd, "setup")) return parseSetup(rest);
@@ -528,6 +530,14 @@ fn parseDaemonHandoffs(args: []const []const u8) Command {
 }
 
 fn parseDaemonTick(args: []const []const u8) Command {
+    return .{ .daemon_tick = parseDaemonTickArgs(args) };
+}
+
+fn parseStayAfloat(args: []const []const u8) Command {
+    return .{ .stay_afloat = parseDaemonTickArgs(args) };
+}
+
+fn parseDaemonTickArgs(args: []const []const u8) Command.DaemonTickArgs {
     var result = Command.DaemonTickArgs{};
     var i: usize = 0;
     while (i < args.len) : (i += 1) {
@@ -565,7 +575,7 @@ fn parseDaemonTick(args: []const []const u8) Command {
             }
         }
     }
-    return .{ .daemon_tick = result };
+    return result;
 }
 
 fn parseConfig(args: []const []const u8) Command {
@@ -737,6 +747,9 @@ pub fn printUsage(writer: anytype) !void {
         \\
         \\  route select|explain [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
         \\      Select or explain a route from recorded liveness without probing.
+        \\
+        \\  stay-afloat [--once|--loop] [--execute] [--iterations <n>] [--interval-ms <ms>] [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
+        \\      Run the portable stay-afloat planner/executor without service-manager assumptions.
         \\
         \\  config validate    Validate the configuration file.
         \\  config path        Print the config file path.
@@ -1193,6 +1206,20 @@ test "parse daemon tick once json selector" {
     }
 }
 
+test "parse stay-afloat once json selector" {
+    const args = [_][]const u8{ "stay-afloat", "--once", "--profile", "codex-max", "--capability", "codex-max", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .stay_afloat => |tick| {
+            try std.testing.expect(tick.once);
+            try std.testing.expect(tick.json);
+            try std.testing.expectEqualStrings("codex-max", tick.profile.?);
+            try std.testing.expectEqualStrings("codex-max", tick.capability.?);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 test "parse daemon tick bounded loop" {
     const args = [_][]const u8{ "daemon", "tick", "--loop", "--execute", "--iterations", "3", "--interval-ms", "250", "--profile", "codex-max", "--capability", "codex-max", "--json" };
     const cmd = parse(&args);
@@ -1226,6 +1253,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n __fish_use_subcommand -a repair-plan -d 'Show non-mutating repair plan'
             \\complete -c oauth-mux -n __fish_use_subcommand -a repair -d 'Run admitted repair actions'
             \\complete -c oauth-mux -n __fish_use_subcommand -a route -d 'Select or explain routes'
+            \\complete -c oauth-mux -n __fish_use_subcommand -a stay-afloat -d 'Run stay-afloat planner'
             \\complete -c oauth-mux -n __fish_use_subcommand -a config -d 'Config operations'
             \\complete -c oauth-mux -n __fish_use_subcommand -a init -d 'Generate config'
             \\complete -c oauth-mux -n __fish_use_subcommand -a setup -d 'First-run setup'
@@ -1233,10 +1261,10 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n __fish_use_subcommand -a daemon -d 'Daemon operations'
             \\complete -c oauth-mux -n __fish_use_subcommand -a version -d 'Print version'
             \\complete -c oauth-mux -n __fish_use_subcommand -a completions -d 'Generate completions'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route' -l profile -s p -d 'Profile name' -r
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route' -l provider -d 'Provider name' -r
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from probe route' -l account -d 'Account name' -r
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route' -l capability -d 'Route capability' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route stay-afloat' -l profile -s p -d 'Profile name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route stay-afloat' -l provider -d 'Provider name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from probe route stay-afloat' -l account -d 'Account name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route stay-afloat' -l capability -d 'Route capability' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from probe' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -a runtime -d 'Runtime readiness checks'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -l json -d 'JSON output'
@@ -1265,6 +1293,12 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from repair' -l confirm-repair -d 'Confirm mutating repair'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from route' -a 'select explain' -d 'Route subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from route' -l json -d 'JSON output'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l json -d 'JSON output'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l once -d 'Run one stay-afloat tick'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l loop -d 'Run bounded foreground stay-afloat ticks'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l execute -d 'Execute one admitted non-interactive action'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l iterations -d 'Number of stay-afloat ticks' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l interval-ms -d 'Milliseconds between ticks' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
@@ -1302,6 +1336,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\    'repair-plan:Show non-mutating repair plan'
             \\    'repair:Run admitted repair actions'
             \\    'route:Select or explain routes'
+            \\    'stay-afloat:Run stay-afloat planner'
             \\    'config:Config operations'
             \\    'init:Generate config'
             \\    'setup:First-run setup'
@@ -1319,7 +1354,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
         try writer.writeAll(
             \\_oauth_mux_completions() {
             \\  local cur="${COMP_WORDS[COMP_CWORD]}"
-            \\  COMPREPLY=($(compgen -W "exec env probe doctor report providers status health discover repair-plan repair route config init setup codex daemon version completions" -- "$cur"))
+            \\  COMPREPLY=($(compgen -W "exec env probe doctor report providers status health discover repair-plan repair route stay-afloat config init setup codex daemon version completions" -- "$cur"))
             \\}
             \\complete -F _oauth_mux_completions oauth-mux
             \\

--- a/src/main.zig
+++ b/src/main.zig
@@ -134,6 +134,13 @@ pub fn main() !void {
             };
         },
 
+        .stay_afloat => |tick_args| {
+            runDaemonTick(allocator, stdout, tick_args, "oauth-mux stay-afloat") catch |e| {
+                log.err("stay-afloat: {s}", .{@errorName(e)});
+                std.process.exit(exitCodeFromPipelineError(e));
+            };
+        },
+
         .completions => |comp_args| {
             try cli.printCompletions(stdout, comp_args.shell);
         },
@@ -166,7 +173,7 @@ pub fn main() !void {
             try repair_state.writeHandoffs(allocator, stdout, events_args.json, events_args.limit, events_args.all);
         },
         .daemon_tick => |tick_args| {
-            runDaemonTick(allocator, stdout, tick_args) catch |e| {
+            runDaemonTick(allocator, stdout, tick_args, "oauth-mux daemon tick") catch |e| {
                 log.err("daemon tick: {s}", .{@errorName(e)});
                 std.process.exit(exitCodeFromPipelineError(e));
             };
@@ -356,7 +363,7 @@ fn writeDiscoverText(writer: anytype, cfg: config.Config, config_path: []const u
     try writer.writeAll("    oauth-mux route explain --profile <profile> --capability <capability> --json\n");
     try writer.writeAll("    oauth-mux route select --profile <profile> --capability <capability> --json\n");
     try writer.writeAll("    oauth-mux repair-plan --profile <profile> --capability <capability> --json\n");
-    try writer.writeAll("    oauth-mux daemon tick --once --profile <profile> --capability <capability> --json\n");
+    try writer.writeAll("    oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json\n");
     try writer.writeAll("    oauth-mux repair run --profile <profile> --capability <capability> --json\n");
     if (codex_configured and !codex_max_configured) {
         try writer.writeAll("    oauth-mux codex config-candidate --json\n");
@@ -462,7 +469,7 @@ fn writeDiscoverJson(writer: anytype, cfg: config.Config, config_path: []const u
         "oauth-mux route explain --profile <profile> --capability <capability> --json",
         "oauth-mux route select --profile <profile> --capability <capability> --json",
         "oauth-mux repair-plan --profile <profile> --capability <capability> --json",
-        "oauth-mux daemon tick --once --profile <profile> --capability <capability> --json",
+        "oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json",
         "oauth-mux repair run --profile <profile> --capability <capability> --json",
         "oauth-mux env --profile <profile> --capability <capability> --shell <shell>",
         "oauth-mux exec --profile <profile> --capability <capability> -- <command>",
@@ -1481,7 +1488,12 @@ fn runRoute(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Rou
     if (args.action == .select and selected_index == null) return error.AllAccountsExhausted;
 }
 
-fn runDaemonTick(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.DaemonTickArgs) !void {
+fn runDaemonTick(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    args: cli.Command.DaemonTickArgs,
+    command_name: []const u8,
+) !void {
     const parsed = try config.load(allocator);
     defer parsed.deinit();
 
@@ -1543,7 +1555,7 @@ fn runDaemonTick(allocator: std.mem.Allocator, writer: anytype, args: cli.Comman
             }
         } else {
             if (iterations > 1) try writer.print("tick {d}/{d}\n", .{ idx + 1, iterations });
-            try writeDaemonTickText(writer, allocator, parsed.value, evaluations.items, selected_index, executions.items, args, observed_at);
+            try writeDaemonTickText(writer, allocator, parsed.value, evaluations.items, selected_index, executions.items, args, observed_at, command_name);
             if (iterations > 1 and idx + 1 < iterations) try writer.writeByte('\n');
         }
 
@@ -1999,8 +2011,9 @@ fn writeDaemonTickText(
     executions: []const DaemonTickExecution,
     args: cli.Command.DaemonTickArgs,
     observed_at: i64,
+    command_name: []const u8,
 ) !void {
-    try writer.writeAll("oauth-mux daemon tick\n\n");
+    try writer.print("{s}\n\n", .{command_name});
     try writer.print("  mode: {s}\n", .{if (args.once) "once" else "loop"});
     try writer.print("  execution_mode: {s}\n", .{if (args.execute) "execute" else "plan"});
     try writer.print("  executed: {s}\n", .{if (daemonTickExecutionsRan(executions)) "yes" else "no"});
@@ -2522,7 +2535,7 @@ fn writeDoctorNextCommandsText(writer: anytype, stats: DoctorStats) !void {
     try writer.writeAll("    oauth-mux doctor runtime --json\n");
     try writer.writeAll("    oauth-mux route explain --profile <profile> --capability <capability> --json\n");
     try writer.writeAll("    oauth-mux route select --profile <profile> --capability <capability> --json\n");
-    try writer.writeAll("    oauth-mux daemon tick --once --profile <profile> --capability <capability> --json\n");
+    try writer.writeAll("    oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json\n");
     try writer.writeAll("    oauth-mux repair run --profile <profile> --capability <capability> --json\n");
     if (stats.codex_configured) {
         if (!stats.codex_max_configured) {
@@ -2558,7 +2571,7 @@ fn writeDoctorNextCommandsJson(writer: anytype, stats: DoctorStats) !void {
     try writeDoctorCommandJson(writer, &first, "oauth-mux route explain --profile <profile> --capability <capability> --json");
     try writeDoctorCommandJson(writer, &first, "oauth-mux route select --profile <profile> --capability <capability> --json");
     try writeDoctorCommandJson(writer, &first, "oauth-mux repair-plan --json");
-    try writeDoctorCommandJson(writer, &first, "oauth-mux daemon tick --once --profile <profile> --capability <capability> --json");
+    try writeDoctorCommandJson(writer, &first, "oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json");
     try writeDoctorCommandJson(writer, &first, "oauth-mux repair run --profile <profile> --capability <capability> --json");
     if (stats.codex_configured) {
         if (!stats.codex_max_configured) {
@@ -2892,7 +2905,7 @@ fn writeDoctorRuntimeJson(
     try writer.writeByte(',');
     try writeCommandJson(writer, "oauth-mux repair-plan --profile <profile> --capability <capability> --json");
     try writer.writeByte(',');
-    try writeCommandJson(writer, "oauth-mux daemon tick --once --profile <profile> --capability <capability> --json");
+    try writeCommandJson(writer, "oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json");
     try writer.writeAll("]}\n");
 }
 
@@ -2936,7 +2949,7 @@ fn writeDoctorRuntimeScopedJson(
     try writer.writeByte(',');
     try writeCommandJson(writer, "oauth-mux repair-plan --profile <profile> --capability <capability> --json");
     try writer.writeByte(',');
-    try writeCommandJson(writer, "oauth-mux daemon tick --once --profile <profile> --capability <capability> --json");
+    try writeCommandJson(writer, "oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json");
     try writer.writeAll("]}\n");
 }
 
@@ -6109,7 +6122,7 @@ test "writeDiscoverJson includes stay-afloat agent-safe commands" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux route explain --profile <profile> --capability <capability> --json") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux route select --profile <profile> --capability <capability> --json") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux repair-plan --profile <profile> --capability <capability> --json") != null);
-    try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux daemon tick --once --profile <profile> --capability <capability> --json") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "oauth-mux repair run --profile <profile> --capability <capability> --json") != null);
 }
 


### PR DESCRIPTION
## Summary
- add root-level `oauth-mux stay-afloat` as the operator-facing alias for the portable daemon tick engine
- keep `oauth-mux daemon tick` as the lower-level implementation surface
- update doctor/discover next commands, docs, completions, and e2e to lead with `stay-afloat`

## Why
The stay-afloat work should be discoverable as a product workflow, not hidden behind daemon internals. This gives users and agents a command they can reach for directly while preserving the existing portable tick semantics.

## Validation
- `nix develop --command just check-local`
- `git diff --check`
- no-spend dogfood: `./zig-out/bin/oauth-mux stay-afloat --once --profile codex-max --capability codex-max --json`