### PR TITLE
Preflight command probe runtime

### DIFF
--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -50,6 +50,9 @@ Current truth:
   no-mutation E2E coverage.
 - `TIN-860` landed in PR `#73`: user-mediated handoffs now have list, ack,
   clear, and named refresh commands.
+- `TIN-865` covers a stay-afloat hardening slice: command-probe runtime
+  failures must surface as runtime repair state without poisoning persisted
+  credential liveness.
 - The default daemon policy refuses provider-spend probes, silent interactive
   auth, and silent mutation.
 - Codex fallback is proven from quota-exhausted `max-1#codex-max` to available
@@ -120,7 +123,9 @@ patterns are settled.
 3. Use `TIN-861` and `TIN-863` to prove the two harder shapes: CLI-owned
    subscription state and MCP resource-bound OAuth.
 4. Return to daemon background scheduling only after wrapper/install decisions
-   and provider proof produce enough real operator evidence.
+   and provider proof produce enough real operator evidence. The immediate
+   daemon-side exception is `TIN-865`, because false liveness evidence would
+   make every later scheduler less trustworthy.
 
 ## Guardrails
 

--- a/docs/spec/stay-afloat-supervisor-contract-2026-05-01.md
+++ b/docs/spec/stay-afloat-supervisor-contract-2026-05-01.md
@@ -54,6 +54,14 @@ The default policy admits only `free_local` and `free_command` budgets. It
 refuses provider-spend probes, interactive auth, and mutation unless config
 explicitly admits them.
 
+Command-adapter runtime failures are not credential evidence. If a command
+probe cannot run because the binary is missing, the selected store is
+unavailable, the store is not writable, a session file is missing, a sandbox
+blocks execution, or another local runtime precondition fails, the supervisor
+must surface `RuntimeReadiness` and a repair action without recording a
+dead/degraded OAuth liveness transition. Only an executed provider command or
+HTTP probe may update credential liveness.
+
 ### Layer 2: local evidence and coordination
 
 This layer does not require a daemon process.

--- a/src/main.zig
+++ b/src/main.zig
@@ -12,6 +12,7 @@ const provider = @import("provider.zig");
 const provider_schema = @import("provider_schema.zig");
 const daemon = @import("daemon.zig");
 const repair_state = @import("repair_state.zig");
+const runtime_mod = @import("runtime.zig");
 const secret_mod = @import("secret.zig");
 
 pub fn main() !void {
@@ -2739,18 +2740,7 @@ const RuntimeDoctorStats = struct {
     }
 };
 
-const RuntimeAccountInfo = struct {
-    readiness: types.RuntimeReadiness = .ready,
-    config_dir_set: bool = false,
-    config_dir_exists: bool = false,
-    config_dir_writable: bool = false,
-    session_paths_total: usize = 0,
-    session_paths_present: usize = 0,
-
-    fn ready(self: RuntimeAccountInfo) bool {
-        return self.readiness.isReady();
-    }
-};
+const RuntimeAccountInfo = runtime_mod.AccountInfo;
 
 fn runDoctorRuntime(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.DoctorArgs) !void {
     const config_path = try paths.configFilePath(allocator);
@@ -3280,153 +3270,7 @@ fn runtimeAccountInfo(
     def: provider_schema.ProviderDefinition,
     kind: ?types.ProviderKind,
 ) !RuntimeAccountInfo {
-    var info = RuntimeAccountInfo{
-        .config_dir_set = account.config_dir != null,
-        .session_paths_total = def.runtime.session_paths.len,
-    };
-
-    for (def.runtime.required_binaries) |binary_name| {
-        if (!try commandAvailable(allocator, binary_name)) {
-            info.readiness = .{ .missing_binary = binary_name };
-            return info;
-        }
-    }
-
-    const env_var = runtimeConfigDirEnv(prov, def, kind);
-    if (account.config_dir == null) {
-        if (env_var != null and (def.runtime.writable_paths.len != 0 or def.runtime.session_paths.len != 0)) {
-            info.readiness = .{ .session_unavailable = "account_config_dir_missing" };
-        }
-        return info;
-    }
-
-    const config_dir = try paths.expandTilde(allocator, account.config_dir.?);
-    defer allocator.free(config_dir);
-
-    const dir_state = checkDirectory(config_dir);
-    switch (dir_state) {
-        .ok => info.config_dir_exists = true,
-        .missing => {
-            info.readiness = .{ .session_unavailable = "config_dir_missing" };
-            return info;
-        },
-        .access_denied => {
-            info.readiness = .{ .permission_denied = .{ .path = "config_dir", .operation = "open" } };
-            return info;
-        },
-        .not_directory => {
-            info.readiness = .{ .session_unavailable = "config_dir_not_directory" };
-            return info;
-        },
-        .other_error => {
-            info.readiness = .{ .session_unavailable = "config_dir_unavailable" };
-            return info;
-        },
-    }
-
-    if (def.runtime.writable_paths.len != 0) {
-        for (def.runtime.writable_paths) |path_spec| {
-            const resolved = try resolveRuntimePath(allocator, path_spec, env_var, config_dir) orelse continue;
-            defer allocator.free(resolved);
-            if (!canWriteDirectoryMarker(allocator, resolved)) {
-                info.readiness = .{ .unwritable_store = "config_dir" };
-                return info;
-            }
-        }
-    } else {
-        info.config_dir_writable = true;
-    }
-
-    if (def.runtime.writable_paths.len != 0) info.config_dir_writable = true;
-
-    for (def.runtime.session_paths) |session_spec| {
-        const resolved = try resolveRuntimePath(allocator, session_spec, env_var, config_dir) orelse continue;
-        defer allocator.free(resolved);
-        switch (checkFile(resolved)) {
-            .exists => info.session_paths_present += 1,
-            .missing => {
-                info.readiness = .{ .needs_reauth = .{
-                    .methods = reauthMethodsFor(def),
-                    .reason = "session_file_missing",
-                } };
-                return info;
-            },
-            .access_denied => {
-                info.readiness = .{ .permission_denied = .{ .path = "session_file", .operation = "read" } };
-                return info;
-            },
-            .other_error => {
-                info.readiness = .{ .session_unavailable = "session_file_unavailable" };
-                return info;
-            },
-        }
-    }
-
-    info.readiness = .ready;
-    return info;
-}
-
-const DirectoryState = enum {
-    ok,
-    missing,
-    access_denied,
-    not_directory,
-    other_error,
-};
-
-const FileState = enum {
-    exists,
-    missing,
-    access_denied,
-    other_error,
-};
-
-fn checkDirectory(path_value: []const u8) DirectoryState {
-    var dir = openDirectory(path_value) catch |e| return switch (e) {
-        error.FileNotFound => .missing,
-        error.AccessDenied => .access_denied,
-        error.NotDir => .not_directory,
-        else => .other_error,
-    };
-    dir.close();
-    return .ok;
-}
-
-fn checkFile(path_value: []const u8) FileState {
-    const file = if (std.fs.path.isAbsolute(path_value))
-        std.fs.openFileAbsolute(path_value, .{}) catch |e| return switch (e) {
-            error.FileNotFound => .missing,
-            error.AccessDenied => .access_denied,
-            else => .other_error,
-        }
-    else
-        std.fs.cwd().openFile(path_value, .{}) catch |e| return switch (e) {
-            error.FileNotFound => .missing,
-            error.AccessDenied => .access_denied,
-            else => .other_error,
-        };
-    file.close();
-    return .exists;
-}
-
-fn openDirectory(path_value: []const u8) !std.fs.Dir {
-    if (std.fs.path.isAbsolute(path_value)) {
-        return std.fs.openDirAbsolute(path_value, .{});
-    }
-    return std.fs.cwd().openDir(path_value, .{});
-}
-
-fn canWriteDirectoryMarker(allocator: std.mem.Allocator, path_value: []const u8) bool {
-    var dir = openDirectory(path_value) catch return false;
-    defer dir.close();
-
-    const marker = std.fmt.allocPrint(allocator, ".oauth-mux-runtime-check-{d}", .{std.time.nanoTimestamp()}) catch return false;
-    defer allocator.free(marker);
-
-    const file = dir.createFile(marker, .{ .exclusive = true }) catch return false;
-    file.close();
-    dir.deleteFile(marker) catch {};
-    return true;
+    return runtime_mod.accountInfo(allocator, prov, account, def, kind);
 }
 
 fn resolveRuntimePath(
@@ -3435,40 +3279,19 @@ fn resolveRuntimePath(
     env_var: ?[]const u8,
     config_dir: []const u8,
 ) !?[]const u8 {
-    if (env_var) |name| {
-        if (std.mem.eql(u8, spec, name)) return try allocator.dupe(u8, config_dir);
-        if (std.mem.startsWith(u8, spec, name) and spec.len > name.len and (spec[name.len] == '/' or spec[name.len] == '\\')) {
-            return try std.fs.path.join(allocator, &.{ config_dir, spec[name.len + 1 ..] });
-        }
-    }
-    if (std.fs.path.isAbsolute(spec) or (spec.len > 0 and spec[0] == '~')) {
-        return try paths.expandTilde(allocator, spec);
-    }
-    return null;
+    return runtime_mod.resolvePath(allocator, spec, env_var, config_dir);
 }
 
 fn runtimeConfigDirEnv(prov: config.ProviderConfig, def: provider_schema.ProviderDefinition, kind: ?types.ProviderKind) ?[]const u8 {
-    if (prov.config_dir_env) |env_var| return env_var;
-    if (def.injection.config_dir_env) |env_var| return env_var;
-    if (kind) |provider_kind| return provider_kind.configDirEnv();
-    return null;
+    return runtime_mod.configDirEnv(prov, def, kind);
 }
 
 fn countMissingRuntimeBinaries(allocator: std.mem.Allocator, def: provider_schema.ProviderDefinition) !usize {
-    var missing: usize = 0;
-    for (def.runtime.required_binaries) |binary_name| {
-        if (!try commandAvailable(allocator, binary_name)) missing += 1;
-    }
-    return missing;
+    return runtime_mod.countMissingBinaries(allocator, def);
 }
 
-fn reauthMethodsFor(def: provider_schema.ProviderDefinition) []const []const u8 {
-    return switch (def.repair.owner) {
-        .upstream_cli_login => &.{"upstream_cli_login"},
-        .oauth_mux_refresh => &.{"oauth_mux_refresh"},
-        .external_secret_owner => &.{"external_secret_owner"},
-        .manual_only => &.{"manual"},
-    };
+fn fileExists(path_value: []const u8) bool {
+    return runtime_mod.fileExists(path_value);
 }
 
 fn codexConfigured(cfg: config.Config) bool {
@@ -4223,25 +4046,7 @@ fn providerRuntimeReadiness(
     def: provider_schema.ProviderDefinition,
     capability: ?[]const u8,
 ) !types.RuntimeReadiness {
-    for (def.runtime.required_binaries) |binary_name| {
-        if (!try commandAvailable(allocator, binary_name)) {
-            return .{ .missing_binary = binary_name };
-        }
-    }
-
-    if (capability) |capability_name| {
-        if (provider_schema.probePlanForCapability(def, capability_name)) |plan| {
-            if (plan.transport == .command) {
-                const argv = plan.command orelse return .{ .session_unavailable = "probe command missing" };
-                if (argv.len == 0) return .{ .session_unavailable = "probe command empty" };
-                if (!try commandAvailable(allocator, argv[0])) {
-                    return .{ .missing_binary = argv[0] };
-                }
-            }
-        }
-    }
-
-    return .ready;
+    return runtime_mod.providerReadiness(allocator, def, capability);
 }
 
 fn routeRuntimeReadiness(
@@ -4250,29 +4055,15 @@ fn routeRuntimeReadiness(
     route: RepairPlanRoute,
     def: provider_schema.ProviderDefinition,
 ) !types.RuntimeReadiness {
-    const provider_runtime = try providerRuntimeReadiness(allocator, def, route.capability);
-    if (!provider_runtime.isReady()) return provider_runtime;
-
-    const prov = cfg.providers.map.get(route.provider) orelse return .{ .session_unavailable = "provider_config_missing" };
-    const account = prov.accounts.map.get(route.account) orelse return .{ .session_unavailable = "account_config_missing" };
-    if (try repair_state.probeRepairLock(allocator, route.provider, route.account)) |progress| {
-        return .{ .repair_in_progress = progress };
-    }
-    const account_runtime = try runtimeAccountInfo(allocator, prov, account, def, config.resolveProviderKind(cfg, route.provider));
-    return account_runtime.readiness;
+    return runtime_mod.routeReadiness(allocator, cfg, .{
+        .provider = route.provider,
+        .account = route.account,
+        .capability = route.capability,
+    }, def);
 }
 
 fn runtimeReadinessSummary(readiness: types.RuntimeReadiness) []const u8 {
-    return switch (readiness) {
-        .ready => "ready",
-        .missing_binary => "missing_binary",
-        .permission_denied => "permission_denied",
-        .unwritable_store => "unwritable_store",
-        .session_unavailable => "session_unavailable",
-        .sandbox_blocked => "sandbox_blocked",
-        .needs_reauth => "needs_reauth",
-        .repair_in_progress => "repair_in_progress",
-    };
+    return runtime_mod.summary(readiness);
 }
 
 fn writeRuntimeReadinessJson(writer: anytype, readiness: types.RuntimeReadiness) !void {
@@ -4323,47 +4114,7 @@ fn circuitName(circuit: types.CircuitState) []const u8 {
 }
 
 fn commandAvailable(allocator: std.mem.Allocator, binary_name: []const u8) !bool {
-    if (binary_name.len == 0) return false;
-
-    if (std.mem.indexOfScalar(u8, binary_name, '/') != null or std.mem.indexOfScalar(u8, binary_name, '\\') != null) {
-        return fileExists(binary_name);
-    }
-
-    const path_env = std.process.getEnvVarOwned(allocator, "PATH") catch return false;
-    defer allocator.free(path_env);
-
-    var dirs = std.mem.splitScalar(u8, path_env, pathDelimiter());
-    while (dirs.next()) |dir| {
-        if (dir.len == 0) continue;
-        const candidate = try std.fs.path.join(allocator, &.{ dir, binary_name });
-        defer allocator.free(candidate);
-        if (fileExists(candidate)) return true;
-
-        if (comptime builtin.os.tag == .windows) {
-            if (!std.ascii.endsWithIgnoreCase(binary_name, ".exe")) {
-                const exe_name = try std.fmt.allocPrint(allocator, "{s}.exe", .{binary_name});
-                defer allocator.free(exe_name);
-                const exe_candidate = try std.fs.path.join(allocator, &.{ dir, exe_name });
-                defer allocator.free(exe_candidate);
-                if (fileExists(exe_candidate)) return true;
-            }
-        }
-    }
-
-    return false;
-}
-
-fn pathDelimiter() u8 {
-    return if (builtin.os.tag == .windows) ';' else ':';
-}
-
-fn fileExists(path_value: []const u8) bool {
-    const file = if (std.fs.path.isAbsolute(path_value))
-        std.fs.openFileAbsolute(path_value, .{}) catch return false
-    else
-        std.fs.cwd().openFile(path_value, .{}) catch return false;
-    file.close();
-    return true;
+    return runtime_mod.commandAvailable(allocator, binary_name);
 }
 
 fn countConfiguredAccounts(cfg: config.Config) usize {
@@ -4565,9 +4316,7 @@ fn writeProbeText(writer: anytype, allocator: std.mem.Allocator, store: *health_
         try writer.writeAll("  probe:    no capability requested; credential parse/expiry validation only\n");
     }
 
-    if (ctx.provider_name) |selected_provider| {
-        const def = config.resolveProviderDefinition(ctx.cfg, selected_provider);
-        const readiness = try providerRuntimeReadiness(allocator, def, ctx.capability_name);
+    if (try probeRuntimeReadiness(allocator, ctx)) |readiness| {
         try writer.print("  runtime:  {s}\n", .{runtimeReadinessSummary(readiness)});
     }
 
@@ -4638,12 +4387,7 @@ fn writeProbeJson(writer: anytype, allocator: std.mem.Allocator, store: *health_
     try writer.writeAll(",\"decision\":");
     try std.json.stringify(@tagName(decision), .{}, writer);
     try writer.writeAll(",\"runtime\":");
-    if (ctx.provider_name) |provider_name| {
-        const def = config.resolveProviderDefinition(ctx.cfg, provider_name);
-        try writeProviderRuntimeJson(writer, allocator, def, ctx.capability_name);
-    } else {
-        try writer.writeAll("null");
-    }
+    try writeProbeRuntimeJson(writer, allocator, ctx);
     try writer.writeAll(",\"health_key\":");
     try std.json.stringify(selection.key.slice(), .{}, writer);
     try writer.writeAll(",\"liveness\":");
@@ -4659,6 +4403,40 @@ fn writeProbeJson(writer: anytype, allocator: std.mem.Allocator, store: *health_
         try writer.writeAll("null");
     }
     try writer.writeAll("}\n");
+}
+
+fn probeRuntimeReadiness(allocator: std.mem.Allocator, ctx: *const pipeline.Context) !?types.RuntimeReadiness {
+    const provider_name = ctx.provider_name orelse return null;
+    const def = config.resolveProviderDefinition(ctx.cfg, provider_name);
+    if (ctx.account_name) |account_name| {
+        return try routeRuntimeReadiness(allocator, ctx.cfg, .{
+            .provider = provider_name,
+            .account = account_name,
+            .capability = ctx.capability_name,
+        }, def);
+    }
+    return try providerRuntimeReadiness(allocator, def, ctx.capability_name);
+}
+
+fn writeProbeRuntimeJson(writer: anytype, allocator: std.mem.Allocator, ctx: *const pipeline.Context) !void {
+    const provider_name = ctx.provider_name orelse {
+        try writer.writeAll("null");
+        return;
+    };
+    const def = config.resolveProviderDefinition(ctx.cfg, provider_name);
+    const readiness = (try probeRuntimeReadiness(allocator, ctx)) orelse .ready;
+    try writer.writeByte('{');
+    try writer.writeAll("\"readiness\":");
+    try writeRuntimeReadinessJson(writer, readiness);
+    try writer.writeAll(",\"required_binaries\":");
+    try writeStringArrayJson(writer, def.runtime.required_binaries);
+    try writer.writeAll(",\"env_vars\":");
+    try writeStringArrayJson(writer, def.runtime.env_vars);
+    try writer.writeAll(",\"writable_paths\":");
+    try writeStringArrayJson(writer, def.runtime.writable_paths);
+    try writer.writeAll(",\"session_paths\":");
+    try writeStringArrayJson(writer, def.runtime.session_paths);
+    try writer.writeByte('}');
 }
 
 fn runHealth(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.HealthArgs) !void {

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -13,6 +13,7 @@ const oauth = @import("oauth.zig");
 const probe = @import("probe.zig");
 const env = @import("env.zig");
 const repair_state = @import("repair_state.zig");
+const runtime = @import("runtime.zig");
 
 pub const Context = struct {
     allocator: std.mem.Allocator,
@@ -246,6 +247,7 @@ fn recordCandidateFailure(ctx: *Context, key: []const u8, err: PipelineError) vo
         error.ConfigNotFound,
         error.ConfigParseError,
         error.ConfigValidationError,
+        error.RuntimeNotReady,
         => {},
         else => ctx.health.recordFailure(key, .error_response),
     }
@@ -456,6 +458,18 @@ fn probeCapability(ctx: *Context) PipelineError!types.MuxDecision {
         .none => "",
         else => return error.TokenParseFailed,
     };
+
+    if (plan.transport == .command) {
+        const readiness = runtime.routeReadiness(ctx.allocator, ctx.cfg, .{
+            .provider = prov,
+            .account = acct,
+            .capability = capability,
+        }, def) catch |e| switch (e) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => return error.RuntimeNotReady,
+        };
+        if (!readiness.isReady()) return error.RuntimeNotReady;
+    }
 
     var probe_env = buildProbeEnv(ctx, prov, acct, def, plan) catch |e| switch (e) {
         error.OutOfMemory => return error.OutOfMemory,
@@ -1295,6 +1309,158 @@ test "runProbe executes auth none command probe without reading missing secret" 
     try std.testing.expectEqual(@as(?u16, 200), ctx.last_probe_status);
     try std.testing.expectEqual(types.MuxDecision.use_this, ctx.last_probe_decision.?);
     try std.testing.expect(store.accounts.get("toy:default#status") != null);
+}
+
+test "runProbe does not poison liveness when command probe binary is missing" {
+    const missing_binary = "omux-definitely-missing-probe-runtime";
+    const json = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "defaults": {{ "provider": "toy" }},
+        \\  "provider_definitions": {{
+        \\    "toy": {{
+        \\      "name": "toy",
+        \\      "capabilities": [
+        \\        {{
+        \\          "name": "status",
+        \\          "probe": {{
+        \\            "transport": "command",
+        \\            "auth": "none",
+        \\            "command": ["{s}", "status"],
+        \\            "budget": "free_command"
+        \\          }}
+        \\        }}
+        \\      ],
+        \\      "failure_rules": [
+        \\        {{ "status_min": 500, "status_max": 599, "class": {{ "provider_degraded": {{}} }} }}
+        \\      ]
+        \\    }}
+        \\  }},
+        \\  "providers": {{
+        \\    "toy": {{
+        \\      "kind": "toy",
+        \\      "accounts": {{
+        \\        "default": {{
+        \\          "secret": {{ "backend": "env", "variable": "OMUX_TEST_SECRET_THAT_IS_NOT_SET" }}
+        \\        }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{
+        \\    "toy": {{ "providers": ["toy:default#status"] }}
+        \\  }},
+        \\  "strategies": {{}}
+        \\}}
+    ,
+        .{missing_binary},
+    );
+    defer std.testing.allocator.free(json);
+
+    const parsed = try config_mod.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+
+    var ctx = Context.init(std.testing.allocator, parsed.value, &store);
+    defer ctx.deinit();
+    ctx.profile_name = "toy";
+    ctx.capability_name = "status";
+
+    try std.testing.expectError(error.RuntimeNotReady, runProbe(&ctx));
+    try std.testing.expect(!ctx.last_probe_executed);
+    try expectUnpoisonedRuntimeHealth(store.accounts.get("toy:default").?);
+    try expectUnpoisonedRuntimeHealth(store.accounts.get("toy:default#status").?);
+}
+
+test "runProbe does not poison liveness when command account runtime is unavailable" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+    const missing_config_dir = try std.fs.path.join(std.testing.allocator, &.{ root, "missing-store" });
+    defer std.testing.allocator.free(missing_config_dir);
+
+    const json = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "defaults": {{ "provider": "toy" }},
+        \\  "provider_definitions": {{
+        \\    "toy": {{
+        \\      "name": "toy",
+        \\      "injection": {{ "config_dir_env": "TOY_HOME" }},
+        \\      "runtime": {{
+        \\        "env_vars": ["TOY_HOME"],
+        \\        "writable_paths": ["TOY_HOME"],
+        \\        "session_paths": ["TOY_HOME/session.json"]
+        \\      }},
+        \\      "capabilities": [
+        \\        {{
+        \\          "name": "status",
+        \\          "probe": {{
+        \\            "transport": "command",
+        \\            "auth": "none",
+        \\            "command": ["sh", "-c", "printf '{{\"loggedIn\":true}}'"],
+        \\            "budget": "free_command"
+        \\          }}
+        \\        }}
+        \\      ],
+        \\      "failure_rules": [
+        \\        {{ "status_min": 500, "status_max": 599, "class": {{ "provider_degraded": {{}} }} }}
+        \\      ]
+        \\    }}
+        \\  }},
+        \\  "providers": {{
+        \\    "toy": {{
+        \\      "kind": "toy",
+        \\      "accounts": {{
+        \\        "default": {{
+        \\          "config_dir": "{s}",
+        \\          "secret": {{ "backend": "env", "variable": "OMUX_TEST_SECRET_THAT_IS_NOT_SET" }}
+        \\        }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{
+        \\    "toy": {{ "providers": ["toy:default#status"] }}
+        \\  }},
+        \\  "strategies": {{}}
+        \\}}
+    ,
+        .{missing_config_dir},
+    );
+    defer std.testing.allocator.free(json);
+
+    const parsed = try config_mod.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+
+    var ctx = Context.init(std.testing.allocator, parsed.value, &store);
+    defer ctx.deinit();
+    ctx.profile_name = "toy";
+    ctx.capability_name = "status";
+
+    try std.testing.expectError(error.RuntimeNotReady, runProbe(&ctx));
+    try std.testing.expect(!ctx.last_probe_executed);
+    try expectUnpoisonedRuntimeHealth(store.accounts.get("toy:default").?);
+    try expectUnpoisonedRuntimeHealth(store.accounts.get("toy:default#status").?);
+}
+
+fn expectUnpoisonedRuntimeHealth(health: health_mod.AccountHealth) !void {
+    switch (health.liveness) {
+        .live => |live| switch (live.availability) {
+            .available => {},
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expect(health.last_http_status == null);
+    try std.testing.expect(health.last_probe_source == null);
 }
 
 test "runEnv skips remaining accounts for degraded provider" {

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1,0 +1,349 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const config = @import("config.zig");
+const paths = @import("paths.zig");
+const provider_schema = @import("provider_schema.zig");
+const repair_state = @import("repair_state.zig");
+const types = @import("types.zig");
+
+pub const RouteRef = struct {
+    provider: []const u8,
+    account: []const u8,
+    capability: ?[]const u8 = null,
+};
+
+pub const AccountInfo = struct {
+    readiness: types.RuntimeReadiness = .ready,
+    config_dir_set: bool = false,
+    config_dir_exists: bool = false,
+    config_dir_writable: bool = false,
+    session_paths_total: usize = 0,
+    session_paths_present: usize = 0,
+
+    pub fn ready(self: AccountInfo) bool {
+        return self.readiness.isReady();
+    }
+};
+
+pub fn providerReadiness(
+    allocator: std.mem.Allocator,
+    def: provider_schema.ProviderDefinition,
+    capability: ?[]const u8,
+) !types.RuntimeReadiness {
+    for (def.runtime.required_binaries) |binary_name| {
+        if (!try commandAvailable(allocator, binary_name)) {
+            return .{ .missing_binary = binary_name };
+        }
+    }
+
+    if (capability) |capability_name| {
+        if (provider_schema.probePlanForCapability(def, capability_name)) |plan| {
+            if (plan.transport == .command) {
+                const argv = plan.command orelse return .{ .session_unavailable = "probe command missing" };
+                if (argv.len == 0) return .{ .session_unavailable = "probe command empty" };
+                if (!try commandAvailable(allocator, argv[0])) {
+                    return .{ .missing_binary = argv[0] };
+                }
+            }
+        }
+    }
+
+    return .ready;
+}
+
+pub fn routeReadiness(
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    route: RouteRef,
+    def: provider_schema.ProviderDefinition,
+) !types.RuntimeReadiness {
+    const provider_runtime = try providerReadiness(allocator, def, route.capability);
+    if (!provider_runtime.isReady()) return provider_runtime;
+
+    const prov = cfg.providers.map.get(route.provider) orelse return .{ .session_unavailable = "provider_config_missing" };
+    const account = prov.accounts.map.get(route.account) orelse return .{ .session_unavailable = "account_config_missing" };
+    if (try repair_state.probeRepairLock(allocator, route.provider, route.account)) |progress| {
+        return .{ .repair_in_progress = progress };
+    }
+    const info = try accountInfo(allocator, prov, account, def, config.resolveProviderKind(cfg, route.provider));
+    return info.readiness;
+}
+
+pub fn accountInfo(
+    allocator: std.mem.Allocator,
+    prov: config.ProviderConfig,
+    account: config.AccountConfig,
+    def: provider_schema.ProviderDefinition,
+    kind: ?types.ProviderKind,
+) !AccountInfo {
+    var info = AccountInfo{
+        .config_dir_set = account.config_dir != null,
+        .session_paths_total = def.runtime.session_paths.len,
+    };
+
+    for (def.runtime.required_binaries) |binary_name| {
+        if (!try commandAvailable(allocator, binary_name)) {
+            info.readiness = .{ .missing_binary = binary_name };
+            return info;
+        }
+    }
+
+    const env_var = configDirEnv(prov, def, kind);
+    if (account.config_dir == null) {
+        if (env_var != null and (def.runtime.writable_paths.len != 0 or def.runtime.session_paths.len != 0)) {
+            info.readiness = .{ .session_unavailable = "account_config_dir_missing" };
+        }
+        return info;
+    }
+
+    const config_dir = try paths.expandTilde(allocator, account.config_dir.?);
+    defer allocator.free(config_dir);
+
+    const dir_state = checkDirectory(config_dir);
+    switch (dir_state) {
+        .ok => info.config_dir_exists = true,
+        .missing => {
+            info.readiness = .{ .session_unavailable = "config_dir_missing" };
+            return info;
+        },
+        .access_denied => {
+            info.readiness = .{ .permission_denied = .{ .path = "config_dir", .operation = "open" } };
+            return info;
+        },
+        .not_directory => {
+            info.readiness = .{ .session_unavailable = "config_dir_not_directory" };
+            return info;
+        },
+        .other_error => {
+            info.readiness = .{ .session_unavailable = "config_dir_unavailable" };
+            return info;
+        },
+    }
+
+    if (def.runtime.writable_paths.len != 0) {
+        for (def.runtime.writable_paths) |path_spec| {
+            const resolved = try resolvePath(allocator, path_spec, env_var, config_dir) orelse continue;
+            defer allocator.free(resolved);
+            if (!canWriteDirectoryMarker(allocator, resolved)) {
+                info.readiness = .{ .unwritable_store = "config_dir" };
+                return info;
+            }
+        }
+        info.config_dir_writable = true;
+    } else {
+        info.config_dir_writable = true;
+    }
+
+    for (def.runtime.session_paths) |session_spec| {
+        const resolved = try resolvePath(allocator, session_spec, env_var, config_dir) orelse continue;
+        defer allocator.free(resolved);
+        switch (checkFile(resolved)) {
+            .exists => info.session_paths_present += 1,
+            .missing => {
+                info.readiness = .{ .needs_reauth = .{
+                    .methods = reauthMethodsFor(def),
+                    .reason = "session_file_missing",
+                } };
+                return info;
+            },
+            .access_denied => {
+                info.readiness = .{ .permission_denied = .{ .path = "session_file", .operation = "read" } };
+                return info;
+            },
+            .other_error => {
+                info.readiness = .{ .session_unavailable = "session_file_unavailable" };
+                return info;
+            },
+        }
+    }
+
+    info.readiness = .ready;
+    return info;
+}
+
+pub fn configDirEnv(prov: config.ProviderConfig, def: provider_schema.ProviderDefinition, kind: ?types.ProviderKind) ?[]const u8 {
+    if (prov.config_dir_env) |env_var| return env_var;
+    if (def.injection.config_dir_env) |env_var| return env_var;
+    if (kind) |provider_kind| return provider_kind.configDirEnv();
+    return null;
+}
+
+pub fn countMissingBinaries(allocator: std.mem.Allocator, def: provider_schema.ProviderDefinition) !usize {
+    var missing: usize = 0;
+    for (def.runtime.required_binaries) |binary_name| {
+        if (!try commandAvailable(allocator, binary_name)) missing += 1;
+    }
+    return missing;
+}
+
+pub fn commandAvailable(allocator: std.mem.Allocator, binary_name: []const u8) !bool {
+    if (binary_name.len == 0) return false;
+
+    if (std.mem.indexOfScalar(u8, binary_name, '/') != null or std.mem.indexOfScalar(u8, binary_name, '\\') != null) {
+        return fileExists(binary_name);
+    }
+
+    const path_env = std.process.getEnvVarOwned(allocator, "PATH") catch return false;
+    defer allocator.free(path_env);
+
+    var dirs = std.mem.splitScalar(u8, path_env, pathDelimiter());
+    while (dirs.next()) |dir| {
+        if (dir.len == 0) continue;
+        const candidate = try std.fs.path.join(allocator, &.{ dir, binary_name });
+        defer allocator.free(candidate);
+        if (fileExists(candidate)) return true;
+
+        if (comptime builtin.os.tag == .windows) {
+            if (!std.ascii.endsWithIgnoreCase(binary_name, ".exe")) {
+                const exe_name = try std.fmt.allocPrint(allocator, "{s}.exe", .{binary_name});
+                defer allocator.free(exe_name);
+                const exe_candidate = try std.fs.path.join(allocator, &.{ dir, exe_name });
+                defer allocator.free(exe_candidate);
+                if (fileExists(exe_candidate)) return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+pub fn summary(readiness: types.RuntimeReadiness) []const u8 {
+    return switch (readiness) {
+        .ready => "ready",
+        .missing_binary => "missing_binary",
+        .permission_denied => "permission_denied",
+        .unwritable_store => "unwritable_store",
+        .session_unavailable => "session_unavailable",
+        .sandbox_blocked => "sandbox_blocked",
+        .needs_reauth => "needs_reauth",
+        .repair_in_progress => "repair_in_progress",
+    };
+}
+
+pub fn resolvePath(
+    allocator: std.mem.Allocator,
+    spec: []const u8,
+    env_var: ?[]const u8,
+    config_dir: []const u8,
+) !?[]const u8 {
+    if (env_var) |name| {
+        if (std.mem.eql(u8, spec, name)) return try allocator.dupe(u8, config_dir);
+        if (std.mem.startsWith(u8, spec, name) and spec.len > name.len and (spec[name.len] == '/' or spec[name.len] == '\\')) {
+            return try std.fs.path.join(allocator, &.{ config_dir, spec[name.len + 1 ..] });
+        }
+    }
+    if (std.fs.path.isAbsolute(spec) or (spec.len > 0 and spec[0] == '~')) {
+        return try paths.expandTilde(allocator, spec);
+    }
+    return null;
+}
+
+fn reauthMethodsFor(def: provider_schema.ProviderDefinition) []const []const u8 {
+    return switch (def.repair.owner) {
+        .upstream_cli_login => &.{"upstream_cli_login"},
+        .oauth_mux_refresh => &.{"oauth_mux_refresh"},
+        .external_secret_owner => &.{"external_secret_owner"},
+        .manual_only => &.{"manual"},
+    };
+}
+
+const DirectoryState = enum {
+    ok,
+    missing,
+    access_denied,
+    not_directory,
+    other_error,
+};
+
+const FileState = enum {
+    exists,
+    missing,
+    access_denied,
+    other_error,
+};
+
+fn checkDirectory(path_value: []const u8) DirectoryState {
+    var dir = openDirectory(path_value) catch |e| return switch (e) {
+        error.FileNotFound => .missing,
+        error.AccessDenied => .access_denied,
+        error.NotDir => .not_directory,
+        else => .other_error,
+    };
+    dir.close();
+    return .ok;
+}
+
+fn checkFile(path_value: []const u8) FileState {
+    const file = if (std.fs.path.isAbsolute(path_value))
+        std.fs.openFileAbsolute(path_value, .{}) catch |e| return switch (e) {
+            error.FileNotFound => .missing,
+            error.AccessDenied => .access_denied,
+            else => .other_error,
+        }
+    else
+        std.fs.cwd().openFile(path_value, .{}) catch |e| return switch (e) {
+            error.FileNotFound => .missing,
+            error.AccessDenied => .access_denied,
+            else => .other_error,
+        };
+    file.close();
+    return .exists;
+}
+
+fn openDirectory(path_value: []const u8) !std.fs.Dir {
+    if (std.fs.path.isAbsolute(path_value)) {
+        return std.fs.openDirAbsolute(path_value, .{});
+    }
+    return std.fs.cwd().openDir(path_value, .{});
+}
+
+fn canWriteDirectoryMarker(allocator: std.mem.Allocator, path_value: []const u8) bool {
+    var dir = openDirectory(path_value) catch return false;
+    defer dir.close();
+
+    const marker = std.fmt.allocPrint(allocator, ".oauth-mux-runtime-check-{d}", .{std.time.nanoTimestamp()}) catch return false;
+    defer allocator.free(marker);
+
+    const file = dir.createFile(marker, .{ .exclusive = true }) catch return false;
+    file.close();
+    dir.deleteFile(marker) catch {};
+    return true;
+}
+
+pub fn fileExists(path_value: []const u8) bool {
+    const file = if (std.fs.path.isAbsolute(path_value))
+        std.fs.openFileAbsolute(path_value, .{}) catch return false
+    else
+        std.fs.cwd().openFile(path_value, .{}) catch return false;
+    file.close();
+    return true;
+}
+
+fn pathDelimiter() u8 {
+    return if (builtin.os.tag == .windows) ';' else ':';
+}
+
+test "routeReadiness reports missing command capability binary" {
+    const missing_binary = "omux-runtime-missing-command-fixture";
+    const def = provider_schema.ProviderDefinition{
+        .name = "toy",
+        .runtime = .{},
+        .capabilities = &.{
+            .{
+                .name = "status",
+                .probe = .{
+                    .transport = .command,
+                    .auth = .none,
+                    .command = &.{missing_binary},
+                    .budget = .free_command,
+                },
+            },
+        },
+    };
+
+    const readiness = try providerReadiness(std.testing.allocator, def, "status");
+    switch (readiness) {
+        .missing_binary => |binary| try std.testing.expectEqualStrings(missing_binary, binary),
+        else => return error.TestUnexpectedResult,
+    }
+}

--- a/src/types.zig
+++ b/src/types.zig
@@ -585,6 +585,7 @@ pub const PipelineError = error{
     TokenRevoked,
     RateLimited,
     NetworkError,
+    RuntimeNotReady,
     ExecFailed,
     ShellDetectionFailed,
     OutOfMemory,


### PR DESCRIPTION
## Summary

- add a shared runtime readiness module for provider/account command prerequisites
- preflight command probes before execution so missing binaries, unavailable stores, repair locks, and missing sessions return `RuntimeNotReady` without mutating credential liveness
- expose route-scoped runtime detail in probe output and document the supervisor invariant

## Why

TIN-865 covers a stay-afloat safety gap: local runtime failures from CLI adapters should not be recorded as OAuth credential failures. This keeps degraded/dead liveness reserved for provider evidence and gives the daemon/repair loop a cleaner boundary for user-mediated fixes.

Refs #67.

## Validation

- `zig build test`
- `nix develop --command just check-local`
- `git diff --check`
