### PR TITLE
[codex] Align provider proof planning docs

### DIFF
--- a/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
+++ b/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
@@ -45,9 +45,13 @@ OAuth and muxing surfaces:
 
 These are the adoption blockers that should stay visible:
 
-1. Non-Codex live provider proof is still mostly schema-level.
+1. Non-Codex provider proof is still capability-level, not provider-level.
    Built-ins exist for Claude, GitHub, Vercel, Linear, Figma, FlakeHub, Gemini,
-   and MCP, but only Codex is currently `live_proven`.
+   and MCP. Codex is provider-level `live_proven`; Claude `auth-status`,
+   GitHub `identity`, Linear `identity-api-key`, and MCP `resource-metadata`
+   now have narrower capability proof statuses. Linear OAuth bearer, MCP
+   bearer-resource, Vercel, Figma, Gemini, and FlakeHub still need explicit
+   proof before public provider-level claims.
 
 2. Clean first-run OAuth is not yet a single captured journey.
    We have install proof and Codex account proof, but we still need recorded

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -127,11 +127,11 @@ patterns are settled.
 
 1. Update website/release copy to use the public `jesssullivan/omux` Homebrew
    tap and close `#66` / `TIN-858` after those surfaces are aligned.
-2. Finish `TIN-862` as the first non-Codex provider proof by running redacted
-   GitHub and Linear identity artifacts after the classifier/documentation
-   patch lands.
-3. Use `TIN-861` and `TIN-863` to prove the two harder shapes: CLI-owned
-   subscription state and MCP resource-bound OAuth.
+2. Finish `TIN-862` by adding Linear OAuth bearer proof. GitHub identity and
+   Linear API-key identity are locally proven; Linear OAuth `identity` remains
+   `needs_operator_proof`.
+3. Continue `TIN-861` and `TIN-863` on their remaining hard shapes: Claude
+   quota/repair semantics and MCP resource-bound bearer-token proof.
 4. Return to daemon background scheduling only after wrapper/install decisions
    and provider proof produce enough real operator evidence. The immediate
    daemon-side exceptions are `TIN-865`, because false liveness evidence would


### PR DESCRIPTION
## Summary

- update dogfood and product-gap specs after capability proof statuses landed
- call out Linear OAuth bearer and MCP bearer resource proof as the remaining gates

## Validation

- nix develop --command just check-local
- git diff --check