### PR TITLE
[codex] Expose runtime diagnostic commands

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -104,6 +104,11 @@ through its upstream CLI. Current automatic refresh follows that contract: it
 will not call a token endpoint unless writeback is admitted, and admitted file
 backends are replaced atomically.
 
+Runtime repair actions also report `diagnostic_command`. That command is for
+the user, wrapper, or permission broker to run in the correct process boundary;
+it is not an automatic repair command and should not be treated as provider
+failure evidence.
+
 ## Provider Author Experience
 
 A new provider should usually start as data, not Zig:

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -249,6 +249,12 @@ Codex and Claude-style CLI-owned stores: a file-backed credential can be
 readable and writable by the current user, while oauth-mux still refuses to
 rewrite it because upstream login owns the session.
 
+When a route needs local runtime repair before any provider call, the action
+also includes `diagnostic_command`. Run that command in the process boundary
+that actually owns the upstream store; for example, a sandboxed agent may need
+the user or wrapper to run the diagnostic in a normal shell before deciding
+whether the account is usable.
+
 The refresh path now uses that same admission gate. File-backed credentials can
 be replaced atomically, but automatic refresh only runs for providers whose
 definition declares `repair.owner = "oauth_mux_refresh"` and whose backend

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -67,6 +67,12 @@ Current truth:
   auth, and silent mutation.
 - Codex fallback is proven from quota-exhausted `max-1#codex-max` to available
   `max-2#codex-max`; automatic reauth and background repair are not proven.
+- A 2026-05-01 recheck split the runtime truth cleanly: inside the current
+  Codex sandbox, all three configured Codex account stores report
+  `unwritable_store`; outside that sandbox, all three stores are runtime-ready
+  and `stay-afloat --once --profile codex-max --capability codex-max --json`
+  selects `codex:max-2#codex-max` with `max-3` still selectable. This is a
+  sandbox/runtime-boundary product concern, not OAuth death or quota failure.
 
 Remaining daemon split:
 
@@ -77,6 +83,10 @@ Remaining daemon split:
   `contract:"experimental_socket_stub"` and `hosts_stay_afloat:false` so
   wrappers do not treat the socket stub as production stay-afloat. Future
   background-daemon work must promote the foreground tick engine deliberately.
+- Runtime repair actions now expose a non-executing `diagnostic_command` such
+  as `oauth-mux doctor runtime --provider codex --account max-1 --capability
+  codex-max --json`, so agents can ask for the precise local proof command
+  without treating diagnostics as automatic repair.
 - Add optional package wrapper examples only after public install lanes and
   stop/status behavior are stable.
 - Keep production background scheduling separate from first-run and release

--- a/docs/spec/provider-proof-github-linear-2026-05-01.md
+++ b/docs/spec/provider-proof-github-linear-2026-05-01.md
@@ -117,6 +117,13 @@ Capability-level promotion is narrower:
   `decision=use_this`.
 - Linear OAuth bearer live QA is still pending. The current shell did not expose
   `LINEAR_ACCESS_TOKEN`.
+- A 2026-05-01 SOPS recheck of `../lab/nix/secrets/common.yaml` found
+  `api.linear`, but it is the same personal API key already exposed as
+  `LINEAR_API_KEY`, not a Linear OAuth bearer. Sourcing that key through SOPS
+  proves `linear:work#identity-api-key` as `live.available`; using the same
+  value against the OAuth-bearer `identity` route returns HTTP 400 and stays
+  `degraded.unknown_4xx`. This confirms the SOPS path is useful for API-key
+  proof but does not unblock OAuth proof.
 
 This is enough to prove the GitHub path locally and the Linear personal API-key
 path locally, but not enough to claim that every Linear auth mode is live-proven.

--- a/docs/spec/stay-afloat-supervisor-contract-2026-05-01.md
+++ b/docs/spec/stay-afloat-supervisor-contract-2026-05-01.md
@@ -187,6 +187,11 @@ should treat `afloat:true` plus a non-null `selected` as the positive route
 condition. They should treat `handoff_queued:true` or `handoff_pending:true` as
 the signal to surface user-mediated repair.
 
+Runtime repair actions expose `action.diagnostic_command` when the route needs
+local runtime proof before any provider call. The diagnostic command is not an
+automatic repair action; it is an agent-safe next command for users, wrappers,
+or permission brokers to run in the right process boundary.
+
 Each per-route `tick` object also carries deterministic scheduling hints:
 
 - `next_tick_after`: Unix timestamp for the next useful revisit, or `null`.

--- a/src/main.zig
+++ b/src/main.zig
@@ -1013,6 +1013,10 @@ fn writeRepairPlanText(
             defer allocator.free(command);
             try writer.print("    command: {s}\n", .{command});
         }
+        if (try runtimeDiagnosticCommandAlloc(allocator, action, route)) |command| {
+            defer allocator.free(command);
+            try writer.print("    diagnostic: {s}\n", .{command});
+        }
     }
 }
 
@@ -1132,6 +1136,13 @@ fn writeRepairActionJson(
     }
     try writer.writeAll(",\"command\":");
     if (try repairCommandAlloc(allocator, action.command, route)) |command| {
+        defer allocator.free(command);
+        try std.json.stringify(command, .{}, writer);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"diagnostic_command\":");
+    if (try runtimeDiagnosticCommandAlloc(allocator, action, route)) |command| {
         defer allocator.free(command);
         try std.json.stringify(command, .{}, writer);
     } else {
@@ -1468,6 +1479,18 @@ fn repairCommandAlloc(
             try std.fmt.allocPrint(allocator, "oauth-mux probe --provider {s} --account {s} --json", .{ route.provider, route.account }),
         .codex_login_device => try std.fmt.allocPrint(allocator, "oauth-mux codex login-device {s}", .{route.account}),
     };
+}
+
+fn runtimeDiagnosticCommandAlloc(
+    allocator: std.mem.Allocator,
+    action: RepairAction,
+    route: RepairPlanRoute,
+) !?[]const u8 {
+    if (!std.mem.eql(u8, action.kind, "fix_runtime")) return null;
+    return if (route.capability) |capability|
+        try std.fmt.allocPrint(allocator, "oauth-mux doctor runtime --provider {s} --account {s} --capability {s} --json", .{ route.provider, route.account, capability })
+    else
+        try std.fmt.allocPrint(allocator, "oauth-mux doctor runtime --provider {s} --account {s} --json", .{ route.provider, route.account });
 }
 
 const RouteEvaluation = struct {
@@ -1999,6 +2022,10 @@ fn writeRouteText(
                 defer allocator.free(command);
                 try writer.print(" command={s}", .{command});
             }
+            if (try runtimeDiagnosticCommandAlloc(allocator, evaluation.action, evaluation.route)) |command| {
+                defer allocator.free(command);
+                try writer.print(" diagnostic={s}", .{command});
+            }
         }
         try writer.writeByte('\n');
     }
@@ -2188,6 +2215,10 @@ fn writeDaemonTickText(
         if (try repairCommandAlloc(allocator, evaluation.action.command, evaluation.route)) |command| {
             defer allocator.free(command);
             try writer.print(" command={s}", .{command});
+        }
+        if (try runtimeDiagnosticCommandAlloc(allocator, evaluation.action, evaluation.route)) |command| {
+            defer allocator.free(command);
+            try writer.print(" diagnostic={s}", .{command});
         }
         try writer.writeByte('\n');
     }
@@ -6535,6 +6566,19 @@ test "writeRepairActionJson emits codex reauth command without running it" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"interactive\":true") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"mutating\":true") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"command\":\"oauth-mux codex login-device max-1\"") != null);
+}
+
+test "writeRepairActionJson emits runtime diagnostic command without executable repair" {
+    const route = RepairPlanRoute{ .provider = "codex", .account = "max-1", .capability = "codex-max" };
+    const action = repairActionFor(route, provider_schema.codex_def, .{ .unwritable_store = "config_dir" }, null, .spend_provider);
+
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+
+    try writeRepairActionJson(buf.writer(), std.testing.allocator, action, route);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"kind\":\"fix_runtime\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"command\":null") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"diagnostic_command\":\"oauth-mux doctor runtime --provider codex --account max-1 --capability codex-max --json\"") != null);
 }
 
 test "repairRunCandidate skips repair when profile already has selectable route" {


### PR DESCRIPTION
## Summary

Adds a non-executing `action.diagnostic_command` to runtime repair actions so agents and wrappers can surface the exact `oauth-mux doctor runtime ... --json` command when a route is blocked by local runtime readiness.

This keeps diagnostics separate from automatic repair: `command` remains `null` for `fix_runtime`, so daemon/stay-afloat execution does not treat the diagnostic as something it should run silently.

Docs now record the 2026-05-01 truthing pass:

- Linear SOPS `api.linear` is a personal API key, not an OAuth bearer.
- SOPS-backed Linear API-key proof passes, but does not unblock Linear OAuth proof.
- Codex store failures inside this sandbox are runtime-boundary evidence; outside the sandbox the real foreground stay-afloat path selects `codex:max-2#codex-max` and keeps `max-3` selectable.

## Validation

- `nix develop --command just check-local`
- SOPS-backed Linear API-key probe returned `linear:work#identity-api-key` as `live.available`.
- The same SOPS value on the Linear OAuth bearer route returned HTTP 400 / `degraded.unknown_4xx`, confirming it is not OAuth proof.
- Sandboxed Codex stay-afloat JSON now exposes `action.diagnostic_command` for `fix_runtime`.
- Outside-sandbox Codex runtime doctor reports all three stores ready, and stay-afloat selects `codex:max-2#codex-max`.