### PR TITLE
[codex] Make stay-afloat handoffs idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,11 @@ that policy. By default it is planning-only and reports `executed:false`.
 runs at most one admitted non-interactive action per tick, such as a
 `free_command` probe, then re-reads route state. Interactive reauth is never run
 silently; execute mode records a redacted `daemon_handoff` event with the user
-command to run. Inspect those queued user-mediated repairs with `oauth-mux
-stay-afloat handoffs --json`; add `--all` to include historical handoff events after
-a later stay-afloat tick has refreshed route evidence. `stay-afloat --loop
+command to run. Repeated ticks report an existing handoff as pending instead of
+duplicating the event. Inspect those queued user-mediated repairs with
+`oauth-mux stay-afloat handoffs --json`; add `--all` to include historical
+handoff events after a later stay-afloat tick has refreshed route evidence.
+`stay-afloat --loop
 --iterations <n> --interval-ms <ms> --json` repeats the same portable
 foreground tick for dogfood and wrappers. No `systemctl`, `launchctl`, service
 manager, browser auth, provider spend, or secret mutation is assumed unless

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -55,7 +55,8 @@ See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
 - `oauth-mux stay-afloat --once --execute --json` as the beta execution
   boundary. It runs at most one admitted non-interactive action per tick,
   re-reads route state afterward, and queues interactive reauth as a redacted
-  `daemon_handoff` event instead of running it silently.
+  `daemon_handoff` event instead of running it silently. Repeated ticks report
+  an existing handoff as pending rather than appending duplicate events.
 - `oauth-mux stay-afloat --loop --iterations <n> --interval-ms <ms> --json`
   for a bounded foreground loop. It re-reads local health/runtime state each
   tick and remains service-manager agnostic.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -192,7 +192,9 @@ recorded route state without requiring a service manager. Provider-spending
 probes, interactive browser/device auth, and credential mutation remain refused
 unless policy explicitly admits them. Interactive reauth is not run in the
 background; execute mode records a redacted `daemon_handoff` event with the
-reviewable user command. Agents and users can list those pending handoffs with:
+reviewable user command. Repeated execute ticks report an existing handoff as
+pending instead of appending duplicate events. Agents and users can list those
+pending handoffs with:
 
 ```bash
 oauth-mux stay-afloat handoffs --json

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -507,6 +507,12 @@ aliases the pending handoff queue. This keeps user-facing recovery flows under
 the same product command while leaving `daemon handoffs` available for lower
 level debugging.
 
+Implementation note, 2026-04-30: execute-mode stay-afloat ticks now check the
+pending handoff queue before recording an interactive reauth handoff. If the
+same route already has a pending handoff, tick JSON reports
+`handoff_pending:true` and `handoff_queued:false` instead of appending duplicate
+events.
+
 ### M3: Refresh Writeback
 
 - Implement backend write capabilities.

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -413,6 +413,13 @@ expect_contains "$daemon_handoff" '"admitted":false' "daemon handoff preserves d
 expect_contains "$daemon_handoff" '"command":"oauth-mux codex login-device max-1"' "daemon handoff reports upstream login command"
 test ! -e "$tmp/reauth-home/auth.json"
 
+printf 'e2e: stay-afloat execute reports existing handoff without duplicating it\n'
+stay_afloat_handoff_pending="$(OMUX_CONFIG="$reauth_config" OMUX_STATE_DIR="$state_dir" "$bin" stay-afloat --once --execute --profile needs-reauth --capability codex-max --json)"
+expect_contains "$stay_afloat_handoff_pending" '"handoff_queued":false' "stay-afloat pending handoff does not queue a duplicate"
+expect_contains "$stay_afloat_handoff_pending" '"handoff_pending":true' "stay-afloat reports pending handoff"
+expect_contains "$stay_afloat_handoff_pending" '"reason":"handoff_pending"' "stay-afloat reports pending handoff reason"
+test ! -e "$tmp/reauth-home/auth.json"
+
 printf 'e2e: daemon handoffs exposes queued user-mediated repair actions\n'
 daemon_handoffs="$(OMUX_STATE_DIR="$state_dir" "$bin" daemon handoffs --json)"
 expect_contains "$daemon_handoffs" '"handoffs":[' "daemon handoffs returns json handoff list"

--- a/src/main.zig
+++ b/src/main.zig
@@ -1721,6 +1721,29 @@ fn queueDaemonHandoff(
     decision: DaemonTickDecision,
     executions: *std.ArrayList(DaemonTickExecution),
 ) !void {
+    const pending = try repair_state.hasPendingHandoff(allocator, .{
+        .profile = args.profile,
+        .provider = evaluation.route.provider,
+        .account = evaluation.route.account,
+        .capability = evaluation.route.capability,
+    });
+    if (pending) {
+        try executions.append(.{
+            .route = evaluation.route,
+            .phase = "handoff",
+            .action = evaluation.action.kind,
+            .admitted = decision.admitted,
+            .executed = false,
+            .ok = false,
+            .handoff = true,
+            .handoff_queued = false,
+            .reason = "handoff_pending",
+            .budget = decision.budget,
+            .command = evaluation.action.command,
+        });
+        return;
+    }
+
     try executions.append(.{
         .route = evaluation.route,
         .phase = "handoff",
@@ -1729,6 +1752,7 @@ fn queueDaemonHandoff(
         .executed = false,
         .ok = false,
         .handoff = true,
+        .handoff_queued = true,
         .reason = "interactive_user_handoff",
         .budget = decision.budget,
         .command = evaluation.action.command,
@@ -1986,6 +2010,7 @@ const DaemonTickExecution = struct {
     executed: bool,
     ok: bool,
     handoff: bool = false,
+    handoff_queued: bool = false,
     reason: []const u8,
     budget: ?types.ActionBudget = null,
     command: RepairCommandKind = .none,
@@ -2066,7 +2091,10 @@ fn writeDaemonTickText(
                 if (execution.ok) "true" else "false",
                 execution.reason,
             });
-            if (execution.handoff) try writer.writeAll(" handoff=true");
+            if (execution.handoff) {
+                try writer.writeAll(" handoff=true");
+                try writer.print(" handoff_queued={s}", .{if (execution.handoff_queued) "true" else "false"});
+            }
             try writer.writeByte('\n');
         }
     }
@@ -2104,6 +2132,8 @@ fn writeDaemonTickJsonObject(
     try writer.writeAll(if (daemonTickExecutionsRan(executions)) "true" else "false");
     try writer.writeAll(",\"handoff_queued\":");
     try writer.writeAll(if (daemonTickHandoffQueued(executions)) "true" else "false");
+    try writer.writeAll(",\"handoff_pending\":");
+    try writer.writeAll(if (daemonTickHandoffPending(executions)) "true" else "false");
     try writer.writeAll(",\"message\":");
     try std.json.stringify(daemonTickMessage(args), .{}, writer);
     try writer.writeAll(",\"policy\":");
@@ -2186,6 +2216,8 @@ fn writeDaemonTickExecutionsJson(
         try writer.writeAll(if (execution.ok) "true" else "false");
         try writer.writeAll(",\"handoff\":");
         try writer.writeAll(if (execution.handoff) "true" else "false");
+        try writer.writeAll(",\"handoff_queued\":");
+        try writer.writeAll(if (execution.handoff_queued) "true" else "false");
         try writer.writeAll(",\"reason\":");
         try std.json.stringify(execution.reason, .{}, writer);
         try writer.writeAll(",\"budget\":");
@@ -2210,6 +2242,13 @@ fn daemonTickExecutionsRan(executions: []const DaemonTickExecution) bool {
 }
 
 fn daemonTickHandoffQueued(executions: []const DaemonTickExecution) bool {
+    for (executions) |execution| {
+        if (execution.handoff_queued) return true;
+    }
+    return false;
+}
+
+fn daemonTickHandoffPending(executions: []const DaemonTickExecution) bool {
     for (executions) |execution| {
         if (execution.handoff) return true;
     }

--- a/src/repair_state.zig
+++ b/src/repair_state.zig
@@ -21,6 +21,13 @@ pub const RepairEvent = struct {
     mutating: bool = false,
 };
 
+pub const HandoffKey = struct {
+    profile: ?[]const u8 = null,
+    provider: []const u8,
+    account: []const u8,
+    capability: ?[]const u8 = null,
+};
+
 pub const RepairLock = struct {
     allocator: std.mem.Allocator,
     path: []const u8,
@@ -60,6 +67,34 @@ pub fn writeHandoffs(allocator: std.mem.Allocator, writer: anytype, json: bool, 
         return;
     }
     try writePendingHandoffView(allocator, writer, json, limit);
+}
+
+pub fn hasPendingHandoff(allocator: std.mem.Allocator, key: HandoffKey) !bool {
+    const path = try eventsPath(allocator);
+    defer allocator.free(path);
+
+    const file = std.fs.openFileAbsolute(path, .{}) catch |e| switch (e) {
+        error.FileNotFound => return false,
+        else => return e,
+    };
+    defer file.close();
+
+    const bytes = try file.readToEndAlloc(allocator, 1024 * 1024);
+    defer allocator.free(bytes);
+
+    var pending = false;
+    var it = std.mem.splitScalar(u8, bytes, '\n');
+    while (it.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (trimmed.len == 0 or !eventRouteKeyMatchesHandoffKey(trimmed, key)) continue;
+        if (isQueuedHandoffEvent(trimmed)) {
+            pending = true;
+        } else if (eventResolvesHandoff(trimmed)) {
+            pending = false;
+        }
+    }
+
+    return pending;
 }
 
 fn writeEventView(
@@ -230,12 +265,26 @@ fn eventRouteKeyMatches(a: []const u8, b: []const u8) bool {
         eventOptionalFieldEquals(a, b, "capability");
 }
 
+fn eventRouteKeyMatchesHandoffKey(line: []const u8, key: HandoffKey) bool {
+    return eventOptionalFieldMatches(line, "profile", key.profile) and
+        eventFieldEquals(line, "provider", key.provider) and
+        eventFieldEquals(line, "account", key.account) and
+        eventOptionalFieldMatches(line, "capability", key.capability);
+}
+
 fn eventOptionalFieldEquals(a: []const u8, b: []const u8, field: []const u8) bool {
     const av = eventFieldString(a, field);
     const bv = eventFieldString(b, field);
     if (av == null and bv == null) return true;
     if (av == null or bv == null) return false;
     return std.mem.eql(u8, av.?, bv.?);
+}
+
+fn eventOptionalFieldMatches(line: []const u8, field: []const u8, expected: ?[]const u8) bool {
+    const actual = eventFieldString(line, field);
+    if (actual == null and expected == null) return true;
+    if (actual == null or expected == null) return false;
+    return std.mem.eql(u8, actual.?, expected.?);
 }
 
 fn eventFieldEquals(line: []const u8, field: []const u8, expected: []const u8) bool {
@@ -520,6 +569,30 @@ test "pending handoff queue resolves by later route event" {
     try std.testing.expectEqual(@as(usize, 1), pending.items.len);
     removeResolvedHandoffs(&pending, resolved);
     try std.testing.expectEqual(@as(usize, 0), pending.items.len);
+}
+
+test "handoff key matching distinguishes pending route" {
+    const handoff =
+        "{\"kind\":\"daemon_handoff\",\"profile\":\"codex-max\",\"provider\":\"codex\",\"account\":\"max-1\",\"capability\":\"codex-max\",\"outcome\":\"handoff_queued\",\"ok\":false}";
+
+    try std.testing.expect(eventRouteKeyMatchesHandoffKey(handoff, .{
+        .profile = "codex-max",
+        .provider = "codex",
+        .account = "max-1",
+        .capability = "codex-max",
+    }));
+    try std.testing.expect(!eventRouteKeyMatchesHandoffKey(handoff, .{
+        .profile = "codex-max",
+        .provider = "codex",
+        .account = "max-2",
+        .capability = "codex-max",
+    }));
+    try std.testing.expect(!eventRouteKeyMatchesHandoffKey(handoff, .{
+        .profile = "codex-max",
+        .provider = "codex",
+        .account = "max-1",
+        .capability = "codex-mini",
+    }));
 }
 
 test "refresh event json carries redacted writeback evidence" {


### PR DESCRIPTION
## Summary
- detect existing pending daemon handoffs before queueing interactive reauth again
- report pending user handoffs with handoff_pending=true and handoff_queued=false
- document the idempotent stay-afloat behavior and cover it in local e2e

## Validation
- nix develop --command just check-local
- git diff --check
- OMUX_CONFIG=examples/codex-max.config.json ./zig-out/bin/oauth-mux stay-afloat --once --profile codex-max --capability codex-max --json
- OMUX_CONFIG=examples/codex-max.config.json ./zig-out/bin/oauth-mux stay-afloat handoffs --json