### PR TITLE
[codex] Prove Vercel identity capability

### DIFF
--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -129,12 +129,16 @@ Next split:
   status is `public_live_proven`. The next slice now has a typed target for
   resource-token routing errors: explicit resource/audience mismatch evidence
   is `degraded.audience_mismatch`, not a revoked account.
-- `TIN-876`: prove Vercel identity. The built-in `identity` capability exists
-  for `GET https://api.vercel.com/v2/user`, but still needs redacted operator
-  proof before promotion.
+- `TIN-876`: prove Vercel identity. A low-impact local proof now shows
+  `vercel:work#identity` returning HTTP 200 and `live.available`; the
+  capability proof status is `local_live_proven`. Broader provider status stays
+  conservative until Vercel token, team, scope, and project/resource failure
+  shapes have redacted fixture coverage.
 - `TIN-877`: prove Figma OAuth, PAT, and plan-token shapes separately.
   `identity`, `identity-pat`, and `file-metadata-plan` must not collapse into a
-  single generic "Figma works" claim.
+  single generic "Figma works" claim. A 2026-05-01 OAuth bearer attempt
+  returned HTTP 403 and correctly classified as `degraded.scope_insufficient`;
+  that is classifier evidence, not live proof.
 - `TIN-878`: prove FlakeHub/Determinate as command-first status, with missing
   binaries and unwritable runtime separated from credential liveness.
 - `TIN-879`: decide and prove the Gemini CLI provider shape before any proof

--- a/docs/spec/provider-proof-vercel-2026-05-01.md
+++ b/docs/spec/provider-proof-vercel-2026-05-01.md
@@ -1,0 +1,87 @@
+# Provider Proof: Vercel Identity
+Date: 2026-05-01
+
+Issue context: GitHub `Jesssullivan/oauth-mux#68`; Linear `TIN-736`,
+`TIN-876`.
+
+## Boundary
+
+Vercel is a bearer-token HTTP provider for the first proof slice. The proven
+capability is `identity`, which maps to Vercel's authenticated user endpoint.
+This proof does not claim team/project mutation, deploy behavior, billing
+state, or OAuth repair.
+
+The official Vercel REST API reference documents `GET /v2/user` as retrieving
+the currently authenticated user and shows bearer-token authentication for that
+request:
+
+- Vercel "Get the User":
+  <https://docs.vercel.com/docs/rest-api/reference/endpoints/user/get-the-user>
+
+The same reference family documents token metadata separately under
+`GET /v5/user/tokens/{tokenId}`, including the special `current` token id. That
+may be useful for future expiry/scope evidence, but this slice does not call it
+or promote it as a required probe:
+
+- Vercel "Get Auth Token Metadata":
+  <https://docs.vercel.com/docs/rest-api/reference/endpoints/authentication/get-auth-token-metadata>
+
+## Local Live Proof
+
+Low-impact local proof used the existing `examples/vercel.config.json` profile
+with a scoped operator token supplied through `OMUX_VERCEL_WORK_TOKEN`. The run
+used a temporary oauth-mux state directory and did not write provider state.
+
+```bash
+OMUX_STATE_DIR=$(mktemp -d) \
+OMUX_CONFIG=$PWD/examples/vercel.config.json \
+OMUX_VERCEL_WORK_TOKEN=$VERCEL_TOKEN \
+./zig-out/bin/oauth-mux probe --profile vercel --capability identity --json
+```
+
+Redacted result:
+
+```json
+{
+  "provider": "vercel",
+  "account": "work",
+  "capability": "identity",
+  "ok": true,
+  "probe_executed": true,
+  "probe_status": 200,
+  "decision": "use_this",
+  "liveness": {
+    "summary": "available",
+    "state": "live",
+    "availability": "available"
+  },
+  "last_probe": {
+    "source": "capability_probe",
+    "hint_class": "none",
+    "decision": "use_this"
+  }
+}
+```
+
+The Vercel `identity` capability can now report `local_live_proven`. Provider
+level status should remain conservative until broader Vercel token, team,
+scope, and project/resource failure shapes have redacted fixture coverage.
+
+## Adjacent Figma Finding
+
+The same proof pass also tested a Figma OAuth bearer identity token through
+`examples/figma.config.json`. That route returned HTTP 403 and correctly
+classified as `degraded.scope_insufficient`.
+
+That is useful evidence for the Figma classifier, but it is not a Figma live
+proof and does not promote any Figma capability. `TIN-877` remains open for
+Figma OAuth, PAT, and plan-token proof.
+
+## Next
+
+- Add Vercel fixture coverage for 401, 403 scope/tier/team, 429, and 5xx
+  response shapes.
+- Consider the token metadata endpoint only if it gives useful redacted expiry
+  or scope evidence without widening the default probe.
+- Keep Vercel probes out of default background loops unless daemon policy
+  explicitly admits the provider budget.

--- a/src/main.zig
+++ b/src/main.zig
@@ -6151,6 +6151,7 @@ test "writeProvidersListJson exposes extension and budget metadata" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"capability_budgets\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"codex-max\",\"proof_status\":\"live_proven\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"auth-status\",\"proof_status\":\"local_live_proven\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"identity\",\"proof_status\":\"local_live_proven\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"resource-metadata\",\"proof_status\":\"public_live_proven\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"resource\",\"proof_status\":\"needs_operator_proof\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"identity-api-key\",\"proof_status\":\"local_live_proven\"") != null);

--- a/src/provider_schema.zig
+++ b/src/provider_schema.zig
@@ -416,6 +416,7 @@ const vercel_capabilities = [_]CapabilityDefinition{
     .{
         .name = "identity",
         .aliases = &.{ "user", "whoami" },
+        .proof_status = proof_local_live,
         .probe = .{
             .method = "GET",
             .url = "https://api.vercel.com/v2/user",


### PR DESCRIPTION
## Summary

- promotes Vercel `identity` capability to `local_live_proven`
- adds a Vercel provider-proof spec with official docs links and redacted live result
- records the adjacent Figma OAuth 403 as classifier evidence, not live proof
- updates the product gap map to keep provider-level Vercel/Figma claims conservative

## Validation

- low-impact Vercel live probe: `probe_status=200`, `live.available`, `decision=use_this`
- Figma OAuth probe returned typed `degraded.scope_insufficient` evidence and was not promoted
- `git diff --check`
- `nix develop --command just check-local`
- `oauth-mux providers list --json` shows Vercel `identity` capability as `local_live_proven`
