### PR TITLE
[codex] Define stay-afloat supervisor contract

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -145,7 +145,9 @@ The current adoption plan is tracked in
 real OAuth flow proof plan is tracked in
 `docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md`. The stay-afloat runtime
 and daemon gap plan is tracked in
-`docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`. Together they cover:
+`docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`, and the portable
+foreground supervisor contract is tracked in
+`docs/spec/stay-afloat-supervisor-contract-2026-05-01.md`. Together they cover:
 
 - website structure and public positioning;
 - `v0.1.3` onboarding/doctor/report scope;

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -25,7 +25,31 @@ explicit confirmation flag.
 planner; it does not start a background service, run probes, open browsers,
 refresh credentials, or rewrite secret stores.
 
-See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
+See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md` for the runtime
+gap analysis and `docs/spec/stay-afloat-supervisor-contract-2026-05-01.md` for
+the portable foreground supervisor contract tracked by `TIN-859`.
+
+## Supervisor Contract
+
+The stable stay-afloat contract is the foreground tick engine, not a platform
+service manager and not the current socket stub:
+
+```bash
+oauth-mux stay-afloat --once --json
+oauth-mux stay-afloat --loop --iterations <n> --interval-ms <ms> --json
+oauth-mux stay-afloat --once --execute --json
+oauth-mux stay-afloat handoffs --json
+```
+
+`oauth-mux daemon tick` is the lower-level alias for wrapper authors. It shares
+the same planner/executor as `stay-afloat`.
+
+`oauth-mux daemon run/start/stop/status` remains experimental socket plumbing.
+It can report a local Unix socket status, but it does not host the stay-afloat
+loop, perform automatic repair, or define production daemon semantics.
+Homebrew services, systemd user units, launchd plists, cron, Windows Services,
+containers, and CI wrappers must preserve the foreground command contract
+rather than introducing separate behavior.
 
 ## Allowed Now
 
@@ -60,6 +84,9 @@ See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
 - `oauth-mux stay-afloat --loop --iterations <n> --interval-ms <ms> --json`
   for a bounded foreground loop. It re-reads local health/runtime state each
   tick and remains service-manager agnostic.
+- `oauth-mux daemon tick --loop --iterations <n> --interval-ms <ms> --json`
+  as the lower-level wrapper-author spelling for the same bounded foreground
+  loop.
 - Account-scoped advisory locks during confirmed `repair run`, reported back as
   `repair_in_progress` by runtime-aware route planning.
 - Config-level daemon admission policy for route planning. The default admits
@@ -85,6 +112,8 @@ See `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
 - Any release gate that depends on a long-running daemon.
 - Treating `systemctl`, `launchctl`, Homebrew services, cron, or Windows
   Services as part of the core product contract.
+- Presenting `oauth-mux daemon run/start` as the production stay-afloat daemon
+  before the socket process is aligned with the foreground tick contract.
 
 ## Promotion Criteria
 

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -59,6 +59,12 @@ Next split:
 - `TIN-860`: add handoff acknowledgement and route-evidence refresh UX for
   user-mediated repairs.
 
+The first `TIN-859` artifact is
+`docs/spec/stay-afloat-supervisor-contract-2026-05-01.md`. It defines the
+foreground tick contract as the portable core, keeps the current socket daemon
+experimental, and treats Homebrew/systemd/launchd/Windows service integration
+as optional wrappers rather than product semantics.
+
 Core product docs must remain service-manager agnostic. `systemctl`,
 `launchctl`, Homebrew services, cron, and Windows Services can become wrapper
 examples only after the portable contract is stable.
@@ -88,8 +94,8 @@ patterns are settled.
 
 1. Resolve `#66` / `TIN-858` enough for website wording: public tap, Jess tap,
    or staged-only.
-2. Implement `TIN-859` before adding service wrappers; this protects
-   cross-platform behavior.
+2. Land `TIN-859` before adding service wrappers; this protects cross-platform
+   behavior.
 3. Implement `TIN-860` so a user can recover from a queued auth handoff with a
    short, documented command path.
 4. Start `TIN-862` as the first non-Codex provider proof because GitHub and

--- a/docs/spec/stay-afloat-supervisor-contract-2026-05-01.md
+++ b/docs/spec/stay-afloat-supervisor-contract-2026-05-01.md
@@ -1,0 +1,291 @@
+# Stay-Afloat Supervisor Contract
+Date: 2026-05-01
+
+Issue context: GitHub `Jesssullivan/oauth-mux#67`; Linear `TIN-738`,
+`TIN-859`, and `TIN-860`.
+
+## Decision
+
+The portable stay-afloat supervisor is a command contract first. The stable
+surface is the foreground tick engine exposed as:
+
+```bash
+oauth-mux stay-afloat --once --json
+oauth-mux stay-afloat --loop --iterations <n> --interval-ms <ms> --json
+oauth-mux stay-afloat --once --execute --json
+oauth-mux stay-afloat handoffs --json
+```
+
+`oauth-mux daemon tick` is the lower-level alias for the same engine. It is
+available for wrapper authors and debugging, but user docs should lead with
+`stay-afloat`.
+
+The existing `oauth-mux daemon run/start/stop/status` socket code is not the
+production supervisor contract. It is a Unix socket status/control stub that is
+useful for local experiments. It is currently unsupported on Windows and does
+not perform automatic repair, route refresh, or background scheduling.
+
+Service managers are wrappers, not core semantics. `systemctl`, `launchctl`,
+Homebrew services, cron, Windows Services, scheduled tasks, containers, and CI
+runners may wrap the foreground command later, but none of them define product
+behavior.
+
+## Contract Layers
+
+### Layer 1: foreground supervisor tick
+
+This is the cross-platform core.
+
+- It reloads config, health, runtime readiness, route state, and locks on each
+  tick.
+- Plan mode reports what would happen and does not run probes, repair commands,
+  browser/device auth, or secret mutation.
+- Execute mode runs at most one admitted non-interactive action per tick.
+- Execute mode queues interactive reauth as a redacted handoff event instead of
+  silently running it.
+- Repeated execute ticks do not append duplicate handoffs for the same route
+  while one is pending.
+- When an admitted action changes state, the tick re-reads route state before
+  rendering JSON.
+- Loops are bounded by `--iterations`; unbounded daemonization is outside this
+  layer.
+
+The default policy admits only `free_local` and `free_command` budgets. It
+refuses provider-spend probes, interactive auth, and mutation unless config
+explicitly admits them.
+
+### Layer 2: local evidence and coordination
+
+This layer does not require a daemon process.
+
+- Recorded liveness lives in the health store.
+- Redacted repair, daemon action, handoff, and token-refresh events live in the
+  event log.
+- Account-scoped repair locks live under the runtime directory.
+- `oauth-mux daemon events --json` and `oauth-mux stay-afloat handoffs --json`
+  read local state directly.
+
+The event stream is append-only JSONL and must not contain tokens, credential
+paths, provider response bodies, or raw upstream CLI output.
+
+### Layer 3: socket stub
+
+The current socket daemon is experimental.
+
+- `daemon run` runs in the foreground on Unix-like platforms.
+- `daemon start` forks on Linux/macOS and starts the same loop.
+- `daemon status --json` reports `running` with a pid and socket path, or
+  `not_running`.
+- The socket handler supports `status`, `stop`, and a placeholder `refresh`
+  response.
+- It does not host the stay-afloat tick engine yet.
+- It must not be required by first-run, release gates, live QA, or provider
+  authoring.
+
+The socket stub can become an implementation detail for a future beta daemon,
+but only after its behavior is aligned with the foreground supervisor contract.
+
+### Layer 4: service wrappers
+
+Wrappers are optional packaging artifacts.
+
+- Homebrew may later provide a `brew services` recipe.
+- Linux packages may later ship an optional systemd user unit.
+- macOS packages may later ship an optional launchd plist.
+- Windows may later ship a service wrapper or scheduled-task recipe.
+- npm and curl installs must remain usable without any service manager.
+
+Wrapper docs must call the same foreground command and preserve the same
+budgets, event log, handoff behavior, and bounded-loop semantics.
+
+## Runtime Paths
+
+Core paths come from the repo path helpers, not platform service assumptions.
+
+Configuration:
+
+- `OMUX_CONFIG` selects the exact config file.
+- `OMUX_CONFIG_DIR` selects the config directory.
+- Otherwise config uses XDG on Linux and `~/Library/Application Support` on
+  macOS.
+
+State:
+
+- `OMUX_STATE_DIR` selects the state directory.
+- Otherwise state uses XDG on Linux and `~/Library/Application Support` on
+  macOS.
+- The event log is `repair-events.jsonl` under the state directory.
+
+Runtime:
+
+- `XDG_RUNTIME_DIR/oauth-mux` when `XDG_RUNTIME_DIR` is set.
+- `/tmp/oauth-mux-$UID` on macOS when no XDG runtime dir is present.
+- `$HOME/.local/state/oauth-mux` on other platforms as the current fallback.
+- The socket path is `daemon.sock` under the runtime directory.
+- Repair locks are under `repair-locks` in the runtime directory.
+
+Wrappers may set these environment variables explicitly, but they should not
+invent a second state model.
+
+## JSON Surfaces
+
+Supervisor consumers should read JSON fields, not human text.
+
+Stable inputs:
+
+```bash
+oauth-mux doctor runtime --json
+oauth-mux route explain --profile <profile> --capability <capability> --json
+oauth-mux route select --profile <profile> --capability <capability> --json
+oauth-mux repair-plan --profile <profile> --capability <capability> --json
+oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json
+oauth-mux stay-afloat --once --execute --profile <profile> --capability <capability> --json
+oauth-mux stay-afloat handoffs --json
+oauth-mux daemon events --json
+```
+
+Tick JSON exposes the core supervisor shape:
+
+- `version`
+- `tick_index`
+- `observed_at`
+- `mode`
+- `execution_mode`
+- `executed`
+- `handoff_queued`
+- `handoff_pending`
+- `message`
+- `policy`
+- `profile`
+- `capability`
+- `afloat`
+- `selected`
+- `summary`
+- `executions`
+- `routes`
+
+Route entries carry both route evaluation and per-tick decision data. Consumers
+should treat `afloat:true` plus a non-null `selected` as the positive route
+condition. They should treat `handoff_queued:true` or `handoff_pending:true` as
+the signal to surface user-mediated repair.
+
+Process exit codes are not the primary supervisor API. Use command failure for
+parse/config/runtime errors, and use JSON fields for route state. `route select`
+may exit nonzero when no route is selectable; long-running wrappers should
+prefer `route explain` or `stay-afloat --json` when they need a full state
+object.
+
+## Tick Semantics
+
+A tick follows this order:
+
+1. Load config and validate it.
+2. Expand requested profile/provider/account/capability selectors into routes.
+3. Load recorded health.
+4. Read runtime readiness for each route.
+5. Read account locks and convert active locks into `repair_in_progress`.
+6. Combine liveness plus runtime readiness into route selectability.
+7. Derive a repair action and daemon admission decision per route.
+8. In plan mode, render the decisions.
+9. In execute mode, run at most one admitted non-interactive action or queue one
+   interactive handoff.
+10. Re-read state after an executed action and render the final state.
+
+If any route is already selectable, the tick is a no-op and the route remains
+afloat. If no route is selectable, the first admitted action wins. If no action
+is admitted, the tick reports the refused action and reason rather than
+escalating silently.
+
+## Admission Policy
+
+Every probe or repair action is classified by budget:
+
+- `free_local`
+- `free_command`
+- `cheap_provider`
+- `spend_provider`
+- `interactive`
+- `mutating`
+
+Default daemon policy:
+
+```json
+{
+  "allowed_budgets": ["free_local", "free_command"],
+  "allow_interactive": false,
+  "allow_mutating": false
+}
+```
+
+This means a default tick may inspect local files, parse health, check runtime
+readiness, and run admitted no-spend commands. It may not spend subscription
+quota, open auth flows, or mutate credential stores.
+
+Future policy changes must preserve explicitness:
+
+- provider-spend probes need explicit operator policy;
+- interactive auth needs explicit operator policy and handoff/evidence;
+- mutation needs explicit operator policy plus writeback admission;
+- provider-owned stores such as Codex and Claude remain command-first until
+  official direct refresh/writeback behavior is proven.
+
+## Handoff Semantics
+
+Interactive repair is user mediated.
+
+- A tick with an interactive action records a `daemon_handoff` event.
+- The event includes route identity, action, command, outcome, and redacted
+  booleans, not secrets.
+- `stay-afloat handoffs --json` shows pending handoffs.
+- `--all` includes historical handoff events.
+- A later `route_selectable`, successful `executed`, or successful `noop`
+  event for the same route clears the pending handoff.
+
+`TIN-860` should build on this by adding an explicit acknowledgement and refresh
+UX, for example a command that lets a user mark a handoff reviewed, run the
+upstream login flow, and re-check route state without scraping event logs.
+
+## Wrapper Requirements
+
+A wrapper is acceptable only if it preserves the core contract.
+
+Required wrapper behavior:
+
+- call `oauth-mux stay-afloat --loop` or `oauth-mux daemon tick --loop`;
+- set explicit config/state/runtime directories when needed;
+- keep loops bounded or use the service manager's restart interval instead of
+  hiding an unbounded busy loop inside oauth-mux;
+- capture stdout/stderr without exposing secrets;
+- leave event logging enabled;
+- surface pending handoffs to the user or agent;
+- document how to stop, restart, and inspect status without assuming a specific
+  shell.
+
+Forbidden wrapper behavior:
+
+- enabling provider-spend probes by default;
+- enabling silent interactive auth by default;
+- mutating upstream CLI-owned credential stores by default;
+- making a wrapper required for first-run success;
+- treating Homebrew/systemd/launchd/Windows wrappers as equivalent proof.
+
+## Promotion Gates
+
+Before calling the background daemon production-ready, the project needs:
+
+1. foreground supervisor contract documented and shipped;
+2. handoff acknowledgement and refresh UX;
+3. daemon socket behavior either aligned with tick JSON or kept clearly
+   experimental;
+4. stop/status semantics proven on macOS and Linux;
+5. Windows daemon behavior implemented or explicitly excluded from package
+   docs;
+6. wrapper examples for at least one package lane without changing core
+   semantics;
+7. live QA proving timeout, auth failure, quota exhaustion, transient
+   rate-limit, runtime permission, and handoff states;
+8. docs that distinguish foreground stay-afloat, experimental socket daemon,
+   and optional service wrappers.
+
+Until those gates are met, public docs should describe stay-afloat as an
+agent-safe foreground beta, not as an always-on background daemon.


### PR DESCRIPTION
## Summary

- adds a TIN-859 stay-afloat supervisor contract spec
- documents the foreground tick engine as the portable core contract
- clarifies that the current socket daemon is experimental and service managers are optional wrappers
- crosslinks the contract from daemon boundary, adoption, and the product gap map

## Validation

- git diff --check
- nix develop --command just check-local

Related: #67