### PR TITLE
add stay-afloat scheduler policy hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ handoff events after a later stay-afloat tick has refreshed route evidence.
 --iterations <n> --interval-ms <ms> --json` repeats the same portable
 foreground tick for dogfood and wrappers. No `systemctl`, `launchctl`, service
 manager, browser auth, provider spend, or secret mutation is assumed unless
-policy and CLI flags explicitly admit it.
+policy and CLI flags explicitly admit it. Tick JSON includes route-level
+`next_tick_after` and `schedule_reason` fields, plus top-level summary wake-up
+hints, so wrappers can sleep or back off without guessing.
 
 Secret read and writeback are also separate. Route and runtime JSON expose a
 `writeback` object with the secret backend capability and whether automatic

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -92,7 +92,10 @@ rather than introducing separate behavior.
   after a user-mediated upstream login.
 - `oauth-mux stay-afloat --loop --iterations <n> --interval-ms <ms> --json`
   for a bounded foreground loop. It re-reads local health/runtime state each
-  tick and remains service-manager agnostic.
+  tick and remains service-manager agnostic. Route ticks expose
+  `next_tick_after` plus `schedule_reason`, and the summary exposes the
+  earliest `next_tick_after` plus `next_tick_reason`, so wrappers can back off
+  without inventing separate scheduler semantics.
 - `oauth-mux daemon tick --loop --iterations <n> --interval-ms <ms> --json`
   as the lower-level wrapper-author spelling for the same bounded foreground
   loop.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -232,7 +232,9 @@ oauth-mux stay-afloat --loop --iterations 2 --interval-ms 0 --profile codex-max 
 Loop mode emits one JSON envelope containing repeated tick snapshots. Each tick
 re-reads local health and runtime state and does not require launchd, systemd,
 Homebrew services, cron, or a platform-specific
-daemon manager.
+daemon manager. Per-route `tick.next_tick_after` and `tick.schedule_reason`,
+plus `summary.next_tick_after` and `summary.next_tick_reason`, are the portable
+sleep/backoff contract for wrappers and agents.
 
 Route, runtime, repair-plan, and stay-afloat JSON include a `writeback` object.
 That object separates the secret backend surface (`readonly`, `replace_file`,

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -3,7 +3,7 @@ Date: 2026-05-01
 
 Issue context: GitHub `Jesssullivan/oauth-mux#66`, `#67`, `#68`; Linear
 `TIN-858`, `TIN-736`, `TIN-738`, `TIN-859`, `TIN-860`, `TIN-861`, `TIN-862`,
-and `TIN-863`.
+`TIN-863`, and `TIN-866`.
 
 ## Baseline
 
@@ -18,7 +18,7 @@ boundaries that need separate tracking.
 | Facet | Public GitHub issue | Linear tracking | Current posture |
 | --- | --- | --- | --- |
 | Homebrew distribution | `#66` | `TIN-858`, related to `TIN-737` | Public Jess-owned tap exists and clean local install QA passes; Tinyland tap remains private/staged. |
-| Stay-afloat daemon | `#67` | `TIN-738`, `TIN-859`, `TIN-860` | Foreground/agent-safe stay-afloat is shipped; production background daemon is not. |
+| Stay-afloat daemon | `#67` | `TIN-738`, `TIN-859`, `TIN-860`, `TIN-866` | Foreground/agent-safe stay-afloat is shipped; production background daemon is not. |
 | Provider expansion | `#68` | `TIN-736`, `TIN-861`, `TIN-862`, `TIN-863` | Codex is live-proven; most other providers are schema-modeled or admitted but not live-proven. |
 
 ## Homebrew Boundary
@@ -53,6 +53,10 @@ Current truth:
 - `TIN-865` covers a stay-afloat hardening slice: command-probe runtime
   failures must surface as runtime repair state without poisoning persisted
   credential liveness.
+- `TIN-866` covers the scheduler policy gate before background daemon wrappers:
+  route-level tick JSON must expose deterministic `next_tick_after` and
+  `schedule_reason` values, and the summary must report the earliest wake-up
+  reason.
 - The default daemon policy refuses provider-spend probes, silent interactive
   auth, and silent mutation.
 - Codex fallback is proven from quota-exhausted `max-1#codex-max` to available
@@ -124,8 +128,10 @@ patterns are settled.
    subscription state and MCP resource-bound OAuth.
 4. Return to daemon background scheduling only after wrapper/install decisions
    and provider proof produce enough real operator evidence. The immediate
-   daemon-side exception is `TIN-865`, because false liveness evidence would
-   make every later scheduler less trustworthy.
+   daemon-side exceptions are `TIN-865`, because false liveness evidence would
+   make every later scheduler less trustworthy, and `TIN-866`, because wrappers
+   need deterministic wake-up hints before any service-manager recipes are
+   honest.
 
 ## Guardrails
 

--- a/docs/spec/stay-afloat-supervisor-contract-2026-05-01.md
+++ b/docs/spec/stay-afloat-supervisor-contract-2026-05-01.md
@@ -2,7 +2,7 @@
 Date: 2026-05-01
 
 Issue context: GitHub `Jesssullivan/oauth-mux#67`; Linear `TIN-738`,
-`TIN-859`, and `TIN-860`.
+`TIN-859`, `TIN-860`, and `TIN-866`.
 
 ## Decision
 
@@ -177,6 +177,16 @@ should treat `afloat:true` plus a non-null `selected` as the positive route
 condition. They should treat `handoff_queued:true` or `handoff_pending:true` as
 the signal to surface user-mediated repair.
 
+Each per-route `tick` object also carries deterministic scheduling hints:
+
+- `next_tick_after`: Unix timestamp for the next useful revisit, or `null`.
+- `schedule_reason`: why that timestamp was chosen.
+
+The top-level `summary` carries the earliest route-level `next_tick_after` as
+`next_tick_after` plus `next_tick_reason`. Wrappers may sleep until that time
+or use their own slower cadence. They must not treat the hint as permission to
+run unbounded busy loops, spend provider budget, or bypass admission policy.
+
 Process exit codes are not the primary supervisor API. Use command failure for
 parse/config/runtime errors, and use JSON fields for route state. `route select`
 may exit nonzero when no route is selectable; long-running wrappers should
@@ -203,6 +213,40 @@ If any route is already selectable, the tick is a no-op and the route remains
 afloat. If no route is selectable, the first admitted action wins. If no action
 is admitted, the tick reports the refused action and reason rather than
 escalating silently.
+
+## Schedule Semantics
+
+Scheduling is part of the portable foreground contract and must stay
+service-manager agnostic. A tick does not daemonize itself. It reports when a
+wrapper, CI job, shell hook, or future socket daemon should next re-check the
+same route state.
+
+Current schedule reasons:
+
+| Reason | Meaning |
+| --- | --- |
+| `route_selectable` | A route is already afloat; no wake-up is required. |
+| `probe_due` | A no-spend or admitted probe is useful immediately. |
+| `retry_after` | Provider rate-limit evidence supplied a retry-after window. |
+| `wait_until` | Quota or cooldown evidence supplied an absolute reset time. |
+| `quota_poll` | Quota is exhausted without a known reset; re-check on the conservative quota cadence. |
+| `repair_poll` | Another repair owns the account lock; poll the lock on the repair cadence. |
+| `runtime_recheck` | Local runtime repair is needed; re-check after the operator or wrapper has time to fix paths, stores, permissions, or sandboxing. |
+| `handoff_recheck` | Interactive user-mediated auth is required or pending; re-check after surfacing the handoff. |
+| `provider_recheck` | Provider plan/degradation evidence should be revisited later without busy-looping. |
+| `no_action` | The route has no follow-up action. |
+| `none` | No schedule rule matched. |
+
+Default cadences are intentionally conservative and deterministic:
+
+- repair-lock polling: 30 seconds;
+- runtime repair re-check: 5 minutes;
+- handoff re-check: 5 minutes;
+- quota-without-reset and provider-plan re-checks: 1 hour.
+
+These values are not platform service policy. Service wrappers may choose a
+slower interval, but faster intervals should still honor the route-level
+`next_tick_after` and admission policy.
 
 ## Admission Policy
 
@@ -290,9 +334,11 @@ Before calling the background daemon production-ready, the project needs:
    docs;
 6. wrapper examples for at least one package lane without changing core
    semantics;
-7. live QA proving timeout, auth failure, quota exhaustion, transient
+7. deterministic scheduler JSON with route-level reasons and top-level summary
+   hints;
+8. live QA proving timeout, auth failure, quota exhaustion, transient
    rate-limit, runtime permission, and handoff states;
-8. docs that distinguish foreground stay-afloat, experimental socket daemon,
+9. docs that distinguish foreground stay-afloat, experimental socket daemon,
    and optional service wrappers.
 
 Until those gates are met, public docs should describe stay-afloat as an

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -294,7 +294,10 @@ expect_contains "$daemon_tick" '"executed":false' "daemon tick does not execute 
 expect_contains "$daemon_tick" '"afloat":true' "daemon tick reports profile afloat"
 expect_contains "$daemon_tick" '"selected":{"provider":"toy","account":"a2"' "daemon tick selects fallback account a2"
 expect_contains "$daemon_tick" '"action":"wait_for_quota"' "daemon tick includes wait action for exhausted route"
+expect_contains "$daemon_tick" '"schedule_reason":"wait_until"' "daemon tick exposes quota reset schedule reason"
+expect_contains "$daemon_tick" '"next_tick_reason":"wait_until"' "daemon tick summary exposes earliest schedule reason"
 expect_contains "$daemon_tick" '"reason":"route_selectable"' "daemon tick marks selectable route as no-op"
+expect_contains "$daemon_tick" '"schedule_reason":"route_selectable"' "daemon tick marks selectable route as unscheduled"
 
 printf 'e2e: stay-afloat aliases daemon tick planning\n'
 stay_afloat="$(omux stay-afloat --once --profile expensive --capability expensive --json)"
@@ -302,6 +305,7 @@ expect_contains "$stay_afloat" '"mode":"once"' "stay-afloat reports one-shot mod
 expect_contains "$stay_afloat" '"executed":false' "stay-afloat remains planning-only by default"
 expect_contains "$stay_afloat" '"afloat":true' "stay-afloat reports profile afloat"
 expect_contains "$stay_afloat" '"selected":{"provider":"toy","account":"a2"' "stay-afloat selects fallback account a2"
+expect_contains "$stay_afloat" '"next_tick_reason":"wait_until"' "stay-afloat exposes scheduler summary"
 
 printf 'e2e: bounded daemon tick loop emits repeated planning snapshots\n'
 daemon_loop="$(omux daemon tick --loop --iterations 2 --interval-ms 0 --profile expensive --capability expensive --json)"

--- a/src/main.zig
+++ b/src/main.zig
@@ -525,6 +525,17 @@ const AdmissionDecision = struct {
     budget: ?types.ActionBudget = null,
 };
 
+const DaemonTickSchedule = struct {
+    next_tick_after: ?i64 = null,
+    reason: []const u8 = "none",
+};
+
+const daemon_repair_poll_s: i64 = 30;
+const daemon_runtime_recheck_s: i64 = 300;
+const daemon_handoff_recheck_s: i64 = 300;
+const daemon_quota_unknown_recheck_s: i64 = 3600;
+const daemon_provider_plan_recheck_s: i64 = 3600;
+
 fn runRepairPlan(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.RepairPlanArgs) !void {
     const parsed = try config.load(allocator);
     defer parsed.deinit();
@@ -2098,6 +2109,7 @@ const DaemonTickDecision = struct {
     executed: bool = false,
     handoff: bool = false,
     next_tick_after: ?i64 = null,
+    schedule_reason: []const u8 = "none",
 };
 
 const DaemonTickExecution = struct {
@@ -2123,6 +2135,7 @@ const DaemonTickStats = struct {
     blocked_repairs: usize = 0,
     no_action: usize = 0,
     next_tick_after: ?i64 = null,
+    next_tick_reason: ?[]const u8 = null,
 };
 
 fn writeDaemonTickText(
@@ -2170,6 +2183,8 @@ fn writeDaemonTickText(
             decision.reason,
         });
         if (decision.budget) |budget| try writer.print(" budget={s}", .{@tagName(budget)});
+        try writer.print(" schedule={s}", .{decision.schedule_reason});
+        if (decision.next_tick_after) |next| try writer.print(" next_tick_after={d}", .{next});
         if (try repairCommandAlloc(allocator, evaluation.action.command, evaluation.route)) |command| {
             defer allocator.free(command);
             try writer.print(" command={s}", .{command});
@@ -2284,6 +2299,12 @@ fn writeDaemonTickStatsJson(writer: anytype, stats: DaemonTickStats) !void {
     } else {
         try writer.writeAll("null");
     }
+    try writer.writeAll(",\"next_tick_reason\":");
+    if (stats.next_tick_reason) |reason| {
+        try std.json.stringify(reason, .{}, writer);
+    } else {
+        try writer.writeAll("null");
+    }
     try writer.writeByte('}');
 }
 
@@ -2371,6 +2392,8 @@ fn writeDaemonTickDecisionJson(writer: anytype, decision: DaemonTickDecision) !v
     try writer.writeAll(if (decision.handoff) "true" else "false");
     try writer.writeAll(",\"next_tick_after\":");
     if (decision.next_tick_after) |next| try writer.print("{d}", .{next}) else try writer.writeAll("null");
+    try writer.writeAll(",\"schedule_reason\":");
+    try std.json.stringify(decision.schedule_reason, .{}, writer);
     try writer.writeByte('}');
 }
 
@@ -2387,7 +2410,10 @@ fn daemonTickStats(policy: config.DaemonPolicyConfig, evaluations: []const Route
             stats.no_action += 1;
         }
         if (decision.next_tick_after) |next| {
-            if (stats.next_tick_after == null or next < stats.next_tick_after.?) stats.next_tick_after = next;
+            if (stats.next_tick_after == null or next < stats.next_tick_after.?) {
+                stats.next_tick_after = next;
+                stats.next_tick_reason = decision.schedule_reason;
+            }
         }
     }
     return stats;
@@ -2400,8 +2426,11 @@ fn daemonTickDecision(policy: config.DaemonPolicyConfig, evaluation: RouteEvalua
             .action = "none",
             .admitted = true,
             .reason = "route_selectable",
+            .schedule_reason = "route_selectable",
         };
     }
+
+    const schedule = daemonTickSchedule(evaluation.action, observed_at);
 
     if (evaluation.action.command == .probe) {
         const admission = daemonProbeAdmission(policy, evaluation.budget);
@@ -2411,7 +2440,8 @@ fn daemonTickDecision(policy: config.DaemonPolicyConfig, evaluation: RouteEvalua
             .admitted = admission.admitted,
             .reason = admission.reason,
             .budget = admission.budget,
-            .next_tick_after = daemonTickNextAfter(evaluation.action, observed_at),
+            .next_tick_after = schedule.next_tick_after,
+            .schedule_reason = schedule.reason,
         };
     }
 
@@ -2424,7 +2454,8 @@ fn daemonTickDecision(policy: config.DaemonPolicyConfig, evaluation: RouteEvalua
             .reason = admission.reason,
             .budget = admission.budget,
             .handoff = evaluation.action.interactive,
-            .next_tick_after = daemonTickNextAfter(evaluation.action, observed_at),
+            .next_tick_after = schedule.next_tick_after,
+            .schedule_reason = schedule.reason,
         };
     }
 
@@ -2435,17 +2466,50 @@ fn daemonTickDecision(policy: config.DaemonPolicyConfig, evaluation: RouteEvalua
         .admitted = admission.admitted,
         .reason = if (admission.admitted) "observe_only" else admission.reason,
         .budget = admission.budget,
-        .next_tick_after = daemonTickNextAfter(evaluation.action, observed_at),
+        .next_tick_after = schedule.next_tick_after,
+        .schedule_reason = schedule.reason,
     };
 }
 
-fn daemonTickNextAfter(action: RepairAction, observed_at: i64) ?i64 {
-    if (action.retry_after_s) |retry_after| return observed_at + @as(i64, retry_after);
-    if (action.wait_until) |wait_until| return wait_until;
-    if (std.mem.eql(u8, action.kind, "wait_for_repair")) return observed_at + 30;
-    if (std.mem.eql(u8, action.kind, "probe_needed")) return observed_at;
-    if (std.mem.eql(u8, action.kind, "reauth")) return observed_at;
-    return null;
+fn daemonTickSchedule(action: RepairAction, observed_at: i64) DaemonTickSchedule {
+    if (action.retry_after_s) |retry_after| return .{
+        .next_tick_after = observed_at + @as(i64, retry_after),
+        .reason = "retry_after",
+    };
+    if (action.wait_until) |wait_until| return .{
+        .next_tick_after = wait_until,
+        .reason = "wait_until",
+    };
+    if (std.mem.eql(u8, action.kind, "wait_for_repair")) return .{
+        .next_tick_after = observed_at + daemon_repair_poll_s,
+        .reason = "repair_poll",
+    };
+    if (action.command == .probe) return .{
+        .next_tick_after = observed_at,
+        .reason = "probe_due",
+    };
+    if (action.interactive) return .{
+        .next_tick_after = observed_at + daemon_handoff_recheck_s,
+        .reason = "handoff_recheck",
+    };
+    if (std.mem.eql(u8, action.kind, "fix_runtime")) return .{
+        .next_tick_after = observed_at + daemon_runtime_recheck_s,
+        .reason = "runtime_recheck",
+    };
+    if (std.mem.eql(u8, action.kind, "wait_for_quota")) return .{
+        .next_tick_after = observed_at + daemon_quota_unknown_recheck_s,
+        .reason = "quota_poll",
+    };
+    if (std.mem.eql(u8, action.kind, "provider_plan") or
+        std.mem.eql(u8, action.kind, "try_next_provider"))
+    {
+        return .{
+            .next_tick_after = observed_at + daemon_provider_plan_recheck_s,
+            .reason = "provider_recheck",
+        };
+    }
+    if (std.mem.eql(u8, action.kind, "none")) return .{ .reason = "no_action" };
+    return .{};
 }
 
 const DoctorStats = struct {
@@ -6306,6 +6370,7 @@ test "daemon tick refuses spend provider probe by default" {
     try std.testing.expectEqual(types.ActionBudget.spend_provider, decision.budget.?);
     try std.testing.expect(!decision.executed);
     try std.testing.expectEqual(@as(?i64, 1000), decision.next_tick_after);
+    try std.testing.expectEqualStrings("probe_due", decision.schedule_reason);
 }
 
 test "daemon tick reports selectable route as no-op" {
@@ -6331,6 +6396,89 @@ test "daemon tick reports selectable route as no-op" {
     try std.testing.expectEqualStrings("route_selectable", decision.reason);
     try std.testing.expect(!decision.executed);
     try std.testing.expect(decision.next_tick_after == null);
+    try std.testing.expectEqualStrings("route_selectable", decision.schedule_reason);
+}
+
+test "daemon tick schedules interactive handoff recheck without admitting silent auth" {
+    const route = RepairPlanRoute{ .provider = "codex", .account = "max-1", .capability = "codex-max" };
+    const decision = daemonTickDecision((config.PolicyConfig{}).daemon, .{
+        .route = route,
+        .runtime = .{ .needs_reauth = .{ .methods = &.{"upstream_cli_login"}, .reason = "session_file_missing" } },
+        .health = null,
+        .budget = .spend_provider,
+        .action = reauthAction(route, provider_schema.codex_def),
+        .selectable = false,
+        .skip_reason = "needs_reauth",
+    }, 1000);
+
+    try std.testing.expectEqualStrings("repair", decision.phase);
+    try std.testing.expectEqualStrings("reauth", decision.action);
+    try std.testing.expect(!decision.admitted);
+    try std.testing.expect(decision.handoff);
+    try std.testing.expectEqualStrings("interactive_not_allowed", decision.reason);
+    try std.testing.expectEqual(@as(?i64, 1300), decision.next_tick_after);
+    try std.testing.expectEqualStrings("handoff_recheck", decision.schedule_reason);
+}
+
+test "daemon tick schedules runtime repair recheck" {
+    const decision = daemonTickDecision((config.PolicyConfig{}).daemon, .{
+        .route = .{ .provider = "codex", .account = "max-1", .capability = "codex-max" },
+        .runtime = .{ .unwritable_store = "/tmp/oauth-mux-test/store" },
+        .health = null,
+        .budget = .free_local,
+        .action = .{
+            .kind = "fix_runtime",
+            .severity = "error",
+            .message = "runtime is not ready",
+            .budget = .free_local,
+        },
+        .selectable = false,
+        .skip_reason = "unwritable_store",
+    }, 1000);
+
+    try std.testing.expectEqualStrings("observe", decision.phase);
+    try std.testing.expect(decision.admitted);
+    try std.testing.expectEqualStrings("observe_only", decision.reason);
+    try std.testing.expectEqual(@as(?i64, 1300), decision.next_tick_after);
+    try std.testing.expectEqualStrings("runtime_recheck", decision.schedule_reason);
+}
+
+test "daemon tick stats carries earliest schedule reason" {
+    const evaluations = [_]RouteEvaluation{
+        .{
+            .route = .{ .provider = "codex", .account = "max-1", .capability = "codex-max" },
+            .runtime = .ready,
+            .health = null,
+            .budget = .free_local,
+            .action = .{
+                .kind = "wait_for_quota",
+                .severity = "warning",
+                .message = "quota exhausted without known reset",
+                .budget = .free_local,
+            },
+            .selectable = false,
+            .skip_reason = "quota_exhausted",
+        },
+        .{
+            .route = .{ .provider = "codex", .account = "max-2", .capability = "codex-max" },
+            .runtime = .{ .unwritable_store = "/tmp/oauth-mux-test/store" },
+            .health = null,
+            .budget = .free_local,
+            .action = .{
+                .kind = "fix_runtime",
+                .severity = "error",
+                .message = "runtime is not ready",
+                .budget = .free_local,
+            },
+            .selectable = false,
+            .skip_reason = "unwritable_store",
+        },
+    };
+    const stats = daemonTickStats((config.PolicyConfig{}).daemon, &evaluations, 1000);
+
+    try std.testing.expectEqual(@as(?i64, 1300), stats.next_tick_after);
+    try std.testing.expect(stats.next_tick_reason != null);
+    try std.testing.expectEqualStrings("runtime_recheck", stats.next_tick_reason.?);
 }
 
 test "repairActionFor classifies quota exhaustion as wait action" {


### PR DESCRIPTION
## Summary

- adds explicit stay-afloat tick scheduling metadata with per-route `schedule_reason` and summary `next_tick_reason`
- replaces the ad hoc next-tick helper with deterministic route-state cadences for probes, handoffs, runtime repair, repair locks, quota polling, and provider rechecks
- documents the scheduler contract in the supervisor contract, daemon boundary, product gap map, onboarding docs, and README
- extends local e2e coverage so daemon/stay-afloat JSON asserts schedule reasons at the shell/user-story layer

## Why

TIN-866 gates the next daemon/stay-afloat arc. Wrappers and future service integrations need a portable sleep/backoff contract before we can honestly promote background stay-afloat behavior. This keeps the core service-manager agnostic and policy-gated.

## Validation

- `zig build test`
- `git diff --check`
- `nix develop --command just check-local`

Refs #67
Linear: TIN-866, TIN-738