### PR TITLE
[codex] Prove daemon supervisor status lifecycle

### DIFF
--- a/docs/spec/stay-afloat-supervisor-contract-2026-05-01.md
+++ b/docs/spec/stay-afloat-supervisor-contract-2026-05-01.md
@@ -289,3 +289,15 @@ Before calling the background daemon production-ready, the project needs:
 
 Until those gates are met, public docs should describe stay-afloat as an
 agent-safe foreground beta, not as an always-on background daemon.
+
+## Local Proof
+
+`scripts/e2e-local.sh` includes a no-mutation foreground daemon check using
+temporary config, state, and runtime directories. It starts `oauth-mux daemon
+run` in the background, waits for `daemon status --json` to report `running`,
+stops it through `daemon stop`, waits for the process to exit, and verifies
+`daemon status --json` reports `not_running`.
+
+That proof is intentionally narrow. It validates the current socket
+status/stop behavior without promoting the socket stub to production
+stay-afloat semantics.

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -13,7 +13,15 @@ if [ ! -x "$bin" ]; then
 fi
 
 tmp="$(mktemp -d "${TMPDIR:-/tmp}/oauth-mux-e2e.XXXXXX")"
-trap 'rm -rf "$tmp"' EXIT
+daemon_pid=""
+cleanup() {
+  if [ -n "${daemon_pid:-}" ]; then
+    kill "$daemon_pid" 2>/dev/null || true
+    wait "$daemon_pid" 2>/dev/null || true
+  fi
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
 
 config="$tmp/config.json"
 state_dir="$tmp/state"
@@ -303,6 +311,42 @@ expect_contains "$daemon_loop" '"ticks":[' "daemon tick loop returns tick array"
 expect_contains "$daemon_loop" '"tick_index":0' "daemon tick loop includes first tick"
 expect_contains "$daemon_loop" '"tick_index":1' "daemon tick loop includes second tick"
 expect_contains "$daemon_loop" '"executed":false' "daemon tick loop remains planning-only"
+
+printf 'e2e: daemon foreground status and stop stay inside temp runtime\n'
+daemon_runtime="$tmp/daemon-runtime"
+daemon_state="$tmp/daemon-state"
+daemon_log="$tmp/daemon.log"
+mkdir -p "$daemon_runtime" "$daemon_state"
+OMUX_CONFIG="$config" \
+  OMUX_STATE_DIR="$daemon_state" \
+  XDG_RUNTIME_DIR="$daemon_runtime" \
+  "$bin" daemon run >"$daemon_log" 2>&1 &
+daemon_pid=$!
+daemon_status=""
+for _ in $(seq 1 200); do
+  daemon_status="$(OMUX_STATE_DIR="$daemon_state" XDG_RUNTIME_DIR="$daemon_runtime" "$bin" daemon status --json || true)"
+  case "$daemon_status" in
+    *'"status":"running"'*) break ;;
+  esac
+done
+expect_contains "$daemon_status" '"status":"running"' "daemon status reports foreground daemon running"
+expect_contains "$daemon_status" '"socket":' "daemon status reports socket path"
+OMUX_STATE_DIR="$daemon_state" XDG_RUNTIME_DIR="$daemon_runtime" "$bin" daemon stop >/dev/null 2>&1
+set +e
+wait "$daemon_pid" 2>/dev/null
+daemon_wait_status=$?
+set -e
+daemon_pid=""
+case "$daemon_wait_status" in
+  0|143) ;;
+  *)
+    printf 'e2e assertion failed: foreground daemon exited unexpectedly with status %s\n' "$daemon_wait_status" >&2
+    printf 'daemon log:\n%s\n' "$(cat "$daemon_log")" >&2
+    exit 1
+    ;;
+esac
+daemon_stopped="$(OMUX_STATE_DIR="$daemon_state" XDG_RUNTIME_DIR="$daemon_runtime" "$bin" daemon status --json)"
+expect_contains "$daemon_stopped" '"status":"not_running"' "daemon status reports stopped foreground daemon"
 
 printf 'e2e: daemon tick execute runs one admitted command probe\n'
 omux health --reset toy:a1 >/dev/null


### PR DESCRIPTION
## Summary

- adds a temp-runtime E2E proof for foreground daemon status and stop
- verifies daemon status reports running, then not_running after daemon stop
- documents the proof as narrow socket lifecycle coverage, not production daemon promotion

## Validation

- git diff --check
- nix develop --command just check-local

Related: #67