### PR TITLE
[codex] Fix auth-none command probes

### DIFF
--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -88,6 +88,10 @@ Current truth:
 Next split:
 
 - `TIN-861`: prove Claude Code through command-owned auth/session behavior.
+  The first no-spend local proof is captured in
+  `docs/spec/provider-proof-claude-command-auth-2026-05-01.md`: `auth-status`
+  can now run through `claude auth status --json` without first reading or
+  mutating Claude's credential store.
 - `TIN-862`: prove GitHub and Linear low-impact identity probes. This is now
   underway with classifier hardening and a proof spec in
   `docs/spec/provider-proof-github-linear-2026-05-01.md`; local GitHub live QA

--- a/docs/spec/provider-proof-claude-command-auth-2026-05-01.md
+++ b/docs/spec/provider-proof-claude-command-auth-2026-05-01.md
@@ -1,0 +1,78 @@
+# Provider Proof: Claude Command Auth
+Date: 2026-05-01
+
+Issue context: Linear `TIN-861`, parent `TIN-736`; GitHub
+`Jesssullivan/oauth-mux#68`.
+
+## Baseline
+
+Claude Code is a CLI-owned subscription/session provider. Its safest first
+probe is not direct OAuth refresh and not a model call. The admitted probe is
+the upstream command:
+
+```bash
+claude auth status --json
+```
+
+`oauth-mux` models that as the built-in `claude` provider capability
+`auth-status` with `transport = command`, `auth = none`, and
+`budget = free_command`. The selected account still supplies
+`CLAUDE_CONFIG_DIR`, but the probe itself must not require `oauth-mux` to parse
+or rewrite Claude's credential store before the upstream CLI has reported its
+own status.
+
+## Bug Found During Dogfood
+
+The first Claude proof attempt failed before invoking `claude auth status`.
+`oauth-mux probe --profile claude --capability auth-status --json` tried to read
+`~/.claude/.credentials.json`, then marked the account dead when that file was
+not readable from the current process.
+
+That was the wrong boundary. For `auth = none` command probes, credential-file
+readability is runtime repair evidence, not a prerequisite for asking the
+provider CLI whether the selected config directory has an active session.
+
+## Pipeline Decision
+
+`runProbe` now marks the pipeline as probe-only while candidate selection runs.
+If the selected capability resolves to a probe plan whose auth mode is `none`,
+the pipeline skips `readSecret` and `validateToken`, executes the command probe,
+records the typed liveness result, and selects or skips the account based on
+the probe's mux decision.
+
+This does not weaken HTTP or bearer-token probes. Non-`none` probe plans still
+require a parsed token before `probe.execute` runs.
+
+## Local Proof
+
+No-spend Claude proof with isolated oauth-mux state:
+
+```bash
+tmp="$(mktemp -d)"
+OMUX_STATE_DIR="$tmp" \
+OMUX_CONFIG=$PWD/examples/claude.config.json \
+  ./zig-out/bin/oauth-mux probe --profile claude --capability auth-status --json
+```
+
+Observed local result on 2026-05-01:
+
+- selected route: `claude:work#auth-status`
+- probe executed: `true`
+- probe status: `200`
+- decision: `use_this`
+- liveness: `live.available`
+- runtime readiness: ready
+
+This proves the command-owned auth-status lane can report a live Claude session
+without reading or mutating Claude's credential file. It does not prove Claude
+quota, tier, or model-call availability, and it does not make direct OAuth
+repair admissible.
+
+## Remaining Work
+
+- Attach this proof to `TIN-861` and GitHub `#68`.
+- Add logged-out and missing-binary operator fixtures when available.
+- Keep Claude as command-first until provider-owned docs expose direct repair
+  semantics that are safe for subscription session stores.
+- Do not schedule Claude model-call probes by default. Any future route probe
+  that spends provider quota must require explicit operator confirmation.

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -28,6 +28,7 @@ pub const Context = struct {
     allocated_values: std.ArrayList([]const u8),
     target_argv: []const []const u8 = &.{},
     shell: types.ShellKind = .posix,
+    probe_only: bool = false,
     last_probe_executed: bool = false,
     last_probe_status: ?u16 = null,
     last_probe_decision: ?types.MuxDecision = null,
@@ -81,6 +82,8 @@ pub fn runEnv(ctx: *Context) PipelineError!void {
 
 pub fn runProbe(ctx: *Context) PipelineError!void {
     try resolveProvider(ctx);
+    ctx.probe_only = true;
+    defer ctx.probe_only = false;
     try selectWithFallback(ctx);
 }
 
@@ -133,6 +136,33 @@ fn selectWithFallback(ctx: *Context) PipelineError!void {
         ctx.account_name = candidate.account;
         ctx.capability_name = candidate.capability;
         ctx.provider_kind = config_mod.resolveProviderKind(ctx.cfg, candidate.provider);
+
+        if (ctx.probe_only and probePlanUsesNoCredential(ctx)) {
+            const post_probe_decision = probeCapability(ctx) catch |e| {
+                recordCandidateFailure(ctx, key.slice(), e);
+                last_err = e;
+                freeCurrentToken(ctx);
+                continue;
+            };
+            switch (post_probe_decision) {
+                .use_this => {},
+                .try_next_provider => {
+                    if (skipped_provider_count < skipped_providers.len) {
+                        skipped_providers[skipped_provider_count] = candidate.provider;
+                        skipped_provider_count += 1;
+                    }
+                    freeCurrentToken(ctx);
+                    continue;
+                },
+                .try_next_account, .wait_and_retry, .give_up => {
+                    freeCurrentToken(ctx);
+                    continue;
+                },
+            }
+
+            log.info("pipeline: using {s}:{s}", .{ candidate.provider, candidate.account });
+            return;
+        }
 
         // Try the read → validate path
         readSecret(ctx) catch |e| {
@@ -190,8 +220,16 @@ fn freeCurrentToken(ctx: *Context) void {
     if (ctx.token) |tok| {
         ctx.allocator.free(tok.access_token);
         if (tok.refresh_token) |rt| ctx.allocator.free(rt);
-        ctx.token = null;
     }
+    ctx.token = null;
+}
+
+fn probePlanUsesNoCredential(ctx: *Context) bool {
+    const capability = ctx.capability_name orelse return false;
+    const prov = ctx.provider_name orelse return false;
+    const def = config_mod.resolveProviderDefinition(ctx.cfg, prov);
+    const plan = provider_schema.probePlanForCapability(def, capability) orelse return false;
+    return plan.auth == .none;
 }
 
 fn recordCandidateFailure(ctx: *Context, key: []const u8, err: PipelineError) void {
@@ -408,11 +446,16 @@ fn validateToken(ctx: *Context) PipelineError!void {
 
 fn probeCapability(ctx: *Context) PipelineError!types.MuxDecision {
     const capability = ctx.capability_name orelse return .use_this;
-    const tok = ctx.token orelse return error.TokenParseFailed;
     const prov = ctx.provider_name orelse return error.ProviderNotFound;
     const acct = ctx.account_name orelse return error.AccountNotFound;
     const def = config_mod.resolveProviderDefinition(ctx.cfg, prov);
     const plan = provider_schema.probePlanForCapability(def, capability) orelse return .use_this;
+    const access_token = if (ctx.token) |tok|
+        tok.access_token
+    else switch (plan.auth) {
+        .none => "",
+        else => return error.TokenParseFailed,
+    };
 
     var probe_env = buildProbeEnv(ctx, prov, acct, def, plan) catch |e| switch (e) {
         error.OutOfMemory => return error.OutOfMemory,
@@ -420,7 +463,7 @@ fn probeCapability(ctx: *Context) PipelineError!types.MuxDecision {
     };
     defer probe_env.deinit();
 
-    const result = probe.execute(ctx.allocator, plan, tok.access_token, probe_env.pairs.items) catch |e| switch (e) {
+    const result = probe.execute(ctx.allocator, plan, access_token, probe_env.pairs.items) catch |e| switch (e) {
         error.OutOfMemory => return error.OutOfMemory,
         error.UnsupportedMethod, error.UnsupportedTransport => return error.ConfigValidationError,
         error.NetworkError => return error.NetworkError,
@@ -1187,6 +1230,71 @@ test "runProbe honors explicit account filter without a configured probe plan" {
     try std.testing.expect(!ctx.last_probe_executed);
     try std.testing.expect(store.accounts.get("codex:max-2") != null);
     try std.testing.expect(store.accounts.get("codex:max-1") == null);
+}
+
+test "runProbe executes auth none command probe without reading missing secret" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "defaults": { "provider": "toy" },
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "capabilities": [
+        \\        {
+        \\          "name": "status",
+        \\          "probe": {
+        \\            "transport": "command",
+        \\            "auth": "none",
+        \\            "command": ["sh", "-c", "printf '{\"loggedIn\":true}'"],
+        \\            "budget": "free_command"
+        \\          }
+        \\        }
+        \\      ],
+        \\      "failure_rules": [
+        \\        {
+        \\          "status": 400,
+        \\          "hint_contains": "\"loggedIn\":false",
+        \\          "class": { "dead": "token_revoked" }
+        \\        }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "OMUX_TEST_SECRET_THAT_IS_NOT_SET" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "toy": { "providers": ["toy:default#status"] }
+        \\  },
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try config_mod.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+
+    var ctx = Context.init(std.testing.allocator, parsed.value, &store);
+    defer ctx.deinit();
+    ctx.profile_name = "toy";
+    ctx.capability_name = "status";
+
+    try runProbe(&ctx);
+
+    try std.testing.expect(ctx.last_probe_executed);
+    try std.testing.expect(ctx.token == null);
+    try std.testing.expectEqual(@as(?u16, 200), ctx.last_probe_status);
+    try std.testing.expectEqual(types.MuxDecision.use_this, ctx.last_probe_decision.?);
+    try std.testing.expect(store.accounts.get("toy:default#status") != null);
 }
 
 test "runEnv skips remaining accounts for degraded provider" {


### PR DESCRIPTION
## Summary

- Allow probe-only command capabilities with `auth = none` to execute without first reading a credential secret.
- Preserve token requirements for bearer/header probes and normal env/exec routes.
- Add a regression test covering an auth-none command probe with a deliberately missing secret.
- Document the Claude Code `auth-status` proof slice and update the product gap map for `TIN-861`.

## Why

Claude Code owns its subscription/session store. The admitted first proof is `claude auth status --json`, which should be able to report the selected `CLAUDE_CONFIG_DIR` session before oauth-mux attempts to parse or repair Claude credential files. Dogfooding showed the old pipeline failed early with `SecretReadFailed` and marked the account dead before the upstream CLI status command could run.

## Validation

- `git diff --check`
- `nix develop --command just check-local`
- no-spend Claude proof with isolated `OMUX_STATE_DIR`: `ok=true`, `provider=claude`, `account=work`, `capability=auth-status`, `probe_status=200`, `decision=use_this`, `live.available`, runtime ready
