### PR TITLE
[codex] Add confirmed Codex enrollment

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ oauth-mux report --redacted
 oauth-mux providers list
 oauth-mux accounts list --json
 oauth-mux enroll plan codex --account max-4 --json
+oauth-mux enroll codex --account max-4 --confirm-enroll --json
 oauth-mux discover --json
 oauth-mux doctor runtime --json
 ```
@@ -125,6 +126,12 @@ into an explicit provider-specific setup plan, marking which steps are
 agent-safe, interactive, mutating, or provider-call-spending before anything is
 run.
 
+`enroll codex --account <name> --confirm-enroll --json` is the first consented
+provider-neutral enrollment mutation. It adds the named Codex account to the
+active oauth-mux config and Codex Max/Mini profiles, bootstraps the isolated
+`CODEX_HOME` directory, and returns the `oauth-mux codex login-device <name>`
+handoff. It does not run Codex login or provider probes.
+
 `repair run` is the explicit mutation boundary. Without `--confirm-repair`, it
 will not open auth flows or run upstream CLI repair commands; it only reports
 whether a route is already selectable, whether no admitted repair exists, or
@@ -184,6 +191,8 @@ oauth-mux doctor
 oauth-mux doctor runtime --json
 oauth-mux accounts list --provider codex --json
 oauth-mux enroll plan codex --account max-4 --json
+oauth-mux enroll codex --account max-4 --confirm-enroll --json
+oauth-mux codex login-device max-4
 oauth-mux setup codex
 oauth-mux codex canary
 oauth-mux codex live-qa

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -35,6 +35,7 @@ oauth-mux report --redacted
 oauth-mux providers list
 oauth-mux accounts list
 oauth-mux enroll plan <provider>
+oauth-mux enroll codex --account <name> --confirm-enroll
 oauth-mux config validate
 oauth-mux discover --json
 oauth-mux doctor runtime --json
@@ -59,6 +60,8 @@ oauth-mux doctor
 oauth-mux doctor runtime --json
 oauth-mux accounts list --provider codex --json
 oauth-mux enroll plan codex --account max-4 --json
+oauth-mux enroll codex --account max-4 --confirm-enroll --json
+oauth-mux codex login-device max-4
 oauth-mux setup codex
 oauth-mux codex canary
 oauth-mux route explain --profile codex-max --capability codex-max --json
@@ -99,6 +102,11 @@ recorded liveness, and safe next commands without reading credential values.
 surface. It does not mutate config or auth state; it marks each provider-specific
 step as agent-safe, interactive, mutating, or provider-call-spending so users
 and agents can ask for consent at the right boundary.
+`oauth-mux enroll codex --account <name> --confirm-enroll --json` is the first
+consented provider-neutral enrollment mutation. It updates oauth-mux config,
+adds the Codex Max/Mini routes, and bootstraps the local account directory. It
+does not run `codex login`, open a browser, or spend provider calls; the login
+handoff remains explicit in `next_commands`.
 After a user-mediated upstream login, `oauth-mux stay-afloat refresh --profile
 <profile> --capability <capability> --json` is the concise evidence refresh
 step that can clear pending handoffs.
@@ -126,7 +134,7 @@ contract before adding a shell hook, CI wrapper, service unit, or agent
 permission broker around stay-afloat.
 The account enrollment and agent inventory contract lives in
 `docs/spec/account-enrollment-agent-contract-2026-05-01.md`. Use that contract
-before adding provider-neutral enrollment commands or MCP mutation tools.
+before broadening provider-neutral enrollment commands or MCP mutation tools.
 
 ## Provider Author Experience
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -40,6 +40,7 @@ oauth-mux doctor runtime --json
 oauth-mux config validate
 oauth-mux accounts list --json
 oauth-mux enroll plan <provider> --json
+oauth-mux enroll codex --account <name> --confirm-enroll --json
 oauth-mux discover
 ```
 
@@ -51,6 +52,8 @@ oauth-mux doctor
 oauth-mux doctor runtime --json
 oauth-mux accounts list --provider codex --json
 oauth-mux enroll plan codex --account max-4 --json
+oauth-mux enroll codex --account max-4 --confirm-enroll --json
+oauth-mux codex login-device max-4
 oauth-mux setup codex
 oauth-mux codex canary
 oauth-mux codex live-qa
@@ -81,8 +84,15 @@ values.
 `oauth-mux enroll plan <provider> --json` is the no-mutation enrollment planner.
 It converts provider inventory into ordered setup steps and labels each step as
 agent-safe, interactive, mutating, or provider-call-spending. Provider-neutral
-enrollment mutation is still intentionally reported as unavailable until the
-provider-owned login and consent contracts are stronger.
+enrollment mutation is only available where the provider-owned consent contract
+has been implemented.
+
+`oauth-mux enroll codex --account <name> --confirm-enroll --json` is the first
+provider-neutral enrollment mutation. It updates the active oauth-mux config,
+adds the Codex Max/Mini profile routes, and creates the isolated Codex account
+directory. It does not run `codex login`, open browser/device auth, or probe the
+provider. The returned `next_commands` include the explicit
+`oauth-mux codex login-device <name>` handoff plus runtime and inventory checks.
 
 For profile-level stay-afloat checks, scope the runtime report:
 `oauth-mux doctor runtime --profile codex-max --capability codex-max --json`.
@@ -415,6 +425,12 @@ handoff, or a live proof run.
 setup sequence. Agents may present steps with `agent_safe:false` to a user or
 permission broker, but must not run those steps without explicit consent.
 
+`enroll codex --account <name> --confirm-enroll --json` is not agent-safe by
+default because it mutates config and creates an account directory. Agents may
+request it through a permission broker, but must not infer that the account is
+authenticated until the user has run the returned login command and runtime
+checks pass.
+
 `report --redacted --json` is the support-bundle surface. It adds platform,
 config shape, provider/account labels, command availability, health summaries,
 and recent probe evidence. It never reads credential values and omits credential
@@ -438,8 +454,11 @@ operator proof, `public_live_proven` for no-secret public metadata proof, and
 5. Run `oauth-mux doctor --json`, `oauth-mux report --redacted --json`, and
    `oauth-mux accounts list --json` plus `oauth-mux discover --json`.
 6. Run `oauth-mux enroll plan <provider> --json` before adding an N+1 account.
-7. Run no-spend checks first: `status`, `health`, and credential parse probes.
-8. Run live probes only through `scripts/live-provider-qa.sh` or the manual
+7. For Codex N+1, run
+   `oauth-mux enroll codex --account <name> --confirm-enroll --json`, then the
+   returned `oauth-mux codex login-device <name>` handoff.
+8. Run no-spend checks first: `status`, `health`, and credential parse probes.
+9. Run live probes only through `scripts/live-provider-qa.sh` or the manual
    Live Provider QA workflow.
 
 ## Operator Definition of Done
@@ -449,6 +468,8 @@ operator proof, `public_live_proven` for no-secret public metadata proof, and
   and liveness state.
 - `enroll plan <provider> --json` describes any remaining setup without running
   it.
+- Confirmed Codex enrollment returns a user-mediated login handoff instead of
+  silently running upstream auth.
 - `discover --json` is usable by agents.
 - `report --redacted --json` is usable for a support bundle without token
   material.

--- a/docs/spec/account-enrollment-agent-contract-2026-05-01.md
+++ b/docs/spec/account-enrollment-agent-contract-2026-05-01.md
@@ -50,6 +50,17 @@ step with `agent_safe`, `interactive`, `mutating`, and
 `spends_provider_calls`, and it explicitly reports provider-neutral enrollment
 mutation as unavailable until provider-owned consent flows are implemented.
 
+The first consented mutation is Codex-only:
+
+```bash
+oauth-mux enroll codex --account max-4 --confirm-enroll --json
+```
+
+Confirmed Codex enrollment mutates only oauth-mux-owned state: active config,
+Codex Max/Mini profile routes, and the isolated local Codex account directory.
+It does not run `codex login`, open browser/device auth, or spend provider
+calls. The output returns the provider-owned login handoff as a next command.
+
 ## User Stories
 
 ### Story A: user adds a fourth Codex account
@@ -62,18 +73,22 @@ Expected flow:
 ```bash
 oauth-mux accounts list --provider codex --json
 oauth-mux enroll plan codex --account max-4 --json
-oauth-mux codex config-candidate --store-root ~/.local/share/oauth-mux/codex --json
-oauth-mux codex config-merge --candidate /tmp/oauth-mux-codex-max.config.json --json
+oauth-mux enroll codex --account max-4 --confirm-enroll --json
 oauth-mux codex login-device max-4
 oauth-mux doctor runtime --provider codex --account max-4 --capability codex-max --json
 oauth-mux stay-afloat refresh --profile codex-max --capability codex-max --json
 ```
 
-Future provider-neutral shape:
+Provider-neutral shape:
 
 ```bash
-oauth-mux enroll codex --account max-4
+oauth-mux enroll codex --account max-4 --confirm-enroll
 ```
+
+If the active config is not already a Codex Max/Mini mux shape, the command
+refuses and returns the existing `codex config-candidate` / `config-merge`
+path. This keeps migration from single-account Codex separate from N+1
+enrollment.
 
 ### Story B: user adds work and personal Claude accounts
 
@@ -152,6 +167,9 @@ handoff rather than trying to run browser/device auth silently.
 - safe next commands;
 - the future provider-neutral mutation command with `available:false`.
 
+For Codex, that command is now available and points to
+`oauth-mux enroll codex --account <name> --confirm-enroll`.
+
 Account state is intentionally coarse:
 
 | State | Meaning |
@@ -205,13 +223,17 @@ Mutation-capable tools such as `enroll.start`, `enroll.complete`, or
 evidence. MCP tools should preserve the same action taxonomy as the CLI:
 diagnostic, handoff, probe, repair, and mutation.
 
+For the current Codex implementation, the mutation-capable tool equivalent
+should expose the same shape as `enroll codex --confirm-enroll`: config/store
+scaffolding only, with provider login returned as a user-mediated handoff.
+
 ## Next Implementation Slices
 
 1. Land `accounts list` as the provider-neutral inventory surface.
 2. Land `enroll plan <provider>` to print the exact provider-specific setup
    steps without mutation.
-3. Promote Codex N+1 enrollment from provider-specific helpers into
-   `enroll codex --account <name>`.
+3. Land Codex N+1 enrollment as
+   `enroll codex --account <name> --confirm-enroll`.
 4. Add Claude account-store config candidate and runtime proof.
-5. Add Figma OAuth/PAT enrollment plan and proof fixtures.
+5. Add Figma OAuth/PAT enrollment mutation planning and proof fixtures.
 6. Define the MCP tool schema against the same JSON surfaces.

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -110,7 +110,10 @@ provider-neutral visibility, admission, and mutation layers for N+1 Codex,
 Claude, Figma, and future MCP-facing enrollment. The first implementation slice
 is the non-mutating `oauth-mux accounts list --json` inventory surface. The
 second slice is `oauth-mux enroll plan <provider> --json`, which explains the
-provider-specific setup path and labels each step before any mutation.
+provider-specific setup path and labels each step before any mutation. The
+third slice is Codex-only `oauth-mux enroll codex --account <name>
+--confirm-enroll --json`, which mutates oauth-mux config/store scaffolding but
+returns upstream login as a user-mediated handoff.
 
 Core product docs must remain service-manager agnostic. `systemctl`,
 `launchctl`, Homebrew services, cron, and Windows Services can become wrapper
@@ -181,16 +184,18 @@ these precise provider-proof children.
 1. Keep provider-neutral account inventory and enrollment planning aligned with
    the account-enrollment contract, so agents can inspect N configured accounts
    and explain setup before route, repair, handoff, or live-proof decisions.
-2. Update website/release copy to use the public `jesssullivan/omux` Homebrew
+2. Use the Codex confirmed enrollment path as the consent/mutation reference
+   before adding Claude, Figma, or MCP mutation tools.
+3. Update website/release copy to use the public `jesssullivan/omux` Homebrew
    tap and close `#66` / `TIN-858` after those surfaces are aligned.
-3. Finish `TIN-862` by adding Linear OAuth bearer proof. GitHub identity and
+4. Finish `TIN-862` by adding Linear OAuth bearer proof. GitHub identity and
    Linear API-key identity are locally proven; Linear OAuth `identity` remains
    `needs_operator_proof`.
-4. Continue `TIN-861` and `TIN-863` on their remaining hard shapes: Claude
+5. Continue `TIN-861` and `TIN-863` on their remaining hard shapes: Claude
    quota/repair semantics and MCP resource-bound bearer-token proof.
-5. Work provider proof in narrow slices: `TIN-876` Vercel, `TIN-877` Figma,
+6. Work provider proof in narrow slices: `TIN-876` Vercel, `TIN-877` Figma,
    `TIN-878` FlakeHub/Determinate, and `TIN-879` Gemini.
-6. Return to daemon background scheduling only after wrapper/install decisions
+7. Return to daemon background scheduling only after wrapper/install decisions
    and provider proof produce enough real operator evidence. The current socket
    daemon decision is complete under `TIN-867`; future production daemon work
    must promote the foreground tick engine deliberately.

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -197,14 +197,30 @@ jq -e '
   and .provider == "codex"
   and .account == "max-4"
   and .provider_configured == true
-  and .provider_neutral_mutation_supported == false
+  and .provider_neutral_mutation_supported == true
   and (.existing_accounts | length) == 3
   and (.steps[] | select(.kind == "inspect_accounts") | .agent_safe == true)
   and (.steps[] | select(.kind == "provider_login") | .command == "oauth-mux codex login-device max-4" and .interactive == true and .agent_safe == false)
   and (.steps[] | select(.kind == "runtime_proof") | .command == "oauth-mux doctor runtime --provider codex --account max-4 --capability codex-max --json" and .agent_safe == true)
-  and .future_provider_neutral_command.available == false
+  and .future_provider_neutral_command.available == true
+  and (.future_provider_neutral_command.command | contains("--confirm-enroll"))
 ' "$enroll_plan_json" >/dev/null
 expect_not_contains "$(cat "$enroll_plan_json")" "$store_root/max-1" "enroll plan does not print concrete Codex store paths"
+test ! -e "$store_root"
+test ! -e "$legacy_store_root"
+
+printf 'first-run e2e: enroll codex requires explicit confirmation\n'
+enroll_unconfirmed_json="$tmp/enroll-codex-unconfirmed.json"
+run_json "$enroll_unconfirmed_json" enroll codex --account max-4 --json
+jq -e '
+  .ok == false
+  and .executed == false
+  and .confirmation_required == true
+  and .requires == "--confirm-enroll"
+  and .mutates == true
+  and .spends_provider_calls == false
+  and (.confirm_command | contains("oauth-mux enroll codex --account max-4 --confirm-enroll --json"))
+' "$enroll_unconfirmed_json" >/dev/null
 test ! -e "$store_root"
 test ! -e "$legacy_store_root"
 
@@ -419,5 +435,35 @@ help_out="$(omux codex canary --help)"
 expect_contains "$help_out" "non-mutating" "Codex help declares non-mutating behavior"
 test ! -e "$store_root"
 test ! -e "$legacy_store_root"
+
+printf 'first-run e2e: confirmed enroll codex adds N+1 account without login\n'
+enroll_confirmed_json="$tmp/enroll-codex-confirmed.json"
+run_json "$enroll_confirmed_json" enroll codex --account max-4 --confirm-enroll --json
+jq -e '
+  .ok == true
+  and .executed == true
+  and .provider == "codex"
+  and .account == "max-4"
+  and .config_changed == true
+  and .store_bootstrapped == true
+  and .ran_provider_login == false
+  and .spends_provider_calls == false
+  and .backup_config != null
+  and (.next_commands | index("oauth-mux codex login-device max-4") != null)
+  and (.next_commands | index("oauth-mux doctor runtime --provider codex --account max-4 --capability codex-max --json") != null)
+' "$enroll_confirmed_json" >/dev/null
+test -d "$store_root/max-4"
+jq -e '
+  (.providers.codex.accounts["max-4"].secret.backend == "file")
+  and (.providers.codex.accounts["max-4"].config_dir | contains("max-4"))
+  and (.profiles["codex-max"].providers | index("codex:max-4#codex-max") != null)
+  and (.profiles["codex-mini"].providers | index("codex:max-4#codex-mini") != null)
+' "$config_path" >/dev/null
+accounts_after_enroll_json="$tmp/accounts-after-enroll.json"
+run_json "$accounts_after_enroll_json" accounts list --provider codex --json
+jq -e '
+  (.accounts | length) == 4
+  and any(.accounts[]; .account == "max-4" and .state == "action_needed")
+' "$accounts_after_enroll_json" >/dev/null
 
 printf 'first-run e2e passed\n'

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -100,6 +100,7 @@ pub const Command = union(enum) {
 
     pub const EnrollAction = enum {
         plan,
+        codex,
     };
 
     pub const EnrollArgs = struct {
@@ -107,6 +108,8 @@ pub const Command = union(enum) {
         provider: ?[]const u8 = null,
         account: ?[]const u8 = null,
         mode: ?[]const u8 = null,
+        store_root: ?[]const u8 = null,
+        confirm_enroll: bool = false,
         json: bool = false,
     };
 
@@ -432,9 +435,17 @@ fn parseEnroll(args: []const []const u8) Command {
     if (args.len > 0 and eql(args[0], "plan")) {
         result.action = .plan;
         i = 1;
+    } else if (args.len > 0 and eql(args[0], "codex")) {
+        result.action = .codex;
+        result.provider = "codex";
+        i = 1;
     }
     if (i < args.len and !std.mem.startsWith(u8, args[i], "--")) {
-        result.provider = args[i];
+        if (result.action == .codex) {
+            result.account = args[i];
+        } else {
+            result.provider = args[i];
+        }
         i += 1;
     }
     while (i < args.len) : (i += 1) {
@@ -447,6 +458,11 @@ fn parseEnroll(args: []const []const u8) Command {
         } else if (eql(args[i], "--mode")) {
             i += 1;
             if (i < args.len) result.mode = args[i];
+        } else if (eql(args[i], "--store-root")) {
+            i += 1;
+            if (i < args.len) result.store_root = args[i];
+        } else if (eql(args[i], "--confirm-enroll") or eql(args[i], "--confirm")) {
+            result.confirm_enroll = true;
         } else if (eql(args[i], "--json")) {
             result.json = true;
         }
@@ -864,6 +880,9 @@ pub fn printUsage(writer: anytype) !void {
         \\  enroll plan <provider> [--account <name>] [--mode <mode>] [--json]
         \\      Show provider-specific enrollment steps without mutating auth state.
         \\
+        \\  enroll codex --account <name> [--store-root <path>] [--confirm-enroll] [--json]
+        \\      Add a Codex account to oauth-mux config; does not run Codex login.
+        \\
         \\  status [--json] [--provider <name>]
         \\      Show active accounts, health scores, and circuit states.
         \\
@@ -1263,6 +1282,22 @@ test "parse enroll plan provider account mode json" {
     }
 }
 
+test "parse enroll codex account confirmation" {
+    const args = [_][]const u8{ "enroll", "codex", "--account", "max-4", "--store-root", "/tmp/codex", "--confirm-enroll", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .enroll => |enroll| {
+            try std.testing.expect(enroll.action == .codex);
+            try std.testing.expectEqualStrings("codex", enroll.provider.?);
+            try std.testing.expectEqualStrings("max-4", enroll.account.?);
+            try std.testing.expectEqualStrings("/tmp/codex", enroll.store_root.?);
+            try std.testing.expect(enroll.confirm_enroll);
+            try std.testing.expect(enroll.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 test "parse repair plan with profile" {
     const args = [_][]const u8{ "repair-plan", "--profile", "codex-max", "--json" };
     const cmd = parse(&args);
@@ -1506,10 +1541,12 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from providers' -a 'list' -d 'Provider subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from accounts' -a 'list' -d 'Accounts subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from accounts' -l provider -d 'Provider name' -r
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -a 'plan' -d 'Enrollment subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -a 'plan codex' -d 'Enrollment subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -l provider -d 'Provider name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -l account -d 'Account name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -l mode -d 'Enrollment mode' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -l store-root -d 'Codex store root' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -l confirm-enroll -d 'Confirm config/store mutation'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from env' -l shell -d 'Shell type' -r -a 'fish zsh bash ksh'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from status' -l json -d 'JSON output'

--- a/src/main.zig
+++ b/src/main.zig
@@ -534,18 +534,427 @@ fn livenessIsAvailable(liveness: types.CredentialLiveness) bool {
 
 fn runEnroll(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.EnrollArgs) !void {
     switch (args.action) {
-        .plan => {},
+        .plan => {
+            var parsed_config: ?std.json.Parsed(config.Config) = config.load(allocator) catch null;
+            defer if (parsed_config) |*parsed| parsed.deinit();
+            const cfg: ?config.Config = if (parsed_config) |parsed| parsed.value else null;
+
+            if (args.json) {
+                try writeEnrollPlanJson(writer, allocator, cfg, args);
+            } else {
+                try writeEnrollPlanText(writer, allocator, cfg, args);
+            }
+        },
+        .codex => try runEnrollCodex(allocator, writer, args),
+    }
+}
+
+const EnrollCodexResult = struct {
+    ok: bool,
+    reason: []const u8,
+    account: []const u8,
+    store_root: []const u8,
+    account_dir: []const u8,
+    active_config: []const u8,
+    backup_config: ?[]const u8 = null,
+    config_changed: bool = false,
+    store_bootstrapped: bool = false,
+};
+
+fn runEnrollCodex(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.EnrollArgs) !void {
+    const account = args.account orelse {
+        if (args.json) {
+            try writer.writeAll("{\"ok\":false,\"error\":\"missing_account\",\"mutates\":true,\"requires\":\"--account <name>\",\"next_commands\":[");
+            try writeCommandJson(writer, "oauth-mux enroll plan codex --json");
+            try writer.writeAll("]}\n");
+        } else {
+            try writer.writeAll("oauth-mux enroll codex\n\n");
+            try writer.writeAll("  missing required --account <name>\n");
+            try writer.writeAll("  next: oauth-mux enroll plan codex --json\n");
+        }
+        return;
+    };
+
+    const store_root = try codexStoreRoot(allocator, .{ .store_root = args.store_root });
+    defer allocator.free(store_root);
+    const account_dir = try codexAccountDir(allocator, store_root, account);
+    defer allocator.free(account_dir);
+    const active_config_path = try paths.configFilePath(allocator);
+    defer allocator.free(active_config_path);
+
+    if (!args.confirm_enroll) {
+        try writeEnrollCodexConfirmationRequired(writer, allocator, args, active_config_path, store_root, account_dir);
+        return;
     }
 
+    var active = config.loadFromPath(allocator, active_config_path) catch |e| {
+        if (args.json) {
+            try writer.writeAll("{\"ok\":false,\"error\":");
+            try std.json.stringify(@errorName(e), .{}, writer);
+            try writer.writeAll(",\"message\":\"active config is required before confirmed Codex enrollment\",\"next_commands\":[");
+            try writeCommandJson(writer, "oauth-mux init --codex-max");
+            try writer.writeAll("]}\n");
+        } else {
+            try writer.writeAll("oauth-mux enroll codex\n\n");
+            try writer.print("  config unavailable: {s}\n", .{@errorName(e)});
+            try writer.writeAll("  next: oauth-mux init --codex-max\n");
+        }
+        return;
+    };
+    defer active.deinit();
+    try config.validate(active.value, std.io.null_writer);
+
+    if (!codexMaxShapeConfigured(active.value)) {
+        try writeEnrollCodexRequiresCodexMax(writer, args.json);
+        return;
+    }
+
+    var result = EnrollCodexResult{
+        .ok = true,
+        .reason = "enrolled_codex_account",
+        .account = account,
+        .store_root = store_root,
+        .account_dir = account_dir,
+        .active_config = active_config_path,
+    };
+
+    const config_changed = !codexEnrollmentShapeConfigured(active.value, account);
+    if (config_changed) {
+        var config_buf = std.ArrayList(u8).init(allocator);
+        defer config_buf.deinit();
+        try writeCodexEnrollConfigJson(allocator, config_buf.writer(), active.value, store_root, account);
+
+        const parsed = try config.loadFromBytes(allocator, config_buf.items);
+        defer parsed.deinit();
+        try config.validate(parsed.value, std.io.null_writer);
+        if (!codexEnrollmentShapeConfigured(parsed.value, account)) return error.ConfigValidationError;
+
+        const backup_path = try defaultCodexConfigBackupPath(allocator, active_config_path);
+        defer allocator.free(backup_path);
+        try writeActiveConfigAtomically(allocator, active_config_path, backup_path, config_buf.items);
+
+        result.backup_config = backup_path;
+        result.config_changed = true;
+    } else {
+        result.reason = "codex_account_already_configured";
+    }
+
+    if (args.json) {
+        try bootstrapOneCodexDir(allocator, std.io.null_writer, store_root, account);
+    } else {
+        try bootstrapOneCodexDir(allocator, writer, store_root, account);
+    }
+    result.store_bootstrapped = true;
+
+    try writeEnrollCodexResult(writer, allocator, result, args.json);
+}
+
+fn writeEnrollCodexConfirmationRequired(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    args: cli.Command.EnrollArgs,
+    active_config_path: []const u8,
+    store_root: []const u8,
+    account_dir: []const u8,
+) !void {
+    const account = args.account orelse "<account>";
+    const confirm_command = try enrollCodexConfirmCommand(allocator, account, args.store_root, args.json);
+    defer allocator.free(confirm_command);
+
+    if (args.json) {
+        try writer.writeAll("{\"ok\":false,\"executed\":false,\"confirmation_required\":true,\"requires\":\"--confirm-enroll\",\"mutates\":true,\"interactive\":false,\"spends_provider_calls\":false,\"provider\":\"codex\",\"account\":");
+        try std.json.stringify(account, .{}, writer);
+        try writer.writeAll(",\"active_config\":");
+        try std.json.stringify(active_config_path, .{}, writer);
+        try writer.writeAll(",\"store_root\":");
+        try std.json.stringify(store_root, .{}, writer);
+        try writer.writeAll(",\"account_dir\":");
+        try std.json.stringify(account_dir, .{}, writer);
+        try writer.writeAll(",\"confirm_command\":");
+        try std.json.stringify(confirm_command, .{}, writer);
+        try writer.writeAll(",\"plan\":");
+        try writeEnrollPlanJsonInline(writer, allocator, args);
+        try writer.writeAll("}\n");
+        return;
+    }
+
+    try writer.writeAll("oauth-mux enroll codex\n\n");
+    try writer.writeAll("  confirmation required: --confirm-enroll\n");
+    try writer.writeAll("  mutates: active oauth-mux config and local Codex account directory\n");
+    try writer.writeAll("  does not run: codex login, provider probes, browser/device auth\n\n");
+    try writer.print("  active config: {s}\n", .{active_config_path});
+    try writer.print("  store root:    {s}\n", .{store_root});
+    try writer.print("  account dir:   {s}\n\n", .{account_dir});
+    try writer.writeAll("next:\n");
+    try writer.print("  {s}\n", .{confirm_command});
+}
+
+fn writeEnrollPlanJsonInline(writer: anytype, allocator: std.mem.Allocator, args: cli.Command.EnrollArgs) !void {
     var parsed_config: ?std.json.Parsed(config.Config) = config.load(allocator) catch null;
     defer if (parsed_config) |*parsed| parsed.deinit();
     const cfg: ?config.Config = if (parsed_config) |parsed| parsed.value else null;
 
-    if (args.json) {
-        try writeEnrollPlanJson(writer, allocator, cfg, args);
-    } else {
-        try writeEnrollPlanText(writer, allocator, cfg, args);
+    const plan_args = cli.Command.EnrollArgs{
+        .action = .plan,
+        .provider = args.provider orelse "codex",
+        .account = args.account,
+        .mode = args.mode,
+        .store_root = args.store_root,
+        .json = true,
+    };
+
+    try writer.writeByte('{');
+    try writer.writeAll("\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"action\":\"plan\",\"mutates\":false,\"provider\":\"codex\",\"account\":");
+    if (plan_args.account) |account| try std.json.stringify(account, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"mode\":null,\"configured\":");
+    try writer.writeAll(if (cfg != null) "true" else "false");
+    try writer.writeAll(",\"provider_configured\":");
+    try writer.writeAll(if (enrollProviderConfigured(cfg, "codex")) "true" else "false");
+    try writer.writeAll(",\"provider_neutral_mutation_supported\":true,\"existing_accounts\":[");
+    try writeEnrollExistingAccountsJson(writer, cfg, "codex");
+    try writer.writeAll("],\"steps\":[");
+    try writeEnrollPlanStepsJson(writer, allocator, plan_args);
+    try writer.writeAll("]}");
+}
+
+fn writeEnrollCodexRequiresCodexMax(writer: anytype, json: bool) !void {
+    if (json) {
+        try writer.writeAll("{\"ok\":false,\"executed\":false,\"error\":\"requires_codex_max_config\",\"message\":\"confirmed Codex enrollment requires the active config to already have codex-max and codex-mini profiles\",\"next_commands\":[");
+        try writeCommandJson(writer, "oauth-mux codex config-candidate --json");
+        try writer.writeByte(',');
+        try writeCommandJson(writer, "oauth-mux codex config-merge --candidate ~/.config/oauth-mux/codex-max.config.json --json");
+        try writer.writeAll("]}\n");
+        return;
     }
+
+    try writer.writeAll("oauth-mux enroll codex\n\n");
+    try writer.writeAll("  active config is not a Codex Max mux shape yet.\n");
+    try writer.writeAll("  next:\n");
+    try writer.writeAll("    oauth-mux codex config-candidate --json\n");
+    try writer.writeAll("    oauth-mux codex config-merge --candidate ~/.config/oauth-mux/codex-max.config.json --json\n");
+}
+
+fn writeEnrollCodexResult(writer: anytype, allocator: std.mem.Allocator, result: EnrollCodexResult, json: bool) !void {
+    const login_command = try enrollCodexLoginCommand(allocator, result.account);
+    defer allocator.free(login_command);
+    const runtime_command = try enrollRuntimeCommand(allocator, "codex", result.account, "codex-max");
+    defer allocator.free(runtime_command);
+    const accounts_command = try enrollAccountsCommand(allocator, "codex");
+    defer allocator.free(accounts_command);
+
+    if (json) {
+        try writer.writeAll("{\"ok\":");
+        try writer.writeAll(if (result.ok) "true" else "false");
+        try writer.writeAll(",\"executed\":true,\"provider\":\"codex\",\"account\":");
+        try std.json.stringify(result.account, .{}, writer);
+        try writer.writeAll(",\"reason\":");
+        try std.json.stringify(result.reason, .{}, writer);
+        try writer.writeAll(",\"config_changed\":");
+        try writer.writeAll(if (result.config_changed) "true" else "false");
+        try writer.writeAll(",\"store_bootstrapped\":");
+        try writer.writeAll(if (result.store_bootstrapped) "true" else "false");
+        try writer.writeAll(",\"active_config\":");
+        try std.json.stringify(result.active_config, .{}, writer);
+        try writer.writeAll(",\"backup_config\":");
+        if (result.backup_config) |backup| try std.json.stringify(backup, .{}, writer) else try writer.writeAll("null");
+        try writer.writeAll(",\"store_root\":");
+        try std.json.stringify(result.store_root, .{}, writer);
+        try writer.writeAll(",\"account_dir\":");
+        try std.json.stringify(result.account_dir, .{}, writer);
+        try writer.writeAll(",\"ran_provider_login\":false,\"spends_provider_calls\":false,\"next_commands\":[");
+        try writeCommandJson(writer, login_command);
+        try writer.writeByte(',');
+        try writeCommandJson(writer, runtime_command);
+        try writer.writeByte(',');
+        try writeCommandJson(writer, accounts_command);
+        try writer.writeByte(',');
+        try writeCommandJson(writer, "oauth-mux stay-afloat refresh --profile codex-max --capability codex-max --json");
+        try writer.writeAll("]}\n");
+        return;
+    }
+
+    try writer.writeAll("oauth-mux enroll codex\n\n");
+    try writer.print("  account:             {s}\n", .{result.account});
+    try writer.print("  config changed:      {s}\n", .{if (result.config_changed) "yes" else "no"});
+    if (result.backup_config) |backup| try writer.print("  backup config:       {s}\n", .{backup});
+    try writer.print("  account dir:         {s}\n", .{result.account_dir});
+    try writer.writeAll("  provider login run:  no\n\n");
+    try writer.writeAll("next:\n");
+    try writer.print("  {s}\n", .{login_command});
+    try writer.print("  {s}\n", .{runtime_command});
+    try writer.print("  {s}\n", .{accounts_command});
+    try writer.writeAll("  oauth-mux stay-afloat refresh --profile codex-max --capability codex-max --json\n");
+}
+
+fn enrollCodexConfirmCommand(allocator: std.mem.Allocator, account: []const u8, store_root: ?[]const u8, json: bool) ![]const u8 {
+    if (store_root) |root| {
+        return try std.fmt.allocPrint(allocator, "oauth-mux enroll codex --account {s} --store-root {s} --confirm-enroll{s}", .{
+            account,
+            root,
+            if (json) " --json" else "",
+        });
+    }
+    return try std.fmt.allocPrint(allocator, "oauth-mux enroll codex --account {s} --confirm-enroll{s}", .{
+        account,
+        if (json) " --json" else "",
+    });
+}
+
+fn codexEnrollmentShapeConfigured(cfg: config.Config, account: []const u8) bool {
+    const codex_provider = cfg.providers.map.get("codex") orelse return false;
+    if (codex_provider.accounts.map.get(account) == null) return false;
+
+    const max_route = health_mod.capabilityKey("codex", account, "codex-max");
+    const mini_route = health_mod.capabilityKey("codex", account, "codex-mini");
+    return profileContainsProvider(cfg, "codex-max", max_route.slice()) and
+        profileContainsProvider(cfg, "codex-mini", mini_route.slice());
+}
+
+fn profileContainsProvider(cfg: config.Config, profile_name: []const u8, provider_ref: []const u8) bool {
+    const profile = cfg.profiles.map.get(profile_name) orelse return false;
+    for (profile.providers) |existing| {
+        if (std.mem.eql(u8, existing, provider_ref)) return true;
+    }
+    return false;
+}
+
+fn writeCodexEnrollConfigJson(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    active: config.Config,
+    store_root: []const u8,
+    account: []const u8,
+) !void {
+    try writer.writeAll("{\"version\":");
+    try writer.print("{d}", .{active.version});
+    try writer.writeAll(",\"defaults\":");
+    try std.json.stringify(active.defaults, .{}, writer);
+    try writer.writeAll(",\"policy\":");
+    try std.json.stringify(active.policy, .{}, writer);
+    try writer.writeAll(",\"provider_definitions\":");
+    try std.json.stringify(active.provider_definitions, .{}, writer);
+    try writer.writeAll(",\"providers\":{");
+
+    var first = true;
+    var provider_it = active.providers.map.iterator();
+    while (provider_it.next()) |entry| {
+        if (!first) try writer.writeByte(',');
+        first = false;
+        try std.json.stringify(entry.key_ptr.*, .{}, writer);
+        try writer.writeByte(':');
+        if (std.mem.eql(u8, entry.key_ptr.*, "codex")) {
+            try writeCodexProviderWithEnrollment(allocator, writer, entry.value_ptr.*, store_root, account);
+        } else {
+            try std.json.stringify(entry.value_ptr.*, .{}, writer);
+        }
+    }
+
+    try writer.writeAll("},\"profiles\":{");
+    first = true;
+    var profile_it = active.profiles.map.iterator();
+    while (profile_it.next()) |entry| {
+        if (!first) try writer.writeByte(',');
+        first = false;
+        const profile_name = entry.key_ptr.*;
+        try std.json.stringify(profile_name, .{}, writer);
+        try writer.writeByte(':');
+        if (std.mem.eql(u8, profile_name, "codex-max")) {
+            const route = health_mod.capabilityKey("codex", account, "codex-max");
+            try writeProfileWithAddedProvider(writer, entry.value_ptr.*, route.slice());
+        } else if (std.mem.eql(u8, profile_name, "codex-mini")) {
+            const route = health_mod.capabilityKey("codex", account, "codex-mini");
+            try writeProfileWithAddedProvider(writer, entry.value_ptr.*, route.slice());
+        } else {
+            try std.json.stringify(entry.value_ptr.*, .{}, writer);
+        }
+    }
+
+    try writer.writeAll("},\"strategies\":");
+    try std.json.stringify(active.strategies, .{}, writer);
+    try writer.writeAll("}\n");
+}
+
+fn writeCodexProviderWithEnrollment(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    active_provider: config.ProviderConfig,
+    store_root: []const u8,
+    account: []const u8,
+) !void {
+    try writer.writeAll("{\"kind\":");
+    try std.json.stringify(active_provider.kind, .{}, writer);
+    try writer.writeAll(",\"config_dir_env\":");
+    if (active_provider.config_dir_env) |config_dir_env| {
+        try std.json.stringify(config_dir_env, .{}, writer);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"accounts\":{");
+
+    var first = true;
+    var next_priority: i32 = 10;
+    var account_it = active_provider.accounts.map.iterator();
+    while (account_it.next()) |entry| {
+        if (!first) try writer.writeByte(',');
+        first = false;
+        try std.json.stringify(entry.key_ptr.*, .{}, writer);
+        try writer.writeByte(':');
+        try std.json.stringify(entry.value_ptr.*, .{}, writer);
+        if (entry.value_ptr.priority <= next_priority) next_priority = entry.value_ptr.priority - 10;
+    }
+
+    if (active_provider.accounts.map.get(account) == null) {
+        if (!first) try writer.writeByte(',');
+        try writeCodexMaxStarterAccount(allocator, writer, store_root, account, next_priority, true);
+    }
+
+    try writer.writeAll("}}");
+}
+
+fn writeProfileWithAddedProvider(writer: anytype, profile: config.ProfileConfig, provider_ref: []const u8) !void {
+    try writer.writeAll("{\"providers\":[");
+    var first = true;
+    var already_present = false;
+    for (profile.providers) |existing| {
+        if (!first) try writer.writeByte(',');
+        first = false;
+        try std.json.stringify(existing, .{}, writer);
+        if (std.mem.eql(u8, existing, provider_ref)) already_present = true;
+    }
+    if (!already_present) {
+        if (!first) try writer.writeByte(',');
+        try std.json.stringify(provider_ref, .{}, writer);
+    }
+    try writer.writeAll("],\"strategy\":");
+    if (profile.strategy) |strategy| {
+        try std.json.stringify(strategy, .{}, writer);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.print(",\"affinity_ttl_minutes\":{d}}}", .{profile.affinity_ttl_minutes});
+}
+
+fn writeActiveConfigAtomically(allocator: std.mem.Allocator, active_config_path: []const u8, backup_path: []const u8, bytes: []const u8) !void {
+    if (fileExistsAbsolute(backup_path)) return error.PathAlreadyExists;
+    if (std.fs.path.dirname(active_config_path)) |dir| try std.fs.cwd().makePath(dir);
+
+    const tmp_path = try std.fmt.allocPrint(allocator, "{s}.tmp-{x}", .{ active_config_path, std.crypto.random.int(u64) });
+    defer allocator.free(tmp_path);
+
+    const tmp_file = try std.fs.createFileAbsolute(tmp_path, .{ .exclusive = true, .mode = 0o600 });
+    errdefer std.fs.deleteFileAbsolute(tmp_path) catch {};
+    {
+        defer tmp_file.close();
+        try tmp_file.writeAll(bytes);
+    }
+
+    try std.fs.renameAbsolute(active_config_path, backup_path);
+    std.fs.renameAbsolute(tmp_path, active_config_path) catch |e| {
+        std.fs.renameAbsolute(backup_path, active_config_path) catch {};
+        return e;
+    };
 }
 
 fn writeEnrollPlanText(
@@ -560,7 +969,9 @@ fn writeEnrollPlanText(
     if (args.account) |account| try writer.print("  account: {s}\n", .{account});
     if (args.mode) |mode| try writer.print("  mode: {s}\n", .{mode});
     try writer.writeAll("  mutates: false\n");
-    try writer.writeAll("  provider-neutral enrollment mutation: not shipped yet\n\n");
+    try writer.print("  provider-neutral enrollment mutation: {s}\n\n", .{
+        if (args.provider != null and isProvider(args.provider.?, "codex")) "available with --confirm-enroll" else "not shipped yet",
+    });
 
     try writer.writeAll("  existing accounts:\n");
     try writeEnrollExistingAccountsText(writer, cfg, args.provider);
@@ -597,7 +1008,8 @@ fn writeEnrollPlanJson(
     try writer.writeAll(if (cfg != null) "true" else "false");
     try writer.writeAll(",\"provider_configured\":");
     try writer.writeAll(if (enrollProviderConfigured(cfg, args.provider)) "true" else "false");
-    try writer.writeAll(",\"provider_neutral_mutation_supported\":false");
+    try writer.writeAll(",\"provider_neutral_mutation_supported\":");
+    try writer.writeAll(if (args.provider != null and isProvider(args.provider.?, "codex")) "true" else "false");
     try writer.writeAll(",\"existing_accounts\":[");
     try writeEnrollExistingAccountsJson(writer, cfg, args.provider);
     try writer.writeAll("],\"steps\":[");
@@ -823,16 +1235,27 @@ fn writeEnrollPlanStepJson(
 
 fn writeEnrollFutureCommandJson(writer: anytype, allocator: std.mem.Allocator, args: cli.Command.EnrollArgs) !void {
     try writer.writeByte('{');
-    try writer.writeAll("\"available\":false,\"command\":");
     const provider_name = args.provider orelse {
+        try writer.writeAll("\"available\":false,\"command\":");
         try writer.writeAll("null,\"reason\":\"provider_required\"}");
         return;
     };
     const account = args.account orelse "<account>";
-    const command = try std.fmt.allocPrint(allocator, "oauth-mux enroll {s} --account {s}", .{ provider_name, account });
+    const available = isProvider(provider_name, "codex");
+    try writer.writeAll("\"available\":");
+    try writer.writeAll(if (available) "true" else "false");
+    try writer.writeAll(",\"command\":");
+    const command = if (available)
+        try std.fmt.allocPrint(allocator, "oauth-mux enroll codex --account {s} --confirm-enroll", .{account})
+    else
+        try std.fmt.allocPrint(allocator, "oauth-mux enroll {s} --account {s}", .{ provider_name, account });
     defer allocator.free(command);
     try std.json.stringify(command, .{}, writer);
-    try writer.writeAll(",\"reason\":\"not_implemented; use enroll plan and provider-owned setup commands\"}");
+    if (available) {
+        try writer.writeAll(",\"reason\":\"available_for_codex_config_and_store_scaffolding; provider login remains a user-run handoff\"}");
+    } else {
+        try writer.writeAll(",\"reason\":\"not_implemented; use enroll plan and provider-owned setup commands\"}");
+    }
 }
 
 fn enrollProviderConfigured(cfg: ?config.Config, provider_filter: ?[]const u8) bool {


### PR DESCRIPTION
## Summary

Adds the first consented provider-neutral enrollment mutation:

- `oauth-mux enroll codex --account <name> --confirm-enroll [--json]`
- refuses mutation without `--confirm-enroll`
- updates oauth-mux config with the new Codex account and Codex Max/Mini routes
- bootstraps the isolated local Codex account directory
- returns `oauth-mux codex login-device <name>` as a user-mediated handoff
- does not run Codex login, open browser/device auth, or spend provider calls

This uses the previously landed `accounts list` and `enroll plan` surfaces as the visibility/admission contract before mutation.

## Validation

- `nix develop --command just check-local`
- first-run E2E now proves: plan-only, confirmation refusal, confirmed N+1 config/store mutation, no provider login
- smoke: `oauth-mux enroll codex --account max-4 --json`
- smoke: `oauth-mux enroll plan codex --account max-4 --json`
