### PR TITLE
Add Claude runtime fixture coverage

### DIFF
--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -91,7 +91,8 @@ Next split:
   The first no-spend local proof is captured in
   `docs/spec/provider-proof-claude-command-auth-2026-05-01.md`: `auth-status`
   can now run through `claude auth status --json` without first reading or
-  mutating Claude's credential store.
+  mutating Claude's credential store. Synthetic fixture coverage now keeps
+  logged-out auth evidence separate from `runtime.missing_binary`.
 - `TIN-862`: prove GitHub and Linear low-impact identity probes. This is now
   underway with classifier hardening and a proof spec in
   `docs/spec/provider-proof-github-linear-2026-05-01.md`; local GitHub live QA

--- a/docs/spec/provider-proof-claude-command-auth-2026-05-01.md
+++ b/docs/spec/provider-proof-claude-command-auth-2026-05-01.md
@@ -68,10 +68,24 @@ without reading or mutating Claude's credential file. It does not prove Claude
 quota, tier, or model-call availability, and it does not make direct OAuth
 repair admissible.
 
+## Fixture Coverage
+
+Synthetic tests now cover the two non-spend states needed before broader Claude
+claims:
+
+- `claude auth status --json` output with `{"loggedIn":false}` is classified as
+  `dead.token_revoked`, which means user-mediated login is required.
+- A missing command-adapter binary is `runtime.missing_binary`, not OAuth
+  liveness and not provider degradation.
+
+These fixtures keep local runtime absence separate from Claude account state.
+They do not replace real operator proof for logged-out, keychain, or quota
+conditions.
+
 ## Remaining Work
 
-- Attach this proof to `TIN-861` and GitHub `#68`.
-- Add logged-out and missing-binary operator fixtures when available.
+- Attach the fixture and live proof evidence to `TIN-861` and GitHub `#68`.
+- Add real logged-out/keychain/session operator fixtures when available.
 - Keep Claude as command-first until provider-owned docs expose direct repair
   semantics that are safe for subscription session stores.
 - Do not schedule Claude model-call probes by default. Any future route probe

--- a/src/main.zig
+++ b/src/main.zig
@@ -6403,6 +6403,42 @@ test "runtime doctor route scope reports only requested profile routes" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"provider\":\"stale\"") == null);
 }
 
+test "provider runtime readiness reports missing command adapter binary" {
+    const missing_binary = "omux-definitely-missing-claude-fixture";
+    const def = provider_schema.ProviderDefinition{
+        .name = "claude",
+        .display_name = "Synthetic Claude",
+        .extension_mode = .command_adapter,
+        .runtime = .{
+            .required_binaries = &.{missing_binary},
+            .env_vars = &.{"CLAUDE_CONFIG_DIR"},
+        },
+        .capabilities = &.{
+            .{
+                .name = "auth-status",
+                .probe = .{
+                    .transport = .command,
+                    .auth = .none,
+                    .command = &.{ missing_binary, "auth", "status", "--json" },
+                    .budget = .free_command,
+                },
+            },
+        },
+    };
+
+    const readiness = try providerRuntimeReadiness(std.testing.allocator, def, "auth-status");
+    switch (readiness) {
+        .missing_binary => |binary| try std.testing.expectEqualStrings(missing_binary, binary),
+        else => return error.TestUnexpectedResult,
+    }
+
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+    try writeRuntimeReadinessJson(buf.writer(), readiness);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"state\":\"missing_binary\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, missing_binary) != null);
+}
+
 test "repairActionFor warns before spending provider quota without health evidence" {
     const def = provider_schema.ProviderDefinition{
         .name = "toy",


### PR DESCRIPTION
## Summary

- adds synthetic runtime fixture coverage for missing command-adapter binaries
- documents that Claude logged-out classifier coverage is credential/dead evidence while missing `claude` is runtime evidence
- updates the product gap map for TIN-861

## Validation

- `git diff --check`
- `nix develop --command just check-local`

## Tracking

- Part of #68 / TIN-861
