### PR TITLE
[codex] Add Linear API key identity proof

### DIFF
--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -148,6 +148,14 @@ OMUX_LINEAR_WORK_TOKEN="$LINEAR_ACCESS_TOKEN" \
   ./zig-out/bin/oauth-mux probe --profile linear --capability identity --json
 ```
 
+Linear personal API keys use a raw `Authorization` header, not `Bearer`. Use
+the explicit API-key capability when proving a personal key:
+
+```bash
+OMUX_CONFIG=$PWD/examples/linear-api-key.config.json \
+  ./zig-out/bin/oauth-mux probe --profile linear-api-key --capability identity-api-key --json
+```
+
 To capture local artifacts through the same wrapper used by hosted provider QA:
 
 ```bash
@@ -163,6 +171,12 @@ OMUX_CONFIG=$PWD/examples/linear.config.json \
 OMUX_LINEAR_WORK_TOKEN="$LINEAR_ACCESS_TOKEN" \
 OMUX_LIVE_QA_PROFILE=linear \
 OMUX_LIVE_QA_CAPABILITIES=identity \
+  just live-qa
+
+OMUX_LIVE_QA_CONFIRM=spend-real-calls \
+OMUX_CONFIG=$PWD/examples/linear-api-key.config.json \
+OMUX_LIVE_QA_PROFILE=linear-api-key \
+OMUX_LIVE_QA_CAPABILITIES=identity-api-key \
   just live-qa
 ```
 

--- a/docs/spec/oauth-mux-formal-model.md
+++ b/docs/spec/oauth-mux-formal-model.md
@@ -342,7 +342,10 @@ The compiled adapter may add provider probes, but the common shape should be
 declarative enough for new OAuth-backed tools to be added without editing the
 selection core. Capability probes are plans, not secrets: token material or
 account-scoped env such as `CODEX_HOME` is added only when the probe executes.
-HTTP probes use `method`, `url`, bearer auth, and optional hint headers.
+HTTP probes use `method`, `url`, explicit auth mode, and optional hint headers.
+OAuth bearer tokens use `bearer`, provider-specific non-Authorization token
+headers use `token_header`, and provider-documented raw Authorization tokens
+use `authorization_header`.
 Command probes use argv plus inherited environment overlays, must have a
 positive `timeout_ms`, and are classified from stdout/stderr cassettes when the
 provider supplies a parser. Failure rules are intentionally small: exact status

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -93,8 +93,8 @@ Next split:
 - `TIN-862`: prove GitHub and Linear low-impact identity probes. This is now
   underway with classifier hardening and a proof spec in
   `docs/spec/provider-proof-github-linear-2026-05-01.md`; local GitHub live QA
-  has passed, while Linear live proof and durable tracking evidence are still
-  pending.
+  has passed, Linear personal API-key live QA has passed, and Linear OAuth
+  bearer proof remains pending.
 - `TIN-863`: prove MCP HTTP authorization and protected-resource metadata.
 
 Later slices should cover Vercel/Figma token variants and Gemini plus

--- a/docs/spec/provider-authoring-checklist-2026-04-26.md
+++ b/docs/spec/provider-authoring-checklist-2026-04-26.md
@@ -210,6 +210,10 @@ session directory is runtime readiness, not OAuth liveness.
 token material such as bearer authorization headers, access tokens, refresh
 tokens, ID tokens, or token-template placeholders. The mux injects credentials
 at execution time; provider schemas describe only how to run the probe.
+Use `auth = bearer` for `Authorization: Bearer <token>`, `auth = token_header`
+for provider-specific non-Authorization headers such as `X-Figma-Token`, and
+`auth = authorization_header` only when provider-owned docs require a raw token
+as the `Authorization` header value.
 
 7. Map failures into liveness.
 

--- a/docs/spec/provider-probe-admission-matrix-2026-04-26.md
+++ b/docs/spec/provider-probe-admission-matrix-2026-04-26.md
@@ -31,7 +31,7 @@ implemented yet.
 | MCP HTTP server | `mcp_profile`; built-in `resource-metadata` and `resource` probe templates | `GET {{OMUX_MCP_RESOURCE_METADATA_URL}}` without auth for RFC 9728 metadata; `GET {{OMUX_MCP_RESOURCE_PROBE_URL}}` with resource-bound bearer token for server probe | 401 invalid/expired token, 403 insufficient_scope or step-up, malformed metadata/schema, provider degraded |
 | MCP stdio server | `admitted_command` / injection | Environment or config injection; MCP HTTP OAuth flow does not apply | missing secret, malformed env/config, child-process failure |
 | GitHub | `admitted_http`; built-in `identity` probe | `GET https://api.github.com/user` with bearer token | 200 live, 401 dead, 403 forbidden/rate-limited, rate-limit headers |
-| Linear | `admitted_http`; built-in `identity` probe | `POST https://api.linear.app/graphql` with `query { viewer { id name email } }` and OAuth bearer token | 200 plus GraphQL errors, 401 dead, 403/scope, 429/rate, 5xx degraded |
+| Linear | `admitted_http`; built-in `identity` and `identity-api-key` probes | `POST https://api.linear.app/graphql` with `query { viewer { id name email } }`; OAuth uses bearer auth, personal API keys use raw `Authorization` | 200 plus GraphQL errors, 401 dead, 403/scope, 429/rate, 5xx degraded |
 | Figma REST | `admitted_http`; built-in OAuth `identity`, PAT `identity-pat`, and plan-token `file-metadata-plan` probes | `GET https://api.figma.com/v1/me` with OAuth bearer token and `current_user:read`; PATs use `X-Figma-Token`; plan access tokens use `GET /v1/files/{{OMUX_FIGMA_PLAN_FILE_KEY}}/meta` with `file_metadata:read` | 200 live, 401 dead, 403 scope/tier, 404 resource not allowed/found, 429/rate, 5xx degraded |
 | Figma Remote MCP | `mcp_profile` | Treat as MCP HTTP resource, not as Figma REST | MCP metadata, scope challenge, tool/schema errors |
 | Vercel | `admitted_http`; built-in `identity` probe | `GET https://api.vercel.com/v2/user`; token metadata endpoint and semantic `softBlock` body checks are later optional refinements | 200 live, 401 dead, 403 forbidden/team/scope, 429/rate, 5xx degraded |
@@ -54,7 +54,8 @@ implemented yet.
    until the provider documents direct resource-server semantics.
 6. Custom token-header probes are explicit. Use `auth = token_header` with a
    non-`Authorization` header name such as `X-Figma-Token`; use `auth = bearer`
-   for OAuth Authorization headers.
+   for OAuth Authorization headers; use `auth = authorization_header` only when
+   provider-owned docs require a raw token in the `Authorization` header.
 7. URL templates are for non-secret resource identifiers only. Placeholder
    names must be env-var shaped (`A_Z0_9_`); runtime values must be URL-safe
    unreserved characters.

--- a/docs/spec/provider-proof-github-linear-2026-05-01.md
+++ b/docs/spec/provider-proof-github-linear-2026-05-01.md
@@ -26,6 +26,12 @@ the `viewer` access pattern. Because GraphQL can return semantic errors under
 HTTP `200`, the provider rule must inspect the body hint and downgrade
 `{"errors":[...]}` to degraded instead of live.
 
+Linear personal API keys use the same GraphQL endpoint and viewer query, but
+the provider-owned docs require `Authorization: <API_KEY>` instead of
+`Authorization: Bearer <ACCESS_TOKEN>`. That is modeled as a separate
+`identity-api-key` capability so OAuth bearer proof and personal-key proof do
+not share an ambiguous auth mode.
+
 ## Classifier Decisions
 
 - `401` remains generic OAuth death: `dead.token_revoked`.
@@ -37,6 +43,8 @@ HTTP `200`, the provider rule must inspect the body hint and downgrade
 - Linear `200` plus GraphQL `errors` is `degraded.unknown_4xx` until a narrower
   Linear error taxonomy is justified by fixtures.
 - Linear `403` remains `degraded.scope_insufficient`.
+- Linear OAuth proof uses `identity`; Linear personal API key proof uses
+  `identity-api-key`.
 - Provider `5xx` remains `provider_degraded`.
 
 The GitHub distinction requires exact matching on the remaining-count hint.
@@ -59,6 +67,13 @@ Local Linear proof, using an already-scoped OAuth access token:
 OMUX_CONFIG=$PWD/examples/linear.config.json \
 OMUX_LINEAR_WORK_TOKEN="$LINEAR_ACCESS_TOKEN" \
   ./zig-out/bin/oauth-mux probe --profile linear --capability identity --json
+```
+
+Local Linear proof, using a personal API key from `LINEAR_API_KEY`:
+
+```bash
+OMUX_CONFIG=$PWD/examples/linear-api-key.config.json \
+  ./zig-out/bin/oauth-mux probe --profile linear-api-key --capability identity-api-key --json
 ```
 
 Artifacted proof should run through `just live-qa` with
@@ -86,13 +101,18 @@ are true:
   supplied by `gh auth token`. The redacted result was
   `github:work#identity`, `probe_status=200`, `live.available`, and
   `decision=use_this`.
-- Linear live QA is still pending. The current shell did not expose
-  `LINEAR_ACCESS_TOKEN`, and this slice intentionally did not search secret
-  stores for a token.
+- Linear personal API key live QA passed on 2026-05-01 through
+  `scripts/live-provider-qa.sh` using `examples/linear-api-key.config.json` and
+  the existing `LINEAR_API_KEY` environment variable. The redacted result was
+  `linear:work#identity-api-key`, `probe_status=200`, `live.available`, and
+  `decision=use_this`.
+- Linear OAuth bearer live QA is still pending. The current shell did not expose
+  `LINEAR_ACCESS_TOKEN`.
 
-This is enough to prove the GitHub path locally, but not enough to promote the
-provider globally. TIN-862 should still collect durable issue evidence and a
-Linear proof before changing public support status.
+This is enough to prove the GitHub path locally and the Linear personal API-key
+path locally, but not enough to claim that every Linear auth mode is live-proven.
+TIN-862 should record the OAuth bearer proof separately before changing public
+support status.
 
 ## Sources
 

--- a/examples/linear-api-key.config.json
+++ b/examples/linear-api-key.config.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "defaults": {
+    "provider": "linear",
+    "strategy": "health-weighted",
+    "shell": "fish"
+  },
+  "providers": {
+    "linear": {
+      "kind": "linear",
+      "accounts": {
+        "work": {
+          "priority": 10,
+          "secret": {
+            "backend": "env",
+            "variable": "LINEAR_API_KEY"
+          },
+          "tags": ["api-key", "linear"]
+        }
+      }
+    }
+  },
+  "profiles": {
+    "linear-api-key": {
+      "providers": ["linear:work#identity-api-key"],
+      "strategy": "health-weighted",
+      "affinity_ttl_minutes": 20
+    }
+  },
+  "strategies": {
+    "health-weighted": {
+      "kind": "health-weighted",
+      "rate_limit_penalty": -10,
+      "failure_penalty": -20,
+      "success_bonus": 1
+    }
+  }
+}

--- a/src/config.zig
+++ b/src/config.zig
@@ -1349,6 +1349,51 @@ test "validate rejects authorization as custom token header" {
     try std.testing.expect(std.mem.indexOf(u8, out.items, "probe.auth_header must be a non-Authorization HTTP header name") != null);
 }
 
+test "validate accepts raw authorization header auth" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "capabilities": [
+        \\        {
+        \\          "name": "identity-api-key",
+        \\          "probe": {
+        \\            "method": "GET",
+        \\            "url": "https://example.invalid/v1/me",
+        \\            "auth": "authorization_header"
+        \\          }
+        \\        }
+        \\      ],
+        \\      "failure_rules": [
+        \\        { "status": 403, "class": { "degraded": "scope_insufficient" } }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "TOY_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try validate(parsed.value, out.writer());
+}
+
 test "validate rejects auth header without token header auth" {
     const json =
         \\{

--- a/src/probe.zig
+++ b/src/probe.zig
@@ -79,6 +79,10 @@ fn executeHttp(
             headers_buf[header_count] = .{ .name = "Authorization", .value = bearer_value.? };
             header_count += 1;
         },
+        .authorization_header => {
+            headers_buf[header_count] = .{ .name = "Authorization", .value = access_token };
+            header_count += 1;
+        },
         .token_header => {
             const header_name = plan.auth_header orelse return error.UnsupportedTransport;
             headers_buf[header_count] = .{ .name = header_name, .value = access_token };

--- a/src/provider_schema.zig
+++ b/src/provider_schema.zig
@@ -164,6 +164,7 @@ pub const ProbeTransport = enum {
 
 pub const ProbeAuth = enum {
     bearer,
+    authorization_header,
     token_header,
     none,
 };
@@ -425,6 +426,18 @@ const linear_capabilities = [_]CapabilityDefinition{
             .body = "{\"query\":\"query Me { viewer { id name email } }\"}",
             .content_type = "application/json",
             .auth = .bearer,
+            .hint_body = true,
+        },
+    },
+    .{
+        .name = "identity-api-key",
+        .aliases = &.{ "api-key", "personal-api-key", "pat", "whoami-api-key" },
+        .probe = .{
+            .method = "POST",
+            .url = "https://api.linear.app/graphql",
+            .body = "{\"query\":\"query Me { viewer { id name email } }\"}",
+            .content_type = "application/json",
+            .auth = .authorization_header,
             .hint_body = true,
         },
     },
@@ -1568,6 +1581,20 @@ test "linear identity capability uses GraphQL viewer probe" {
     try std.testing.expectEqualStrings("identity", plan.capability);
     try std.testing.expectEqualStrings("POST", plan.method);
     try std.testing.expectEqualStrings("https://api.linear.app/graphql", plan.url);
+    try std.testing.expect(plan.body != null);
+    try std.testing.expect(std.mem.indexOf(u8, plan.body.?, "viewer") != null);
+    try std.testing.expectEqualStrings("application/json", plan.content_type.?);
+    try std.testing.expect(plan.hint_body);
+}
+
+test "linear api key identity capability uses raw authorization probe" {
+    const plan = probePlanForCapability(linear_def, "personal-api-key").?;
+    try std.testing.expectEqual(ProbeTransport.http, plan.transport);
+    try std.testing.expectEqualStrings("identity-api-key", plan.capability);
+    try std.testing.expectEqualStrings("POST", plan.method);
+    try std.testing.expectEqualStrings("https://api.linear.app/graphql", plan.url);
+    try std.testing.expectEqual(ProbeAuth.authorization_header, plan.auth);
+    try std.testing.expect(plan.auth_header == null);
     try std.testing.expect(plan.body != null);
     try std.testing.expect(std.mem.indexOf(u8, plan.body.?, "viewer") != null);
     try std.testing.expectEqualStrings("application/json", plan.content_type.?);


### PR DESCRIPTION
## Summary

- Add explicit `authorization_header` probe auth for providers that document raw `Authorization: <token>` semantics.
- Add Linear `identity-api-key` capability and `examples/linear-api-key.config.json`.
- Document the Linear OAuth bearer vs personal API key split in live QA and provider-proof docs.

## Dogfood / Proof

- Local Linear API-key probe passed with the existing `LINEAR_API_KEY`: `linear:work#identity-api-key`, `probe_status=200`, `live.available`, `decision=use_this`.
- Artifacted local live QA passed through `scripts/live-provider-qa.sh` with `examples/linear-api-key.config.json`.
- Linear OAuth bearer proof remains pending because this shell does not expose `LINEAR_ACCESS_TOKEN`.

## Validation

- `git diff --check`
- `nix develop --command just check-local`