### PR TITLE
[codex] Decide Homebrew public lane

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -17,7 +17,10 @@ Target install surfaces:
 
 The Homebrew command above is proven for the Tinyland tap, but it is not yet a
 public Homebrew distribution promise. Track that decision in
-`docs/spec/product-gap-issue-map-2026-05-01.md`.
+`docs/spec/product-gap-issue-map-2026-05-01.md`. The recommended public lane is
+a Jess-owned tap, `Jesssullivan/homebrew-omux`, documented in
+`docs/spec/homebrew-public-lane-decision-2026-05-01.md`; do not publish public
+Homebrew install copy until that tap exists and clean-machine QA passes.
 
 Each release artifact should be derived from the same CI release tree. npm is
 published only from CI tarballs; workstation `npm publish` is not supported.

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -14,7 +14,7 @@ files, SOPS plaintext, or token-shaped values here.
 | npm one-shot | 0.1.6 | macOS arm64 | public npm registry | Pass | `npx -y oauth-mux@0.1.6 version` returns `oauth-mux 0.1.6`. |
 | GitHub release tarball | 0.1.6 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Release workflow `25195318899` published all tarballs, packages, checksums, formula, and installer. |
 | `curl | sh` installer | 0.1.6 | macOS arm64 and `../lab` | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass | Default installer repo is canonical; no `REPO=...` override needed. |
-| Homebrew formula | 0.1.6 | macOS arm64 | `tinyland/tools` tap | Pass | `just homebrew-qa 0.1.6` installs from the private `tinyland-inc/homebrew-tools` tap, runs `brew audit`, `brew test`, `oauth-mux version`, and `oauth-mux doctor --json`. |
+| Homebrew formula | 0.1.6 | macOS arm64 | `tinyland/tools` tap | Pass | `just homebrew-qa 0.1.6` installs from the private `tinyland-inc/homebrew-tools` tap, runs `brew audit`, `brew test`, `oauth-mux version`, and `oauth-mux doctor --json`. Public lane recommendation is `Jesssullivan/homebrew-omux`, pending repo creation and QA. |
 | deb package | 0.1.6 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25195456319` installed package and ran `/usr/bin/oauth-mux version`. |
 | rpm package | 0.1.6 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25195456319` installed package and ran `/usr/bin/oauth-mux version`. |
 | Codex route dogfood | 0.1.6 | macOS arm64 | public npm one-shot | Pass with degraded route | Published npm binary selected `max-2#codex-max` while recorded liveness kept `max-1#codex-max` quota exhausted. |
@@ -173,3 +173,7 @@ just system-package-qa 0.1.6
 2. For each release that changes deb/rpm packaging, run the workflow after the
    GitHub Release assets exist.
 3. Treat registry metadata checks as insufficient without this install proof.
+4. Create the public Jess-owned Homebrew tap from
+   `docs/spec/homebrew-public-lane-decision-2026-05-01.md`, then rerun
+   Homebrew QA with `OMUX_HOMEBREW_TAP_NAME=jesssullivan/omux` and
+   `OMUX_HOMEBREW_TAP_GIT_URL=https://github.com/Jesssullivan/homebrew-omux.git`.

--- a/docs/spec/homebrew-public-lane-decision-2026-05-01.md
+++ b/docs/spec/homebrew-public-lane-decision-2026-05-01.md
@@ -1,0 +1,111 @@
+# Homebrew Public Lane Decision
+Date: 2026-05-01
+
+Issue context: GitHub `Jesssullivan/oauth-mux#66`; Linear `TIN-858`.
+
+## Decision
+
+Use a Jess-owned public tap for public Homebrew adoption. Keep
+`tinyland-inc/homebrew-tools` as the private/staged Tinyland tap.
+
+Recommended public repository:
+
+```text
+Jesssullivan/homebrew-omux
+```
+
+Recommended install command after the public tap exists:
+
+```bash
+brew tap jesssullivan/omux https://github.com/Jesssullivan/homebrew-omux.git
+brew install jesssullivan/omux/oauth-mux
+```
+
+Until that repository exists and clean-machine QA passes, public docs and the
+website must keep Homebrew marked as staged/private and should advertise npm,
+GitHub Release tarballs, `curl | sh`, deb, and rpm first.
+
+## Current Truth
+
+- `tinyland-inc/homebrew-tools` exists and is private.
+- `tinyland/tools/oauth-mux` installs v0.1.6 from that private tap.
+- The private tap has passed local Homebrew QA: tap, audit, install/reinstall,
+  test, `oauth-mux version`, and `oauth-mux doctor --json`.
+- No accessible `Jesssullivan/homebrew-omux` or `Jesssullivan/homebrew-tools`
+  repo exists at this checkpoint.
+- The release workflow already emits `oauth-mux.rb` and `SHA256SUMS` from the
+  public GitHub Release tree.
+
+## Rationale
+
+The core repository is a Jess Sullivan FOSS project, with Tinyland acting as
+the development and release-infrastructure partner. A Jess-owned Homebrew tap
+matches that ownership shape better than making the internal Tinyland tools tap
+public.
+
+Keeping the Tinyland tap private also reduces accidental public exposure of
+future internal formulas, private staging workflows, or org-specific package
+policy. The public tap can stay intentionally small: one formula, one release
+source, one rollback path.
+
+## Publication Contract
+
+The public tap formula must be derived from public release artifacts, not from a
+developer workstation:
+
+1. Cut the `oauth-mux` release through the existing CI release workflow.
+2. Use the generated public release assets:
+   - `oauth-mux.rb`
+   - `SHA256SUMS`
+   - platform tarballs
+3. Copy or automate the generated formula into the public tap.
+4. Run Homebrew QA against the public tap URL.
+5. Only then update public adoption docs from staged/private wording to public
+   Homebrew wording.
+
+The existing `scripts/homebrew-install-qa.sh` already supports this by
+overriding:
+
+```bash
+OMUX_HOMEBREW_TAP_NAME=jesssullivan/omux
+OMUX_HOMEBREW_TAP_GIT_URL=https://github.com/Jesssullivan/homebrew-omux.git
+```
+
+## Rollback
+
+Rollback should be a tap commit, not a local formula edit:
+
+1. Revert the public tap commit that introduced the bad formula.
+2. Confirm `brew update` sees the reverted formula.
+3. Run `scripts/homebrew-install-qa.sh <last-good-version>` against the public
+   tap.
+4. If a GitHub Release asset is bad, mark the release as bad in release notes
+   and cut a patch release rather than mutating published checksums in place.
+
+## Website Wording
+
+Before public tap creation:
+
+```text
+Homebrew: staged/private tap; npm, GitHub Release, curl, deb, and rpm are the
+public install lanes today.
+```
+
+After public tap creation and QA:
+
+```text
+brew tap jesssullivan/omux https://github.com/Jesssullivan/homebrew-omux.git
+brew install jesssullivan/omux/oauth-mux
+```
+
+Do not describe this as Homebrew core. It is a public tap.
+
+## Completion Gate
+
+Close `#66` / `TIN-858` only after:
+
+1. `Jesssullivan/homebrew-omux` exists and is public.
+2. The formula is populated from a public `oauth-mux` release asset.
+3. Clean-machine QA passes against the public tap.
+4. `docs/adoption.md`, `docs/install-beta-matrix.md`, the website, and release
+   notes use the public tap wording.

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -17,7 +17,7 @@ boundaries that need separate tracking.
 
 | Facet | Public GitHub issue | Linear tracking | Current posture |
 | --- | --- | --- | --- |
-| Homebrew distribution | `#66` | `TIN-858`, related to `TIN-737` | Private/staged Tinyland tap works; public Homebrew lane undecided. |
+| Homebrew distribution | `#66` | `TIN-858`, related to `TIN-737` | Private/staged Tinyland tap works; recommended public lane is a Jess-owned tap, pending repo creation and QA. |
 | Stay-afloat daemon | `#67` | `TIN-738`, `TIN-859`, `TIN-860` | Foreground/agent-safe stay-afloat is shipped; production background daemon is not. |
 | Provider expansion | `#68` | `TIN-736`, `TIN-861`, `TIN-862`, `TIN-863` | Codex is live-proven; most other providers are schema-modeled or admitted but not live-proven. |
 
@@ -34,12 +34,16 @@ Current truth:
 
 Decision options:
 
-1. Make `tinyland-inc/homebrew-tools` public.
-2. Create a public Jess-owned tap, such as `Jesssullivan/homebrew-omux`.
-3. Keep Homebrew staged/private and advertise npm, GitHub Release, curl, and
-   deb/rpm as the public install surfaces.
+1. Recommended: create a public Jess-owned tap,
+   `Jesssullivan/homebrew-omux`, and use tap name `jesssullivan/omux`.
+2. Keep `tinyland-inc/homebrew-tools` private as staged Tinyland
+   infrastructure.
+3. Continue advertising npm, GitHub Release, curl, deb, and rpm as the public
+   install surfaces until public tap QA passes.
 
-The website must use staged/private wording until this is decided.
+The decision record is
+`docs/spec/homebrew-public-lane-decision-2026-05-01.md`. The website must keep
+staged/private wording until the public tap exists and clean-machine QA passes.
 
 ## Stay-Afloat Daemon Boundary
 
@@ -103,8 +107,9 @@ patterns are settled.
 
 ## Immediate Execution Order
 
-1. Resolve `#66` / `TIN-858` enough for website wording: public tap, Jess tap,
-   or staged-only.
+1. Create and prove the public Jess-owned Homebrew tap from
+   `docs/spec/homebrew-public-lane-decision-2026-05-01.md`, or keep website
+   wording staged/private until that work lands.
 2. Finish `TIN-862` as the first non-Codex provider proof by running redacted
    GitHub and Linear identity artifacts after the classifier/documentation
    patch lands.


### PR DESCRIPTION
## Summary

- records the Homebrew public lane decision as a Jess-owned public tap
- keeps tinyland-inc/homebrew-tools documented as private/staged infrastructure
- updates adoption and install-beta docs so public website copy stays staged until clean-machine public tap QA passes

## Validation

- git diff --check
- nix develop --command just check-local

## Tracking

- Closes toward #66
- Linear: TIN-858