### PR TITLE
[codex] Prove FlakeHub status capability

### DIFF
--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -139,8 +139,12 @@ Next split:
   single generic "Figma works" claim. A 2026-05-01 OAuth bearer attempt
   returned HTTP 403 and correctly classified as `degraded.scope_insufficient`;
   that is classifier evidence, not live proof.
-- `TIN-878`: prove FlakeHub/Determinate as command-first status, with missing
-  binaries and unwritable runtime separated from credential liveness.
+- `TIN-878`: prove FlakeHub/Determinate as command-first status. A low-impact
+  local proof now shows `flakehub:work#status` through `determinate-nixd
+  status` returning HTTP-shaped status 200 and `live.available`; the capability
+  proof status is `local_live_proven`. Broader provider status stays
+  conservative until logged-out, missing-binary, timeout, cache/apply, and
+  private-flake permission states have fixture coverage.
 - `TIN-879`: decide and prove the Gemini CLI provider shape before any proof
   promotion; do not assume generic Google OAuth token behavior is enough for
   the harness.

--- a/docs/spec/provider-proof-flakehub-determinate-2026-05-01.md
+++ b/docs/spec/provider-proof-flakehub-determinate-2026-05-01.md
@@ -1,0 +1,87 @@
+# Provider Proof: FlakeHub / Determinate Status
+Date: 2026-05-01
+
+Issue context: GitHub `Jesssullivan/oauth-mux#68`; Linear `TIN-736`,
+`TIN-878`.
+
+## Boundary
+
+FlakeHub / Determinate is command-owned in oauth-mux. The first proven
+capability is `status`, implemented as a no-token command probe through
+`determinate-nixd status`. oauth-mux does not own or rewrite Determinate Nixd's
+credential store.
+
+The official Determinate Nix docs describe `determinate-nixd login` as the
+FlakeHub login path and `determinate-nixd status` as the command that shows the
+current FlakeHub login status:
+
+- Determinate Nix:
+  <https://docs.determinate.systems/determinate-nix/>
+
+The official authentication docs describe FlakeHub/Determinate authentication
+through generated tokens and Determinate Nixd registration:
+
+- FlakeHub authentication:
+  <https://docs.determinate.systems/flakehub/concepts/authentication/>
+
+The separate `fh` CLI also has its own `fh status` command, but this proof does
+not depend on `fh` being present. The current built-in provider uses
+`determinate-nixd status` because that binary is the installed command owner on
+the dogfood host.
+
+## Local Live Proof
+
+Low-impact local proof used the existing `examples/flakehub.config.json`
+profile with a temporary oauth-mux state directory. The command probe uses
+`auth = none`, so oauth-mux did not read or write a FlakeHub token.
+
+```bash
+OMUX_STATE_DIR=$(mktemp -d) \
+OMUX_CONFIG=$PWD/examples/flakehub.config.json \
+./zig-out/bin/oauth-mux probe --profile flakehub --capability status --json
+```
+
+Redacted result:
+
+```json
+{
+  "provider": "flakehub",
+  "account": "work",
+  "capability": "status",
+  "ok": true,
+  "probe_executed": true,
+  "probe_status": 200,
+  "decision": "use_this",
+  "runtime": {
+    "readiness": {
+      "state": "ready"
+    },
+    "required_binaries": ["determinate-nixd"]
+  },
+  "liveness": {
+    "summary": "available",
+    "state": "live",
+    "availability": "available"
+  },
+  "last_probe": {
+    "source": "capability_probe",
+    "hint_class": "none",
+    "decision": "use_this"
+  }
+}
+```
+
+The FlakeHub `status` capability can now report `local_live_proven`. Provider
+level status should remain conservative until logged-out, missing-binary,
+timeout, and cache/apply permission states have redacted or synthetic fixture
+coverage.
+
+## Next
+
+- Add synthetic command fixtures for logged-out status and missing
+  `determinate-nixd`.
+- Decide whether `fh status` should be an alternate command capability or only
+  documented as an adjacent CLI.
+- Keep `fh apply` / cache access / private flake resolution outside the proven
+  status capability until those behaviors have their own proof and admission
+  policy.

--- a/src/main.zig
+++ b/src/main.zig
@@ -6152,6 +6152,7 @@ test "writeProvidersListJson exposes extension and budget metadata" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"codex-max\",\"proof_status\":\"live_proven\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"auth-status\",\"proof_status\":\"local_live_proven\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"identity\",\"proof_status\":\"local_live_proven\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"status\",\"proof_status\":\"local_live_proven\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"resource-metadata\",\"proof_status\":\"public_live_proven\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"resource\",\"proof_status\":\"needs_operator_proof\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"identity-api-key\",\"proof_status\":\"local_live_proven\"") != null);

--- a/src/provider_schema.zig
+++ b/src/provider_schema.zig
@@ -558,6 +558,7 @@ const flakehub_capabilities = [_]CapabilityDefinition{
     .{
         .name = "status",
         .aliases = &.{ "identity", "whoami" },
+        .proof_status = proof_local_live,
         .probe = .{
             .transport = .command,
             .auth = .none,


### PR DESCRIPTION
## Summary

- promotes FlakeHub/Determinate `status` capability to `local_live_proven`
- adds a provider-proof spec for the command-owned `determinate-nixd status` path
- updates the product gap map while keeping broader FlakeHub/cache/apply claims conservative

## Validation

- low-impact FlakeHub live command probe: `probe_status=200`, `live.available`, `decision=use_this`
- `git diff --check`
- `nix develop --command just check-local`
- `oauth-mux providers list --json` shows FlakeHub `status` capability as `local_live_proven`
