### PR TITLE
[codex] Expose daemon socket contract status

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ oauth-mux state directory. Confirmed repair uses an account-scoped advisory
 lock so concurrent repair attempts surface as `repair_in_progress` in runtime
 readiness instead of racing an upstream CLI login flow. Inspect recent events
 with `oauth-mux daemon events --json`; this does not require the daemon to be
-running.
+running. `oauth-mux daemon status --json` is local socket inspection only; it
+reports `contract:"experimental_socket_stub"` and `hosts_stay_afloat:false` so
+wrappers do not mistake the socket stub for the stay-afloat supervisor.
 
 Refresh attempts use the same local event stream. `token_refresh` events record
 only route identity, writeback capability, admission, outcome, and redacted
@@ -146,11 +148,10 @@ command to run. Repeated ticks report an existing handoff as pending instead of
 duplicating the event. Inspect those queued user-mediated repairs with
 `oauth-mux stay-afloat handoffs --json`; add `--all` to include historical
 handoff events after a later stay-afloat tick has refreshed route evidence.
-`stay-afloat --loop
---iterations <n> --interval-ms <ms> --json` repeats the same portable
-foreground tick for dogfood and wrappers. No `systemctl`, `launchctl`, service
-manager, browser auth, provider spend, or secret mutation is assumed unless
-policy and CLI flags explicitly admit it. Tick JSON includes route-level
+`stay-afloat --loop --iterations <n> --interval-ms <ms> --json` repeats the same
+portable foreground tick for dogfood and wrappers. No `systemctl`, `launchctl`,
+service manager, browser auth, provider spend, or secret mutation is assumed
+unless policy and CLI flags explicitly admit it. Tick JSON includes route-level
 `next_tick_after` and `schedule_reason` fields, plus top-level summary wake-up
 hints, so wrappers can sleep or back off without guessing.
 

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -50,6 +50,9 @@ loop, perform automatic repair, or define production daemon semantics.
 Homebrew services, systemd user units, launchd plists, cron, Windows Services,
 containers, and CI wrappers must preserve the foreground command contract
 rather than introducing separate behavior.
+`oauth-mux daemon status --json` reports this boundary directly with
+`contract:"experimental_socket_stub"`, `production_supported:false`,
+`hosts_stay_afloat:false`, and `wrapper_contract:"foreground_tick"`.
 
 ## Allowed Now
 
@@ -62,7 +65,8 @@ rather than introducing separate behavior.
 - `oauth-mux repair run` for one explicit, confirmed repair command.
 - `oauth-mux daemon repair-plan` as a compatibility alias for the same
   one-shot planner.
-- `oauth-mux daemon status --json` for local inspection.
+- `oauth-mux daemon status --json` for local inspection and machine-readable
+  socket-daemon contract metadata.
 - `oauth-mux daemon events --json` for the redacted repair-run event log. This
   reads local state and does not require a daemon process. The same stream also
   carries redacted `token_refresh` events for refresh admission/writeback

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -236,6 +236,11 @@ daemon manager. Per-route `tick.next_tick_after` and `tick.schedule_reason`,
 plus `summary.next_tick_after` and `summary.next_tick_reason`, are the portable
 sleep/backoff contract for wrappers and agents.
 
+`oauth-mux daemon status --json` is socket-stub inspection, not the stay-afloat
+supervisor. It reports `contract:"experimental_socket_stub"` and
+`hosts_stay_afloat:false` until the socket daemon is deliberately aligned with
+the foreground tick contract.
+
 Route, runtime, repair-plan, and stay-afloat JSON include a `writeback` object.
 That object separates the secret backend surface (`readonly`, `replace_file`,
 `command_write`, `keychain_write`, `sops_write`, or `unsupported`) from whether

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -66,6 +66,10 @@ Remaining daemon split:
 
 - Align the experimental socket daemon with the foreground tick contract before
   calling it a beta background daemon.
+- `TIN-867` now tracks that socket-daemon alignment decision. Until it is
+  resolved, `daemon status --json` exposes `contract:"experimental_socket_stub"`
+  and `hosts_stay_afloat:false` so wrappers do not treat the socket stub as
+  production stay-afloat.
 - Add optional package wrapper examples only after public install lanes and
   stop/status behavior are stable.
 - Keep production background scheduling separate from first-run and release

--- a/docs/spec/stay-afloat-supervisor-contract-2026-05-01.md
+++ b/docs/spec/stay-afloat-supervisor-contract-2026-05-01.md
@@ -84,6 +84,11 @@ The current socket daemon is experimental.
 - `daemon start` forks on Linux/macOS and starts the same loop.
 - `daemon status --json` reports `running` with a pid and socket path, or
   `not_running`.
+- `daemon status --json` also reports
+  `contract:"experimental_socket_stub"`, `production_supported:false`,
+  `hosts_stay_afloat:false`, and `wrapper_contract:"foreground_tick"` so
+  agents and wrappers do not mistake the socket stub for the stay-afloat
+  supervisor.
 - The socket handler supports `status`, `stop`, and a placeholder `refresh`
   response.
 - It does not host the stay-afloat tick engine yet.

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -337,6 +337,8 @@ for _ in $(seq 1 200); do
 done
 expect_contains "$daemon_status" '"status":"running"' "daemon status reports foreground daemon running"
 expect_contains "$daemon_status" '"socket":' "daemon status reports socket path"
+expect_contains "$daemon_status" '"contract":"experimental_socket_stub"' "daemon status reports socket contract"
+expect_contains "$daemon_status" '"hosts_stay_afloat":false' "daemon status does not claim to host stay-afloat"
 OMUX_STATE_DIR="$daemon_state" XDG_RUNTIME_DIR="$daemon_runtime" "$bin" daemon stop >/dev/null 2>&1
 set +e
 wait "$daemon_pid" 2>/dev/null
@@ -353,6 +355,7 @@ case "$daemon_wait_status" in
 esac
 daemon_stopped="$(OMUX_STATE_DIR="$daemon_state" XDG_RUNTIME_DIR="$daemon_runtime" "$bin" daemon status --json)"
 expect_contains "$daemon_stopped" '"status":"not_running"' "daemon status reports stopped foreground daemon"
+expect_contains "$daemon_stopped" '"wrapper_contract":"foreground_tick"' "daemon status reports wrapper contract when stopped"
 
 printf 'e2e: daemon tick execute runs one admitted command probe\n'
 omux health --reset toy:a1 >/dev/null

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -126,19 +126,34 @@ pub fn status(allocator: std.mem.Allocator, writer: anytype, json: bool) !void {
         const sock = try paths.socketPath(allocator);
         defer allocator.free(sock);
         if (json) {
-            try writer.print("{{\"status\":\"running\",\"pid\":{d},\"socket\":", .{pid});
+            try writer.writeAll("{\"status\":\"running\"");
+            try writeStatusContractJson(writer);
+            try writer.print(",\"pid\":{d},\"socket\":", .{pid});
             try std.json.stringify(sock, .{}, writer);
             try writer.writeAll("}\n");
         } else {
             try writer.print("daemon: running (pid {d}, socket {s})\n", .{ pid, sock });
+            try writer.writeAll("daemon: experimental socket stub; stay-afloat contract is the foreground tick engine\n");
         }
     } else {
         if (json) {
-            try writer.writeAll("{\"status\":\"not_running\"}\n");
+            try writer.writeAll("{\"status\":\"not_running\"");
+            try writeStatusContractJson(writer);
+            try writer.writeAll("}\n");
         } else {
             try writer.writeAll("daemon: not running\n");
+            try writer.writeAll("daemon: experimental socket stub; stay-afloat contract is the foreground tick engine\n");
         }
     }
+}
+
+fn writeStatusContractJson(writer: anytype) !void {
+    try writer.writeAll(",\"contract\":\"experimental_socket_stub\"");
+    try writer.writeAll(",\"production_supported\":false");
+    try writer.writeAll(",\"hosts_stay_afloat\":false");
+    try writer.writeAll(",\"wrapper_contract\":\"foreground_tick\"");
+    try writer.writeAll(",\"socket_transport_supported\":");
+    try writer.writeAll(if (builtin.os.tag == .windows) "false" else "true");
 }
 
 fn isRunning(allocator: std.mem.Allocator) bool {
@@ -264,4 +279,16 @@ fn readPidFile(allocator: std.mem.Allocator, path: []const u8) !Pid {
 
 test "isRunning returns false when no daemon" {
     try std.testing.expect(!isRunning(std.testing.allocator));
+}
+
+test "status json exposes socket daemon contract" {
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+
+    try status(std.testing.allocator, buf.writer(), true);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"status\":\"not_running\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"contract\":\"experimental_socket_stub\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"production_supported\":false") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"hosts_stay_afloat\":false") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"wrapper_contract\":\"foreground_tick\"") != null);
 }


### PR DESCRIPTION
## Summary

- make daemon status JSON expose the socket daemon contract explicitly
- document that the socket stub does not host stay-afloat and is not production-supported
- assert the new contract fields in unit and e2e coverage

## Validation

- zig build test
- nix develop --command just check-local
- git diff --check

## Tracking

TIN-867 / GitHub #67