### PR TITLE
[codex] Alias stay-afloat handoffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ runs at most one admitted non-interactive action per tick, such as a
 `free_command` probe, then re-reads route state. Interactive reauth is never run
 silently; execute mode records a redacted `daemon_handoff` event with the user
 command to run. Inspect those queued user-mediated repairs with `oauth-mux
-daemon handoffs --json`; add `--all` to include historical handoff events after
+stay-afloat handoffs --json`; add `--all` to include historical handoff events after
 a later stay-afloat tick has refreshed route evidence. `stay-afloat --loop
 --iterations <n> --interval-ms <ms> --json` repeats the same portable
 foreground tick for dogfood and wrappers. No `systemctl`, `launchctl`, service

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -32,6 +32,7 @@ oauth-mux discover --json
 oauth-mux doctor runtime --json
 oauth-mux route explain --profile <profile> --capability <capability> --json
 oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json
+oauth-mux stay-afloat handoffs --json
 oauth-mux stay-afloat --loop --iterations 2 --interval-ms 0 --profile <profile> --capability <capability> --json
 ```
 
@@ -52,6 +53,7 @@ oauth-mux codex canary
 oauth-mux route explain --profile codex-max --capability codex-max --json
 oauth-mux route select --profile codex-max --capability codex-max --json
 oauth-mux stay-afloat --once --profile codex-max --capability codex-max --json
+oauth-mux stay-afloat handoffs --json
 oauth-mux stay-afloat --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
 ```
 

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -43,10 +43,11 @@ See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
   reads local state and does not require a daemon process. The same stream also
   carries redacted `token_refresh` events for refresh admission/writeback
   outcomes.
-- `oauth-mux daemon handoffs --json` for the filtered pending queue of
+- `oauth-mux stay-afloat handoffs --json` for the filtered pending queue of
   user-mediated daemon handoffs, such as upstream CLI login commands that must
-  not run silently in the background. `--all` keeps the historical handoff
-  events visible after later route evidence clears a pending prompt.
+  not run silently in the background. `oauth-mux daemon handoffs --json` is the
+  lower-level alias. `--all` keeps the historical handoff events visible after
+  later route evidence clears a pending prompt.
 - `oauth-mux stay-afloat --once --json` for one portable, policy-gated
   daemon-shaped planning pass. `oauth-mux daemon tick --once --json` is the
   lower-level alias. Without `--execute`, it reports `executed:false` and does

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -195,11 +195,11 @@ background; execute mode records a redacted `daemon_handoff` event with the
 reviewable user command. Agents and users can list those pending handoffs with:
 
 ```bash
-oauth-mux daemon handoffs --json
+oauth-mux stay-afloat handoffs --json
 ```
 
 The default handoff view is pending as of the daemon's last route evidence. Use
-`oauth-mux daemon handoffs --json --all` when you need the historical audit
+`oauth-mux stay-afloat handoffs --json --all` when you need the historical audit
 trail instead. After a user completes an upstream CLI login, another
 `stay-afloat --once --execute ... --json` can refresh route evidence and clear
 the pending prompt.

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -502,6 +502,11 @@ operator-facing alias for the same portable tick engine. `daemon tick` remains
 available as the lower-level implementation surface, but docs and onboarding
 should lead with `stay-afloat --once` and `stay-afloat --loop`.
 
+Implementation note, 2026-04-30: `oauth-mux stay-afloat handoffs --json` now
+aliases the pending handoff queue. This keeps user-facing recovery flows under
+the same product command while leaving `daemon handoffs` available for lower
+level debugging.
+
 ### M3: Refresh Writeback
 
 - Implement backend write capabilities.

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -419,6 +419,8 @@ expect_contains "$daemon_handoffs" '"handoffs":[' "daemon handoffs returns json 
 expect_contains "$daemon_handoffs" '"kind":"daemon_handoff"' "daemon handoffs includes handoff events"
 expect_contains "$daemon_handoffs" '"outcome":"handoff_queued"' "daemon handoffs includes queued outcome"
 expect_contains "$daemon_handoffs" '"command":"oauth-mux codex login-device max-1"' "daemon handoffs includes upstream command"
+stay_afloat_handoffs="$(OMUX_STATE_DIR="$state_dir" "$bin" stay-afloat handoffs --json)"
+expect_contains "$stay_afloat_handoffs" '"kind":"daemon_handoff"' "stay-afloat handoffs aliases pending handoff queue"
 
 repair_reauth_confirmed_json="$tmp/repair-run-reauth-confirmed.json"
 set +e

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -534,6 +534,7 @@ fn parseDaemonTick(args: []const []const u8) Command {
 }
 
 fn parseStayAfloat(args: []const []const u8) Command {
+    if (args.len > 0 and eql(args[0], "handoffs")) return parseDaemonHandoffs(args[1..]);
     return .{ .stay_afloat = parseDaemonTickArgs(args) };
 }
 
@@ -750,6 +751,8 @@ pub fn printUsage(writer: anytype) !void {
         \\
         \\  stay-afloat [--once|--loop] [--execute] [--iterations <n>] [--interval-ms <ms>] [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
         \\      Run the portable stay-afloat planner/executor without service-manager assumptions.
+        \\  stay-afloat handoffs [--json] [--limit <n>] [--all]
+        \\      Show pending user-mediated stay-afloat handoffs; --all includes history.
         \\
         \\  config validate    Validate the configuration file.
         \\  config path        Print the config file path.
@@ -1220,6 +1223,19 @@ test "parse stay-afloat once json selector" {
     }
 }
 
+test "parse stay-afloat handoffs json limit" {
+    const args = [_][]const u8{ "stay-afloat", "handoffs", "--json", "--limit", "2", "--all" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .daemon_handoffs => |events| {
+            try std.testing.expect(events.json);
+            try std.testing.expectEqual(@as(usize, 2), events.limit);
+            try std.testing.expect(events.all);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 test "parse daemon tick bounded loop" {
     const args = [_][]const u8{ "daemon", "tick", "--loop", "--execute", "--iterations", "3", "--interval-ms", "250", "--profile", "codex-max", "--capability", "codex-max", "--json" };
     const cmd = parse(&args);
@@ -1294,11 +1310,14 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from route' -a 'select explain' -d 'Route subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from route' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l json -d 'JSON output'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -a handoffs -d 'Show pending handoffs'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l once -d 'Run one stay-afloat tick'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l loop -d 'Run bounded foreground stay-afloat ticks'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l execute -d 'Execute one admitted non-interactive action'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l iterations -d 'Number of stay-afloat ticks' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l interval-ms -d 'Milliseconds between ticks' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l limit -d 'Limit handoff count' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l all -d 'Include historical handoff events'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'


### PR DESCRIPTION
## Summary
- route `oauth-mux stay-afloat handoffs` to the pending daemon handoff queue
- keep `oauth-mux daemon handoffs` as the lower-level alias
- update docs, completions, parser tests, and local e2e coverage

## Why
After adding the root `stay-afloat` product command, a natural recovery flow is `oauth-mux stay-afloat handoffs --json`. This avoids treating `handoffs` as an ignored tick argument and keeps recovery UX under one command family.

## Validation
- `nix develop --command just check-local`
- `git diff --check`
- smoke: `./zig-out/bin/oauth-mux stay-afloat handoffs --json`
- smoke: `./zig-out/bin/oauth-mux stay-afloat handoffs --json --all`