### PR TITLE
[codex] Add enrollment planning surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ oauth-mux doctor
 oauth-mux report --redacted
 oauth-mux providers list
 oauth-mux accounts list --json
+oauth-mux enroll plan codex --account max-4 --json
 oauth-mux discover --json
 oauth-mux doctor runtime --json
 ```
@@ -119,6 +120,11 @@ configured provider accounts, secret backend names, runtime readiness,
 writeback admission, capability proof, recorded liveness, selectability, and
 safe next commands without reading credential values.
 
+`enroll plan <provider> --json` is also non-mutating. It turns the inventory
+into an explicit provider-specific setup plan, marking which steps are
+agent-safe, interactive, mutating, or provider-call-spending before anything is
+run.
+
 `repair run` is the explicit mutation boundary. Without `--confirm-repair`, it
 will not open auth flows or run upstream CLI repair commands; it only reports
 whether a route is already selectable, whether no admitted repair exists, or
@@ -177,6 +183,7 @@ oauth-mux init --codex-max
 oauth-mux doctor
 oauth-mux doctor runtime --json
 oauth-mux accounts list --provider codex --json
+oauth-mux enroll plan codex --account max-4 --json
 oauth-mux setup codex
 oauth-mux codex canary
 oauth-mux codex live-qa

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -34,6 +34,7 @@ oauth-mux doctor
 oauth-mux report --redacted
 oauth-mux providers list
 oauth-mux accounts list
+oauth-mux enroll plan <provider>
 oauth-mux config validate
 oauth-mux discover --json
 oauth-mux doctor runtime --json
@@ -57,6 +58,7 @@ oauth-mux init --codex-max
 oauth-mux doctor
 oauth-mux doctor runtime --json
 oauth-mux accounts list --provider codex --json
+oauth-mux enroll plan codex --account max-4 --json
 oauth-mux setup codex
 oauth-mux codex canary
 oauth-mux route explain --profile codex-max --capability codex-max --json
@@ -93,6 +95,10 @@ useful for support bundles and full-machine cleanup.
 `oauth-mux accounts list --json` is the provider-neutral account inventory
 surface. It reports configured accounts, runtime readiness, capability proof,
 recorded liveness, and safe next commands without reading credential values.
+`oauth-mux enroll plan <provider> --json` is the provider-neutral planning
+surface. It does not mutate config or auth state; it marks each provider-specific
+step as agent-safe, interactive, mutating, or provider-call-spending so users
+and agents can ask for consent at the right boundary.
 After a user-mediated upstream login, `oauth-mux stay-afloat refresh --profile
 <profile> --capability <capability> --json` is the concise evidence refresh
 step that can clear pending handoffs.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -39,6 +39,7 @@ oauth-mux doctor
 oauth-mux doctor runtime --json
 oauth-mux config validate
 oauth-mux accounts list --json
+oauth-mux enroll plan <provider> --json
 oauth-mux discover
 ```
 
@@ -49,6 +50,7 @@ oauth-mux init --codex-max
 oauth-mux doctor
 oauth-mux doctor runtime --json
 oauth-mux accounts list --provider codex --json
+oauth-mux enroll plan codex --account max-4 --json
 oauth-mux setup codex
 oauth-mux codex canary
 oauth-mux codex live-qa
@@ -75,6 +77,12 @@ planning: it reports each configured provider/account, secret backend name,
 runtime readiness, writeback admission, capability proof status, recorded
 liveness, selectability, and safe next commands without reading credential
 values.
+
+`oauth-mux enroll plan <provider> --json` is the no-mutation enrollment planner.
+It converts provider inventory into ordered setup steps and labels each step as
+agent-safe, interactive, mutating, or provider-call-spending. Provider-neutral
+enrollment mutation is still intentionally reported as unavailable until the
+provider-owned login and consent contracts are stronger.
 
 For profile-level stay-afloat checks, scope the runtime report:
 `oauth-mux doctor runtime --profile codex-max --capability codex-max --json`.
@@ -352,6 +360,7 @@ oauth-mux doctor --json
 oauth-mux report --redacted --json
 oauth-mux providers list --json
 oauth-mux accounts list --json
+oauth-mux enroll plan <provider> --json
 oauth-mux discover --json
 oauth-mux status --json
 oauth-mux health --json
@@ -402,6 +411,10 @@ it after `providers list --json` when deciding whether the next step is a
 provider-specific setup command, a runtime diagnostic, a route explanation, a
 handoff, or a live proof run.
 
+`enroll plan <provider> --json` is safe for agents because it only explains the
+setup sequence. Agents may present steps with `agent_safe:false` to a user or
+permission broker, but must not run those steps without explicit consent.
+
 `report --redacted --json` is the support-bundle surface. It adds platform,
 config shape, provider/account labels, command availability, health summaries,
 and recent probe evidence. It never reads credential values and omits credential
@@ -424,8 +437,9 @@ operator proof, `public_live_proven` for no-secret public metadata proof, and
 4. Run `oauth-mux config validate`.
 5. Run `oauth-mux doctor --json`, `oauth-mux report --redacted --json`, and
    `oauth-mux accounts list --json` plus `oauth-mux discover --json`.
-6. Run no-spend checks first: `status`, `health`, and credential parse probes.
-7. Run live probes only through `scripts/live-provider-qa.sh` or the manual
+6. Run `oauth-mux enroll plan <provider> --json` before adding an N+1 account.
+7. Run no-spend checks first: `status`, `health`, and credential parse probes.
+8. Run live probes only through `scripts/live-provider-qa.sh` or the manual
    Live Provider QA workflow.
 
 ## Operator Definition of Done
@@ -433,6 +447,8 @@ operator proof, `public_live_proven` for no-secret public metadata proof, and
 - Config validates.
 - `accounts list --json` exposes every expected account with redacted runtime
   and liveness state.
+- `enroll plan <provider> --json` describes any remaining setup without running
+  it.
 - `discover --json` is usable by agents.
 - `report --redacted --json` is usable for a support bundle without token
   material.

--- a/docs/spec/account-enrollment-agent-contract-2026-05-01.md
+++ b/docs/spec/account-enrollment-agent-contract-2026-05-01.md
@@ -37,6 +37,19 @@ oauth-mux accounts list --provider codex --json
 surface for deciding which provider-specific or future provider-neutral
 enrollment command should run next.
 
+The second slice adds non-mutating admission planning through:
+
+```bash
+oauth-mux enroll plan <provider> --json
+oauth-mux enroll plan codex --account max-4 --json
+oauth-mux enroll plan figma --account work --mode pat --json
+```
+
+`enroll plan` does not mutate config or auth state. It labels every proposed
+step with `agent_safe`, `interactive`, `mutating`, and
+`spends_provider_calls`, and it explicitly reports provider-neutral enrollment
+mutation as unavailable until provider-owned consent flows are implemented.
+
 ## User Stories
 
 ### Story A: user adds a fourth Codex account
@@ -48,6 +61,7 @@ Expected flow:
 
 ```bash
 oauth-mux accounts list --provider codex --json
+oauth-mux enroll plan codex --account max-4 --json
 oauth-mux codex config-candidate --store-root ~/.local/share/oauth-mux/codex --json
 oauth-mux codex config-merge --candidate /tmp/oauth-mux-codex-max.config.json --json
 oauth-mux codex login-device max-4
@@ -72,6 +86,7 @@ Expected future flow:
 ```bash
 oauth-mux enroll claude --account work
 oauth-mux enroll claude --account personal
+oauth-mux enroll plan claude --account work --json
 oauth-mux accounts list --provider claude --json
 oauth-mux stay-afloat --once --profile claude --capability auth-status --json
 ```
@@ -89,6 +104,7 @@ Expected future flow:
 ```bash
 oauth-mux enroll figma --account work --mode oauth
 oauth-mux enroll figma --account service --mode pat
+oauth-mux enroll plan figma --account service --mode pat --json
 oauth-mux accounts list --provider figma --json
 oauth-mux probe --provider figma --account service --capability identity-pat --json
 ```
@@ -103,6 +119,7 @@ An agent should start with inventory, not mutation:
 ```bash
 oauth-mux discover --json
 oauth-mux accounts list --json
+oauth-mux enroll plan <provider> --json
 oauth-mux doctor runtime --json
 oauth-mux route explain --profile <profile> --capability <capability> --json
 oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json
@@ -124,6 +141,16 @@ handoff rather than trying to run browser/device auth silently.
 - per-capability proof, runtime readiness, recorded liveness, selectability,
   and safe action shape;
 - agent-safe next commands.
+
+`enroll plan --json` reports:
+
+- requested provider, account, and mode;
+- whether the provider is already configured;
+- existing configured accounts with secret backend names only;
+- ordered steps, each labeled for agent safety, interactivity, mutation, and
+  provider-call spend;
+- safe next commands;
+- the future provider-neutral mutation command with `available:false`.
 
 Account state is intentionally coarse:
 
@@ -166,6 +193,7 @@ Account state is intentionally coarse:
 The MCP-facing surface should expose inventory and explanation before mutation:
 
 - `accounts.list`
+- `enroll.plan`
 - `providers.list`
 - `doctor.runtime`
 - `route.explain`
@@ -180,7 +208,7 @@ diagnostic, handoff, probe, repair, and mutation.
 ## Next Implementation Slices
 
 1. Land `accounts list` as the provider-neutral inventory surface.
-2. Add `enroll plan <provider>` to print the exact provider-specific setup
+2. Land `enroll plan <provider>` to print the exact provider-specific setup
    steps without mutation.
 3. Promote Codex N+1 enrollment from provider-specific helpers into
    `enroll codex --account <name>`.

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -108,7 +108,9 @@ The account-enrollment artifact is
 `docs/spec/account-enrollment-agent-contract-2026-05-01.md`. It defines the
 provider-neutral visibility, admission, and mutation layers for N+1 Codex,
 Claude, Figma, and future MCP-facing enrollment. The first implementation slice
-is the non-mutating `oauth-mux accounts list --json` inventory surface.
+is the non-mutating `oauth-mux accounts list --json` inventory surface. The
+second slice is `oauth-mux enroll plan <provider> --json`, which explains the
+provider-specific setup path and labels each step before any mutation.
 
 Core product docs must remain service-manager agnostic. `systemctl`,
 `launchctl`, Homebrew services, cron, and Windows Services can become wrapper
@@ -176,9 +178,9 @@ these precise provider-proof children.
 
 ## Immediate Execution Order
 
-1. Land the provider-neutral account inventory surface and keep it aligned with
+1. Keep provider-neutral account inventory and enrollment planning aligned with
    the account-enrollment contract, so agents can inspect N configured accounts
-   before route, repair, handoff, or live-proof decisions.
+   and explain setup before route, repair, handoff, or live-proof decisions.
 2. Update website/release copy to use the public `jesssullivan/omux` Homebrew
    tap and close `#66` / `TIN-858` after those surfaces are aligned.
 3. Finish `TIN-862` by adding Linear OAuth bearer proof. GitHub identity and

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -292,6 +292,20 @@ expect_contains "$accounts_json" '"oauth-mux repair-plan --provider <provider> -
 expect_not_contains "$accounts_json" "omux-e2e-a1" "accounts list does not expose env secret value"
 expect_not_contains "$accounts_json" "omux-e2e-a2" "accounts list does not expose env secret value"
 
+printf 'e2e: enroll plan reports non-mutating provider-neutral setup plan\n'
+enroll_plan_json="$(omux enroll plan toy --account a3 --json)"
+expect_contains "$enroll_plan_json" '"action":"plan"' "enroll plan reports plan action"
+expect_contains "$enroll_plan_json" '"mutates":false' "enroll plan is non-mutating"
+expect_contains "$enroll_plan_json" '"provider":"toy"' "enroll plan reports provider"
+expect_contains "$enroll_plan_json" '"account":"a3"' "enroll plan reports target account"
+expect_contains "$enroll_plan_json" '"provider_configured":true' "enroll plan sees configured provider"
+expect_contains "$enroll_plan_json" '"account":"a1"' "enroll plan includes existing account a1"
+expect_contains "$enroll_plan_json" '"kind":"runtime_proof"' "enroll plan includes runtime proof step"
+expect_contains "$enroll_plan_json" '"command":"oauth-mux doctor runtime --provider toy --account a3 --json"' "enroll plan builds account-scoped runtime command"
+expect_contains "$enroll_plan_json" '"provider_neutral_mutation_supported":false' "enroll plan refuses to claim mutation support"
+expect_not_contains "$enroll_plan_json" "omux-e2e-a1" "enroll plan does not expose env secret value"
+expect_not_contains "$enroll_plan_json" "omux-e2e-a2" "enroll plan does not expose env secret value"
+
 printf 'e2e: cheap route selects first healthy account\n'
 cheap_env="$(omux env --profile cheap --capability cheap --shell bash)"
 expect_contains "$cheap_env" "export TOY_TOKEN='omux-e2e-a1'" "cheap env injects account a1 token"

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -188,6 +188,26 @@ expect_not_contains "$(cat "$accounts_json")" "$store_root/max-1" "accounts list
 test ! -e "$store_root"
 test ! -e "$legacy_store_root"
 
+printf 'first-run e2e: enroll plan is provider-neutral and non-mutating\n'
+enroll_plan_json="$tmp/enroll-plan-codex.json"
+run_json "$enroll_plan_json" enroll plan codex --account max-4 --json
+jq -e '
+  .action == "plan"
+  and .mutates == false
+  and .provider == "codex"
+  and .account == "max-4"
+  and .provider_configured == true
+  and .provider_neutral_mutation_supported == false
+  and (.existing_accounts | length) == 3
+  and (.steps[] | select(.kind == "inspect_accounts") | .agent_safe == true)
+  and (.steps[] | select(.kind == "provider_login") | .command == "oauth-mux codex login-device max-4" and .interactive == true and .agent_safe == false)
+  and (.steps[] | select(.kind == "runtime_proof") | .command == "oauth-mux doctor runtime --provider codex --account max-4 --capability codex-max --json" and .agent_safe == true)
+  and .future_provider_neutral_command.available == false
+' "$enroll_plan_json" >/dev/null
+expect_not_contains "$(cat "$enroll_plan_json")" "$store_root/max-1" "enroll plan does not print concrete Codex store paths"
+test ! -e "$store_root"
+test ! -e "$legacy_store_root"
+
 printf 'first-run e2e: discovery is redacted and agent-usable\n'
 discover_json="$tmp/discover.json"
 run_json "$discover_json" discover --json
@@ -197,6 +217,7 @@ jq -e '
   and (.providers[] | select(.name == "codex") | .accounts | length) == 3
   and (.agent_safe_commands | index("oauth-mux report --redacted --json") != null)
   and (.agent_safe_commands | index("oauth-mux doctor runtime --json") != null)
+  and (.agent_safe_commands | index("oauth-mux enroll plan <provider> --json") != null)
   and (.agent_safe_commands | index("oauth-mux route explain --profile <profile> --capability <capability> --json") != null)
   and (.agent_safe_commands | index("oauth-mux route select --profile <profile> --capability <capability> --json") != null)
   and (.agent_safe_commands | index("oauth-mux repair-plan --profile <profile> --capability <capability> --json") != null)

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -11,6 +11,7 @@ pub const Command = union(enum) {
     report: ReportArgs,
     providers: ProvidersArgs,
     accounts: AccountsArgs,
+    enroll: EnrollArgs,
     status: StatusArgs,
     health: HealthArgs,
     discover: DiscoverArgs,
@@ -94,6 +95,18 @@ pub const Command = union(enum) {
     pub const AccountsArgs = struct {
         action: AccountsAction = .list,
         provider: ?[]const u8 = null,
+        json: bool = false,
+    };
+
+    pub const EnrollAction = enum {
+        plan,
+    };
+
+    pub const EnrollArgs = struct {
+        action: EnrollAction = .plan,
+        provider: ?[]const u8 = null,
+        account: ?[]const u8 = null,
+        mode: ?[]const u8 = null,
         json: bool = false,
     };
 
@@ -237,6 +250,7 @@ pub fn parse(args: []const []const u8) Command {
     if (eql(cmd, "report")) return parseReport(rest);
     if (eql(cmd, "providers")) return parseProviders(rest);
     if (eql(cmd, "accounts")) return parseAccounts(rest);
+    if (eql(cmd, "enroll")) return parseEnroll(rest);
     if (eql(cmd, "status")) return parseStatus(rest);
     if (eql(cmd, "health")) return parseHealth(rest);
     if (eql(cmd, "discover")) return parseDiscover(rest);
@@ -410,6 +424,34 @@ fn parseAccounts(args: []const []const u8) Command {
         }
     }
     return .{ .accounts = result };
+}
+
+fn parseEnroll(args: []const []const u8) Command {
+    var result = Command.EnrollArgs{};
+    var i: usize = 0;
+    if (args.len > 0 and eql(args[0], "plan")) {
+        result.action = .plan;
+        i = 1;
+    }
+    if (i < args.len and !std.mem.startsWith(u8, args[i], "--")) {
+        result.provider = args[i];
+        i += 1;
+    }
+    while (i < args.len) : (i += 1) {
+        if (eql(args[i], "--provider")) {
+            i += 1;
+            if (i < args.len) result.provider = args[i];
+        } else if (eql(args[i], "--account")) {
+            i += 1;
+            if (i < args.len) result.account = args[i];
+        } else if (eql(args[i], "--mode")) {
+            i += 1;
+            if (i < args.len) result.mode = args[i];
+        } else if (eql(args[i], "--json")) {
+            result.json = true;
+        }
+    }
+    return .{ .enroll = result };
 }
 
 fn parseStatus(args: []const []const u8) Command {
@@ -819,6 +861,9 @@ pub fn printUsage(writer: anytype) !void {
         \\  accounts list [--provider <name>] [--json]
         \\      Show configured accounts, runtime readiness, liveness evidence, and safe next commands.
         \\
+        \\  enroll plan <provider> [--account <name>] [--mode <mode>] [--json]
+        \\      Show provider-specific enrollment steps without mutating auth state.
+        \\
         \\  status [--json] [--provider <name>]
         \\      Show active accounts, health scores, and circuit states.
         \\
@@ -1203,6 +1248,21 @@ test "parse accounts list provider json" {
     }
 }
 
+test "parse enroll plan provider account mode json" {
+    const args = [_][]const u8{ "enroll", "plan", "figma", "--account", "work", "--mode", "pat", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .enroll => |enroll| {
+            try std.testing.expect(enroll.action == .plan);
+            try std.testing.expectEqualStrings("figma", enroll.provider.?);
+            try std.testing.expectEqualStrings("work", enroll.account.?);
+            try std.testing.expectEqualStrings("pat", enroll.mode.?);
+            try std.testing.expect(enroll.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 test "parse repair plan with profile" {
     const args = [_][]const u8{ "repair-plan", "--profile", "codex-max", "--json" };
     const cmd = parse(&args);
@@ -1414,6 +1474,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n __fish_use_subcommand -a report -d 'Print redacted support report'
             \\complete -c oauth-mux -n __fish_use_subcommand -a providers -d 'List provider support'
             \\complete -c oauth-mux -n __fish_use_subcommand -a accounts -d 'List configured accounts'
+            \\complete -c oauth-mux -n __fish_use_subcommand -a enroll -d 'Plan account enrollment'
             \\complete -c oauth-mux -n __fish_use_subcommand -a status -d 'Show status'
             \\complete -c oauth-mux -n __fish_use_subcommand -a health -d 'Show health data'
             \\complete -c oauth-mux -n __fish_use_subcommand -a discover -d 'Show agent-safe inventory'
@@ -1445,6 +1506,11 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from providers' -a 'list' -d 'Provider subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from accounts' -a 'list' -d 'Accounts subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from accounts' -l provider -d 'Provider name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -a 'plan' -d 'Enrollment subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -l provider -d 'Provider name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -l account -d 'Account name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -l mode -d 'Enrollment mode' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from env' -l shell -d 'Shell type' -r -a 'fish zsh bash ksh'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from status' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from discover' -l json -d 'JSON output'
@@ -1504,6 +1570,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\    'report:Print redacted support report'
             \\    'providers:List provider support'
             \\    'accounts:List configured accounts'
+            \\    'enroll:Plan account enrollment'
             \\    'status:Show status'
             \\    'health:Show health data'
             \\    'discover:Show agent-safe inventory'
@@ -1528,7 +1595,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
         try writer.writeAll(
             \\_oauth_mux_completions() {
             \\  local cur="${COMP_WORDS[COMP_CWORD]}"
-            \\  COMPREPLY=($(compgen -W "exec env probe doctor report providers accounts status health discover repair-plan repair route stay-afloat config init setup codex daemon version completions" -- "$cur"))
+            \\  COMPREPLY=($(compgen -W "exec env probe doctor report providers accounts enroll status health discover repair-plan repair route stay-afloat config init setup codex daemon version completions" -- "$cur"))
             \\}
             \\complete -F _oauth_mux_completions oauth-mux
             \\

--- a/src/main.zig
+++ b/src/main.zig
@@ -92,6 +92,10 @@ pub fn main() !void {
             try runAccounts(allocator, stdout, accounts_args);
         },
 
+        .enroll => |enroll_args| {
+            try runEnroll(allocator, stdout, enroll_args);
+        },
+
         .exec => |exec_args| {
             runExec(allocator, exec_args) catch |e| {
                 log.err("exec: {s}", .{@errorName(e)});
@@ -528,6 +532,375 @@ fn livenessIsAvailable(liveness: types.CredentialLiveness) bool {
     };
 }
 
+fn runEnroll(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.EnrollArgs) !void {
+    switch (args.action) {
+        .plan => {},
+    }
+
+    var parsed_config: ?std.json.Parsed(config.Config) = config.load(allocator) catch null;
+    defer if (parsed_config) |*parsed| parsed.deinit();
+    const cfg: ?config.Config = if (parsed_config) |parsed| parsed.value else null;
+
+    if (args.json) {
+        try writeEnrollPlanJson(writer, allocator, cfg, args);
+    } else {
+        try writeEnrollPlanText(writer, allocator, cfg, args);
+    }
+}
+
+fn writeEnrollPlanText(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: ?config.Config,
+    args: cli.Command.EnrollArgs,
+) !void {
+    const provider_label = args.provider orelse "<provider>";
+    try writer.writeAll("oauth-mux enroll plan\n\n");
+    try writer.print("  provider: {s}\n", .{provider_label});
+    if (args.account) |account| try writer.print("  account: {s}\n", .{account});
+    if (args.mode) |mode| try writer.print("  mode: {s}\n", .{mode});
+    try writer.writeAll("  mutates: false\n");
+    try writer.writeAll("  provider-neutral enrollment mutation: not shipped yet\n\n");
+
+    try writer.writeAll("  existing accounts:\n");
+    try writeEnrollExistingAccountsText(writer, cfg, args.provider);
+
+    try writer.writeAll("\n  plan:\n");
+    try writeEnrollPlanStepsText(writer, allocator, args);
+
+    try writer.writeAll("\n  agent-safe next:\n");
+    try writer.writeAll("    oauth-mux providers list --json\n");
+    if (args.provider) |provider_name| {
+        try writer.print("    oauth-mux accounts list --provider {s} --json\n", .{provider_name});
+    } else {
+        try writer.writeAll("    oauth-mux accounts list --json\n");
+    }
+    try writer.writeAll("    oauth-mux config validate\n");
+}
+
+fn writeEnrollPlanJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: ?config.Config,
+    args: cli.Command.EnrollArgs,
+) !void {
+    try writer.writeByte('{');
+    try writer.writeAll("\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"action\":\"plan\",\"mutates\":false,\"provider\":");
+    if (args.provider) |provider_name| try std.json.stringify(provider_name, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"account\":");
+    if (args.account) |account| try std.json.stringify(account, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"mode\":");
+    if (args.mode) |mode| try std.json.stringify(mode, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"configured\":");
+    try writer.writeAll(if (cfg != null) "true" else "false");
+    try writer.writeAll(",\"provider_configured\":");
+    try writer.writeAll(if (enrollProviderConfigured(cfg, args.provider)) "true" else "false");
+    try writer.writeAll(",\"provider_neutral_mutation_supported\":false");
+    try writer.writeAll(",\"existing_accounts\":[");
+    try writeEnrollExistingAccountsJson(writer, cfg, args.provider);
+    try writer.writeAll("],\"steps\":[");
+    try writeEnrollPlanStepsJson(writer, allocator, args);
+    try writer.writeAll("],\"agent_safe_commands\":[");
+    try writeCommandJson(writer, "oauth-mux providers list --json");
+    try writer.writeByte(',');
+    const accounts_command = try enrollAccountsCommand(allocator, args.provider);
+    defer allocator.free(accounts_command);
+    try writeCommandJson(writer, accounts_command);
+    try writer.writeByte(',');
+    try writeCommandJson(writer, "oauth-mux config validate");
+    try writer.writeAll("],\"future_provider_neutral_command\":");
+    try writeEnrollFutureCommandJson(writer, allocator, args);
+    try writer.writeAll("}\n");
+}
+
+fn writeEnrollExistingAccountsText(writer: anytype, cfg: ?config.Config, provider_filter: ?[]const u8) !void {
+    const config_value = cfg orelse {
+        try writer.writeAll("    config unavailable\n");
+        return;
+    };
+
+    var count: usize = 0;
+    var provider_it = config_value.providers.map.iterator();
+    while (provider_it.next()) |entry| {
+        const provider_name = entry.key_ptr.*;
+        const prov = entry.value_ptr.*;
+        if (!enrollProviderMatches(provider_filter, provider_name, prov.kind)) continue;
+        var account_it = prov.accounts.map.iterator();
+        while (account_it.next()) |acct_entry| {
+            count += 1;
+            try writer.print("    {s}:{s} secret={s}\n", .{
+                provider_name,
+                acct_entry.key_ptr.*,
+                acct_entry.value_ptr.secret.backend,
+            });
+        }
+    }
+
+    if (count == 0) try writer.writeAll("    none configured\n");
+}
+
+fn writeEnrollExistingAccountsJson(writer: anytype, cfg: ?config.Config, provider_filter: ?[]const u8) !void {
+    const config_value = cfg orelse return;
+
+    var first = true;
+    var provider_it = config_value.providers.map.iterator();
+    while (provider_it.next()) |entry| {
+        const provider_name = entry.key_ptr.*;
+        const prov = entry.value_ptr.*;
+        if (!enrollProviderMatches(provider_filter, provider_name, prov.kind)) continue;
+        var account_it = prov.accounts.map.iterator();
+        while (account_it.next()) |acct_entry| {
+            if (!first) try writer.writeByte(',');
+            first = false;
+            try writer.writeByte('{');
+            try writer.writeAll("\"provider\":");
+            try std.json.stringify(provider_name, .{}, writer);
+            try writer.writeAll(",\"kind\":");
+            try std.json.stringify(prov.kind, .{}, writer);
+            try writer.writeAll(",\"account\":");
+            try std.json.stringify(acct_entry.key_ptr.*, .{}, writer);
+            try writer.writeAll(",\"secret_backend\":");
+            try std.json.stringify(acct_entry.value_ptr.secret.backend, .{}, writer);
+            try writer.writeAll("}");
+        }
+    }
+}
+
+fn writeEnrollPlanStepsText(writer: anytype, allocator: std.mem.Allocator, args: cli.Command.EnrollArgs) !void {
+    const provider_name = args.provider orelse {
+        try writer.writeAll("    1. Pick a provider after inspecting provider support.\n");
+        try writer.writeAll("       command: oauth-mux providers list --json\n");
+        try writer.writeAll("    2. Inspect already configured accounts.\n");
+        try writer.writeAll("       command: oauth-mux accounts list --json\n");
+        try writer.writeAll("    3. Re-run this plan with a provider.\n");
+        try writer.writeAll("       command: oauth-mux enroll plan <provider> --json\n");
+        return;
+    };
+
+    if (isProvider(provider_name, "codex")) {
+        const accounts_command = try enrollAccountsCommand(allocator, provider_name);
+        defer allocator.free(accounts_command);
+        try writeEnrollPlanStepText(writer, 1, "Inspect configured Codex accounts.", accounts_command, false, false, false);
+        try writeEnrollPlanStepText(writer, 2, "Generate or review the Codex Max config sidecar when the active config is not already N-account.", "oauth-mux codex config-candidate --json", true, false, false);
+        const login_command = try enrollCodexLoginCommand(allocator, args.account);
+        defer allocator.free(login_command);
+        try writeEnrollPlanStepText(writer, 3, "Run provider-owned Codex login for the target account.", login_command, true, true, false);
+        const runtime_command = try enrollRuntimeCommand(allocator, provider_name, args.account, "codex-max");
+        defer allocator.free(runtime_command);
+        try writeEnrollPlanStepText(writer, 4, "Recheck local runtime readiness for that account.", runtime_command, false, false, false);
+        try writeEnrollPlanStepText(writer, 5, "Refresh recorded route evidence after user-mediated login.", "oauth-mux stay-afloat refresh --profile codex-max --capability codex-max --json", true, false, false);
+    } else if (isProvider(provider_name, "claude")) {
+        const accounts_command = try enrollAccountsCommand(allocator, provider_name);
+        defer allocator.free(accounts_command);
+        try writeEnrollPlanStepText(writer, 1, "Inspect configured Claude accounts.", accounts_command, false, false, false);
+        try writeEnrollPlanStepText(writer, 2, "Create or review an account-scoped CLAUDE_CONFIG_DIR config entry.", null, true, false, false);
+        try writeEnrollPlanStepText(writer, 3, "Run Claude CLI-owned login in the selected config directory.", "claude auth login", true, true, false);
+        const runtime_command = try enrollRuntimeCommand(allocator, provider_name, args.account, "auth-status");
+        defer allocator.free(runtime_command);
+        try writeEnrollPlanStepText(writer, 4, "Prove low-impact auth status before broader quota/repair claims.", runtime_command, false, false, false);
+    } else if (isProvider(provider_name, "figma")) {
+        const capability = figmaCapabilityForMode(args.mode);
+        const accounts_command = try enrollAccountsCommand(allocator, provider_name);
+        defer allocator.free(accounts_command);
+        try writeEnrollPlanStepText(writer, 1, "Inspect configured Figma identities.", accounts_command, false, false, false);
+        try writeEnrollPlanStepText(writer, 2, "Configure OAuth/PAT/plan-token mode explicitly in the account secret backend.", null, true, false, false);
+        try writeEnrollPlanStepText(writer, 3, "Validate config before any provider call.", "oauth-mux config validate", false, false, false);
+        const probe_command = try enrollProbeCommand(allocator, provider_name, args.account, capability);
+        defer allocator.free(probe_command);
+        try writeEnrollPlanStepText(writer, 4, "Run the chosen low-impact Figma proof only with user consent.", probe_command, false, false, true);
+    } else if (isProvider(provider_name, "mcp")) {
+        const accounts_command = try enrollAccountsCommand(allocator, provider_name);
+        defer allocator.free(accounts_command);
+        try writeEnrollPlanStepText(writer, 1, "Inspect configured MCP resource-server accounts.", accounts_command, false, false, false);
+        try writeEnrollPlanStepText(writer, 2, "Probe protected-resource metadata before assuming OAuth server details.", "oauth-mux probe --provider mcp --capability resource-metadata --json", false, false, false);
+        try writeEnrollPlanStepText(writer, 3, "Only then attach a bearer resource token and prove audience/resource matching.", null, true, false, true);
+    } else {
+        const accounts_command = try enrollAccountsCommand(allocator, provider_name);
+        defer allocator.free(accounts_command);
+        try writeEnrollPlanStepText(writer, 1, "Inspect provider support and configured accounts.", accounts_command, false, false, false);
+        try writeEnrollPlanStepText(writer, 2, "Validate config after adding a named account and secret backend.", "oauth-mux config validate", false, false, false);
+        const runtime_command = try enrollRuntimeCommand(allocator, provider_name, args.account, null);
+        defer allocator.free(runtime_command);
+        try writeEnrollPlanStepText(writer, 3, "Run runtime diagnostics before provider calls.", runtime_command, false, false, false);
+    }
+}
+
+fn writeEnrollPlanStepsJson(writer: anytype, allocator: std.mem.Allocator, args: cli.Command.EnrollArgs) !void {
+    var first = true;
+    const provider_name = args.provider orelse {
+        try writeEnrollPlanStepJson(writer, &first, "choose_provider", "Pick a provider after inspecting provider support.", "oauth-mux providers list --json", false, false, false);
+        try writeEnrollPlanStepJson(writer, &first, "inspect_accounts", "Inspect already configured accounts.", "oauth-mux accounts list --json", false, false, false);
+        try writeEnrollPlanStepJson(writer, &first, "rerun_plan", "Re-run this plan with a provider.", "oauth-mux enroll plan <provider> --json", false, false, false);
+        return;
+    };
+
+    const accounts_command = try enrollAccountsCommand(allocator, provider_name);
+    defer allocator.free(accounts_command);
+    try writeEnrollPlanStepJson(writer, &first, "inspect_accounts", "Inspect configured accounts for this provider.", accounts_command, false, false, false);
+
+    if (isProvider(provider_name, "codex")) {
+        try writeEnrollPlanStepJson(writer, &first, "config_candidate", "Generate or review the Codex Max config sidecar when the active config is not already N-account.", "oauth-mux codex config-candidate --json", true, false, false);
+        const login_command = try enrollCodexLoginCommand(allocator, args.account);
+        defer allocator.free(login_command);
+        try writeEnrollPlanStepJson(writer, &first, "provider_login", "Run provider-owned Codex login for the target account.", login_command, true, true, false);
+        const runtime_command = try enrollRuntimeCommand(allocator, provider_name, args.account, "codex-max");
+        defer allocator.free(runtime_command);
+        try writeEnrollPlanStepJson(writer, &first, "runtime_proof", "Recheck local runtime readiness for that account.", runtime_command, false, false, false);
+        try writeEnrollPlanStepJson(writer, &first, "refresh_evidence", "Refresh recorded route evidence after user-mediated login.", "oauth-mux stay-afloat refresh --profile codex-max --capability codex-max --json", true, false, false);
+    } else if (isProvider(provider_name, "claude")) {
+        try writeEnrollPlanStepJson(writer, &first, "config_entry", "Create or review an account-scoped CLAUDE_CONFIG_DIR config entry.", null, true, false, false);
+        try writeEnrollPlanStepJson(writer, &first, "provider_login", "Run Claude CLI-owned login in the selected config directory.", "claude auth login", true, true, false);
+        const runtime_command = try enrollRuntimeCommand(allocator, provider_name, args.account, "auth-status");
+        defer allocator.free(runtime_command);
+        try writeEnrollPlanStepJson(writer, &first, "runtime_proof", "Prove low-impact auth status before broader quota/repair claims.", runtime_command, false, false, false);
+    } else if (isProvider(provider_name, "figma")) {
+        const capability = figmaCapabilityForMode(args.mode);
+        try writeEnrollPlanStepJson(writer, &first, "secret_backend", "Configure OAuth/PAT/plan-token mode explicitly in the account secret backend.", null, true, false, false);
+        try writeEnrollPlanStepJson(writer, &first, "validate_config", "Validate config before any provider call.", "oauth-mux config validate", false, false, false);
+        const probe_command = try enrollProbeCommand(allocator, provider_name, args.account, capability);
+        defer allocator.free(probe_command);
+        try writeEnrollPlanStepJson(writer, &first, "provider_proof", "Run the chosen low-impact Figma proof only with user consent.", probe_command, false, false, true);
+    } else if (isProvider(provider_name, "mcp")) {
+        try writeEnrollPlanStepJson(writer, &first, "resource_metadata", "Probe protected-resource metadata before assuming OAuth server details.", "oauth-mux probe --provider mcp --capability resource-metadata --json", false, false, false);
+        try writeEnrollPlanStepJson(writer, &first, "bearer_resource", "Only then attach a bearer resource token and prove audience/resource matching.", null, true, false, true);
+    } else {
+        try writeEnrollPlanStepJson(writer, &first, "validate_config", "Validate config after adding a named account and secret backend.", "oauth-mux config validate", false, false, false);
+        const runtime_command = try enrollRuntimeCommand(allocator, provider_name, args.account, null);
+        defer allocator.free(runtime_command);
+        try writeEnrollPlanStepJson(writer, &first, "runtime_proof", "Run runtime diagnostics before provider calls.", runtime_command, false, false, false);
+    }
+}
+
+fn writeEnrollPlanStepText(
+    writer: anytype,
+    index: usize,
+    description: []const u8,
+    command: ?[]const u8,
+    mutating: bool,
+    interactive: bool,
+    spends_provider_calls: bool,
+) !void {
+    try writer.print("    {d}. {s}\n", .{ index, description });
+    if (command) |cmd| try writer.print("       command: {s}\n", .{cmd});
+    try writer.print("       mutating={s} interactive={s} spends_provider_calls={s}\n", .{
+        if (mutating) "true" else "false",
+        if (interactive) "true" else "false",
+        if (spends_provider_calls) "true" else "false",
+    });
+}
+
+fn writeEnrollPlanStepJson(
+    writer: anytype,
+    first: *bool,
+    kind: []const u8,
+    description: []const u8,
+    command: ?[]const u8,
+    mutating: bool,
+    interactive: bool,
+    spends_provider_calls: bool,
+) !void {
+    if (!first.*) try writer.writeByte(',');
+    first.* = false;
+    try writer.writeByte('{');
+    try writer.writeAll("\"kind\":");
+    try std.json.stringify(kind, .{}, writer);
+    try writer.writeAll(",\"description\":");
+    try std.json.stringify(description, .{}, writer);
+    try writer.writeAll(",\"command\":");
+    if (command) |cmd| try std.json.stringify(cmd, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"mutating\":");
+    try writer.writeAll(if (mutating) "true" else "false");
+    try writer.writeAll(",\"interactive\":");
+    try writer.writeAll(if (interactive) "true" else "false");
+    try writer.writeAll(",\"spends_provider_calls\":");
+    try writer.writeAll(if (spends_provider_calls) "true" else "false");
+    try writer.writeAll(",\"agent_safe\":");
+    try writer.writeAll(if (!mutating and !interactive and !spends_provider_calls) "true" else "false");
+    try writer.writeByte('}');
+}
+
+fn writeEnrollFutureCommandJson(writer: anytype, allocator: std.mem.Allocator, args: cli.Command.EnrollArgs) !void {
+    try writer.writeByte('{');
+    try writer.writeAll("\"available\":false,\"command\":");
+    const provider_name = args.provider orelse {
+        try writer.writeAll("null,\"reason\":\"provider_required\"}");
+        return;
+    };
+    const account = args.account orelse "<account>";
+    const command = try std.fmt.allocPrint(allocator, "oauth-mux enroll {s} --account {s}", .{ provider_name, account });
+    defer allocator.free(command);
+    try std.json.stringify(command, .{}, writer);
+    try writer.writeAll(",\"reason\":\"not_implemented; use enroll plan and provider-owned setup commands\"}");
+}
+
+fn enrollProviderConfigured(cfg: ?config.Config, provider_filter: ?[]const u8) bool {
+    const config_value = cfg orelse return false;
+    const filter = provider_filter orelse return config_value.providers.map.count() > 0;
+    var provider_it = config_value.providers.map.iterator();
+    while (provider_it.next()) |entry| {
+        if (enrollProviderMatches(filter, entry.key_ptr.*, entry.value_ptr.kind)) return true;
+    }
+    return false;
+}
+
+fn enrollProviderMatches(provider_filter: ?[]const u8, provider_name: []const u8, provider_kind: []const u8) bool {
+    const filter = provider_filter orelse return true;
+    return std.mem.eql(u8, filter, provider_name) or std.mem.eql(u8, filter, provider_kind);
+}
+
+fn isProvider(provider_name: []const u8, expected: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(provider_name, expected);
+}
+
+fn figmaCapabilityForMode(mode: ?[]const u8) []const u8 {
+    const value = mode orelse return "identity";
+    if (isProvider(value, "pat")) return "identity-pat";
+    if (isProvider(value, "plan") or isProvider(value, "file") or isProvider(value, "file-metadata")) return "file-metadata-plan";
+    return "identity";
+}
+
+fn enrollAccountsCommand(allocator: std.mem.Allocator, provider_name: ?[]const u8) ![]const u8 {
+    if (provider_name) |name| return std.fmt.allocPrint(allocator, "oauth-mux accounts list --provider {s} --json", .{name});
+    return allocator.dupe(u8, "oauth-mux accounts list --json");
+}
+
+fn enrollCodexLoginCommand(allocator: std.mem.Allocator, account: ?[]const u8) ![]const u8 {
+    if (account) |name| return std.fmt.allocPrint(allocator, "oauth-mux codex login-device {s}", .{name});
+    return allocator.dupe(u8, "oauth-mux setup codex --status-only");
+}
+
+fn enrollRuntimeCommand(
+    allocator: std.mem.Allocator,
+    provider_name: []const u8,
+    account: ?[]const u8,
+    capability: ?[]const u8,
+) ![]const u8 {
+    if (account) |account_name| {
+        if (capability) |capability_name| {
+            return std.fmt.allocPrint(allocator, "oauth-mux doctor runtime --provider {s} --account {s} --capability {s} --json", .{ provider_name, account_name, capability_name });
+        }
+        return std.fmt.allocPrint(allocator, "oauth-mux doctor runtime --provider {s} --account {s} --json", .{ provider_name, account_name });
+    }
+    if (capability) |capability_name| {
+        return std.fmt.allocPrint(allocator, "oauth-mux doctor runtime --provider {s} --capability {s} --json", .{ provider_name, capability_name });
+    }
+    return std.fmt.allocPrint(allocator, "oauth-mux doctor runtime --provider {s} --json", .{provider_name});
+}
+
+fn enrollProbeCommand(
+    allocator: std.mem.Allocator,
+    provider_name: []const u8,
+    account: ?[]const u8,
+    capability: []const u8,
+) ![]const u8 {
+    if (account) |account_name| {
+        return std.fmt.allocPrint(allocator, "oauth-mux probe --provider {s} --account {s} --capability {s} --json", .{ provider_name, account_name, capability });
+    }
+    return std.fmt.allocPrint(allocator, "oauth-mux probe --provider {s} --capability {s} --json", .{ provider_name, capability });
+}
+
 fn runDiscover(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.DiscoverArgs) !void {
     const config_path = try paths.configFilePath(allocator);
     defer allocator.free(config_path);
@@ -553,6 +926,8 @@ fn runDiscover(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.
             try writer.writeByte(',');
             try writeCommandJson(writer, "oauth-mux accounts list");
             try writer.writeByte(',');
+            try writeCommandJson(writer, "oauth-mux enroll plan <provider>");
+            try writer.writeByte(',');
             try writeCommandJson(writer, "oauth-mux report --redacted");
             try writer.writeAll("]}\n");
         } else {
@@ -565,6 +940,7 @@ fn runDiscover(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.
             try writer.writeAll("    oauth-mux doctor\n");
             try writer.writeAll("    oauth-mux providers list\n");
             try writer.writeAll("    oauth-mux accounts list\n");
+            try writer.writeAll("    oauth-mux enroll plan <provider>\n");
             try writer.writeAll("    oauth-mux report --redacted\n");
             try writer.writeAll("    oauth-mux config validate\n");
         }
@@ -649,6 +1025,7 @@ fn writeDiscoverText(writer: anytype, cfg: config.Config, config_path: []const u
     try writer.writeAll("    oauth-mux report --redacted --json\n");
     try writer.writeAll("    oauth-mux providers list --json\n");
     try writer.writeAll("    oauth-mux accounts list --json\n");
+    try writer.writeAll("    oauth-mux enroll plan <provider> --json\n");
     try writer.writeAll("    oauth-mux status --json\n");
     try writer.writeAll("    oauth-mux health --json\n");
     try writer.writeAll("    oauth-mux doctor runtime --json\n");
@@ -756,6 +1133,7 @@ fn writeDiscoverJson(writer: anytype, cfg: config.Config, config_path: []const u
         "oauth-mux report --redacted --json",
         "oauth-mux providers list --json",
         "oauth-mux accounts list --json",
+        "oauth-mux enroll plan <provider> --json",
         "oauth-mux status --json",
         "oauth-mux health --json",
         "oauth-mux doctor runtime --json",


### PR DESCRIPTION
## Summary

Adds the non-mutating enrollment planner:

- `oauth-mux enroll plan <provider> [--account <name>] [--mode <mode>] [--json]`
- provider-specific plans for Codex, Claude, Figma, MCP, and generic providers
- step labels for `agent_safe`, `interactive`, `mutating`, and `spends_provider_calls`
- discover/docs/spec updates so agents can start with inventory, then planning, before any setup mutation

This deliberately does not implement provider-neutral enrollment mutation yet. It makes the next action inspectable and consent-scoped first.

## Validation

- `nix develop --command just check-local`
- smoke: `oauth-mux enroll plan codex --account max-4 --json`
- smoke: `oauth-mux enroll plan figma --account work --mode pat --json`
