### PR TITLE
[codex] Promote public Homebrew tap

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -9,18 +9,16 @@ they must not become requirements for ordinary users.
 Target install surfaces:
 
 - npm: `npm install -g oauth-mux`
-- Homebrew staged/private tap:
-  `brew tap tinyland/tools https://github.com/tinyland-inc/homebrew-tools.git && brew install tinyland/tools/oauth-mux`
+- Homebrew public tap:
+  `brew tap jesssullivan/omux https://github.com/Jesssullivan/homebrew-omux.git && brew install jesssullivan/omux/oauth-mux`
 - curl installer: `curl -fsSL ... | sh`
 - deb/rpm packages for Linux hosts
 - raw release tarballs for air-gapped or policy-managed systems
 
-The Homebrew command above is proven for the Tinyland tap, but it is not yet a
-public Homebrew distribution promise. Track that decision in
-`docs/spec/product-gap-issue-map-2026-05-01.md`. The recommended public lane is
-a Jess-owned tap, `Jesssullivan/homebrew-omux`, documented in
-`docs/spec/homebrew-public-lane-decision-2026-05-01.md`; do not publish public
-Homebrew install copy until that tap exists and clean-machine QA passes.
+The public Homebrew tap is `Jesssullivan/homebrew-omux`, documented in
+`docs/spec/homebrew-public-lane-decision-2026-05-01.md`. The older
+`tinyland-inc/homebrew-tools` tap remains private/staged Tinyland
+infrastructure, not public adoption copy.
 
 Each release artifact should be derived from the same CI release tree. npm is
 published only from CI tarballs; workstation `npm publish` is not supported.

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -14,7 +14,7 @@ files, SOPS plaintext, or token-shaped values here.
 | npm one-shot | 0.1.6 | macOS arm64 | public npm registry | Pass | `npx -y oauth-mux@0.1.6 version` returns `oauth-mux 0.1.6`. |
 | GitHub release tarball | 0.1.6 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Release workflow `25195318899` published all tarballs, packages, checksums, formula, and installer. |
 | `curl | sh` installer | 0.1.6 | macOS arm64 and `../lab` | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass | Default installer repo is canonical; no `REPO=...` override needed. |
-| Homebrew formula | 0.1.6 | macOS arm64 | `tinyland/tools` tap | Pass | `just homebrew-qa 0.1.6` installs from the private `tinyland-inc/homebrew-tools` tap, runs `brew audit`, `brew test`, `oauth-mux version`, and `oauth-mux doctor --json`. Public lane recommendation is `Jesssullivan/homebrew-omux`, pending repo creation and QA. |
+| Homebrew formula | 0.1.6 | macOS arm64 + hosted Ubuntu dry-run | public `jesssullivan/omux` tap | Pass | Clean local uninstall/untap followed by `just homebrew-qa 0.1.6` installed from `Jesssullivan/homebrew-omux`; hosted registry dry-run `25199131583` checked out the public tap and passed the Homebrew lane. |
 | deb package | 0.1.6 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25195456319` installed package and ran `/usr/bin/oauth-mux version`. |
 | rpm package | 0.1.6 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25195456319` installed package and ran `/usr/bin/oauth-mux version`. |
 | Codex route dogfood | 0.1.6 | macOS arm64 | public npm one-shot | Pass with degraded route | Published npm binary selected `max-2#codex-max` while recorded liveness kept `max-1#codex-max` quota exhausted. |
@@ -87,7 +87,7 @@ just homebrew-qa 0.1.6
 Expected output includes:
 
 ```text
-Homebrew install QA passed for oauth-mux 0.1.6 via tinyland/tools/oauth-mux
+Homebrew install QA passed for oauth-mux 0.1.6 via jesssullivan/omux/oauth-mux
 ```
 
 First-run source e2e:
@@ -125,6 +125,22 @@ OMUX_LIVE_QA_CONFIRM=spend-real-calls \
 ```
 
 Latest local Homebrew dogfood proof:
+
+```text
+brew uninstall oauth-mux: pass
+brew untap jesssullivan/omux: pass
+brew tap jesssullivan/omux https://github.com/Jesssullivan/homebrew-omux.git: pass
+brew install jesssullivan/omux/oauth-mux: pass
+brew audit --formula --strict jesssullivan/omux/oauth-mux: pass
+brew test jesssullivan/omux/oauth-mux: pass
+/opt/homebrew/bin/oauth-mux version: oauth-mux 0.1.6
+/opt/homebrew/bin/oauth-mux doctor --json: ok
+Public tap repository: `Jesssullivan/homebrew-omux`, default branch `main`.
+Hosted registry dry-run `25199131583`: pass, checked out public tap and passed
+the Homebrew lane.
+```
+
+Latest private/staged Homebrew proof:
 
 ```text
 brew tap tinyland/tools https://github.com/tinyland-inc/homebrew-tools.git: pass
@@ -173,7 +189,6 @@ just system-package-qa 0.1.6
 2. For each release that changes deb/rpm packaging, run the workflow after the
    GitHub Release assets exist.
 3. Treat registry metadata checks as insufficient without this install proof.
-4. Create the public Jess-owned Homebrew tap from
-   `docs/spec/homebrew-public-lane-decision-2026-05-01.md`, then rerun
-   Homebrew QA with `OMUX_HOMEBREW_TAP_NAME=jesssullivan/omux` and
-   `OMUX_HOMEBREW_TAP_GIT_URL=https://github.com/Jesssullivan/homebrew-omux.git`.
+4. Keep Homebrew release updates derived from public GitHub Release
+   `oauth-mux.rb` and `SHA256SUMS`, then rerun `just homebrew-qa <version>`
+   against the public `jesssullivan/omux` tap.

--- a/docs/registry-dry-runs-and-rollback.md
+++ b/docs/registry-dry-runs-and-rollback.md
@@ -66,7 +66,8 @@ Required secret and variable surfaces:
 - `OMUX_HOMEBREW_TAP_REPOSITORY` plus optional `OMUX_HOMEBREW_TAP_REF` when
   the workflow should check out the tap before the Homebrew lane.
 - `OMUX_HOMEBREW_TAP_NAME` when Homebrew requires auditing by tap/formula name
-  instead of by formula path, for example `tinyland/tools`.
+  instead of by formula path. Public release dry-runs should use
+  `jesssullivan/omux`; `tinyland/tools` is the private staged tap.
 - `OMUX_BREW_BIN` when the Homebrew executable is not available as `brew`.
   The GitHub workflow installs Homebrew on Ubuntu and sets this automatically.
 - `OMUX_HOMEBREW_AUDIT_ONLINE=1` only after the homepage and release URLs are

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -211,6 +211,11 @@ Current release evidence:
   and execute `/usr/bin/oauth-mux version`.
 - Homebrew tap PR `tinyland-inc/homebrew-tools#4` updated `tinyland/tools` to
   v0.1.6; `just homebrew-qa 0.1.6` passed against the production tap.
+- Public Homebrew tap `Jesssullivan/homebrew-omux` now serves
+  `jesssullivan/omux/oauth-mux` v0.1.6; strict local QA removed the prior
+  install/tap and `just homebrew-qa 0.1.6` passed against the public tap.
+- Registry dry-run run `25199131583` completed the Homebrew lane against the
+  public `Jesssullivan/homebrew-omux` tap checkout.
 - NPM publish workflow run `25195456341` completed from `main` with
   `dry_run=true` for v0.1.6.
 - NPM publish workflow run `25195609579` published v0.1.6 through the CI-only

--- a/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
+++ b/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
@@ -27,7 +27,7 @@ Install surfaces:
 | npm one-shot | `npx -y oauth-mux@0.1.6 version` passed from `../lab`. |
 | GitHub Release tarball | v0.1.6 macOS arm64 tarball verifies against `SHA256SUMS` and runs. |
 | curl installer | v0.1.6 installer downloads public release assets, verifies checksums, and runs on macOS and `../lab`. |
-| Homebrew | `just homebrew-qa 0.1.6` installs from `tinyland/tools`, runs `brew audit`, `brew test`, `version`, and `doctor --json`. The tap is still private. |
+| Homebrew | `just homebrew-qa 0.1.6` installs from public `jesssullivan/omux`, runs `brew audit`, `brew test`, `version`, and `doctor --json`. The private `tinyland/tools` tap remains a staged internal lane. |
 | deb/rpm | Hosted System Package Install QA run `25195456319` installed published v0.1.6 `.deb` and `.rpm` assets in Debian/Rocky containers. |
 | lab dogfood | Public npm one-shot `oauth-mux@0.1.6` reports healthy `doctor --json` against the local config/state. |
 
@@ -65,10 +65,10 @@ These are the adoption blockers that should stay visible:
    stdin, and env references need explicit e2e proof before public copy implies
    they are equally dogfooded.
 
-5. Homebrew is private-tap proven, not public-tap proven.
-   The private tap now tracks v0.1.6 and passes install QA, but public website
-   copy should still say the tap is private/staged or wait for a public tap
-   stance.
+5. Homebrew is public-tap proven for v0.1.6, but release automation still needs
+   to keep future formula updates derived from public GitHub Release assets.
+   The public tap is `Jesssullivan/homebrew-omux`; the private Tinyland tap is
+   staging infrastructure.
 
 6. The daemon remains deferred.
    Daemon start/stop/status exist, but background refresh/probe behavior is not

--- a/docs/spec/homebrew-public-lane-decision-2026-05-01.md
+++ b/docs/spec/homebrew-public-lane-decision-2026-05-01.md
@@ -21,9 +21,9 @@ brew tap jesssullivan/omux https://github.com/Jesssullivan/homebrew-omux.git
 brew install jesssullivan/omux/oauth-mux
 ```
 
-Until that repository exists and clean-machine QA passes, public docs and the
-website must keep Homebrew marked as staged/private and should advertise npm,
-GitHub Release tarballs, `curl | sh`, deb, and rpm first.
+As of the implementation update below, that repository exists and clean local
+install QA passes. Public docs may use the public tap wording, while still
+avoiding any claim that this is Homebrew core.
 
 ## Current Truth
 
@@ -31,10 +31,32 @@ GitHub Release tarballs, `curl | sh`, deb, and rpm first.
 - `tinyland/tools/oauth-mux` installs v0.1.6 from that private tap.
 - The private tap has passed local Homebrew QA: tap, audit, install/reinstall,
   test, `oauth-mux version`, and `oauth-mux doctor --json`.
-- No accessible `Jesssullivan/homebrew-omux` or `Jesssullivan/homebrew-tools`
-  repo exists at this checkpoint.
+- `Jesssullivan/homebrew-omux` now exists as the public tap, with default
+  branch `main`.
 - The release workflow already emits `oauth-mux.rb` and `SHA256SUMS` from the
   public GitHub Release tree.
+
+## Implementation Update
+
+On 2026-05-01, `Jesssullivan/homebrew-omux` was created as a public repository
+and populated from the public `oauth-mux` v0.1.6 release asset
+`oauth-mux.rb`.
+
+Strict local dogfood then removed the existing local `oauth-mux` install and
+public tap, tapped `jesssullivan/omux` from
+`https://github.com/Jesssullivan/homebrew-omux.git`, installed
+`jesssullivan/omux/oauth-mux`, ran `brew audit`, ran `brew test`, checked
+`oauth-mux version`, and ran `oauth-mux doctor --json`.
+
+Hosted registry dry-run `25199131583` also checked out
+`Jesssullivan/homebrew-omux` and passed the Homebrew lane against the public
+tap.
+
+Result:
+
+```text
+Homebrew install QA passed for oauth-mux 0.1.6 via jesssullivan/omux/oauth-mux
+```
 
 ## Rationale
 
@@ -84,7 +106,7 @@ Rollback should be a tap commit, not a local formula edit:
 
 ## Website Wording
 
-Before public tap creation:
+Before public tap creation, historical wording was:
 
 ```text
 Homebrew: staged/private tap; npm, GitHub Release, curl, deb, and rpm are the
@@ -106,6 +128,9 @@ Close `#66` / `TIN-858` only after:
 
 1. `Jesssullivan/homebrew-omux` exists and is public.
 2. The formula is populated from a public `oauth-mux` release asset.
-3. Clean-machine QA passes against the public tap.
+3. Clean-machine or clean-local QA passes against the public tap.
 4. `docs/adoption.md`, `docs/install-beta-matrix.md`, the website, and release
    notes use the public tap wording.
+
+Items 1-3 have clean-local v0.1.6 proof as of 2026-05-01. Item 4 remains the
+cross-repo alignment gate.

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -9,15 +9,15 @@ and `TIN-863`.
 
 `oauth-mux` v0.1.6 is published and dogfooded for the Codex three-account
 route. The release has public GitHub assets, npm `latest`, `curl | sh`,
-deb/rpm assets, and a private/staged Homebrew tap path. The remaining adoption
-risks are no longer general release mechanics. They are three specific product
+deb/rpm assets, and a public Jess-owned Homebrew tap. The remaining adoption
+risks are no longer general release mechanics. They are specific product
 boundaries that need separate tracking.
 
 ## Public Issue Map
 
 | Facet | Public GitHub issue | Linear tracking | Current posture |
 | --- | --- | --- | --- |
-| Homebrew distribution | `#66` | `TIN-858`, related to `TIN-737` | Private/staged Tinyland tap works; recommended public lane is a Jess-owned tap, pending repo creation and QA. |
+| Homebrew distribution | `#66` | `TIN-858`, related to `TIN-737` | Public Jess-owned tap exists and clean local install QA passes; Tinyland tap remains private/staged. |
 | Stay-afloat daemon | `#67` | `TIN-738`, `TIN-859`, `TIN-860` | Foreground/agent-safe stay-afloat is shipped; production background daemon is not. |
 | Provider expansion | `#68` | `TIN-736`, `TIN-861`, `TIN-862`, `TIN-863` | Codex is live-proven; most other providers are schema-modeled or admitted but not live-proven. |
 
@@ -25,25 +25,19 @@ boundaries that need separate tracking.
 
 Current truth:
 
-- `brew tap tinyland/tools https://github.com/tinyland-inc/homebrew-tools.git`
-  plus `brew install tinyland/tools/oauth-mux` installs v0.1.6.
-- The tap is still private/staged infrastructure, not Homebrew core and not a
-  public tap promise.
+- `brew tap jesssullivan/omux https://github.com/Jesssullivan/homebrew-omux.git`
+  plus `brew install jesssullivan/omux/oauth-mux` installs v0.1.6 from the
+  public tap.
+- The public tap is `Jesssullivan/homebrew-omux`, default branch `main`.
+- `tinyland-inc/homebrew-tools` still exists and remains private/staged
+  Tinyland infrastructure.
+- This is not Homebrew core. It is a public Homebrew tap.
 - Formula updates must continue to come from public GitHub Release
   `oauth-mux.rb` and `SHA256SUMS`, not local `dist/out` output.
 
-Decision options:
-
-1. Recommended: create a public Jess-owned tap,
-   `Jesssullivan/homebrew-omux`, and use tap name `jesssullivan/omux`.
-2. Keep `tinyland-inc/homebrew-tools` private as staged Tinyland
-   infrastructure.
-3. Continue advertising npm, GitHub Release, curl, deb, and rpm as the public
-   install surfaces until public tap QA passes.
-
 The decision record is
-`docs/spec/homebrew-public-lane-decision-2026-05-01.md`. The website must keep
-staged/private wording until the public tap exists and clean-machine QA passes.
+`docs/spec/homebrew-public-lane-decision-2026-05-01.md`. The website can now
+use public tap wording once it matches this repo truth.
 
 ## Stay-Afloat Daemon Boundary
 
@@ -107,9 +101,8 @@ patterns are settled.
 
 ## Immediate Execution Order
 
-1. Create and prove the public Jess-owned Homebrew tap from
-   `docs/spec/homebrew-public-lane-decision-2026-05-01.md`, or keep website
-   wording staged/private until that work lands.
+1. Update website/release copy to use the public `jesssullivan/omux` Homebrew
+   tap and close `#66` / `TIN-858` after those surfaces are aligned.
 2. Finish `TIN-862` as the first non-Codex provider proof by running redacted
    GitHub and Linear identity artifacts after the classifier/documentation
    patch lands.
@@ -120,8 +113,7 @@ patterns are settled.
 
 ## Guardrails
 
-- Do not advertise Homebrew as public until the tap visibility/ownership is
-  settled.
+- Do not describe the public tap as Homebrew core.
 - Do not make daemon execution a first-run or release gate.
 - Do not run live probes by default.
 - Do not mutate upstream CLI-owned credential stores.

--- a/scripts/homebrew-install-qa.sh
+++ b/scripts/homebrew-install-qa.sh
@@ -10,8 +10,8 @@ Installs oauth-mux from the configured Homebrew tap, runs brew audit/test, and
 verifies the installed binary version.
 
 Environment:
-  OMUX_HOMEBREW_TAP_NAME       Homebrew tap name. Default: tinyland/tools
-  OMUX_HOMEBREW_TAP_GIT_URL    Tap git URL. Default: https://github.com/tinyland-inc/homebrew-tools.git
+  OMUX_HOMEBREW_TAP_NAME       Homebrew tap name. Default: jesssullivan/omux
+  OMUX_HOMEBREW_TAP_GIT_URL    Tap git URL. Default: https://github.com/Jesssullivan/homebrew-omux.git
   OMUX_BREW_BIN                brew executable. Default: brew
   OMUX_HOMEBREW_KEEP_INSTALLED Keep oauth-mux installed after QA. Default: preserve prior state
   OMUX_HOMEBREW_KEEP_TAP       Keep tap after QA. Default: preserve prior state
@@ -22,8 +22,8 @@ EOF
 fi
 
 brew_cmd="${OMUX_BREW_BIN:-brew}"
-tap_name="${OMUX_HOMEBREW_TAP_NAME:-tinyland/tools}"
-tap_url="${OMUX_HOMEBREW_TAP_GIT_URL:-https://github.com/tinyland-inc/homebrew-tools.git}"
+tap_name="${OMUX_HOMEBREW_TAP_NAME:-jesssullivan/omux}"
+tap_url="${OMUX_HOMEBREW_TAP_GIT_URL:-https://github.com/Jesssullivan/homebrew-omux.git}"
 formula="${tap_name}/oauth-mux"
 
 require_command() {

--- a/scripts/release-handoff.sh
+++ b/scripts/release-handoff.sh
@@ -173,7 +173,8 @@ still private at publication time, use the CI-only npm workflow with
 
 ## Homebrew Tap
 
-Copy the rendered formula into the tap and review the four platform checksums:
+Copy the rendered formula into the public tap
+\`Jesssullivan/homebrew-omux\` and review the four platform checksums:
 
 \`\`\`bash
 cp dist/out/v${version}/homebrew/oauth-mux.rb <tap-checkout>/Formula/oauth-mux.rb


### PR DESCRIPTION
## Summary

- make the public `jesssullivan/omux` tap the default Homebrew QA/adoption path
- update install, release, rollback, dogfood, and gap docs with public tap proof
- preserve `tinyland/tools` as the private/staged tap, not public copy

## Public tap proof

- created public repo `Jesssullivan/homebrew-omux`
- populated `Formula/oauth-mux.rb` from the public v0.1.6 `oauth-mux.rb` release asset
- strict local uninstall/untap then `just homebrew-qa 0.1.6` passed via `jesssullivan/omux/oauth-mux`
- repo variables now point Homebrew dry-runs at `Jesssullivan/homebrew-omux` / `jesssullivan/omux`
- hosted Registry Dry Run `25199131583` passed the Homebrew lane against the public tap

## Validation

- git diff --check
- nix develop --command just check-local
- OMUX_HOMEBREW_KEEP_INSTALLED=1 OMUX_HOMEBREW_KEEP_TAP=1 just homebrew-qa 0.1.6
- hosted Registry Dry Run 25199131583

## Tracking

- Closes toward #66
- Linear: TIN-858