### PR TITLE
Record 0.1.6 release dogfood truth

### DIFF
--- a/.github/workflows/system-package-install-qa.yml
+++ b/.github/workflows/system-package-install-qa.yml
@@ -13,7 +13,7 @@ on:
       version:
         description: "Published version to install from GitHub Release assets"
         required: false
-        default: "0.1.5"
+        default: "0.1.6"
         type: string
 
 permissions:
@@ -35,6 +35,6 @@ jobs:
           set -euo pipefail
           version="${{ github.event.inputs.version }}"
           if [ -z "$version" ]; then
-            version="0.1.5"
+            version="0.1.6"
           fi
           ./scripts/system-package-install-qa.sh "$version"

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -1,6 +1,6 @@
 # Install Beta Matrix
 
-Updated: 2026-04-30
+Updated: 2026-05-01
 
 This matrix tracks clean-install proof for the public adoption surfaces. It is
 operator evidence, not a credential runbook: do not paste OAuth stores, `.env`
@@ -10,15 +10,15 @@ files, SOPS plaintext, or token-shaped values here.
 
 | Surface | Version | Host | Source | Result | Caveat |
 | --- | --- | --- | --- | --- | --- |
-| npm global install | 0.1.5 | macOS arm64 | public npm registry | Pass | Public registry reports `oauth-mux@0.1.5` plus all six platform packages. |
-| npm one-shot | 0.1.5 | macOS arm64 | public npm registry | Pass | `npx -y oauth-mux@0.1.5 version` returns `oauth-mux 0.1.5`. |
-| GitHub release tarball | 0.1.5 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Release workflow `25171997189` published all tarballs, packages, checksums, formula, and installer. |
-| `curl | sh` installer | 0.1.5 | macOS arm64 and `../lab` | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass | Default installer repo is canonical; no `REPO=...` override needed. |
-| Homebrew formula | 0.1.5 | macOS arm64 | `tinyland/tools` tap | Pass | `just homebrew-qa 0.1.5` installs from the private `tinyland-inc/homebrew-tools` tap, runs `brew audit`, `brew test`, `oauth-mux version`, and `oauth-mux doctor --json`. |
-| deb package | 0.1.5 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25172711458` installed package and ran `/usr/bin/oauth-mux version`. |
-| rpm package | 0.1.5 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25172711458` installed package and ran `/usr/bin/oauth-mux version`. |
-| Codex live dogfood | 0.1.5 | macOS arm64 | public npm one-shot | Pass with degraded route | Published npm binary reported `max-1#codex-max` quota exhausted while `max-2` and `max-3` covered `codex-max`; `codex-mini` remained covered. |
-| lab dogfood | 0.1.5 | macOS arm64 | public npm one-shot | Pass | Installed `oauth-mux doctor --json` reports `ok: true` against local config/state. |
+| npm global install | 0.1.6 | macOS arm64 | public npm registry | Pass | Public registry reports `oauth-mux@0.1.6` plus all six platform packages. |
+| npm one-shot | 0.1.6 | macOS arm64 | public npm registry | Pass | `npx -y oauth-mux@0.1.6 version` returns `oauth-mux 0.1.6`. |
+| GitHub release tarball | 0.1.6 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Release workflow `25195318899` published all tarballs, packages, checksums, formula, and installer. |
+| `curl | sh` installer | 0.1.6 | macOS arm64 and `../lab` | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass | Default installer repo is canonical; no `REPO=...` override needed. |
+| Homebrew formula | 0.1.6 | macOS arm64 | `tinyland/tools` tap | Pass | `just homebrew-qa 0.1.6` installs from the private `tinyland-inc/homebrew-tools` tap, runs `brew audit`, `brew test`, `oauth-mux version`, and `oauth-mux doctor --json`. |
+| deb package | 0.1.6 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25195456319` installed package and ran `/usr/bin/oauth-mux version`. |
+| rpm package | 0.1.6 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25195456319` installed package and ran `/usr/bin/oauth-mux version`. |
+| Codex route dogfood | 0.1.6 | macOS arm64 | public npm one-shot | Pass with degraded route | Published npm binary selected `max-2#codex-max` while recorded liveness kept `max-1#codex-max` quota exhausted. |
+| lab dogfood | 0.1.6 | macOS arm64 | public npm one-shot | Pass | Installed `oauth-mux doctor --json` reports `ok: true` against local config/state. |
 | first-run source e2e | main | macOS arm64 | source checkout | Pass | `just first-run-e2e` runs with temporary HOME/XDG roots and proves no-config `init --codex-max`, JSON diagnostics, runtime diagnostics, redacted report, no-spend route explanation/select refusal, and non-mutating Codex help. |
 
 ## Evidence Commands
@@ -28,7 +28,7 @@ npm clean install:
 ```bash
 tmp="$(mktemp -d)"
 npm_config_cache="$tmp/cache" \
-  npm install --prefix "$tmp/app" --install-strategy=shallow oauth-mux@0.1.5 \
+  npm install --prefix "$tmp/app" --install-strategy=shallow oauth-mux@0.1.6 \
   --ignore-scripts=false --no-audit --no-fund
 "$tmp/app/node_modules/.bin/oauth-mux" version
 rm -rf "$tmp"
@@ -37,7 +37,7 @@ rm -rf "$tmp"
 Expected output includes:
 
 ```text
-oauth-mux 0.1.5
+oauth-mux 0.1.6
 ```
 
 Raw release tarball:
@@ -45,9 +45,9 @@ Raw release tarball:
 ```bash
 tmp="$(mktemp -d)"
 curl -fsSL -o "$tmp/oauth-mux-aarch64-macos.tar.gz" \
-  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.5/oauth-mux-aarch64-macos.tar.gz
+  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.6/oauth-mux-aarch64-macos.tar.gz
 curl -fsSL -o "$tmp/SHA256SUMS" \
-  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.5/SHA256SUMS
+  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.6/SHA256SUMS
 (cd "$tmp" && shasum -a 256 -c --ignore-missing SHA256SUMS)
 tar -xzf "$tmp/oauth-mux-aarch64-macos.tar.gz" -C "$tmp"
 "$tmp/oauth-mux" version
@@ -58,16 +58,16 @@ Expected output includes:
 
 ```text
 oauth-mux-aarch64-macos.tar.gz: OK
-oauth-mux 0.1.5
+oauth-mux 0.1.6
 ```
 
-Public installer for v0.1.5:
+Public installer for v0.1.6:
 
 ```bash
 tmp="$(mktemp -d)"
-VERSION=0.1.5 \
+VERSION=0.1.6 \
 INSTALL_DIR="$tmp/bin" \
-  sh -c 'curl -fsSL https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.5/install.sh | sh'
+  sh -c 'curl -fsSL https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.6/install.sh | sh'
 "$tmp/bin/oauth-mux" version
 rm -rf "$tmp"
 ```
@@ -75,19 +75,19 @@ rm -rf "$tmp"
 Expected output includes:
 
 ```text
-oauth-mux 0.1.5
+oauth-mux 0.1.6
 ```
 
 Homebrew tap install:
 
 ```bash
-just homebrew-qa 0.1.5
+just homebrew-qa 0.1.6
 ```
 
 Expected output includes:
 
 ```text
-Homebrew install QA passed for oauth-mux 0.1.5 via tinyland/tools/oauth-mux
+Homebrew install QA passed for oauth-mux 0.1.6 via tinyland/tools/oauth-mux
 ```
 
 First-run source e2e:
@@ -108,7 +108,7 @@ first-run e2e passed
 To keep the formula installed after dogfood QA:
 
 ```bash
-OMUX_HOMEBREW_KEEP_INSTALLED=1 OMUX_HOMEBREW_KEEP_TAP=1 just homebrew-qa 0.1.5
+OMUX_HOMEBREW_KEEP_INSTALLED=1 OMUX_HOMEBREW_KEEP_TAP=1 just homebrew-qa 0.1.6
 ```
 
 To include the three-account Codex canary from the installed Homebrew binary:
@@ -121,7 +121,7 @@ OMUX_HOMEBREW_KEEP_TAP=1 \
 OMUX_HOMEBREW_CODEX_CANARY=1 \
 OMUX_HOMEBREW_CODEX_LIVE=1 \
 OMUX_LIVE_QA_CONFIRM=spend-real-calls \
-  just homebrew-qa 0.1.5
+  just homebrew-qa 0.1.6
 ```
 
 Latest local Homebrew dogfood proof:
@@ -131,50 +131,40 @@ brew tap tinyland/tools https://github.com/tinyland-inc/homebrew-tools.git: pass
 brew install tinyland/tools/oauth-mux: pass
 brew audit --formula --strict tinyland/tools/oauth-mux: pass
 brew test tinyland/tools/oauth-mux: pass
-/opt/homebrew/bin/oauth-mux version: oauth-mux 0.1.5
+/opt/homebrew/bin/oauth-mux version: oauth-mux 0.1.6
 /opt/homebrew/bin/oauth-mux doctor --json: ok
-Homebrew-installed oauth-mux codex live-qa --confirm-spend with examples/codex-max.config.json:
-  max-1, max-2, max-3 available for codex-mini and codex-max
+Production tap PR `tinyland-inc/homebrew-tools#4` merged at `f3016e3`.
 ```
 
 Latest public npm dogfood proof:
 
 ```text
-npx -y oauth-mux@0.1.5 version: oauth-mux 0.1.5
-npx -y oauth-mux@0.1.5 doctor --json: ok
-npx -y oauth-mux@0.1.5 codex live-qa --json: confirmation_required without --confirm-spend
-confirmed live QA:
-  routes_total: 6
-  routes_available: 5
-  routes_unavailable: 1
-  probe_errors: 0
-  capabilities_covered: 2
-  capabilities_uncovered: 0
-  max-1#codex-mini: available
+npm publish workflow run 25195609579: pass
+npm view oauth-mux version: 0.1.6
+npx -y oauth-mux@0.1.6 version: oauth-mux 0.1.6
+npx -y oauth-mux@0.1.6 doctor --json: ok
+npx -y oauth-mux@0.1.6 route select --profile codex-max --capability codex-max --json:
+  selected: codex:max-2#codex-max
   max-1#codex-max: quota_exhausted reset@1777987200
-  max-2#codex-mini: available
-  max-2#codex-max: available
-  max-3#codex-mini: available
-  max-3#codex-max: available
 ```
 
 System package install QA after GitHub Release publication:
 
 ```bash
-gh workflow run system-package-install-qa.yml -f version=0.1.5
+gh workflow run system-package-install-qa.yml -f version=0.1.6
 ```
 
 Latest hosted proof:
 
 ```text
-System Package Install QA run 25172711458: pass
-job 73796295655: deb/rpm install from published release assets
+System Package Install QA run 25195456319: pass
+job 73874903526: deb/rpm install from published release assets
 ```
 
 Local reproduction on a host with healthy Docker:
 
 ```bash
-just system-package-qa 0.1.5
+just system-package-qa 0.1.6
 ```
 
 ## Next Proof

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -135,7 +135,7 @@ at the staged artifact directory instead of GitHub Releases.
 After the GitHub Release exists, run the hosted system-package install proof:
 
 ```bash
-gh workflow run system-package-install-qa.yml -f version=0.1.5
+gh workflow run system-package-install-qa.yml -f version=0.1.6
 ```
 
 This workflow downloads the published `.deb` and `.rpm` release assets, verifies
@@ -145,7 +145,7 @@ Linux containers on `ubuntu-latest`, and runs `/usr/bin/oauth-mux version`.
 For local reproduction on a healthy Docker-compatible host:
 
 ```bash
-just system-package-qa 0.1.5
+just system-package-qa 0.1.6
 ```
 
 This is stricter than the registry `system` dry-run lane. The dry-run lane
@@ -201,11 +201,20 @@ Current release evidence:
 - Main CI run `25032478278` completed `test`, `nix`, all six cross-compiles,
   and real GloriousFlywheel cache-first validation after the evidence docs
   merged.
-- System Package Install QA run `25172711458` completed for v0.1.5 and proved
+- Release workflow run `25195318899` published v0.1.6 GitHub Release assets:
+  tarballs, npm package bundles, deb/rpm packages, formula, installer, and
+  checksums.
+- Registry dry-run run `25195456326` completed
+  `plan,github,npm,homebrew,system` for v0.1.6 without mutating registries.
+- System Package Install QA run `25195456319` completed for v0.1.6 and proved
   published `.deb` and `.rpm` assets install in hosted Debian/Rocky containers
   and execute `/usr/bin/oauth-mux version`.
-- Homebrew tap PR `tinyland-inc/homebrew-tools#3` updated `tinyland/tools` to
-  v0.1.5; `just homebrew-qa 0.1.5` passed against the production tap.
+- Homebrew tap PR `tinyland-inc/homebrew-tools#4` updated `tinyland/tools` to
+  v0.1.6; `just homebrew-qa 0.1.6` passed against the production tap.
+- NPM publish workflow run `25195456341` completed from `main` with
+  `dry_run=true` for v0.1.6.
+- NPM publish workflow run `25195609579` published v0.1.6 through the CI-only
+  SOPS-backed path; `npm view oauth-mux version` reports `0.1.6`.
 
 ## Before Marking A PR Ready
 

--- a/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
+++ b/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
@@ -23,13 +23,13 @@ Install surfaces:
 
 | Surface | Current proof |
 | --- | --- |
-| npm global install | `oauth-mux@0.1.5` installs from the public npm registry and returns `oauth-mux 0.1.5`. |
-| npm one-shot | `npx -y oauth-mux@0.1.5 version` passed from `../lab`. |
-| GitHub Release tarball | v0.1.5 macOS arm64 tarball verifies against `SHA256SUMS` and runs. |
-| curl installer | v0.1.5 installer downloads public release assets, verifies checksums, and runs on macOS and `../lab`. |
-| Homebrew | `just homebrew-qa 0.1.5` installs from `tinyland/tools`, runs `brew audit`, `brew test`, `version`, and `doctor --json`. The tap is still private. |
-| deb/rpm | Hosted System Package Install QA run `25172711458` installed published v0.1.5 `.deb` and `.rpm` assets in Debian/Rocky containers. |
-| lab dogfood | Public npm one-shot `oauth-mux@0.1.5` reports healthy `doctor --json` against the local config/state. |
+| npm global install | `oauth-mux@0.1.6` installs from the public npm registry and returns `oauth-mux 0.1.6`. |
+| npm one-shot | `npx -y oauth-mux@0.1.6 version` passed from `../lab`. |
+| GitHub Release tarball | v0.1.6 macOS arm64 tarball verifies against `SHA256SUMS` and runs. |
+| curl installer | v0.1.6 installer downloads public release assets, verifies checksums, and runs on macOS and `../lab`. |
+| Homebrew | `just homebrew-qa 0.1.6` installs from `tinyland/tools`, runs `brew audit`, `brew test`, `version`, and `doctor --json`. The tap is still private. |
+| deb/rpm | Hosted System Package Install QA run `25195456319` installed published v0.1.6 `.deb` and `.rpm` assets in Debian/Rocky containers. |
+| lab dogfood | Public npm one-shot `oauth-mux@0.1.6` reports healthy `doctor --json` against the local config/state. |
 
 OAuth and muxing surfaces:
 
@@ -66,7 +66,7 @@ These are the adoption blockers that should stay visible:
    they are equally dogfooded.
 
 5. Homebrew is private-tap proven, not public-tap proven.
-   The private tap now tracks v0.1.5 and passes install QA, but public website
+   The private tap now tracks v0.1.6 and passes install QA, but public website
    copy should still say the tap is private/staged or wait for a public tap
    stance.
 

--- a/justfile
+++ b/justfile
@@ -119,10 +119,10 @@ release-handoff VERSION="0.1.0":
 registry-dry-run VERSION="0.1.0":
     nix develop --command ./scripts/registry-dry-run.sh {{VERSION}}
 
-system-package-qa VERSION="0.1.5":
+system-package-qa VERSION="0.1.6":
     ./scripts/system-package-install-qa.sh {{VERSION}}
 
-homebrew-qa VERSION="0.1.5":
+homebrew-qa VERSION="0.1.6":
     ./scripts/homebrew-install-qa.sh {{VERSION}}
 
 npm-deprecate-plan VERSION="0.1.1":


### PR DESCRIPTION
## Summary
- update install matrix and dogfood plan to the published v0.1.6 surfaces
- update Homebrew and system-package QA defaults to 0.1.6
- record release, registry dry-run, system-package QA, npm dry-run/publish, and Homebrew tap evidence

## Validation
- `nix develop --command just check-local`
- `git diff --check`
- `just --list`
- `npm view oauth-mux version --json` -> `0.1.6`
- fresh-cache `npm install oauth-mux@0.1.6` -> `oauth-mux 0.1.6`
- `npx -y oauth-mux@0.1.6 version` and `doctor --json`
- public GitHub tarball verifies against `SHA256SUMS` and runs
- public `install.sh` v0.1.6 runs from oauth-mux and `../lab`
- `OMUX_HOMEBREW_KEEP_INSTALLED=1 OMUX_HOMEBREW_KEEP_TAP=1 just homebrew-qa 0.1.6`

## Hosted evidence
- release workflow `25195318899`
- registry dry-run `25195456326`
- system package QA `25195456319`
- npm dry-run `25195456341`
- npm publish `25195609579`
- Homebrew tap PR tinyland-inc/homebrew-tools#4