### PR TITLE
[codex] Harden GitHub and Linear provider proof

### DIFF
--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -120,6 +120,57 @@ Hosted evidence from PR-branch run `25134175687` on 2026-04-29:
   `OMUX_LIVE_QA_STORE_TGZ_B64` from a minimized credential bundle containing
   only `auth.json`, `installation_id`, and per-account `config.toml` files.
 
+## Low-Impact Identity Probes
+
+GitHub and Linear are the first non-Codex provider-proof lane because their
+built-in `identity` capabilities use provider-owned identity endpoints and do
+not send model prompts, create records, or mutate upstream state.
+
+GitHub uses `GET https://api.github.com/user` with bearer auth. A fine-grained
+token does not need explicit permissions for the endpoint; OAuth app tokens and
+classic PATs may need `user` scope only for private profile fields. The probe
+captures the `x-ratelimit-remaining` header as a classification hint and never
+stores the raw token.
+
+```bash
+OMUX_CONFIG=$PWD/examples/github.config.json \
+OMUX_GITHUB_WORK_TOKEN="$(gh auth token)" \
+  ./zig-out/bin/oauth-mux probe --profile github --capability identity --json
+```
+
+Linear uses `POST https://api.linear.app/graphql` with
+`query Me { viewer { id name email } }` and OAuth bearer auth. A GraphQL `200`
+with an `errors` array is treated as degraded instead of live.
+
+```bash
+OMUX_CONFIG=$PWD/examples/linear.config.json \
+OMUX_LINEAR_WORK_TOKEN="$LINEAR_ACCESS_TOKEN" \
+  ./zig-out/bin/oauth-mux probe --profile linear --capability identity --json
+```
+
+To capture local artifacts through the same wrapper used by hosted provider QA:
+
+```bash
+OMUX_LIVE_QA_CONFIRM=spend-real-calls \
+OMUX_CONFIG=$PWD/examples/github.config.json \
+OMUX_GITHUB_WORK_TOKEN="$(gh auth token)" \
+OMUX_LIVE_QA_PROFILE=github \
+OMUX_LIVE_QA_CAPABILITIES=identity \
+  just live-qa
+
+OMUX_LIVE_QA_CONFIRM=spend-real-calls \
+OMUX_CONFIG=$PWD/examples/linear.config.json \
+OMUX_LINEAR_WORK_TOKEN="$LINEAR_ACCESS_TOKEN" \
+OMUX_LIVE_QA_PROFILE=linear \
+OMUX_LIVE_QA_CAPABILITIES=identity \
+  just live-qa
+```
+
+These probes are still explicit live provider calls. Keep them out of default
+checks and scheduled daemon loops. Promote GitHub or Linear from
+`needs_operator_proof` only after a redacted artifact run is attached to the
+tracking issue.
+
 ## GitHub Workflow
 
 `.github/workflows/live-provider-qa.yml` is manual-only. It requires the

--- a/docs/spec/oauth-mux-formal-model.md
+++ b/docs/spec/oauth-mux-formal-model.md
@@ -347,8 +347,8 @@ Command probes use argv plus inherited environment overlays, must have a
 positive `timeout_ms`, and are classified from stdout/stderr cassettes when the
 provider supplies a parser. Failure rules are intentionally small: exact status
 or status range, optional `retry_after` threshold, optional case-insensitive
-hint substring, and a typed liveness class. This keeps provider extension
-friendly without introducing regex engines or plugin code.
+exact or substring hint, and a typed liveness class. This keeps provider
+extension friendly without introducing regex engines or plugin code.
 
 ## Health Evidence
 

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -90,7 +90,11 @@ Current truth:
 Next split:
 
 - `TIN-861`: prove Claude Code through command-owned auth/session behavior.
-- `TIN-862`: prove GitHub and Linear low-impact identity probes.
+- `TIN-862`: prove GitHub and Linear low-impact identity probes. This is now
+  underway with classifier hardening and a proof spec in
+  `docs/spec/provider-proof-github-linear-2026-05-01.md`; local GitHub live QA
+  has passed, while Linear live proof and durable tracking evidence are still
+  pending.
 - `TIN-863`: prove MCP HTTP authorization and protected-resource metadata.
 
 Later slices should cover Vercel/Figma token variants and Gemini plus
@@ -101,8 +105,9 @@ patterns are settled.
 
 1. Resolve `#66` / `TIN-858` enough for website wording: public tap, Jess tap,
    or staged-only.
-2. Start `TIN-862` as the first non-Codex provider proof because GitHub and
-   Linear identity checks are low-impact and do not require model spend.
+2. Finish `TIN-862` as the first non-Codex provider proof by running redacted
+   GitHub and Linear identity artifacts after the classifier/documentation
+   patch lands.
 3. Use `TIN-861` and `TIN-863` to prove the two harder shapes: CLI-owned
    subscription state and MCP resource-bound OAuth.
 4. Return to daemon background scheduling only after wrapper/install decisions

--- a/docs/spec/provider-authoring-checklist-2026-04-26.md
+++ b/docs/spec/provider-authoring-checklist-2026-04-26.md
@@ -228,8 +228,8 @@ Every provider should define the smallest useful `failure_rules` set:
 `config validate` requires schema-defined providers with capability probes to
 include failure rules. It also rejects catch-all failure rules: every rule must
 include at least one matcher such as `status`, `status_min`, `status_max`,
-`retry_after_gte`, `retry_after_lt`, or `hint_contains`. Empty
-`hint_contains` values are invalid.
+`retry_after_gte`, `retry_after_lt`, `hint_equals`, or `hint_contains`. Empty
+`hint_equals` and `hint_contains` values are invalid.
 
 Failure classes use Zig tagged-union JSON shape: payload variants use
 `{ "dead": "token_revoked" }` or `{ "degraded": "scope_insufficient" }`;

--- a/docs/spec/provider-proof-github-linear-2026-05-01.md
+++ b/docs/spec/provider-proof-github-linear-2026-05-01.md
@@ -1,0 +1,106 @@
+# Provider Proof: GitHub And Linear
+Date: 2026-05-01
+
+Issue context: Linear `TIN-862`, parent `TIN-736`; GitHub
+`Jesssullivan/oauth-mux#68`.
+
+## Baseline
+
+Codex is live-proven. GitHub and Linear are schema-modeled with admitted
+low-impact identity probes, but they should remain `needs_operator_proof` until
+redacted live artifacts exist. This slice tightens the provider semantics needed
+before running those proofs.
+
+## Provider Contracts
+
+GitHub's admitted probe is `GET https://api.github.com/user` with bearer auth.
+GitHub documents `200`, `401`, and `403` for the authenticated-user endpoint.
+GitHub also documents `x-ratelimit-remaining` as the remaining primary-window
+request count and says primary rate-limit exhaustion returns `403` or `429`
+with that header set to `0`.
+
+Linear's admitted probe is a GraphQL `viewer` query over
+`POST https://api.linear.app/graphql`. Linear documents OAuth bearer auth for
+GraphQL requests and documents OAuth access tokens, refresh tokens, expiry, and
+the `viewer` access pattern. Because GraphQL can return semantic errors under
+HTTP `200`, the provider rule must inspect the body hint and downgrade
+`{"errors":[...]}` to degraded instead of live.
+
+## Classifier Decisions
+
+- `401` remains generic OAuth death: `dead.token_revoked`.
+- `429` remains generic provider availability: short `Retry-After` values are
+  `rate_limited`; long values are `quota_exhausted`.
+- GitHub `403` plus `x-ratelimit-remaining: 0` is `rate_limited`.
+- GitHub `403` with any nonzero remaining count is not rate exhaustion and is
+  classified as `degraded.scope_insufficient`.
+- Linear `200` plus GraphQL `errors` is `degraded.unknown_4xx` until a narrower
+  Linear error taxonomy is justified by fixtures.
+- Linear `403` remains `degraded.scope_insufficient`.
+- Provider `5xx` remains `provider_degraded`.
+
+The GitHub distinction requires exact matching on the remaining-count hint.
+Substring matching is wrong because values such as `10` contain `0` but still
+mean remaining capacity exists.
+
+## Proof Commands
+
+Local GitHub proof, using the installed GitHub CLI token without printing it:
+
+```bash
+OMUX_CONFIG=$PWD/examples/github.config.json \
+OMUX_GITHUB_WORK_TOKEN="$(gh auth token)" \
+  ./zig-out/bin/oauth-mux probe --profile github --capability identity --json
+```
+
+Local Linear proof, using an already-scoped OAuth access token:
+
+```bash
+OMUX_CONFIG=$PWD/examples/linear.config.json \
+OMUX_LINEAR_WORK_TOKEN="$LINEAR_ACCESS_TOKEN" \
+  ./zig-out/bin/oauth-mux probe --profile linear --capability identity --json
+```
+
+Artifacted proof should run through `just live-qa` with
+`OMUX_LIVE_QA_CONFIRM=spend-real-calls` even though these are low-impact
+identity calls. That keeps provider-proof evidence under `dist/live-qa/` with
+the same redaction and pass/fail semantics as Codex.
+
+## Promotion Gate
+
+Do not mark GitHub or Linear `live_proven` in `src/main.zig` until all of these
+are true:
+
+1. Unit tests cover provider-specific classification and generic OAuth fallback.
+2. A local or hosted live artifact shows `live.available` for the identity
+   probe without leaking token or raw profile response data.
+3. GitHub issue `#68` and Linear `TIN-862` link the proof artifact or a redacted
+   summary of the run.
+4. The docs keep `schema_modeled`, `needs_operator_proof`, and `live_proven`
+   separate.
+
+## Current Evidence
+
+- GitHub local live QA passed on 2026-05-01 through
+  `scripts/live-provider-qa.sh` using `examples/github.config.json` and a token
+  supplied by `gh auth token`. The redacted result was
+  `github:work#identity`, `probe_status=200`, `live.available`, and
+  `decision=use_this`.
+- Linear live QA is still pending. The current shell did not expose
+  `LINEAR_ACCESS_TOKEN`, and this slice intentionally did not search secret
+  stores for a token.
+
+This is enough to prove the GitHub path locally, but not enough to promote the
+provider globally. TIN-862 should still collect durable issue evidence and a
+Linear proof before changing public support status.
+
+## Sources
+
+- GitHub REST authenticated user endpoint:
+  <https://docs.github.com/en/rest/users/users#get-the-authenticated-user>
+- GitHub REST rate-limit headers:
+  <https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api>
+- Linear GraphQL authentication:
+  <https://linear.app/developers/graphql>
+- Linear OAuth token and viewer request examples:
+  <https://linear.app/developers/oauth-2-0-authentication>

--- a/src/config.zig
+++ b/src/config.zig
@@ -375,6 +375,13 @@ fn validateFailureRule(
         ok.* = false;
     }
 
+    if (rule.hint_equals) |hint| {
+        if (hint.len == 0) {
+            try writer.print("config error: provider_definitions.{s}.failure_rules[{d}].hint_equals must not be empty\n", .{ def_key, rule_idx });
+            ok.* = false;
+        }
+    }
+
     if (rule.hint_contains) |hint| {
         if (hint.len == 0) {
             try writer.print("config error: provider_definitions.{s}.failure_rules[{d}].hint_contains must not be empty\n", .{ def_key, rule_idx });
@@ -407,6 +414,7 @@ fn failureRuleHasMatcher(rule: provider_schema.FailureRule) bool {
         rule.status_max != null or
         rule.retry_after_gte != null or
         rule.retry_after_lt != null or
+        rule.hint_equals != null or
         rule.hint_contains != null;
 }
 
@@ -1506,6 +1514,77 @@ test "validate rejects catch-all failure rule" {
     defer out.deinit();
     try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
     try std.testing.expect(std.mem.indexOf(u8, out.items, "failure_rules[0] must include at least one matcher") != null);
+}
+
+test "validate accepts exact failure rule hint matcher" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "failure_rules": [
+        \\        { "hint_equals": "0", "class": { "rate_limited": {} } }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try validate(parsed.value, out.writer());
+}
+
+test "validate rejects empty failure rule exact hint" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "failure_rules": [
+        \\        { "status": 403, "hint_equals": "", "class": { "degraded": "unknown_4xx" } }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "failure_rules[0].hint_equals must not be empty") != null);
 }
 
 test "validate rejects empty failure rule hint" {

--- a/src/provider_schema.zig
+++ b/src/provider_schema.zig
@@ -66,8 +66,8 @@ pub const ProviderDefinition = struct {
 
     // ── Failure Classification ──
     // Provider-specific HTTP/status/body hints that override generic OAuth
-    // fallback classification. No regex; only exact status/range and substring
-    // hints so the parser remains std-only.
+    // fallback classification. No regex; only exact status/range and simple
+    // exact/substring hints so the parser remains std-only.
     failure_rules: []const FailureRule = &.{},
 };
 
@@ -202,6 +202,7 @@ pub const FailureRule = struct {
     status_max: ?u16 = null,
     retry_after_gte: ?u32 = null,
     retry_after_lt: ?u32 = null,
+    hint_equals: ?[]const u8 = null,
     hint_contains: ?[]const u8 = null,
     class: FailureClass,
 };
@@ -341,7 +342,7 @@ const codex_failure_rules = [_]FailureRule{
 const github_failure_rules = [_]FailureRule{
     .{
         .status = 403,
-        .hint_contains = "0",
+        .hint_equals = "0",
         .class = .rate_limited,
     },
     .{
@@ -1052,6 +1053,10 @@ fn failureRuleMatches(rule: FailureRule, status: u16, retry_after: ?u32, hint: ?
         const wait = retry_after orelse return false;
         if (wait >= max_wait) return false;
     }
+    if (rule.hint_equals) |expected| {
+        const h = hint orelse return false;
+        if (!equalsIgnoreAsciiCaseTrimmed(h, expected)) return false;
+    }
     if (rule.hint_contains) |needle| {
         const h = hint orelse return false;
         if (!containsIgnoreAsciiCase(h, needle)) return false;
@@ -1079,6 +1084,16 @@ fn classificationFromRule(class: FailureClass, retry_after: ?u32) types.HttpClas
 
 fn windowFromRetryAfter(wait: u32) types.RateLimitWindow {
     return if (wait <= 60) .per_minute else if (wait <= 3600) .per_hour else .per_day;
+}
+
+fn equalsIgnoreAsciiCaseTrimmed(left: []const u8, right: []const u8) bool {
+    const left_trimmed = std.mem.trim(u8, left, " \t\r\n");
+    const right_trimmed = std.mem.trim(u8, right, " \t\r\n");
+    if (left_trimmed.len != right_trimmed.len) return false;
+    for (left_trimmed, right_trimmed) |l, r| {
+        if (std.ascii.toLower(l) != std.ascii.toLower(r)) return false;
+    }
+    return true;
 }
 
 fn containsIgnoreAsciiCase(haystack: []const u8, needle: []const u8) bool {
@@ -1567,6 +1582,23 @@ test "linear failure rules classify GraphQL errors as degraded" {
     }
 }
 
+test "linear generic OAuth failures stay typed" {
+    const revoked = classifyHttp(linear_def, 401, null, null);
+    switch (revoked) {
+        .dead => |reason| try std.testing.expectEqual(types.DeadReason.token_revoked, reason),
+        else => return error.TestUnexpectedResult,
+    }
+
+    const limited = classifyHttp(linear_def, 429, 45, null);
+    switch (limited) {
+        .rate_limited => |rl| {
+            try std.testing.expectEqual(@as(u32, 45), rl.retry_after_s);
+            try std.testing.expectEqual(types.RateLimitWindow.per_minute, rl.window);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
 test "figma identity capability uses OAuth me probe" {
     const plan = probePlanForCapability(figma_def, "me").?;
     try std.testing.expectEqual(ProbeTransport.http, plan.transport);
@@ -1630,7 +1662,7 @@ test "flakehub failure rules classify logged out status as dead" {
 }
 
 test "github failure rules distinguish rate limit from scope degradation" {
-    const limited = classifyHttp(github_def, 403, null, "0");
+    const limited = classifyHttp(github_def, 403, null, " 0 ");
     switch (limited) {
         .rate_limited => |rl| try std.testing.expectEqual(@as(u32, 30), rl.retry_after_s),
         else => return error.TestUnexpectedResult,
@@ -1639,6 +1671,29 @@ test "github failure rules distinguish rate limit from scope degradation" {
     const forbidden = classifyHttp(github_def, 403, null, "1");
     switch (forbidden) {
         .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.scope_insufficient, reason),
+        else => return error.TestUnexpectedResult,
+    }
+
+    const double_digit_remaining = classifyHttp(github_def, 403, null, "10");
+    switch (double_digit_remaining) {
+        .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.scope_insufficient, reason),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "github generic OAuth failures stay typed" {
+    const revoked = classifyHttp(github_def, 401, null, null);
+    switch (revoked) {
+        .dead => |reason| try std.testing.expectEqual(types.DeadReason.token_revoked, reason),
+        else => return error.TestUnexpectedResult,
+    }
+
+    const limited = classifyHttp(github_def, 429, 90, null);
+    switch (limited) {
+        .rate_limited => |rl| {
+            try std.testing.expectEqual(@as(u32, 90), rl.retry_after_s);
+            try std.testing.expectEqual(types.RateLimitWindow.per_hour, rl.window);
+        },
         else => return error.TestUnexpectedResult,
     }
 }


### PR DESCRIPTION
## Summary

- Add exact `hint_equals` matching for provider failure rules so GitHub `x-ratelimit-remaining: 10` is not misclassified as exhausted.
- Extend config validation and provider docs for exact hints.
- Add GitHub/Linear classifier tests, a TIN-862 proof spec, and low-impact identity live-QA instructions.

## Dogfood / Proof

- Local GitHub identity live QA passed through `scripts/live-provider-qa.sh`: `github:work#identity`, `probe_status=200`, `live.available`, `decision=use_this`.
- Linear live proof is still pending because this shell did not expose `LINEAR_ACCESS_TOKEN`.
- `providers list --json` still reports GitHub and Linear as `needs_operator_proof`; this PR does not over-promote public support status.

## Validation

- `git diff --check`
- `nix develop --command just check-local`