### PR TITLE
Bump version to 0.1.6

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .oauth_mux,
-    .version = "0.1.5",
+    .version = "0.1.6",
     .fingerprint = 0x21c445132f61984e,
     .minimum_zig_version = "0.14.0",
     .paths = .{

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 
-pub const version = "0.1.5";
+pub const version = "0.1.6";
 
 pub const Command = union(enum) {
     exec: ExecArgs,


### PR DESCRIPTION
## Summary
- bump CLI-reported version to 0.1.6
- bump Zig package metadata to 0.1.6

## Validation
- nix develop --command zig fmt src/cli.zig build.zig.zon
- nix develop --command just check-local
- git diff --check
- ./zig-out/bin/oauth-mux version