### PR TITLE
[codex] Finalize socket daemon boundary decision

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -161,7 +161,9 @@ foreground supervisor contract is tracked in
 - `v0.1.3` onboarding/doctor/report scope;
 - launch sequencing and outreach;
 - provider-author feedback loops;
-- follow-up Linear split from `TIN-491`.
+- follow-up Linear split from `TIN-491`;
+- the `TIN-867` decision that the socket daemon remains non-product
+  status/control plumbing for the current release line.
 
 ## Ownership And URL
 

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -8,6 +8,14 @@ Keep daemon usage optional until provider-specific refresh semantics are proven
 for each OAuth-backed harness. The default production path remains explicit
 selection, explicit probe, env injection, and exec handoff.
 
+For the current product line, the socket daemon is not the stay-afloat product
+surface. It remains local experimental status/control plumbing. Wrappers,
+package recipes, CI jobs, and agents should call the foreground tick contract:
+`oauth-mux stay-afloat ...` or the lower-level `oauth-mux daemon tick ...`.
+If a production background daemon is added later, it must be a deliberate beta
+promotion of the same foreground tick engine, not a semantic fork of the socket
+stub.
+
 The 2026-04-30 stay-afloat review keeps this boundary in place. Real Codex
 dogfood proved route-scoped fallback from `codex:max-1#codex-max` quota
 exhaustion to `codex:max-2#codex-max`, but it also exposed that runtime
@@ -46,7 +54,8 @@ the same planner/executor as `stay-afloat`.
 
 `oauth-mux daemon run/start/stop/status` remains experimental socket plumbing.
 It can report a local Unix socket status, but it does not host the stay-afloat
-loop, perform automatic repair, or define production daemon semantics.
+loop, perform automatic repair, or define production daemon semantics. This is
+the final TIN-867 decision for the current release line.
 Homebrew services, systemd user units, launchd plists, cron, Windows Services,
 containers, and CI wrappers must preserve the foreground command contract
 rather than introducing separate behavior.
@@ -129,7 +138,7 @@ rather than introducing separate behavior.
 - Treating `systemctl`, `launchctl`, Homebrew services, cron, or Windows
   Services as part of the core product contract.
 - Presenting `oauth-mux daemon run/start` as the production stay-afloat daemon
-  before the socket process is aligned with the foreground tick contract.
+  in the current product line.
 
 ## Promotion Criteria
 

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -66,10 +66,11 @@ Remaining daemon split:
 
 - Align the experimental socket daemon with the foreground tick contract before
   calling it a beta background daemon.
-- `TIN-867` now tracks that socket-daemon alignment decision. Until it is
-  resolved, `daemon status --json` exposes `contract:"experimental_socket_stub"`
-  and `hosts_stay_afloat:false` so wrappers do not treat the socket stub as
-  production stay-afloat.
+- `TIN-867` resolved the current release-line decision: keep the socket daemon
+  out of the product stay-afloat surface. `daemon status --json` exposes
+  `contract:"experimental_socket_stub"` and `hosts_stay_afloat:false` so
+  wrappers do not treat the socket stub as production stay-afloat. Future
+  background-daemon work must promote the foreground tick engine deliberately.
 - Add optional package wrapper examples only after public install lanes and
   stop/status behavior are stable.
 - Keep production background scheduling separate from first-run and release

--- a/docs/spec/stay-afloat-supervisor-contract-2026-05-01.md
+++ b/docs/spec/stay-afloat-supervisor-contract-2026-05-01.md
@@ -24,6 +24,9 @@ The existing `oauth-mux daemon run/start/stop/status` socket code is not the
 production supervisor contract. It is a Unix socket status/control stub that is
 useful for local experiments. It is currently unsupported on Windows and does
 not perform automatic repair, route refresh, or background scheduling.
+The TIN-867 decision is to keep that socket daemon out of the supported
+stay-afloat product surface for the current release line. Wrapper authors
+should call the foreground tick engine directly.
 
 Service managers are wrappers, not core semantics. `systemctl`, `launchctl`,
 Homebrew services, cron, Windows Services, scheduled tasks, containers, and CI
@@ -91,12 +94,14 @@ The current socket daemon is experimental.
   supervisor.
 - The socket handler supports `status`, `stop`, and a placeholder `refresh`
   response.
-- It does not host the stay-afloat tick engine yet.
+- It does not host the stay-afloat tick engine in the supported product
+  contract.
 - It must not be required by first-run, release gates, live QA, or provider
   authoring.
 
-The socket stub can become an implementation detail for a future beta daemon,
-but only after its behavior is aligned with the foreground supervisor contract.
+The socket stub can become an implementation detail for a future beta daemon
+only through a new promotion slice that aligns it with the foreground
+supervisor contract and repeats the daemon promotion gates.
 
 ### Layer 4: service wrappers
 


### PR DESCRIPTION
## Summary

- finalize the TIN-867 decision that the socket daemon remains non-product plumbing for this release line
- state that wrappers should call the foreground stay-afloat/daemon tick contract directly
- keep future background daemon promotion as a deliberate new slice, not a semantic fork of the socket stub

## Validation

- nix develop --command just check-local
- git diff --check

## Tracking

TIN-867 / GitHub #67