### PR TITLE
[codex] Record Homebrew 0.1.5 dogfood truth

### DIFF
--- a/.github/workflows/system-package-install-qa.yml
+++ b/.github/workflows/system-package-install-qa.yml
@@ -13,7 +13,7 @@ on:
       version:
         description: "Published version to install from GitHub Release assets"
         required: false
-        default: "0.1.3"
+        default: "0.1.5"
         type: string
 
 permissions:
@@ -35,6 +35,6 @@ jobs:
           set -euo pipefail
           version="${{ github.event.inputs.version }}"
           if [ -z "$version" ]; then
-            version="0.1.3"
+            version="0.1.5"
           fi
           ./scripts/system-package-install-qa.sh "$version"

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -14,7 +14,7 @@ files, SOPS plaintext, or token-shaped values here.
 | npm one-shot | 0.1.5 | macOS arm64 | public npm registry | Pass | `npx -y oauth-mux@0.1.5 version` returns `oauth-mux 0.1.5`. |
 | GitHub release tarball | 0.1.5 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Release workflow `25171997189` published all tarballs, packages, checksums, formula, and installer. |
 | `curl | sh` installer | 0.1.5 | macOS arm64 and `../lab` | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass | Default installer repo is canonical; no `REPO=...` override needed. |
-| Homebrew formula | 0.1.3 | macOS arm64 | `tinyland/tools` tap | Pass | `just homebrew-qa 0.1.3` installs from the private `tinyland-inc/homebrew-tools` tap, runs `brew audit`, `brew test`, `oauth-mux version`, and `oauth-mux doctor --json`. |
+| Homebrew formula | 0.1.5 | macOS arm64 | `tinyland/tools` tap | Pass | `just homebrew-qa 0.1.5` installs from the private `tinyland-inc/homebrew-tools` tap, runs `brew audit`, `brew test`, `oauth-mux version`, and `oauth-mux doctor --json`. |
 | deb package | 0.1.5 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25172711458` installed package and ran `/usr/bin/oauth-mux version`. |
 | rpm package | 0.1.5 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25172711458` installed package and ran `/usr/bin/oauth-mux version`. |
 | Codex live dogfood | 0.1.5 | macOS arm64 | public npm one-shot | Pass with degraded route | Published npm binary reported `max-1#codex-max` quota exhausted while `max-2` and `max-3` covered `codex-max`; `codex-mini` remained covered. |
@@ -81,13 +81,13 @@ oauth-mux 0.1.5
 Homebrew tap install:
 
 ```bash
-just homebrew-qa 0.1.3
+just homebrew-qa 0.1.5
 ```
 
 Expected output includes:
 
 ```text
-Homebrew install QA passed for oauth-mux 0.1.3 via tinyland/tools/oauth-mux
+Homebrew install QA passed for oauth-mux 0.1.5 via tinyland/tools/oauth-mux
 ```
 
 First-run source e2e:
@@ -108,7 +108,7 @@ first-run e2e passed
 To keep the formula installed after dogfood QA:
 
 ```bash
-OMUX_HOMEBREW_KEEP_INSTALLED=1 OMUX_HOMEBREW_KEEP_TAP=1 just homebrew-qa 0.1.3
+OMUX_HOMEBREW_KEEP_INSTALLED=1 OMUX_HOMEBREW_KEEP_TAP=1 just homebrew-qa 0.1.5
 ```
 
 To include the three-account Codex canary from the installed Homebrew binary:
@@ -121,7 +121,7 @@ OMUX_HOMEBREW_KEEP_TAP=1 \
 OMUX_HOMEBREW_CODEX_CANARY=1 \
 OMUX_HOMEBREW_CODEX_LIVE=1 \
 OMUX_LIVE_QA_CONFIRM=spend-real-calls \
-  just homebrew-qa 0.1.3
+  just homebrew-qa 0.1.5
 ```
 
 Latest local Homebrew dogfood proof:
@@ -131,6 +131,7 @@ brew tap tinyland/tools https://github.com/tinyland-inc/homebrew-tools.git: pass
 brew install tinyland/tools/oauth-mux: pass
 brew audit --formula --strict tinyland/tools/oauth-mux: pass
 brew test tinyland/tools/oauth-mux: pass
+/opt/homebrew/bin/oauth-mux version: oauth-mux 0.1.5
 /opt/homebrew/bin/oauth-mux doctor --json: ok
 Homebrew-installed oauth-mux codex live-qa --confirm-spend with examples/codex-max.config.json:
   max-1, max-2, max-3 available for codex-mini and codex-max

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -135,7 +135,7 @@ at the staged artifact directory instead of GitHub Releases.
 After the GitHub Release exists, run the hosted system-package install proof:
 
 ```bash
-gh workflow run system-package-install-qa.yml -f version=0.1.3
+gh workflow run system-package-install-qa.yml -f version=0.1.5
 ```
 
 This workflow downloads the published `.deb` and `.rpm` release assets, verifies
@@ -145,7 +145,7 @@ Linux containers on `ubuntu-latest`, and runs `/usr/bin/oauth-mux version`.
 For local reproduction on a healthy Docker-compatible host:
 
 ```bash
-just system-package-qa 0.1.3
+just system-package-qa 0.1.5
 ```
 
 This is stricter than the registry `system` dry-run lane. The dry-run lane
@@ -201,9 +201,11 @@ Current release evidence:
 - Main CI run `25032478278` completed `test`, `nix`, all six cross-compiles,
   and real GloriousFlywheel cache-first validation after the evidence docs
   merged.
-- System Package Install QA run `25137323710` completed for v0.1.3 and proved
+- System Package Install QA run `25172711458` completed for v0.1.5 and proved
   published `.deb` and `.rpm` assets install in hosted Debian/Rocky containers
   and execute `/usr/bin/oauth-mux version`.
+- Homebrew tap PR `tinyland-inc/homebrew-tools#3` updated `tinyland/tools` to
+  v0.1.5; `just homebrew-qa 0.1.5` passed against the production tap.
 
 ## Before Marking A PR Ready
 

--- a/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
+++ b/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
@@ -27,7 +27,7 @@ Install surfaces:
 | npm one-shot | `npx -y oauth-mux@0.1.5 version` passed from `../lab`. |
 | GitHub Release tarball | v0.1.5 macOS arm64 tarball verifies against `SHA256SUMS` and runs. |
 | curl installer | v0.1.5 installer downloads public release assets, verifies checksums, and runs on macOS and `../lab`. |
-| Homebrew | `just homebrew-qa 0.1.3` installs from `tinyland/tools`, runs `brew audit`, `brew test`, `version`, and `doctor --json`. The tap is still private. |
+| Homebrew | `just homebrew-qa 0.1.5` installs from `tinyland/tools`, runs `brew audit`, `brew test`, `version`, and `doctor --json`. The tap is still private. |
 | deb/rpm | Hosted System Package Install QA run `25172711458` installed published v0.1.5 `.deb` and `.rpm` assets in Debian/Rocky containers. |
 | lab dogfood | Public npm one-shot `oauth-mux@0.1.5` reports healthy `doctor --json` against the local config/state. |
 
@@ -66,8 +66,9 @@ These are the adoption blockers that should stay visible:
    they are equally dogfooded.
 
 5. Homebrew is private-tap proven, not public-tap proven.
-   This is fine for operator dogfood, but public website copy should either say
-   the tap is private/staged or wait for a public tap stance.
+   The private tap now tracks v0.1.5 and passes install QA, but public website
+   copy should still say the tap is private/staged or wait for a public tap
+   stance.
 
 6. The daemon remains deferred.
    Daemon start/stop/status exist, but background refresh/probe behavior is not

--- a/justfile
+++ b/justfile
@@ -119,10 +119,10 @@ release-handoff VERSION="0.1.0":
 registry-dry-run VERSION="0.1.0":
     nix develop --command ./scripts/registry-dry-run.sh {{VERSION}}
 
-system-package-qa VERSION="0.1.3":
+system-package-qa VERSION="0.1.5":
     ./scripts/system-package-install-qa.sh {{VERSION}}
 
-homebrew-qa VERSION="0.1.3":
+homebrew-qa VERSION="0.1.5":
     ./scripts/homebrew-install-qa.sh {{VERSION}}
 
 npm-deprecate-plan VERSION="0.1.1":


### PR DESCRIPTION
## Summary
- update Homebrew/system-package QA defaults to 0.1.5
- record the merged tinyland/tools oauth-mux 0.1.5 tap proof in install/adoption docs
- keep the caveat that Homebrew is private-tap proven, not public-tap proven

## Validation
- git diff --check
- just --list confirms homebrew-qa and system-package-qa default to 0.1.5
- OMUX_HOMEBREW_KEEP_INSTALLED=1 OMUX_HOMEBREW_KEEP_TAP=1 just homebrew-qa
- production tap PR merged: tinyland-inc/homebrew-tools#3
- brew info tinyland/tools/oauth-mux reports stable 0.1.5
- brew list --versions oauth-mux reports oauth-mux 0.1.5