### PR TITLE
[codex] Validate MCP protected resource metadata

### DIFF
--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -98,6 +98,10 @@ Next split:
   has passed, Linear personal API-key live QA has passed, and Linear OAuth
   bearer proof remains pending.
 - `TIN-863`: prove MCP HTTP authorization and protected-resource metadata.
+  The first metadata hardening slice is captured in
+  `docs/spec/provider-proof-mcp-http-authorization-2026-05-01.md`: MCP
+  `resource-metadata` no longer treats any HTTP 200 body as live unless the
+  RFC 9728/MCP metadata fields are structurally valid.
 
 Later slices should cover Vercel/Figma token variants and Gemini plus
 FlakeHub/Determinate command-first status once the first three provider-proof

--- a/docs/spec/provider-proof-mcp-http-authorization-2026-05-01.md
+++ b/docs/spec/provider-proof-mcp-http-authorization-2026-05-01.md
@@ -1,0 +1,117 @@
+# Provider Proof: MCP HTTP Authorization
+Date: 2026-05-01
+
+Issue context: Linear `TIN-863`, parent `TIN-736`; GitHub
+`Jesssullivan/oauth-mux#68`.
+
+## Baseline
+
+MCP HTTP authorization is not a generic bearer-token check. The MCP
+authorization profile treats a protected MCP server as an OAuth resource server
+and requires protected resource metadata for authorization-server discovery.
+The oauth-mux MCP provider therefore needs two distinct proof surfaces:
+
+- `resource-metadata`: a no-secret `GET` against the RFC 9728 metadata
+  document.
+- `resource`: a bearer-token probe against a concrete MCP resource URL using a
+  token minted for that resource.
+
+These are intentionally separate. A valid metadata document does not prove a
+user token is live, and a live token for one MCP resource must not be replayed
+against another MCP resource.
+
+## Current Spec Truth
+
+The current MCP spec revision found on 2026-05-01 is `2025-11-25`. Its
+authorization page says MCP servers must implement OAuth 2.0 Protected Resource
+Metadata and MCP clients must use it for authorization server discovery. The
+same page says MCP clients must support both `WWW-Authenticate` resource
+metadata discovery and well-known URI fallback.
+
+For MCP specifically, the protected resource metadata document must include an
+`authorization_servers` field with at least one authorization server. RFC 9728
+defines the `resource` metadata parameter as required and defines
+`authorization_servers` as the list of OAuth authorization server issuer
+identifiers for the protected resource.
+
+Relevant sources:
+
+- MCP Authorization, 2025-11-25:
+  <https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization>
+- MCP 2025-11-25 changelog:
+  <https://modelcontextprotocol.io/specification/2025-11-25/changelog>
+- RFC 9728, OAuth 2.0 Protected Resource Metadata:
+  <https://datatracker.ietf.org/doc/html/rfc9728>
+
+## Implementation Decision
+
+`oauth-mux` now treats successful MCP `resource-metadata` HTTP status as only
+the transport-level result. It separately validates the body before recording
+the probe as live:
+
+- body must parse as JSON object;
+- `resource` must be a non-fragment HTTPS URL string;
+- `authorization_servers` must be a non-empty array;
+- every authorization server entry must be a non-fragment HTTPS URL string.
+
+Malformed or incomplete metadata is classified as `degraded.schema_invalid`.
+This keeps MCP proof aligned with the formal liveness model instead of treating
+any HTTP 200 response as usable authorization evidence.
+
+The generic URL-template guard also now distinguishes full URL placeholders
+from embedded path placeholders. Full HTTPS URLs are accepted only when the
+entire probe URL template is a single placeholder such as
+`{{OMUX_MCP_RESOURCE_METADATA_URL}}`; embedded placeholder values remain limited
+to URL-safe unreserved path fragments. That keeps MCP's operator-selected
+resource URLs possible without loosening every provider URL template.
+
+## Public Metadata Proof
+
+Figma's public remote MCP endpoint exposes protected resource metadata at both
+the root and MCP-path well-known URLs:
+
+```bash
+curl -fsS https://mcp.figma.com/.well-known/oauth-protected-resource
+curl -fsS https://mcp.figma.com/.well-known/oauth-protected-resource/mcp
+```
+
+The observed metadata on 2026-05-01 contained:
+
+- `resource`: `https://mcp.figma.com/mcp`
+- `authorization_servers`: `["https://api.figma.com"]`
+- `bearer_methods_supported`: `["header"]`
+- `scopes_supported`: `["mcp:connect"]`
+
+That is enough to prove the no-secret metadata lane. The oauth-mux probe also
+passes when pointed at that metadata URL:
+
+```bash
+tmp="$(mktemp -d)"
+OMUX_STATE_DIR="$tmp" \
+OMUX_CONFIG=$PWD/examples/mcp-http.config.json \
+OMUX_MCP_RESOURCE_METADATA_URL=https://mcp.figma.com/.well-known/oauth-protected-resource \
+  ./zig-out/bin/oauth-mux probe --profile mcp-metadata \
+    --capability resource-metadata --json
+```
+
+Observed local result on 2026-05-01:
+
+- selected route: `mcp:figma#resource-metadata`
+- probe executed: `true`
+- probe status: `200`
+- decision: `use_this`
+- liveness: `live.available`
+- last probe source: `capability_probe`
+
+This is not enough to prove resource-token liveness because that requires a
+resource-bound access token.
+
+## Remaining Work
+
+- Add a resource-token proof only with a scoped MCP token minted for
+  `https://mcp.figma.com/mcp` or another explicit test resource.
+- Keep `resource` bearer-token proof out of default daemon loops. MCP resource
+  probes are provider calls and require an explicit operator-selected resource.
+- Later: implement challenge discovery from `WWW-Authenticate:
+  resource_metadata=...` so configs can start from a resource URL instead of a
+  precomputed metadata URL.

--- a/src/probe.zig
+++ b/src/probe.zig
@@ -26,6 +26,13 @@ pub fn classifyResult(
     plan: provider_schema.ProbePlan,
     result: ProbeResult,
 ) types.HttpClassification {
+    if (isMcpResourceMetadataPlan(def, plan) and
+        result.status >= plan.success_status_min and
+        result.status <= plan.success_status_max)
+    {
+        return classifyMcpProtectedResourceMetadata(allocator, result.hint);
+    }
+
     if (plan.transport == .command) {
         if (std.mem.eql(u8, def.name, "codex")) {
             if (result.hint) |hint| {
@@ -41,6 +48,54 @@ pub fn classifyResult(
         return if (classified == .success) .success else classified;
     }
     return classified;
+}
+
+fn isMcpResourceMetadataPlan(
+    def: provider_schema.ProviderDefinition,
+    plan: provider_schema.ProbePlan,
+) bool {
+    return std.mem.eql(u8, def.name, "mcp") and
+        std.mem.eql(u8, plan.capability, "resource-metadata");
+}
+
+fn classifyMcpProtectedResourceMetadata(
+    allocator: std.mem.Allocator,
+    hint: ?[]const u8,
+) types.HttpClassification {
+    const body = hint orelse return schemaInvalid();
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, body, .{}) catch return schemaInvalid();
+    defer parsed.deinit();
+
+    const obj = switch (parsed.value) {
+        .object => |obj| obj,
+        else => return schemaInvalid(),
+    };
+
+    const resource = jsonString(obj.get("resource") orelse return schemaInvalid()) orelse return schemaInvalid();
+    if (!isSafeAbsoluteHttpsUrl(resource)) return schemaInvalid();
+
+    const authorization_servers = switch (obj.get("authorization_servers") orelse return schemaInvalid()) {
+        .array => |arr| arr,
+        else => return schemaInvalid(),
+    };
+    if (authorization_servers.items.len == 0) return schemaInvalid();
+    for (authorization_servers.items) |server_value| {
+        const server = jsonString(server_value) orelse return schemaInvalid();
+        if (!isSafeAbsoluteHttpsUrl(server)) return schemaInvalid();
+    }
+
+    return .success;
+}
+
+fn jsonString(value: std.json.Value) ?[]const u8 {
+    return switch (value) {
+        .string => |s| s,
+        else => null,
+    };
+}
+
+fn schemaInvalid() types.HttpClassification {
+    return .{ .degraded = .schema_invalid };
 }
 
 pub fn execute(
@@ -136,6 +191,17 @@ fn executeHttp(
 }
 
 fn expandUrlTemplate(allocator: std.mem.Allocator, template: []const u8) ProbeError![]const u8 {
+    if (singlePlaceholderName(template)) |name| {
+        const value = std.process.getEnvVarOwned(allocator, name) catch |e| switch (e) {
+            error.EnvironmentVariableNotFound => return error.UnsupportedTransport,
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.UnsupportedTransport,
+        };
+        errdefer allocator.free(value);
+        if (!isSafeTemplateValue(value) and !isSafeAbsoluteHttpsUrl(value)) return error.UnsupportedTransport;
+        return value;
+    }
+
     var out = std.ArrayList(u8).init(allocator);
     errdefer out.deinit();
 
@@ -163,6 +229,14 @@ fn expandUrlTemplate(allocator: std.mem.Allocator, template: []const u8) ProbeEr
     return try out.toOwnedSlice();
 }
 
+fn singlePlaceholderName(template: []const u8) ?[]const u8 {
+    if (!std.mem.startsWith(u8, template, "{{")) return null;
+    if (!std.mem.endsWith(u8, template, "}}")) return null;
+    if (std.mem.indexOfPos(u8, template, 2, "{{") != null) return null;
+    const name = template[2 .. template.len - 2];
+    return if (isSafeTemplateName(name)) name else null;
+}
+
 fn isSafeTemplateName(name: []const u8) bool {
     if (name.len == 0) return false;
     for (name) |c| {
@@ -177,6 +251,16 @@ fn isSafeTemplateValue(value: []const u8) bool {
     for (value) |c| {
         if (std.ascii.isAlphanumeric(c) or c == '-' or c == '.' or c == '_' or c == '~') continue;
         return false;
+    }
+    return true;
+}
+
+fn isSafeAbsoluteHttpsUrl(value: []const u8) bool {
+    if (!std.mem.startsWith(u8, value, "https://")) return false;
+    if (value.len == "https://".len) return false;
+    if (std.mem.indexOfScalar(u8, value, '#') != null) return false;
+    for (value) |c| {
+        if (std.ascii.isWhitespace(c)) return false;
     }
     return true;
 }
@@ -449,10 +533,65 @@ test "classifyResult uses hint text" {
     }
 }
 
+test "classifyResult validates MCP protected resource metadata" {
+    const plan = provider_schema.probePlanForCapability(provider_schema.mcp_def, "metadata").?;
+    const body =
+        \\{
+        \\  "resource": "https://mcp.figma.com/mcp",
+        \\  "authorization_servers": ["https://api.figma.com"],
+        \\  "bearer_methods_supported": ["header"],
+        \\  "scopes_supported": ["mcp:connect"]
+        \\}
+    ;
+    const classified = classifyResult(std.testing.allocator, provider_schema.mcp_def, plan, .{
+        .status = 200,
+        .hint = body,
+    });
+    try std.testing.expectEqual(types.HttpClassification.success, classified);
+}
+
+test "classifyResult rejects malformed MCP protected resource metadata" {
+    const plan = provider_schema.probePlanForCapability(provider_schema.mcp_def, "metadata").?;
+    const missing_authorization_servers = classifyResult(std.testing.allocator, provider_schema.mcp_def, plan, .{
+        .status = 200,
+        .hint = "{\"resource\":\"https://mcp.example.com/mcp\"}",
+    });
+    switch (missing_authorization_servers) {
+        .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.schema_invalid, reason),
+        else => return error.TestUnexpectedResult,
+    }
+
+    const wrong_resource_scheme = classifyResult(std.testing.allocator, provider_schema.mcp_def, plan, .{
+        .status = 200,
+        .hint = "{\"resource\":\"http://mcp.example.com/mcp\",\"authorization_servers\":[\"https://auth.example.com\"]}",
+    });
+    switch (wrong_resource_scheme) {
+        .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.schema_invalid, reason),
+        else => return error.TestUnexpectedResult,
+    }
+
+    const invalid_json = classifyResult(std.testing.allocator, provider_schema.mcp_def, plan, .{
+        .status = 200,
+        .hint = "not json",
+    });
+    switch (invalid_json) {
+        .degraded => |reason| try std.testing.expectEqual(types.DegradedReason.schema_invalid, reason),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
 test "expandUrlTemplate rejects malformed placeholder" {
     try std.testing.expectError(error.UnsupportedTransport, expandUrlTemplate(std.testing.allocator, "https://example.invalid/{{BAD"));
     try std.testing.expectError(error.UnsupportedTransport, expandUrlTemplate(std.testing.allocator, "https://example.invalid/BAD}}"));
     try std.testing.expectError(error.UnsupportedTransport, expandUrlTemplate(std.testing.allocator, "https://example.invalid/{{BAD-NAME}}"));
+}
+
+test "single placeholder URL templates may carry absolute HTTPS URLs" {
+    try std.testing.expectEqualStrings("OMUX_MCP_RESOURCE_METADATA_URL", singlePlaceholderName("{{OMUX_MCP_RESOURCE_METADATA_URL}}").?);
+    try std.testing.expect(singlePlaceholderName("https://example.invalid/{{OMUX_MCP_RESOURCE_METADATA_URL}}") == null);
+    try std.testing.expect(isSafeAbsoluteHttpsUrl("https://mcp.figma.com/.well-known/oauth-protected-resource/mcp"));
+    try std.testing.expect(!isSafeAbsoluteHttpsUrl("http://mcp.figma.com/.well-known/oauth-protected-resource/mcp"));
+    try std.testing.expect(!isSafeAbsoluteHttpsUrl("https://mcp.figma.com/mcp#fragment"));
 }
 
 test "classifyResult can downgrade successful GraphQL status from body hint" {


### PR DESCRIPTION
## Summary

- Validate MCP `resource-metadata` response bodies before classifying an HTTP 200 as live.
- Require RFC 9728/MCP metadata basics: HTTPS `resource` and non-empty HTTPS `authorization_servers`.
- Allow full HTTPS URL values only for single-placeholder probe URL templates, so `{{OMUX_MCP_RESOURCE_METADATA_URL}}` works while embedded placeholders remain path-fragment safe.
- Add TIN-863 proof documentation with public Figma MCP metadata evidence.

## Why

MCP HTTP authorization is resource-server scoped. The previous implementation could mark any successful metadata HTTP response as live, and the built-in MCP metadata probe could not accept a full operator-selected metadata URL because URL-template values were restricted to unreserved path fragments.

## Validation

- `git diff --check`
- `zig build test`
- `nix develop --command just check-local`
- no-secret Figma MCP metadata proof: `mcp:figma#resource-metadata`, `probe_status=200`, `live.available`, `decision=use_this`

## Sources

- MCP Authorization 2025-11-25: https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
- RFC 9728: https://datatracker.ietf.org/doc/html/rfc9728
