### PR TITLE
[codex] Align dogfood version truth

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .oauth_mux,
-    .version = "0.1.3",
+    .version = "0.1.5",
     .fingerprint = 0x21c445132f61984e,
     .minimum_zig_version = "0.14.0",
     .paths = .{

--- a/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
+++ b/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
@@ -23,13 +23,13 @@ Install surfaces:
 
 | Surface | Current proof |
 | --- | --- |
-| npm global install | `oauth-mux@0.1.3` installs from the public npm registry and returns `oauth-mux 0.1.3`. |
-| npm one-shot | `npx -y oauth-mux@0.1.3 version` passed from `../lab`. |
-| GitHub Release tarball | v0.1.3 macOS arm64 tarball verifies against `SHA256SUMS` and runs. |
-| curl installer | v0.1.3 installer downloads public release assets, verifies checksums, and runs on macOS and `../lab`. |
+| npm global install | `oauth-mux@0.1.5` installs from the public npm registry and returns `oauth-mux 0.1.5`. |
+| npm one-shot | `npx -y oauth-mux@0.1.5 version` passed from `../lab`. |
+| GitHub Release tarball | v0.1.5 macOS arm64 tarball verifies against `SHA256SUMS` and runs. |
+| curl installer | v0.1.5 installer downloads public release assets, verifies checksums, and runs on macOS and `../lab`. |
 | Homebrew | `just homebrew-qa 0.1.3` installs from `tinyland/tools`, runs `brew audit`, `brew test`, `version`, and `doctor --json`. The tap is still private. |
-| deb/rpm | Hosted System Package Install QA run `25137323710`, job `73678810909`, installed published `.deb` and `.rpm` assets in Debian/Rocky containers. |
-| lab dogfood | Installed CLI reports healthy `doctor --json` against the local config/state. |
+| deb/rpm | Hosted System Package Install QA run `25172711458` installed published v0.1.5 `.deb` and `.rpm` assets in Debian/Rocky containers. |
+| lab dogfood | Public npm one-shot `oauth-mux@0.1.5` reports healthy `doctor --json` against the local config/state. |
 
 OAuth and muxing surfaces:
 


### PR DESCRIPTION
## Summary
- align build.zig.zon package metadata with the current CLI/public version 0.1.5
- update the dogfood E2E proof table from stale 0.1.3 install evidence to current 0.1.5 npm/GitHub/curl/system package truth
- leave Homebrew noted as private-tap 0.1.3 proof because that is still the current tap evidence

## Validation
- nix develop --command zig fmt build.zig.zon
- nix develop --command just check-local
- git diff --check