### PR TITLE
[codex] Add capability proof statuses

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -120,7 +120,9 @@ or core liveness algebra changes.
 
 Provider authors should use `oauth-mux providers list --json` to verify whether
 their provider is currently `built_in`, `schema_modeled`, `live_proven`, or still
-waiting on `needs_operator_proof`.
+waiting on `needs_operator_proof`. Capability entries can be promoted more
+narrowly with `local_live_proven` or `public_live_proven` before the whole
+provider family is proven.
 
 ## Non-Tinyland Deployments
 

--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -181,9 +181,10 @@ OMUX_LIVE_QA_CAPABILITIES=identity-api-key \
 ```
 
 These probes are still explicit live provider calls. Keep them out of default
-checks and scheduled daemon loops. Promote GitHub or Linear from
-`needs_operator_proof` only after a redacted artifact run is attached to the
-tracking issue.
+checks and scheduled daemon loops. A successful local artifact may promote the
+specific capability to `local_live_proven`, but do not promote the whole GitHub
+or Linear provider from `needs_operator_proof` until the provider's intended
+auth modes have attached redacted evidence.
 
 ## GitHub Workflow
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -381,8 +381,12 @@ paths unless the user explicitly passes `--include-paths`.
 
 `providers list --json` separates support status from proof status. `codex` is
 `live_proven`; shipped schemas are `built_in`; user JSON providers are
-`schema_modeled`; non-Codex providers still carry `needs_operator_proof` until
-live provider QA proves them.
+`schema_modeled`; non-Codex providers still carry provider-level
+`needs_operator_proof` until live provider QA proves the full route family.
+Capability entries expose narrower proof status in `capability_budgets`:
+`live_proven` for hosted secret-scoped proof, `local_live_proven` for local
+operator proof, `public_live_proven` for no-secret public metadata proof, and
+`needs_operator_proof` for modeled-but-unproven capabilities.
 
 ## Provider Onboarding Checklist
 

--- a/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
+++ b/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
@@ -267,7 +267,10 @@ Wave 2 should cover OAuth/MCP and plan-token complexity:
 Public copy should use these words precisely:
 
 - `live_proven`: real credential or account store, explicit consent, redacted
-  artifact, typed liveness, and successful hosted or local proof.
+  artifact, typed liveness, and successful hosted proof for the provider or
+  route.
+- `local_live_proven`: local redacted operator proof for one capability.
+- `public_live_proven`: no-secret public metadata proof for one capability.
 - `built_in`: compiled provider schema, probes, and failure rules exist, but
   live proof is not yet recorded.
 - `schema_modeled`: user or example JSON provider definition validates.

--- a/docs/spec/product-adoption-sprint-2026-04-28.md
+++ b/docs/spec/product-adoption-sprint-2026-04-28.md
@@ -183,7 +183,8 @@ Candidate CLI additions:
 
 - `oauth-mux providers list --json`
   - reports provider status as `built_in`, `schema_modeled`, `live_proven`, or
-    `needs_operator_proof`.
+    `needs_operator_proof`, plus capability-level proof status for narrower
+    local or public proof.
 
 Initial implementation status:
 

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -90,7 +90,9 @@ Current truth:
   FlakeHub/Determinate, Gemini, Anthropic API key, and MCP HTTP resource
   servers.
 - Public claims should keep `schema_modeled`, `needs_operator_proof`, and
-  `live_proven` separate.
+  `live_proven` separate. Capability proof can be narrower than provider proof:
+  `local_live_proven` means a local redacted operator proof exists, while
+  `public_live_proven` means a no-secret public metadata route was verified.
 
 Next split:
 
@@ -98,20 +100,24 @@ Next split:
   The first no-spend local proof is captured in
   `docs/spec/provider-proof-claude-command-auth-2026-05-01.md`: `auth-status`
   can now run through `claude auth status --json` without first reading or
-  mutating Claude's credential store. Synthetic fixture coverage now keeps
-  logged-out auth evidence separate from `runtime.missing_binary`.
+  mutating Claude's credential store. Its capability proof status is
+  `local_live_proven`. Synthetic fixture coverage now keeps logged-out auth
+  evidence separate from `runtime.missing_binary`.
 - `TIN-862`: prove GitHub and Linear low-impact identity probes. This is now
   underway with classifier hardening and a proof spec in
   `docs/spec/provider-proof-github-linear-2026-05-01.md`; local GitHub live QA
   has passed, Linear personal API-key live QA has passed, and Linear OAuth
-  bearer proof remains pending.
+  bearer proof remains pending. GitHub `identity` and Linear
+  `identity-api-key` are `local_live_proven`; Linear OAuth `identity` remains
+  `needs_operator_proof`.
 - `TIN-863`: prove MCP HTTP authorization and protected-resource metadata.
   The first metadata hardening slice is captured in
   `docs/spec/provider-proof-mcp-http-authorization-2026-05-01.md`: MCP
   `resource-metadata` no longer treats any HTTP 200 body as live unless the
-  RFC 9728/MCP metadata fields are structurally valid. The next slice now has a
-  typed target for resource-token routing errors: explicit resource/audience
-  mismatch evidence is `degraded.audience_mismatch`, not a revoked account.
+  RFC 9728/MCP metadata fields are structurally valid. Its capability proof
+  status is `public_live_proven`. The next slice now has a typed target for
+  resource-token routing errors: explicit resource/audience mismatch evidence
+  is `degraded.audience_mismatch`, not a revoked account.
 
 Later slices should cover Vercel/Figma token variants and Gemini plus
 FlakeHub/Determinate command-first status once the first three provider-proof
@@ -140,4 +146,5 @@ patterns are settled.
 - Do not run live probes by default.
 - Do not mutate upstream CLI-owned credential stores.
 - Do not promote a provider to `live_proven` without redacted fixtures and an
-  explicit proof run.
+  explicit proof run. Promote individual capabilities first when the evidence
+  only covers one route shape.

--- a/docs/spec/provider-proof-claude-command-auth-2026-05-01.md
+++ b/docs/spec/provider-proof-claude-command-auth-2026-05-01.md
@@ -66,7 +66,9 @@ Observed local result on 2026-05-01:
 This proves the command-owned auth-status lane can report a live Claude session
 without reading or mutating Claude's credential file. It does not prove Claude
 quota, tier, or model-call availability, and it does not make direct OAuth
-repair admissible.
+repair admissible. The capability can be reported as `local_live_proven`, while
+the provider remains `needs_operator_proof` for broader Claude account and quota
+semantics.
 
 ## Fixture Coverage
 

--- a/docs/spec/provider-proof-github-linear-2026-05-01.md
+++ b/docs/spec/provider-proof-github-linear-2026-05-01.md
@@ -7,9 +7,10 @@ Issue context: Linear `TIN-862`, parent `TIN-736`; GitHub
 ## Baseline
 
 Codex is live-proven. GitHub and Linear are schema-modeled with admitted
-low-impact identity probes, but they should remain `needs_operator_proof` until
-redacted live artifacts exist. This slice tightens the provider semantics needed
-before running those proofs.
+low-impact identity probes. Provider-level status should remain
+`needs_operator_proof` until the intended auth modes have redacted evidence, but
+individual capabilities can now carry narrower proof status when a local or
+public proof exists.
 
 ## Provider Contracts
 
@@ -83,16 +84,24 @@ the same redaction and pass/fail semantics as Codex.
 
 ## Promotion Gate
 
-Do not mark GitHub or Linear `live_proven` in `src/main.zig` until all of these
-are true:
+Do not mark GitHub or Linear provider-level `live_proven` in `src/main.zig`
+until all of these are true:
 
 1. Unit tests cover provider-specific classification and generic OAuth fallback.
 2. A local or hosted live artifact shows `live.available` for the identity
    probe without leaking token or raw profile response data.
 3. GitHub issue `#68` and Linear `TIN-862` link the proof artifact or a redacted
    summary of the run.
-4. The docs keep `schema_modeled`, `needs_operator_proof`, and `live_proven`
-   separate.
+4. The docs keep `schema_modeled`, `needs_operator_proof`,
+   `local_live_proven`, and `live_proven` separate.
+
+Capability-level promotion is narrower:
+
+- GitHub `identity`: `local_live_proven` after the local redacted artifact.
+- Linear `identity-api-key`: `local_live_proven` after the local redacted
+  artifact.
+- Linear `identity`: stays `needs_operator_proof` until OAuth bearer proof
+  exists.
 
 ## Current Evidence
 
@@ -112,7 +121,7 @@ are true:
 This is enough to prove the GitHub path locally and the Linear personal API-key
 path locally, but not enough to claim that every Linear auth mode is live-proven.
 TIN-862 should record the OAuth bearer proof separately before changing public
-support status.
+provider support status.
 
 ## Sources
 

--- a/docs/spec/provider-proof-mcp-http-authorization-2026-05-01.md
+++ b/docs/spec/provider-proof-mcp-http-authorization-2026-05-01.md
@@ -110,7 +110,9 @@ Observed local result on 2026-05-01:
 - last probe source: `capability_probe`
 
 This is not enough to prove resource-token liveness because that requires a
-resource-bound access token.
+resource-bound access token. The metadata capability can be reported as
+`public_live_proven`, while the bearer-token `resource` capability remains
+`needs_operator_proof`.
 
 ## Remaining Work
 

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -253,6 +253,8 @@ providers_json="$(omux providers list --json)"
 expect_contains "$providers_json" '"name":"toy"' "providers list includes custom toy provider"
 expect_contains "$providers_json" '"support_status":"schema_modeled"' "providers list classifies custom provider"
 expect_contains "$providers_json" '"proof_status":"needs_operator_proof"' "providers list marks custom provider proof state"
+expect_contains "$providers_json" '"name":"cheap","proof_status":"needs_operator_proof"' "providers list marks custom capability proof state"
+expect_contains "$providers_json" '"name":"codex-max","proof_status":"live_proven"' "providers list marks Codex capability proof state"
 expect_contains "$providers_json" '"configured_accounts":2' "providers list counts custom provider accounts"
 
 printf 'e2e: cheap route selects first healthy account\n'

--- a/src/main.zig
+++ b/src/main.zig
@@ -3658,8 +3658,8 @@ fn writeProvidersListText(
         }
     }
 
-    try writer.writeAll("\n  support: live_proven means hosted secret-scoped QA has proved a real route.\n");
-    try writer.writeAll("  proof: needs_operator_proof means the schema exists but needs live provider evidence.\n");
+    try writer.writeAll("\n  support: live_proven means hosted secret-scoped QA has proved a real provider route.\n");
+    try writer.writeAll("  proof: provider proof remains conservative; capability proof details are in --json.\n");
     _ = allocator;
 }
 
@@ -3802,6 +3802,8 @@ fn writeCapabilityBudgetsJson(writer: anytype, def: provider_schema.ProviderDefi
         try writer.writeByte('{');
         try writer.writeAll("\"name\":");
         try std.json.stringify(capability.name, .{}, writer);
+        try writer.writeAll(",\"proof_status\":");
+        try std.json.stringify(capability.proof_status, .{}, writer);
         try writer.writeAll(",\"budget\":");
         if (capability.probe) |probe_def| {
             try std.json.stringify(@tagName(probe_def.budget orelse provider_schema.defaultProbeBudget(probe_def.transport)), .{}, writer);
@@ -4082,14 +4084,14 @@ fn supportStatusForConfig(cfg: config.Config, provider_name: []const u8, provide
 }
 
 fn supportStatus(def_name: []const u8, built_in: bool) []const u8 {
-    if (std.mem.eql(u8, def_name, "codex")) return "live_proven";
+    if (std.mem.eql(u8, def_name, "codex")) return provider_schema.proof_live;
     if (built_in) return "built_in";
     return "schema_modeled";
 }
 
 fn proofStatus(def_name: []const u8) []const u8 {
-    if (std.mem.eql(u8, def_name, "codex")) return "live_proven";
-    return "needs_operator_proof";
+    if (std.mem.eql(u8, def_name, "codex")) return provider_schema.proof_live;
+    return provider_schema.proof_needs_operator;
 }
 
 fn providerDisplayName(def: provider_schema.ProviderDefinition) []const u8 {
@@ -6147,6 +6149,11 @@ test "writeProvidersListJson exposes extension and budget metadata" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"repair_owner\":\"upstream_cli_login\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"runtime\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"capability_budgets\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"codex-max\",\"proof_status\":\"live_proven\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"auth-status\",\"proof_status\":\"local_live_proven\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"resource-metadata\",\"proof_status\":\"public_live_proven\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"resource\",\"proof_status\":\"needs_operator_proof\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"identity-api-key\",\"proof_status\":\"local_live_proven\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"budget\":\"spend_provider\"") != null);
 }
 

--- a/src/provider_schema.zig
+++ b/src/provider_schema.zig
@@ -2,6 +2,11 @@ const std = @import("std");
 const types = @import("types.zig");
 const log = @import("log.zig");
 
+pub const proof_needs_operator = "needs_operator_proof";
+pub const proof_live = "live_proven";
+pub const proof_local_live = "local_live_proven";
+pub const proof_public_live = "public_live_proven";
+
 // ── Declarative Provider Definition ──
 //
 // A provider is fully described by data — no code required.
@@ -137,6 +142,7 @@ pub const RepairConfig = struct {
 pub const CapabilityDefinition = struct {
     name: []const u8,
     aliases: []const []const u8 = &.{},
+    proof_status: []const u8 = proof_needs_operator,
     probe: ?ProbeDefinition = null,
 };
 
@@ -264,6 +270,7 @@ const claude_capabilities = [_]CapabilityDefinition{
     .{
         .name = "auth-status",
         .aliases = &.{ "status", "identity", "whoami" },
+        .proof_status = proof_local_live,
         .probe = .{
             .transport = .command,
             .auth = .none,
@@ -336,6 +343,7 @@ const mcp_capabilities = [_]CapabilityDefinition{
     .{
         .name = "resource-metadata",
         .aliases = &.{ "metadata", "protected-resource-metadata" },
+        .proof_status = proof_public_live,
         .probe = .{
             .method = "GET",
             .url = "{{OMUX_MCP_RESOURCE_METADATA_URL}}",
@@ -420,6 +428,7 @@ const github_capabilities = [_]CapabilityDefinition{
     .{
         .name = "identity",
         .aliases = &.{ "user", "whoami" },
+        .proof_status = proof_local_live,
         .probe = .{
             .method = "GET",
             .url = "https://api.github.com/user",
@@ -462,6 +471,7 @@ const linear_capabilities = [_]CapabilityDefinition{
     .{
         .name = "identity-api-key",
         .aliases = &.{ "api-key", "personal-api-key", "pat", "whoami-api-key" },
+        .proof_status = proof_local_live,
         .probe = .{
             .method = "POST",
             .url = "https://api.linear.app/graphql",
@@ -561,6 +571,7 @@ const codex_capabilities = [_]CapabilityDefinition{
     .{
         .name = "codex-max",
         .aliases = &.{ "max", "gpt-5.3-codex", "gpt-5.1-codex-max" },
+        .proof_status = proof_live,
         .probe = .{
             .transport = .command,
             .auth = .none,
@@ -581,6 +592,7 @@ const codex_capabilities = [_]CapabilityDefinition{
     .{
         .name = "codex-mini",
         .aliases = &.{ "mini", "spark", "gpt-5.3-codex-spark", "gpt-5.1-codex-mini" },
+        .proof_status = proof_live,
         .probe = .{
             .transport = .command,
             .auth = .none,


### PR DESCRIPTION
## Summary

- add capability-level proof_status metadata to provider definitions
- expose capability proof status in providers list --json without promoting whole providers
- document current proof truth for Codex, Claude, GitHub, Linear, and MCP

## Validation

- zig build test
- nix develop --command just check-local
- git diff --check
- live QA: GitHub identity returned live.available
- live QA: Linear API-key identity returned live.available

## Notes

Linear OAuth bearer proof remains pending because LINEAR_ACCESS_TOKEN is not present in this shell. Provider-level non-Codex proof_status remains needs_operator_proof by design.