### PR TITLE
[codex] Add account inventory surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Discover the redacted, agent-safe inventory:
 oauth-mux doctor
 oauth-mux report --redacted
 oauth-mux providers list
+oauth-mux accounts list --json
 oauth-mux discover --json
 oauth-mux doctor runtime --json
 ```
@@ -94,6 +95,7 @@ mutating auth state:
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux route explain --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux route select --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair-plan --profile codex-max --capability codex-max --json
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux accounts list --provider codex --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair run --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux stay-afloat --once --profile codex-max --capability codex-max --json
@@ -111,6 +113,11 @@ and expected session files without reading token values or contacting providers.
 Use `doctor runtime --profile <name> --capability <name> --json` when a user or
 agent needs profile-level truth without letting a stale unrelated account poison
 the stay-afloat decision.
+
+`accounts list --json` is the provider-neutral account inventory. It reports
+configured provider accounts, secret backend names, runtime readiness,
+writeback admission, capability proof, recorded liveness, selectability, and
+safe next commands without reading credential values.
 
 `repair run` is the explicit mutation boundary. Without `--confirm-repair`, it
 will not open auth flows or run upstream CLI repair commands; it only reports
@@ -169,6 +176,7 @@ First-run Codex subscription path:
 oauth-mux init --codex-max
 oauth-mux doctor
 oauth-mux doctor runtime --json
+oauth-mux accounts list --provider codex --json
 oauth-mux setup codex
 oauth-mux codex canary
 oauth-mux codex live-qa

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -33,6 +33,7 @@ oauth-mux init
 oauth-mux doctor
 oauth-mux report --redacted
 oauth-mux providers list
+oauth-mux accounts list
 oauth-mux config validate
 oauth-mux discover --json
 oauth-mux doctor runtime --json
@@ -55,6 +56,7 @@ For Codex subscription users working from a source checkout today:
 oauth-mux init --codex-max
 oauth-mux doctor
 oauth-mux doctor runtime --json
+oauth-mux accounts list --provider codex --json
 oauth-mux setup codex
 oauth-mux codex canary
 oauth-mux route explain --profile codex-max --capability codex-max --json
@@ -88,6 +90,9 @@ handoff event. Prefer scoped runtime checks such as
 `oauth-mux doctor runtime --profile codex-max --capability codex-max --json`
 when dogfooding a specific stay-afloat route; global runtime doctor is still
 useful for support bundles and full-machine cleanup.
+`oauth-mux accounts list --json` is the provider-neutral account inventory
+surface. It reports configured accounts, runtime readiness, capability proof,
+recorded liveness, and safe next commands without reading credential values.
 After a user-mediated upstream login, `oauth-mux stay-afloat refresh --profile
 <profile> --capability <capability> --json` is the concise evidence refresh
 step that can clear pending handoffs.
@@ -113,6 +118,9 @@ The wrapper contract lives in
 `docs/spec/stay-afloat-permission-broker-contract-2026-05-01.md`. Use that
 contract before adding a shell hook, CI wrapper, service unit, or agent
 permission broker around stay-afloat.
+The account enrollment and agent inventory contract lives in
+`docs/spec/account-enrollment-agent-contract-2026-05-01.md`. Use that contract
+before adding provider-neutral enrollment commands or MCP mutation tools.
 
 ## Provider Author Experience
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -38,6 +38,7 @@ oauth-mux init
 oauth-mux doctor
 oauth-mux doctor runtime --json
 oauth-mux config validate
+oauth-mux accounts list --json
 oauth-mux discover
 ```
 
@@ -47,6 +48,7 @@ Codex Max three-account starter:
 oauth-mux init --codex-max
 oauth-mux doctor
 oauth-mux doctor runtime --json
+oauth-mux accounts list --provider codex --json
 oauth-mux setup codex
 oauth-mux codex canary
 oauth-mux codex live-qa
@@ -66,6 +68,13 @@ upstream binary availability, configured account store directories, local write
 access via a temporary marker file, and expected session-file presence. It does
 not read token values, run live probes, open auth flows, or create missing
 account stores.
+
+`oauth-mux accounts list --json` is the no-spend account inventory. It is the
+first provider-neutral surface for N-account enrollment and stay-afloat
+planning: it reports each configured provider/account, secret backend name,
+runtime readiness, writeback admission, capability proof status, recorded
+liveness, selectability, and safe next commands without reading credential
+values.
 
 For profile-level stay-afloat checks, scope the runtime report:
 `oauth-mux doctor runtime --profile codex-max --capability codex-max --json`.
@@ -342,6 +351,7 @@ Agents should start with:
 oauth-mux doctor --json
 oauth-mux report --redacted --json
 oauth-mux providers list --json
+oauth-mux accounts list --json
 oauth-mux discover --json
 oauth-mux status --json
 oauth-mux health --json
@@ -387,6 +397,11 @@ Agents must not:
 providers, account names, secret backend names, tags, profiles, and safe command
 templates. It does not include token material.
 
+`accounts list --json` is the richer per-account state surface for agents. Use
+it after `providers list --json` when deciding whether the next step is a
+provider-specific setup command, a runtime diagnostic, a route explanation, a
+handoff, or a live proof run.
+
 `report --redacted --json` is the support-bundle surface. It adds platform,
 config shape, provider/account labels, command availability, health summaries,
 and recent probe evidence. It never reads credential values and omits credential
@@ -408,7 +423,7 @@ operator proof, `public_live_proven` for no-secret public metadata proof, and
 3. Add profiles that encode provider/account/capability fallback order.
 4. Run `oauth-mux config validate`.
 5. Run `oauth-mux doctor --json`, `oauth-mux report --redacted --json`, and
-   `oauth-mux discover --json`.
+   `oauth-mux accounts list --json` plus `oauth-mux discover --json`.
 6. Run no-spend checks first: `status`, `health`, and credential parse probes.
 7. Run live probes only through `scripts/live-provider-qa.sh` or the manual
    Live Provider QA workflow.
@@ -416,6 +431,8 @@ operator proof, `public_live_proven` for no-secret public metadata proof, and
 ## Operator Definition of Done
 
 - Config validates.
+- `accounts list --json` exposes every expected account with redacted runtime
+  and liveness state.
 - `discover --json` is usable by agents.
 - `report --redacted --json` is usable for a support bundle without token
   material.

--- a/docs/spec/account-enrollment-agent-contract-2026-05-01.md
+++ b/docs/spec/account-enrollment-agent-contract-2026-05-01.md
@@ -1,0 +1,189 @@
+# Account Enrollment And Agent Contract
+Date: 2026-05-01
+
+Issue context: GitHub `Jesssullivan/oauth-mux#67` and `#68`; Linear `TIN-736`,
+`TIN-738`, and `TIN-891`.
+
+## Baseline
+
+Codex is product-proven for the current three-account path, but the first-run
+surface is still more provider-specific than the final product should be.
+Claude and Figma have provider definitions and partial proof, but not a boring
+N-account enrollment contract.
+
+The goal is a stable shape where users and agents can add the N+1 account,
+inspect what changed, and keep work afloat without memorizing each provider's
+storage quirks.
+
+## Product Contract
+
+Enrollment is a three-layer contract:
+
+1. **Visibility**: list configured accounts, runtime readiness, capability
+   proof, and recorded liveness without reading secret values.
+2. **Admission**: explain whether an action is a diagnostic, a handoff, a
+   provider-spend probe, or mutating repair.
+3. **Mutation**: run only explicit provider-owned setup/login flows, with user
+   consent and redacted evidence.
+
+This PR starts with visibility through:
+
+```bash
+oauth-mux accounts list --json
+oauth-mux accounts list --provider codex --json
+```
+
+`accounts list` is intentionally non-mutating. It is an agent-safe inventory
+surface for deciding which provider-specific or future provider-neutral
+enrollment command should run next.
+
+## User Stories
+
+### Story A: user adds a fourth Codex account
+
+The user wants one more Codex subscription account without breaking the current
+three-account setup.
+
+Expected flow:
+
+```bash
+oauth-mux accounts list --provider codex --json
+oauth-mux codex config-candidate --store-root ~/.local/share/oauth-mux/codex --json
+oauth-mux codex config-merge --candidate /tmp/oauth-mux-codex-max.config.json --json
+oauth-mux codex login-device max-4
+oauth-mux doctor runtime --provider codex --account max-4 --capability codex-max --json
+oauth-mux stay-afloat refresh --profile codex-max --capability codex-max --json
+```
+
+Future provider-neutral shape:
+
+```bash
+oauth-mux enroll codex --account max-4
+```
+
+### Story B: user adds work and personal Claude accounts
+
+Claude is command-owned. oauth-mux should isolate `CLAUDE_CONFIG_DIR` per
+account, hand off login to the Claude CLI, and avoid silently rewriting
+Claude-owned state.
+
+Expected future flow:
+
+```bash
+oauth-mux enroll claude --account work
+oauth-mux enroll claude --account personal
+oauth-mux accounts list --provider claude --json
+oauth-mux stay-afloat --once --profile claude --capability auth-status --json
+```
+
+The first proof target is account-store isolation and `auth-status`, not
+automatic quota repair.
+
+### Story C: user adds multiple Figma identities
+
+Figma needs auth-mode separation. OAuth bearer, PAT, and plan/file metadata
+routes must not collapse into one "Figma works" claim.
+
+Expected future flow:
+
+```bash
+oauth-mux enroll figma --account work --mode oauth
+oauth-mux enroll figma --account service --mode pat
+oauth-mux accounts list --provider figma --json
+oauth-mux probe --provider figma --account service --capability identity-pat --json
+```
+
+The proof gate must distinguish `scope_insufficient`, revoked token,
+resource/file permission, rate limit, and provider degradation.
+
+### Story D: agent discovers the next safe action
+
+An agent should start with inventory, not mutation:
+
+```bash
+oauth-mux discover --json
+oauth-mux accounts list --json
+oauth-mux doctor runtime --json
+oauth-mux route explain --profile <profile> --capability <capability> --json
+oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json
+```
+
+If `action.diagnostic_command` is present, the agent surfaces that command to
+the user or permission broker. If a handoff is queued, the agent shows the
+handoff rather than trying to run browser/device auth silently.
+
+## JSON Shape
+
+`accounts list --json` reports:
+
+- configured provider/account identity;
+- provider support and proof status;
+- secret backend name, not secret values;
+- account-level runtime readiness;
+- writeback admission;
+- per-capability proof, runtime readiness, recorded liveness, selectability,
+  and safe action shape;
+- agent-safe next commands.
+
+Account state is intentionally coarse:
+
+| State | Meaning |
+| --- | --- |
+| `configured` | Account is in config, but no liveness evidence is recorded. |
+| `available` | At least one account or capability health record is live and available. |
+| `has_evidence` | Health evidence exists but no live-available capability is recorded. |
+| `action_needed` | Runtime is not ready, so provider liveness should not be inferred. |
+
+## Provider Requirements
+
+### Codex
+
+- N-account `CODEX_HOME` isolation.
+- Device login handoff per account.
+- `codex-mini` and `codex-max` capability proof.
+- Runtime diagnostics across normal shell and agent sandbox.
+- Quota-exhausted, rate-limited, auth-dead, and store-unwritable fixtures.
+
+### Claude
+
+- N-account `CLAUDE_CONFIG_DIR` isolation.
+- `claude auth status --json` proof per account.
+- Login handoff owned by Claude CLI.
+- Runtime and keychain behavior documented without relying on undocumented
+  hashes as public product semantics.
+- Quota/usage proof only after low-impact status proof is stable.
+
+### Figma
+
+- Separate OAuth bearer, PAT, and resource/file routes.
+- Explicit scopes and scope-insufficient classification.
+- Redacted fixtures for 200 identity, 401 revoked, 403 insufficient scope,
+  file/resource permission failure, 429, and 5xx.
+- No provider-level promotion until auth modes are proven separately.
+
+## MCP And In-Agent Surface
+
+The MCP-facing surface should expose inventory and explanation before mutation:
+
+- `accounts.list`
+- `providers.list`
+- `doctor.runtime`
+- `route.explain`
+- `stay_afloat.once`
+- `handoffs.list`
+
+Mutation-capable tools such as `enroll.start`, `enroll.complete`, or
+`repair.run` must require explicit user consent and must return redacted
+evidence. MCP tools should preserve the same action taxonomy as the CLI:
+diagnostic, handoff, probe, repair, and mutation.
+
+## Next Implementation Slices
+
+1. Land `accounts list` as the provider-neutral inventory surface.
+2. Add `enroll plan <provider>` to print the exact provider-specific setup
+   steps without mutation.
+3. Promote Codex N+1 enrollment from provider-specific helpers into
+   `enroll codex --account <name>`.
+4. Add Claude account-store config candidate and runtime proof.
+5. Add Figma OAuth/PAT enrollment plan and proof fixtures.
+6. Define the MCP tool schema against the same JSON surfaces.

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -104,6 +104,12 @@ how agents, shells, CI jobs, and optional service wrappers should handle
 `action.diagnostic_command` in the right process boundary without turning
 runtime diagnostics into OAuth liveness or automatic repair evidence.
 
+The account-enrollment artifact is
+`docs/spec/account-enrollment-agent-contract-2026-05-01.md`. It defines the
+provider-neutral visibility, admission, and mutation layers for N+1 Codex,
+Claude, Figma, and future MCP-facing enrollment. The first implementation slice
+is the non-mutating `oauth-mux accounts list --json` inventory surface.
+
 Core product docs must remain service-manager agnostic. `systemctl`,
 `launchctl`, Homebrew services, cron, and Windows Services can become wrapper
 examples only after the portable contract is stable.
@@ -170,16 +176,19 @@ these precise provider-proof children.
 
 ## Immediate Execution Order
 
-1. Update website/release copy to use the public `jesssullivan/omux` Homebrew
+1. Land the provider-neutral account inventory surface and keep it aligned with
+   the account-enrollment contract, so agents can inspect N configured accounts
+   before route, repair, handoff, or live-proof decisions.
+2. Update website/release copy to use the public `jesssullivan/omux` Homebrew
    tap and close `#66` / `TIN-858` after those surfaces are aligned.
-2. Finish `TIN-862` by adding Linear OAuth bearer proof. GitHub identity and
+3. Finish `TIN-862` by adding Linear OAuth bearer proof. GitHub identity and
    Linear API-key identity are locally proven; Linear OAuth `identity` remains
    `needs_operator_proof`.
-3. Continue `TIN-861` and `TIN-863` on their remaining hard shapes: Claude
+4. Continue `TIN-861` and `TIN-863` on their remaining hard shapes: Claude
    quota/repair semantics and MCP resource-bound bearer-token proof.
-4. Work provider proof in narrow slices: `TIN-876` Vercel, `TIN-877` Figma,
+5. Work provider proof in narrow slices: `TIN-876` Vercel, `TIN-877` Figma,
    `TIN-878` FlakeHub/Determinate, and `TIN-879` Gemini.
-5. Return to daemon background scheduling only after wrapper/install decisions
+6. Return to daemon background scheduling only after wrapper/install decisions
    and provider proof produce enough real operator evidence. The current socket
    daemon decision is complete under `TIN-867`; future production daemon work
    must promote the foreground tick engine deliberately.

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -216,6 +216,25 @@ expect_contains() {
   esac
 }
 
+expect_not_contains() {
+  haystack="$1"
+  needle="$2"
+  label="$3"
+
+  if [ -z "$needle" ]; then
+    return
+  fi
+
+  case "$haystack" in
+    *"$needle"*)
+      printf 'e2e assertion failed: %s\n' "$label" >&2
+      printf 'did not expect to find: %s\n' "$needle" >&2
+      printf 'output was:\n%s\n' "$haystack" >&2
+      exit 1
+      ;;
+  esac
+}
+
 printf 'e2e: validate generated config\n'
 omux config validate >/dev/null
 
@@ -256,6 +275,22 @@ expect_contains "$providers_json" '"proof_status":"needs_operator_proof"' "provi
 expect_contains "$providers_json" '"name":"cheap","proof_status":"needs_operator_proof"' "providers list marks custom capability proof state"
 expect_contains "$providers_json" '"name":"codex-max","proof_status":"live_proven"' "providers list marks Codex capability proof state"
 expect_contains "$providers_json" '"configured_accounts":2' "providers list counts custom provider accounts"
+
+printf 'e2e: accounts list reports redacted account inventory before probes\n'
+accounts_json="$(omux accounts list --provider toy --json)"
+expect_contains "$accounts_json" '"configured":true' "accounts list reports configured state"
+expect_contains "$accounts_json" '"filter_provider":"toy"' "accounts list reports provider filter"
+expect_contains "$accounts_json" '"provider":"toy"' "accounts list includes toy provider"
+expect_contains "$accounts_json" '"account":"a1"' "accounts list includes account a1"
+expect_contains "$accounts_json" '"account":"a2"' "accounts list includes account a2"
+expect_contains "$accounts_json" '"state":"configured"' "accounts list distinguishes configured without liveness evidence"
+expect_contains "$accounts_json" '"runtime":{"state":"ready"}' "accounts list includes runtime readiness"
+expect_contains "$accounts_json" '"name":"cheap","proof_status":"needs_operator_proof"' "accounts list reports capability proof status"
+expect_contains "$accounts_json" '"health_recorded":false' "accounts list reports missing liveness evidence"
+expect_contains "$accounts_json" '"selectable":false' "accounts list refuses selection without recorded health"
+expect_contains "$accounts_json" '"oauth-mux repair-plan --provider <provider> --account <account> --capability <capability> --json"' "accounts list advertises safe repair plan"
+expect_not_contains "$accounts_json" "omux-e2e-a1" "accounts list does not expose env secret value"
+expect_not_contains "$accounts_json" "omux-e2e-a2" "accounts list does not expose env secret value"
 
 printf 'e2e: cheap route selects first healthy account\n'
 cheap_env="$(omux env --profile cheap --capability cheap --shell bash)"

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -171,6 +171,23 @@ expect_not_contains "$(cat "$runtime_doctor_scoped")" "$store_root/max-1" "scope
 test ! -e "$store_root"
 test ! -e "$legacy_store_root"
 
+printf 'first-run e2e: accounts inventory is redacted and non-mutating\n'
+accounts_json="$tmp/accounts-codex.json"
+run_json "$accounts_json" accounts list --provider codex --json
+jq -e '
+  .configured == true
+  and .filter_provider == "codex"
+  and (.accounts | length) == 3
+  and all(.accounts[]; .provider == "codex" and .state == "action_needed" and .secret_backend == "file")
+  and all(.accounts[]; (.capabilities | length) == 2)
+  and all(.accounts[].capabilities[]; .proof_status == "live_proven" and .health_recorded == false and .selectable == false)
+  and (.agent_safe_commands | index("oauth-mux accounts list --json") != null)
+  and (.agent_safe_commands | index("oauth-mux doctor runtime --provider <provider> --account <account> --json") != null)
+' "$accounts_json" >/dev/null
+expect_not_contains "$(cat "$accounts_json")" "$store_root/max-1" "accounts list does not print concrete Codex store paths"
+test ! -e "$store_root"
+test ! -e "$legacy_store_root"
+
 printf 'first-run e2e: discovery is redacted and agent-usable\n'
 discover_json="$tmp/discover.json"
 run_json "$discover_json" discover --json

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -10,6 +10,7 @@ pub const Command = union(enum) {
     doctor: DoctorArgs,
     report: ReportArgs,
     providers: ProvidersArgs,
+    accounts: AccountsArgs,
     status: StatusArgs,
     health: HealthArgs,
     discover: DiscoverArgs,
@@ -83,6 +84,16 @@ pub const Command = union(enum) {
 
     pub const ProvidersArgs = struct {
         action: ProvidersAction = .list,
+        json: bool = false,
+    };
+
+    pub const AccountsAction = enum {
+        list,
+    };
+
+    pub const AccountsArgs = struct {
+        action: AccountsAction = .list,
+        provider: ?[]const u8 = null,
         json: bool = false,
     };
 
@@ -225,6 +236,7 @@ pub fn parse(args: []const []const u8) Command {
     if (eql(cmd, "doctor")) return parseDoctor(rest);
     if (eql(cmd, "report")) return parseReport(rest);
     if (eql(cmd, "providers")) return parseProviders(rest);
+    if (eql(cmd, "accounts")) return parseAccounts(rest);
     if (eql(cmd, "status")) return parseStatus(rest);
     if (eql(cmd, "health")) return parseHealth(rest);
     if (eql(cmd, "discover")) return parseDiscover(rest);
@@ -380,6 +392,24 @@ fn parseProviders(args: []const []const u8) Command {
         if (eql(args[i], "--json")) result.json = true;
     }
     return .{ .providers = result };
+}
+
+fn parseAccounts(args: []const []const u8) Command {
+    var result = Command.AccountsArgs{};
+    var i: usize = 0;
+    if (args.len > 0 and eql(args[0], "list")) {
+        result.action = .list;
+        i = 1;
+    }
+    while (i < args.len) : (i += 1) {
+        if (eql(args[i], "--provider")) {
+            i += 1;
+            if (i < args.len) result.provider = args[i];
+        } else if (eql(args[i], "--json")) {
+            result.json = true;
+        }
+    }
+    return .{ .accounts = result };
 }
 
 fn parseStatus(args: []const []const u8) Command {
@@ -786,6 +816,9 @@ pub fn printUsage(writer: anytype) !void {
         \\  providers list [--json]
         \\      Show built-in and configured provider support status.
         \\
+        \\  accounts list [--provider <name>] [--json]
+        \\      Show configured accounts, runtime readiness, liveness evidence, and safe next commands.
+        \\
         \\  status [--json] [--provider <name>]
         \\      Show active accounts, health scores, and circuit states.
         \\
@@ -1157,6 +1190,19 @@ test "parse discover json" {
     }
 }
 
+test "parse accounts list provider json" {
+    const args = [_][]const u8{ "accounts", "list", "--provider", "codex", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .accounts => |accounts| {
+            try std.testing.expect(accounts.action == .list);
+            try std.testing.expectEqualStrings("codex", accounts.provider.?);
+            try std.testing.expect(accounts.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 test "parse repair plan with profile" {
     const args = [_][]const u8{ "repair-plan", "--profile", "codex-max", "--json" };
     const cmd = parse(&args);
@@ -1367,6 +1413,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n __fish_use_subcommand -a doctor -d 'Run readiness checks'
             \\complete -c oauth-mux -n __fish_use_subcommand -a report -d 'Print redacted support report'
             \\complete -c oauth-mux -n __fish_use_subcommand -a providers -d 'List provider support'
+            \\complete -c oauth-mux -n __fish_use_subcommand -a accounts -d 'List configured accounts'
             \\complete -c oauth-mux -n __fish_use_subcommand -a status -d 'Show status'
             \\complete -c oauth-mux -n __fish_use_subcommand -a health -d 'Show health data'
             \\complete -c oauth-mux -n __fish_use_subcommand -a discover -d 'Show agent-safe inventory'
@@ -1392,10 +1439,12 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -l provider -d 'Provider name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -l account -d 'Account name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -l capability -d 'Route capability' -r
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from report providers' -l json -d 'JSON output'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from report providers accounts' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from report' -l redacted -d 'Redact credential paths and values'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from report' -l include-paths -d 'Include non-token paths'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from providers' -a 'list' -d 'Provider subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from accounts' -a 'list' -d 'Accounts subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from accounts' -l provider -d 'Provider name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from env' -l shell -d 'Shell type' -r -a 'fish zsh bash ksh'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from status' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from discover' -l json -d 'JSON output'
@@ -1454,6 +1503,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\    'doctor:Run readiness checks'
             \\    'report:Print redacted support report'
             \\    'providers:List provider support'
+            \\    'accounts:List configured accounts'
             \\    'status:Show status'
             \\    'health:Show health data'
             \\    'discover:Show agent-safe inventory'
@@ -1478,7 +1528,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
         try writer.writeAll(
             \\_oauth_mux_completions() {
             \\  local cur="${COMP_WORDS[COMP_CWORD]}"
-            \\  COMPREPLY=($(compgen -W "exec env probe doctor report providers status health discover repair-plan repair route stay-afloat config init setup codex daemon version completions" -- "$cur"))
+            \\  COMPREPLY=($(compgen -W "exec env probe doctor report providers accounts status health discover repair-plan repair route stay-afloat config init setup codex daemon version completions" -- "$cur"))
             \\}
             \\complete -F _oauth_mux_completions oauth-mux
             \\

--- a/src/main.zig
+++ b/src/main.zig
@@ -88,6 +88,10 @@ pub fn main() !void {
             try runProviders(allocator, stdout, providers_args);
         },
 
+        .accounts => |accounts_args| {
+            try runAccounts(allocator, stdout, accounts_args);
+        },
+
         .exec => |exec_args| {
             runExec(allocator, exec_args) catch |e| {
                 log.err("exec: {s}", .{@errorName(e)});
@@ -247,6 +251,283 @@ fn runStatus(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.St
     }
 }
 
+fn runAccounts(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.AccountsArgs) !void {
+    switch (args.action) {
+        .list => {},
+    }
+
+    const parsed = config.load(allocator) catch |e| {
+        if (args.json) {
+            try writer.writeAll("{\"version\":");
+            try std.json.stringify(cli.version, .{}, writer);
+            try writer.writeAll(",\"configured\":false,\"config_error\":");
+            try std.json.stringify(@errorName(e), .{}, writer);
+            try writer.writeAll(",\"accounts\":[],\"agent_safe_commands\":[");
+            try writeCommandJson(writer, "oauth-mux init");
+            try writer.writeByte(',');
+            try writeCommandJson(writer, "oauth-mux init --codex-max");
+            try writer.writeByte(',');
+            try writeCommandJson(writer, "oauth-mux accounts list --json");
+            try writer.writeAll("]}\n");
+        } else {
+            try writer.writeAll("oauth-mux accounts\n\n");
+            try writer.print("  config: unavailable ({s})\n", .{@errorName(e)});
+            try writer.writeAll("  next: oauth-mux init\n");
+        }
+        return;
+    };
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+
+    if (args.json) {
+        try writeAccountsListJson(writer, allocator, parsed.value, &store, args);
+    } else {
+        try writeAccountsListText(writer, allocator, parsed.value, &store, args);
+    }
+}
+
+fn writeAccountsListText(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    store: *health_mod.HealthStore,
+    args: cli.Command.AccountsArgs,
+) !void {
+    try writer.writeAll("oauth-mux accounts\n\n");
+    if (args.provider) |provider_filter| try writer.print("  provider: {s}\n\n", .{provider_filter});
+
+    var count: usize = 0;
+    var provider_it = cfg.providers.map.iterator();
+    while (provider_it.next()) |entry| {
+        const provider_name = entry.key_ptr.*;
+        const prov = entry.value_ptr.*;
+        if (!accountsProviderMatches(args, provider_name, prov.kind)) continue;
+
+        const def = config.resolveProviderDefinition(cfg, provider_name);
+        const kind = config.resolveProviderKind(cfg, provider_name);
+        var account_it = prov.accounts.map.iterator();
+        while (account_it.next()) |acct_entry| {
+            count += 1;
+            const account_name = acct_entry.key_ptr.*;
+            const account = acct_entry.value_ptr.*;
+            const info = try runtime_mod.accountInfo(allocator, prov, account, def, kind);
+            const state = accountEnrollmentState(store, provider_name, account_name, def, info.readiness);
+            try writer.print("  {s}:{s} state={s} runtime={s} secret={s}", .{
+                provider_name,
+                account_name,
+                state,
+                runtimeReadinessSummary(info.readiness),
+                account.secret.backend,
+            });
+            if (account.config_dir != null) try writer.writeAll(" config_dir=set");
+            try writer.writeByte('\n');
+
+            for (def.capabilities) |capability| {
+                const route = RepairPlanRoute{ .provider = provider_name, .account = account_name, .capability = capability.name };
+                const runtime = try routeRuntimeReadiness(allocator, cfg, route, def);
+                const health = routeHealth(store, route);
+                const selectable = routeSelectable(runtime, health);
+                try writer.print("    {s} proof={s} selectable={s} runtime={s}", .{
+                    capability.name,
+                    capability.proof_status,
+                    if (selectable) "true" else "false",
+                    runtimeReadinessSummary(runtime),
+                });
+                if (health) |h| {
+                    try writer.writeAll(" liveness=");
+                    try health_mod.writeLivenessSummary(writer, h.liveness);
+                } else {
+                    try writer.writeAll(" liveness=unrecorded");
+                }
+                try writer.writeByte('\n');
+            }
+        }
+    }
+
+    if (count == 0) try writer.writeAll("  no configured accounts\n");
+    try writer.writeAll("\n  agent-safe next:\n");
+    try writer.writeAll("    oauth-mux accounts list --json\n");
+    try writer.writeAll("    oauth-mux doctor runtime --provider <provider> --account <account> --json\n");
+    try writer.writeAll("    oauth-mux repair-plan --provider <provider> --account <account> --capability <capability> --json\n");
+    try writer.writeAll("    oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json\n");
+}
+
+fn writeAccountsListJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    store: *health_mod.HealthStore,
+    args: cli.Command.AccountsArgs,
+) !void {
+    try writer.writeByte('{');
+    try writer.writeAll("\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"configured\":true,\"filter_provider\":");
+    if (args.provider) |provider_filter| try std.json.stringify(provider_filter, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"accounts\":[");
+
+    var first = true;
+    var provider_it = cfg.providers.map.iterator();
+    while (provider_it.next()) |entry| {
+        const provider_name = entry.key_ptr.*;
+        const prov = entry.value_ptr.*;
+        if (!accountsProviderMatches(args, provider_name, prov.kind)) continue;
+
+        const def = config.resolveProviderDefinition(cfg, provider_name);
+        const kind = config.resolveProviderKind(cfg, provider_name);
+        var account_it = prov.accounts.map.iterator();
+        while (account_it.next()) |acct_entry| {
+            if (!first) try writer.writeByte(',');
+            first = false;
+            try writeAccountListJsonEntry(writer, allocator, cfg, store, provider_name, prov, acct_entry.key_ptr.*, acct_entry.value_ptr.*, def, kind);
+        }
+    }
+
+    try writer.writeAll("],\"agent_safe_commands\":[");
+    try writeCommandJson(writer, "oauth-mux accounts list --json");
+    try writer.writeByte(',');
+    try writeCommandJson(writer, "oauth-mux doctor runtime --provider <provider> --account <account> --json");
+    try writer.writeByte(',');
+    try writeCommandJson(writer, "oauth-mux repair-plan --provider <provider> --account <account> --capability <capability> --json");
+    try writer.writeByte(',');
+    try writeCommandJson(writer, "oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json");
+    try writer.writeAll("]}\n");
+}
+
+fn writeAccountListJsonEntry(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    store: *health_mod.HealthStore,
+    provider_name: []const u8,
+    prov: config.ProviderConfig,
+    account_name: []const u8,
+    account: config.AccountConfig,
+    def: provider_schema.ProviderDefinition,
+    kind: ?types.ProviderKind,
+) !void {
+    const info = try runtime_mod.accountInfo(allocator, prov, account, def, kind);
+    const state = accountEnrollmentState(store, provider_name, account_name, def, info.readiness);
+
+    try writer.writeByte('{');
+    try writer.writeAll("\"provider\":");
+    try std.json.stringify(provider_name, .{}, writer);
+    try writer.writeAll(",\"kind\":");
+    try std.json.stringify(prov.kind, .{}, writer);
+    try writer.writeAll(",\"display_name\":");
+    try std.json.stringify(providerDisplayName(def), .{}, writer);
+    try writer.writeAll(",\"support_status\":");
+    try std.json.stringify(supportStatusForConfig(cfg, provider_name, prov.kind), .{}, writer);
+    try writer.writeAll(",\"provider_proof_status\":");
+    try std.json.stringify(proofStatus(prov.kind), .{}, writer);
+    try writer.writeAll(",\"account\":");
+    try std.json.stringify(account_name, .{}, writer);
+    try writer.writeAll(",\"state\":");
+    try std.json.stringify(state, .{}, writer);
+    try writer.print(",\"priority\":{d}", .{account.priority});
+    try writer.writeAll(",\"secret_backend\":");
+    try std.json.stringify(account.secret.backend, .{}, writer);
+    try writer.writeAll(",\"config_dir_set\":");
+    try writer.writeAll(if (account.config_dir != null) "true" else "false");
+    try writer.writeAll(",\"config_dir_env\":");
+    if (runtime_mod.configDirEnv(prov, def, kind)) |env_var| try std.json.stringify(env_var, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"tags\":[");
+    if (account.tags) |tags| {
+        for (tags, 0..) |tag, idx| {
+            if (idx > 0) try writer.writeByte(',');
+            try std.json.stringify(tag, .{}, writer);
+        }
+    }
+    try writer.writeAll("],\"runtime\":");
+    try writeRuntimeReadinessJson(writer, info.readiness);
+    try writer.writeAll(",\"writeback\":");
+    try writeAccountWritebackJson(writer, account, def);
+    try writer.writeAll(",\"capabilities\":[");
+    for (def.capabilities, 0..) |capability, idx| {
+        if (idx > 0) try writer.writeByte(',');
+        try writeAccountCapabilityJson(writer, allocator, cfg, store, provider_name, account_name, def, capability);
+    }
+    try writer.writeAll("]}");
+}
+
+fn writeAccountCapabilityJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    store: *health_mod.HealthStore,
+    provider_name: []const u8,
+    account_name: []const u8,
+    def: provider_schema.ProviderDefinition,
+    capability: provider_schema.CapabilityDefinition,
+) !void {
+    const route = RepairPlanRoute{ .provider = provider_name, .account = account_name, .capability = capability.name };
+    const runtime = try routeRuntimeReadiness(allocator, cfg, route, def);
+    const health = routeHealth(store, route);
+    const budget = routeProbeBudget(def, capability.name);
+    const action = repairActionFor(route, def, runtime, health, budget);
+    const selectable = routeSelectable(runtime, health);
+
+    try writer.writeByte('{');
+    try writer.writeAll("\"name\":");
+    try std.json.stringify(capability.name, .{}, writer);
+    try writer.writeAll(",\"proof_status\":");
+    try std.json.stringify(capability.proof_status, .{}, writer);
+    try writer.writeAll(",\"budget\":");
+    if (budget) |probe_budget| try std.json.stringify(@tagName(probe_budget), .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"runtime\":");
+    try writeRuntimeReadinessJson(writer, runtime);
+    try writer.writeAll(",\"health_recorded\":");
+    try writer.writeAll(if (health != null) "true" else "false");
+    try writer.writeAll(",\"liveness\":");
+    if (health) |h| try writeLivenessJson(writer, h.liveness) else try writer.writeAll("null");
+    try writer.writeAll(",\"selectable\":");
+    try writer.writeAll(if (selectable) "true" else "false");
+    try writer.writeAll(",\"action\":");
+    try writeRepairActionJson(writer, allocator, action, route);
+    try writer.writeByte('}');
+}
+
+fn accountsProviderMatches(args: cli.Command.AccountsArgs, provider_name: []const u8, provider_kind: []const u8) bool {
+    const provider_filter = args.provider orelse return true;
+    return std.mem.eql(u8, provider_filter, provider_name) or std.mem.eql(u8, provider_filter, provider_kind);
+}
+
+fn accountEnrollmentState(
+    store: *health_mod.HealthStore,
+    provider_name: []const u8,
+    account_name: []const u8,
+    def: provider_schema.ProviderDefinition,
+    runtime: types.RuntimeReadiness,
+) []const u8 {
+    if (!runtime.isReady()) return "action_needed";
+    var has_evidence = false;
+
+    const account_key = health_mod.accountKey(provider_name, account_name);
+    if (store.accounts.get(account_key.slice())) |health| {
+        has_evidence = true;
+        if (livenessIsAvailable(health.liveness)) return "available";
+    }
+
+    for (def.capabilities) |capability| {
+        const capability_key = health_mod.capabilityKey(provider_name, account_name, capability.name);
+        if (store.accounts.get(capability_key.slice())) |health| {
+            has_evidence = true;
+            if (livenessIsAvailable(health.liveness)) return "available";
+        }
+    }
+
+    return if (has_evidence) "has_evidence" else "configured";
+}
+
+fn livenessIsAvailable(liveness: types.CredentialLiveness) bool {
+    return switch (liveness) {
+        .live => |live| live.availability == .available,
+        .degraded, .dead => false,
+    };
+}
+
 fn runDiscover(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.DiscoverArgs) !void {
     const config_path = try paths.configFilePath(allocator);
     defer allocator.free(config_path);
@@ -270,6 +551,8 @@ fn runDiscover(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.
             try writer.writeByte(',');
             try writeCommandJson(writer, "oauth-mux providers list");
             try writer.writeByte(',');
+            try writeCommandJson(writer, "oauth-mux accounts list");
+            try writer.writeByte(',');
             try writeCommandJson(writer, "oauth-mux report --redacted");
             try writer.writeAll("]}\n");
         } else {
@@ -281,6 +564,7 @@ fn runDiscover(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.
             try writer.writeAll("    oauth-mux init --codex-max\n");
             try writer.writeAll("    oauth-mux doctor\n");
             try writer.writeAll("    oauth-mux providers list\n");
+            try writer.writeAll("    oauth-mux accounts list\n");
             try writer.writeAll("    oauth-mux report --redacted\n");
             try writer.writeAll("    oauth-mux config validate\n");
         }
@@ -364,6 +648,7 @@ fn writeDiscoverText(writer: anytype, cfg: config.Config, config_path: []const u
     try writer.writeAll("    oauth-mux doctor --json\n");
     try writer.writeAll("    oauth-mux report --redacted --json\n");
     try writer.writeAll("    oauth-mux providers list --json\n");
+    try writer.writeAll("    oauth-mux accounts list --json\n");
     try writer.writeAll("    oauth-mux status --json\n");
     try writer.writeAll("    oauth-mux health --json\n");
     try writer.writeAll("    oauth-mux doctor runtime --json\n");
@@ -470,6 +755,7 @@ fn writeDiscoverJson(writer: anytype, cfg: config.Config, config_path: []const u
         "oauth-mux doctor --json",
         "oauth-mux report --redacted --json",
         "oauth-mux providers list --json",
+        "oauth-mux accounts list --json",
         "oauth-mux status --json",
         "oauth-mux health --json",
         "oauth-mux doctor runtime --json",


### PR DESCRIPTION
## Summary

Adds a provider-neutral account inventory surface for N-account enrollment and stay-afloat planning:

- `oauth-mux accounts list [--provider <name>] [--json]`
- per-account runtime readiness, writeback admission, proof status, recorded liveness, selectability, and safe next commands
- docs/spec contract for account enrollment and future MCP/in-agent surfaces
- README, onboarding, adoption, product-gap docs aligned to the new first-run inventory command

This is intentionally non-mutating. It gives users and agents a boring place to inspect N configured accounts before deciding whether to run setup, diagnostics, route explanation, handoff, or live proof.

## Validation

- `nix develop --command just check-local`
- smoke: `oauth-mux accounts list --json`
- smoke: `OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux accounts list --provider codex --json`
