### PR TITLE
[codex] Add stay-afloat handoff recovery UX

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -38,6 +38,7 @@ oauth-mux doctor runtime --json
 oauth-mux route explain --profile <profile> --capability <capability> --json
 oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json
 oauth-mux stay-afloat handoffs --json
+oauth-mux stay-afloat refresh --profile <profile> --capability <capability> --json
 oauth-mux stay-afloat --loop --iterations 2 --interval-ms 0 --profile <profile> --capability <capability> --json
 ```
 
@@ -59,6 +60,7 @@ oauth-mux route explain --profile codex-max --capability codex-max --json
 oauth-mux route select --profile codex-max --capability codex-max --json
 oauth-mux stay-afloat --once --profile codex-max --capability codex-max --json
 oauth-mux stay-afloat handoffs --json
+oauth-mux stay-afloat refresh --profile codex-max --capability codex-max --json
 oauth-mux stay-afloat --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
 ```
 
@@ -85,6 +87,9 @@ handoff event. Prefer scoped runtime checks such as
 `oauth-mux doctor runtime --profile codex-max --capability codex-max --json`
 when dogfooding a specific stay-afloat route; global runtime doctor is still
 useful for support bundles and full-machine cleanup.
+After a user-mediated upstream login, `oauth-mux stay-afloat refresh --profile
+<profile> --capability <capability> --json` is the concise evidence refresh
+step that can clear pending handoffs.
 
 `oauth-mux repair run --profile <profile> --capability <capability> --json` is
 also safe without confirmation. It will not open a browser, run `codex login`,

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -72,6 +72,12 @@ rather than introducing separate behavior.
   not run silently in the background. `oauth-mux daemon handoffs --json` is the
   lower-level alias. `--all` keeps the historical handoff events visible after
   later route evidence clears a pending prompt.
+- `oauth-mux stay-afloat handoff ack --provider <provider> --account <account>
+  [--profile <profile>] [--capability <capability>] --json` to record that a
+  pending user-mediated repair was seen without clearing it.
+- `oauth-mux stay-afloat handoff clear --provider <provider> --account
+  <account> [--profile <profile>] [--capability <capability>] --json` to
+  explicitly dismiss a stale pending handoff.
 - `oauth-mux stay-afloat --once --json` for one portable, policy-gated
   daemon-shaped planning pass. `oauth-mux daemon tick --once --json` is the
   lower-level alias. Without `--execute`, it reports `executed:false` and does
@@ -81,6 +87,9 @@ rather than introducing separate behavior.
   re-reads route state afterward, and queues interactive reauth as a redacted
   `daemon_handoff` event instead of running it silently. Repeated ticks report
   an existing handoff as pending rather than appending duplicate events.
+- `oauth-mux stay-afloat refresh --profile <profile> --capability <capability>
+  --json` as the named one-shot execute tick for refreshing route evidence
+  after a user-mediated upstream login.
 - `oauth-mux stay-afloat --loop --iterations <n> --interval-ms <ms> --json`
   for a bounded foreground loop. It re-reads local health/runtime state each
   tick and remains service-manager agnostic.
@@ -144,6 +153,7 @@ oauth-mux probe --profile <profile> --capability <capability> --json
 oauth-mux repair-plan --profile <profile> --capability <capability> --json
 oauth-mux repair run --profile <profile> --capability <capability> --json
 oauth-mux stay-afloat --loop --iterations 2 --interval-ms 0 --profile <profile> --capability <capability> --json
+oauth-mux stay-afloat refresh --profile <profile> --capability <capability> --json
 oauth-mux daemon events --json
 oauth-mux exec --profile <profile> --capability <capability> -- <command>
 ```

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -202,9 +202,26 @@ oauth-mux stay-afloat handoffs --json
 
 The default handoff view is pending as of the daemon's last route evidence. Use
 `oauth-mux stay-afloat handoffs --json --all` when you need the historical audit
-trail instead. After a user completes an upstream CLI login, another
-`stay-afloat --once --execute ... --json` can refresh route evidence and clear
-the pending prompt.
+trail instead. A user or agent can acknowledge that the handoff has been seen
+without clearing it:
+
+```bash
+oauth-mux stay-afloat handoff ack --provider codex --account max-1 --profile codex-max --capability codex-max --json
+```
+
+The recovery loop after an auth expiry is:
+
+```bash
+oauth-mux stay-afloat --once --execute --profile codex-max --capability codex-max --json
+# run the redacted upstream command printed in the handoff, such as:
+oauth-mux codex login-device max-1
+oauth-mux stay-afloat refresh --profile codex-max --capability codex-max --json
+```
+
+`stay-afloat refresh` is a named one-shot execute tick. It refreshes route
+evidence after user-mediated login and clears the pending prompt when the route
+becomes selectable. Use `stay-afloat handoff clear ... --json` only to dismiss a
+stale pending prompt that the operator has decided is no longer actionable.
 
 For a bounded foreground loop, use:
 

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -473,6 +473,28 @@ expect_contains "$daemon_handoffs" '"command":"oauth-mux codex login-device max-
 stay_afloat_handoffs="$(OMUX_STATE_DIR="$state_dir" "$bin" stay-afloat handoffs --json)"
 expect_contains "$stay_afloat_handoffs" '"kind":"daemon_handoff"' "stay-afloat handoffs aliases pending handoff queue"
 
+printf 'e2e: stay-afloat handoff ack records user acknowledgement without clearing pending work\n'
+stay_afloat_ack="$(OMUX_CONFIG="$reauth_config" OMUX_STATE_DIR="$state_dir" "$bin" stay-afloat handoff ack --profile needs-reauth --provider codex --account max-1 --capability codex-max --json)"
+expect_contains "$stay_afloat_ack" '"handoff_acknowledged":true' "stay-afloat handoff ack records acknowledgement"
+expect_contains "$stay_afloat_ack" '"handoff_pending":true' "stay-afloat handoff ack leaves route pending"
+expect_contains "$stay_afloat_ack" '"event_recorded":true' "stay-afloat handoff ack records an event"
+daemon_handoffs_after_ack="$(OMUX_STATE_DIR="$state_dir" "$bin" daemon handoffs --json)"
+expect_contains "$daemon_handoffs_after_ack" '"outcome":"handoff_queued"' "daemon handoffs still shows pending queue after acknowledgement"
+daemon_handoffs_all_after_ack="$(OMUX_STATE_DIR="$state_dir" "$bin" daemon handoffs --json --all)"
+expect_contains "$daemon_handoffs_all_after_ack" '"outcome":"handoff_acknowledged"' "daemon handoffs --all shows acknowledgement history"
+
+printf 'e2e: stay-afloat handoff clear dismisses stale pending work explicitly\n'
+stay_afloat_clear="$(OMUX_CONFIG="$reauth_config" OMUX_STATE_DIR="$state_dir" "$bin" stay-afloat handoff clear --profile needs-reauth --provider codex --account max-1 --capability codex-max --json)"
+expect_contains "$stay_afloat_clear" '"handoff_resolved":true' "stay-afloat handoff clear records resolution"
+expect_contains "$stay_afloat_clear" '"handoff_pending":false' "stay-afloat handoff clear removes pending route"
+daemon_handoffs_after_clear="$(OMUX_STATE_DIR="$state_dir" "$bin" daemon handoffs --json)"
+expect_contains "$daemon_handoffs_after_clear" '"handoffs":[]' "daemon handoffs clears after explicit handoff clear"
+daemon_handoffs_all_after_clear="$(OMUX_STATE_DIR="$state_dir" "$bin" daemon handoffs --json --all)"
+expect_contains "$daemon_handoffs_all_after_clear" '"outcome":"handoff_resolved"' "daemon handoffs --all shows explicit handoff resolution"
+
+daemon_handoff_requeued="$(OMUX_CONFIG="$reauth_config" OMUX_STATE_DIR="$state_dir" "$bin" daemon tick --once --execute --profile needs-reauth --capability codex-max --json)"
+expect_contains "$daemon_handoff_requeued" '"handoff_queued":true' "daemon tick can requeue handoff after explicit clear"
+
 repair_reauth_confirmed_json="$tmp/repair-run-reauth-confirmed.json"
 set +e
 OMUX_CONFIG="$reauth_config" \
@@ -492,13 +514,15 @@ test ! -e "$tmp/reauth-home/auth.json"
 
 printf 'e2e: daemon handoffs clears after route evidence refresh\n'
 printf '%s\n' '{"access_token":"reauth-e2e"}' >"$tmp/reauth-home/auth.json"
-daemon_repaired="$(OMUX_CONFIG="$reauth_config" OMUX_STATE_DIR="$state_dir" "$bin" daemon tick --once --execute --profile needs-reauth --capability codex-max --json)"
-expect_contains "$daemon_repaired" '"executed":true' "daemon repaired tick runs probe after user-mediated login"
-expect_contains "$daemon_repaired" '"phase":"probe"' "daemon repaired tick records probe phase"
+daemon_repaired="$(OMUX_CONFIG="$reauth_config" OMUX_STATE_DIR="$state_dir" "$bin" stay-afloat refresh --profile needs-reauth --capability codex-max --json)"
+expect_contains "$daemon_repaired" '"execution_mode":"execute"' "stay-afloat refresh runs execute tick"
+expect_contains "$daemon_repaired" '"executed":true' "stay-afloat refresh runs probe after user-mediated login"
+expect_contains "$daemon_repaired" '"phase":"probe"' "stay-afloat refresh records probe phase"
 daemon_handoffs_cleared="$(OMUX_STATE_DIR="$state_dir" "$bin" daemon handoffs --json)"
 expect_contains "$daemon_handoffs_cleared" '"handoffs":[]' "daemon handoffs clears resolved handoff"
 daemon_handoffs_all="$(OMUX_STATE_DIR="$state_dir" "$bin" daemon handoffs --json --all)"
 expect_contains "$daemon_handoffs_all" '"kind":"daemon_handoff"' "daemon handoffs --all preserves historical handoff events"
+expect_contains "$daemon_handoffs_all" '"outcome":"handoff_acknowledged"' "daemon handoffs --all preserves acknowledgement events"
 
 printf 'e2e: daemon events exposes redacted repair run audit trail\n'
 repair_events="$(OMUX_STATE_DIR="$state_dir" "$bin" daemon events --json)"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -17,6 +17,7 @@ pub const Command = union(enum) {
     repair_run: RepairRunArgs,
     route: RouteArgs,
     stay_afloat: DaemonTickArgs,
+    stay_afloat_handoff: HandoffArgs,
     config_validate,
     config_path,
     init: InitArgs,
@@ -194,6 +195,20 @@ pub const Command = union(enum) {
         iterations: u32 = 1,
         interval_ms: u64 = 60_000,
         execute: bool = false,
+        json: bool = false,
+    };
+
+    pub const HandoffAction = enum {
+        ack,
+        clear,
+    };
+
+    pub const HandoffArgs = struct {
+        action: HandoffAction = .ack,
+        profile: ?[]const u8 = null,
+        provider: ?[]const u8 = null,
+        account: ?[]const u8 = null,
+        capability: ?[]const u8 = null,
         json: bool = false,
     };
 };
@@ -535,7 +550,47 @@ fn parseDaemonTick(args: []const []const u8) Command {
 
 fn parseStayAfloat(args: []const []const u8) Command {
     if (args.len > 0 and eql(args[0], "handoffs")) return parseDaemonHandoffs(args[1..]);
+    if (args.len > 0 and eql(args[0], "handoff")) return parseStayAfloatHandoff(args[1..]);
+    if (args.len > 0 and eql(args[0], "refresh")) {
+        var tick = parseDaemonTickArgs(args[1..]);
+        tick.once = true;
+        tick.iterations = 1;
+        tick.execute = true;
+        return .{ .stay_afloat = tick };
+    }
     return .{ .stay_afloat = parseDaemonTickArgs(args) };
+}
+
+fn parseStayAfloatHandoff(args: []const []const u8) Command {
+    var result = Command.HandoffArgs{};
+    var i: usize = 0;
+    if (args.len > 0) {
+        if (eql(args[0], "clear") or eql(args[0], "resolve")) {
+            result.action = .clear;
+            i = 1;
+        } else if (eql(args[0], "ack") or eql(args[0], "acknowledge")) {
+            result.action = .ack;
+            i = 1;
+        }
+    }
+    while (i < args.len) : (i += 1) {
+        if (eql(args[i], "--profile") or eql(args[i], "-p")) {
+            i += 1;
+            if (i < args.len) result.profile = args[i];
+        } else if (eql(args[i], "--provider")) {
+            i += 1;
+            if (i < args.len) result.provider = args[i];
+        } else if (eql(args[i], "--account")) {
+            i += 1;
+            if (i < args.len) result.account = args[i];
+        } else if (eql(args[i], "--capability")) {
+            i += 1;
+            if (i < args.len) result.capability = args[i];
+        } else if (eql(args[i], "--json")) {
+            result.json = true;
+        }
+    }
+    return .{ .stay_afloat_handoff = result };
 }
 
 fn parseDaemonTickArgs(args: []const []const u8) Command.DaemonTickArgs {
@@ -751,8 +806,12 @@ pub fn printUsage(writer: anytype) !void {
         \\
         \\  stay-afloat [--once|--loop] [--execute] [--iterations <n>] [--interval-ms <ms>] [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
         \\      Run the portable stay-afloat planner/executor without service-manager assumptions.
+        \\  stay-afloat refresh [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
+        \\      Run one execute tick to refresh route evidence after user-mediated auth.
         \\  stay-afloat handoffs [--json] [--limit <n>] [--all]
         \\      Show pending user-mediated stay-afloat handoffs; --all includes history.
+        \\  stay-afloat handoff ack|clear --provider <name> --account <name> [--profile <name>] [--capability <name>] [--json]
+        \\      Acknowledge or clear a pending user-mediated handoff.
         \\
         \\  config validate    Validate the configuration file.
         \\  config path        Print the config file path.
@@ -1236,6 +1295,51 @@ test "parse stay-afloat handoffs json limit" {
     }
 }
 
+test "parse stay-afloat refresh enables execute tick" {
+    const args = [_][]const u8{ "stay-afloat", "refresh", "--profile", "codex-max", "--capability", "codex-max", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .stay_afloat => |tick| {
+            try std.testing.expect(tick.once);
+            try std.testing.expect(tick.execute);
+            try std.testing.expect(tick.json);
+            try std.testing.expectEqualStrings("codex-max", tick.profile.?);
+            try std.testing.expectEqualStrings("codex-max", tick.capability.?);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse stay-afloat handoff acknowledgement" {
+    const args = [_][]const u8{ "stay-afloat", "handoff", "ack", "--profile", "codex-max", "--provider", "codex", "--account", "max-1", "--capability", "codex-max", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .stay_afloat_handoff => |handoff| {
+            try std.testing.expectEqual(Command.HandoffAction.ack, handoff.action);
+            try std.testing.expectEqualStrings("codex-max", handoff.profile.?);
+            try std.testing.expectEqualStrings("codex", handoff.provider.?);
+            try std.testing.expectEqualStrings("max-1", handoff.account.?);
+            try std.testing.expectEqualStrings("codex-max", handoff.capability.?);
+            try std.testing.expect(handoff.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse stay-afloat handoff clear" {
+    const args = [_][]const u8{ "stay-afloat", "handoff", "clear", "--provider", "codex", "--account", "max-1", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .stay_afloat_handoff => |handoff| {
+            try std.testing.expectEqual(Command.HandoffAction.clear, handoff.action);
+            try std.testing.expectEqualStrings("codex", handoff.provider.?);
+            try std.testing.expectEqualStrings("max-1", handoff.account.?);
+            try std.testing.expect(handoff.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 test "parse daemon tick bounded loop" {
     const args = [_][]const u8{ "daemon", "tick", "--loop", "--execute", "--iterations", "3", "--interval-ms", "250", "--profile", "codex-max", "--capability", "codex-max", "--json" };
     const cmd = parse(&args);
@@ -1310,7 +1414,8 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from route' -a 'select explain' -d 'Route subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from route' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l json -d 'JSON output'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -a handoffs -d 'Show pending handoffs'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -a 'handoffs handoff refresh' -d 'Stay-afloat subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from handoff' -a 'ack clear' -d 'Handoff action'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l once -d 'Run one stay-afloat tick'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l loop -d 'Run bounded foreground stay-afloat ticks'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l execute -d 'Execute one admitted non-interactive action'

--- a/src/main.zig
+++ b/src/main.zig
@@ -141,6 +141,13 @@ pub fn main() !void {
             };
         },
 
+        .stay_afloat_handoff => |handoff_args| {
+            runStayAfloatHandoff(allocator, stdout, handoff_args) catch |e| {
+                log.err("stay-afloat handoff: {s}", .{@errorName(e)});
+                std.process.exit(exitCodeFromPipelineError(e));
+            };
+        },
+
         .completions => |comp_args| {
             try cli.printCompletions(stdout, comp_args.shell);
         },
@@ -1588,6 +1595,89 @@ fn sleepBetweenDaemonTicks(args: cli.Command.DaemonTickArgs, idx: u32, iteration
     const max_ms = std.math.maxInt(u64) / std.time.ns_per_ms;
     const bounded_ms = @min(args.interval_ms, max_ms);
     std.time.sleep(bounded_ms * std.time.ns_per_ms);
+}
+
+fn runStayAfloatHandoff(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    args: cli.Command.HandoffArgs,
+) !void {
+    const provider_name = args.provider orelse return error.ConfigValidationError;
+    const account = args.account orelse return error.ConfigValidationError;
+    const key = repair_state.HandoffKey{
+        .profile = args.profile,
+        .provider = provider_name,
+        .account = account,
+        .capability = args.capability,
+    };
+    const pending_before = try repair_state.hasPendingHandoff(allocator, key);
+
+    var event_recorded = false;
+    const outcome = switch (args.action) {
+        .ack => "handoff_acknowledged",
+        .clear => "handoff_resolved",
+    };
+    const reason = switch (args.action) {
+        .ack => if (pending_before) "user_acknowledged" else "no_pending_handoff",
+        .clear => if (pending_before) "manual_clear" else "no_pending_handoff",
+    };
+
+    if (pending_before) {
+        try repair_state.appendEvent(allocator, .{
+            .kind = "daemon_handoff",
+            .profile = args.profile,
+            .provider = provider_name,
+            .account = account,
+            .capability = args.capability,
+            .action = @tagName(args.action),
+            .outcome = outcome,
+            .reason = reason,
+            .ok = true,
+            .executed = false,
+            .interactive = true,
+            .mutating = false,
+        });
+        event_recorded = true;
+    }
+
+    const pending_after = try repair_state.hasPendingHandoff(allocator, key);
+
+    if (args.json) {
+        try writer.writeAll("{\"ok\":true,\"action\":");
+        try std.json.stringify(@tagName(args.action), .{}, writer);
+        try writer.writeAll(",\"profile\":");
+        if (args.profile) |profile| try std.json.stringify(profile, .{}, writer) else try writer.writeAll("null");
+        try writer.writeAll(",\"provider\":");
+        try std.json.stringify(provider_name, .{}, writer);
+        try writer.writeAll(",\"account\":");
+        try std.json.stringify(account, .{}, writer);
+        try writer.writeAll(",\"capability\":");
+        if (args.capability) |capability| try std.json.stringify(capability, .{}, writer) else try writer.writeAll("null");
+        try writer.writeAll(",\"handoff_pending\":");
+        try writer.writeAll(if (pending_after) "true" else "false");
+        try writer.writeAll(",\"handoff_acknowledged\":");
+        try writer.writeAll(if (args.action == .ack and event_recorded) "true" else "false");
+        try writer.writeAll(",\"handoff_resolved\":");
+        try writer.writeAll(if (args.action == .clear and event_recorded and !pending_after) "true" else "false");
+        try writer.writeAll(",\"event_recorded\":");
+        try writer.writeAll(if (event_recorded) "true" else "false");
+        try writer.writeAll(",\"reason\":");
+        try std.json.stringify(reason, .{}, writer);
+        try writer.writeAll("}\n");
+        return;
+    }
+
+    try writer.writeAll("oauth-mux stay-afloat handoff\n\n");
+    try writer.print("  action: {s}\n", .{@tagName(args.action)});
+    try writer.print("  provider: {s}\n", .{provider_name});
+    try writer.print("  account: {s}\n", .{account});
+    if (args.profile) |profile| try writer.print("  profile: {s}\n", .{profile});
+    if (args.capability) |capability| try writer.print("  capability: {s}\n", .{capability});
+    try writer.print("  handoff_pending: {s}\n", .{if (pending_after) "true" else "false"});
+    try writer.print("  handoff_acknowledged: {s}\n", .{if (args.action == .ack and event_recorded) "true" else "false"});
+    try writer.print("  handoff_resolved: {s}\n", .{if (args.action == .clear and event_recorded and !pending_after) "true" else "false"});
+    try writer.print("  event_recorded: {s}\n", .{if (event_recorded) "true" else "false"});
+    try writer.print("  reason: {s}\n", .{reason});
 }
 
 fn daemonTickMessage(args: cli.Command.DaemonTickArgs) []const u8 {

--- a/src/repair_state.zig
+++ b/src/repair_state.zig
@@ -253,6 +253,7 @@ fn removeResolvedHandoffs(pending: *std.ArrayList([]const u8), event_line: []con
 
 fn eventResolvesHandoff(line: []const u8) bool {
     if (eventFieldEquals(line, "outcome", "route_selectable")) return true;
+    if (eventFieldEquals(line, "outcome", "handoff_resolved")) return true;
     if (eventFieldBool(line, "ok") == true and eventFieldEquals(line, "outcome", "executed")) return true;
     if (eventFieldBool(line, "ok") == true and eventFieldEquals(line, "outcome", "noop")) return true;
     return false;
@@ -566,6 +567,24 @@ test "pending handoff queue resolves by later route event" {
     try upsertPendingHandoff(&pending, handoff);
     try std.testing.expectEqual(@as(usize, 1), pending.items.len);
     removeResolvedHandoffs(&pending, unrelated);
+    try std.testing.expectEqual(@as(usize, 1), pending.items.len);
+    removeResolvedHandoffs(&pending, resolved);
+    try std.testing.expectEqual(@as(usize, 0), pending.items.len);
+}
+
+test "pending handoff queue resolves by explicit handoff event" {
+    var pending = std.ArrayList([]const u8).init(std.testing.allocator);
+    defer pending.deinit();
+
+    const handoff =
+        "{\"kind\":\"daemon_handoff\",\"profile\":\"codex-max\",\"provider\":\"codex\",\"account\":\"max-1\",\"capability\":\"codex-max\",\"outcome\":\"handoff_queued\",\"ok\":false}";
+    const acknowledged =
+        "{\"kind\":\"daemon_handoff\",\"profile\":\"codex-max\",\"provider\":\"codex\",\"account\":\"max-1\",\"capability\":\"codex-max\",\"outcome\":\"handoff_acknowledged\",\"ok\":true}";
+    const resolved =
+        "{\"kind\":\"daemon_handoff\",\"profile\":\"codex-max\",\"provider\":\"codex\",\"account\":\"max-1\",\"capability\":\"codex-max\",\"outcome\":\"handoff_resolved\",\"ok\":true}";
+
+    try upsertPendingHandoff(&pending, handoff);
+    removeResolvedHandoffs(&pending, acknowledged);
     try std.testing.expectEqual(@as(usize, 1), pending.items.len);
     removeResolvedHandoffs(&pending, resolved);
     try std.testing.expectEqual(@as(usize, 0), pending.items.len);


### PR DESCRIPTION
## Summary

- adds `stay-afloat refresh` as a named one-shot execute tick for route evidence refresh after user-mediated auth
- adds `stay-afloat handoff ack|clear` for explicit pending handoff acknowledgement and stale prompt dismissal
- extends handoff event handling with `handoff_acknowledged` and `handoff_resolved` states
- updates E2E and docs for queued handoff -> ack/clear -> requeue -> user action -> refresh -> pending queue cleared

## Validation

- `git diff --check`
- `nix develop --command just check-local`

Related: #67
Linear: TIN-860