### PR TITLE
[figma] Add confirmed Figma enrollment

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ oauth-mux enroll plan codex --account max-4 --json
 oauth-mux enroll codex --account max-4 --confirm-enroll --json
 oauth-mux enroll plan claude --account work --json
 oauth-mux enroll claude --account work --confirm-enroll --json
+oauth-mux enroll plan figma --account design --mode pat --json
+oauth-mux enroll figma --account design --mode pat --secret-env OMUX_FIGMA_DESIGN_PAT --confirm-enroll --json
 oauth-mux discover --json
 oauth-mux doctor runtime --json
 ```
@@ -128,12 +130,12 @@ into an explicit provider-specific setup plan, marking which steps are
 agent-safe, interactive, mutating, or provider-call-spending before anything is
 run.
 
-`enroll codex --account <name> --confirm-enroll --json` and
-`enroll claude --account <name> --confirm-enroll --json` are the first
-consented provider-neutral enrollment mutations. They add named accounts to the
-active oauth-mux config, bootstrap isolated provider-owned config directories,
-and return explicit upstream login handoffs. They do not run provider login or
-provider probes.
+`enroll codex --account <name> --confirm-enroll --json`,
+`enroll claude --account <name> --confirm-enroll --json`, and
+`enroll figma --account <name> --mode <oauth|pat|plan> --confirm-enroll
+--json` are the first consented provider-neutral enrollment mutations. They add
+named accounts to the active oauth-mux config and return explicit login, secret,
+or proof handoffs. They do not run provider login or provider probes.
 
 `repair run` is the explicit mutation boundary. Without `--confirm-repair`, it
 will not open auth flows or run upstream CLI repair commands; it only reports
@@ -197,6 +199,8 @@ oauth-mux enroll plan codex --account max-4 --json
 oauth-mux enroll codex --account max-4 --confirm-enroll --json
 oauth-mux enroll plan claude --account work --json
 oauth-mux enroll claude --account work --confirm-enroll --json
+oauth-mux enroll plan figma --account design --mode pat --json
+oauth-mux enroll figma --account design --mode pat --secret-env OMUX_FIGMA_DESIGN_PAT --confirm-enroll --json
 oauth-mux codex login-device max-4
 oauth-mux setup codex
 oauth-mux codex canary

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -37,6 +37,7 @@ oauth-mux accounts list
 oauth-mux enroll plan <provider>
 oauth-mux enroll codex --account <name> --confirm-enroll
 oauth-mux enroll claude --account <name> --confirm-enroll
+oauth-mux enroll figma --account <name> --mode pat --confirm-enroll
 oauth-mux config validate
 oauth-mux discover --json
 oauth-mux doctor runtime --json
@@ -64,6 +65,8 @@ oauth-mux enroll plan codex --account max-4 --json
 oauth-mux enroll codex --account max-4 --confirm-enroll --json
 oauth-mux enroll plan claude --account work --json
 oauth-mux enroll claude --account work --confirm-enroll --json
+oauth-mux enroll plan figma --account design --mode pat --json
+oauth-mux enroll figma --account design --mode pat --secret-env OMUX_FIGMA_DESIGN_PAT --confirm-enroll --json
 oauth-mux codex login-device max-4
 oauth-mux setup codex
 oauth-mux codex canary
@@ -105,12 +108,13 @@ recorded liveness, and safe next commands without reading credential values.
 surface. It does not mutate config or auth state; it marks each provider-specific
 step as agent-safe, interactive, mutating, or provider-call-spending so users
 and agents can ask for consent at the right boundary.
-`oauth-mux enroll codex --account <name> --confirm-enroll --json` and
-`oauth-mux enroll claude --account <name> --confirm-enroll --json` are the
-first consented provider-neutral enrollment mutations. They update oauth-mux
-config, add provider routes, and bootstrap isolated local account directories.
-They do not run upstream login, open a browser, or spend provider calls; login
-handoffs remain explicit in `next_commands`.
+`oauth-mux enroll codex --account <name> --confirm-enroll --json`,
+`oauth-mux enroll claude --account <name> --confirm-enroll --json`, and
+`oauth-mux enroll figma --account <name> --mode <oauth|pat|plan>
+--confirm-enroll --json` are the first consented provider-neutral enrollment
+mutations. They update oauth-mux config, add provider routes, and return
+explicit login, secret, or proof handoffs. They do not run upstream login, open
+a browser, create token material, or spend provider calls.
 After a user-mediated upstream login, `oauth-mux stay-afloat refresh --profile
 <profile> --capability <capability> --json` is the concise evidence refresh
 step that can clear pending handoffs.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -42,6 +42,7 @@ oauth-mux accounts list --json
 oauth-mux enroll plan <provider> --json
 oauth-mux enroll codex --account <name> --confirm-enroll --json
 oauth-mux enroll claude --account <name> --confirm-enroll --json
+oauth-mux enroll figma --account <name> --mode pat --confirm-enroll --json
 oauth-mux discover
 ```
 
@@ -56,6 +57,8 @@ oauth-mux enroll plan codex --account max-4 --json
 oauth-mux enroll codex --account max-4 --confirm-enroll --json
 oauth-mux enroll plan claude --account work --json
 oauth-mux enroll claude --account work --confirm-enroll --json
+oauth-mux enroll plan figma --account design --mode pat --json
+oauth-mux enroll figma --account design --mode pat --secret-env OMUX_FIGMA_DESIGN_PAT --confirm-enroll --json
 oauth-mux codex login-device max-4
 oauth-mux setup codex
 oauth-mux codex canary
@@ -90,13 +93,15 @@ agent-safe, interactive, mutating, or provider-call-spending. Provider-neutral
 enrollment mutation is only available where the provider-owned consent contract
 has been implemented.
 
-`oauth-mux enroll codex --account <name> --confirm-enroll --json` and
-`oauth-mux enroll claude --account <name> --confirm-enroll --json` are the first
-provider-neutral enrollment mutations. They update the active oauth-mux config,
-add provider routes, and create isolated account directories. They do not run
-upstream login, open browser/device auth, or probe providers. The returned
-`next_commands` include explicit provider login handoffs plus runtime and
-inventory checks.
+`oauth-mux enroll codex --account <name> --confirm-enroll --json`,
+`oauth-mux enroll claude --account <name> --confirm-enroll --json`, and
+`oauth-mux enroll figma --account <name> --mode <oauth|pat|plan>
+--confirm-enroll --json` are the first provider-neutral enrollment mutations.
+They update the active oauth-mux config and add provider routes; Codex and
+Claude also create isolated account directories. Figma enrollment never creates
+token material. These commands do not run upstream login, open browser/device
+auth, or probe providers. The returned `next_commands` include explicit login,
+secret, proof, runtime, and inventory handoffs as appropriate.
 
 For profile-level stay-afloat checks, scope the runtime report:
 `oauth-mux doctor runtime --profile codex-max --capability codex-max --json`.
@@ -429,12 +434,12 @@ handoff, or a live proof run.
 setup sequence. Agents may present steps with `agent_safe:false` to a user or
 permission broker, but must not run those steps without explicit consent.
 
-`enroll codex --account <name> --confirm-enroll --json` and
-`enroll claude --account <name> --confirm-enroll --json` are not agent-safe by
-default because they mutate config and create account directories. Agents may
-request them through a permission broker, but must not infer that the account is
-authenticated until the user has run the returned login command and runtime
-checks pass.
+`enroll codex --account <name> --confirm-enroll --json`,
+`enroll claude --account <name> --confirm-enroll --json`, and
+`enroll figma --account <name> --confirm-enroll --json` are not agent-safe by
+default because they mutate config. Agents may request them through a
+permission broker, but must not infer that the account is authenticated until
+the user has run the returned login/secret/proof handoffs and checks pass.
 
 `report --redacted --json` is the support-bundle surface. It adds platform,
 config shape, provider/account labels, command availability, health summaries,
@@ -465,8 +470,12 @@ operator proof, `public_live_proven` for no-secret public metadata proof, and
 8. For Claude N+1, run
    `oauth-mux enroll claude --account <name> --confirm-enroll --json`, then the
    returned `env CLAUDE_CONFIG_DIR=... claude auth login` handoff.
-9. Run no-spend checks first: `status`, `health`, and credential parse probes.
-10. Run live probes only through `scripts/live-provider-qa.sh` or the manual
+9. For Figma N+1, run
+   `oauth-mux enroll figma --account <name> --mode <oauth|pat|plan>
+   --confirm-enroll --json`, then set the returned secret env var before any
+   proof probe.
+10. Run no-spend checks first: `status`, `health`, and credential parse probes.
+11. Run live probes only through `scripts/live-provider-qa.sh` or the manual
    Live Provider QA workflow.
 
 ## Operator Definition of Done

--- a/docs/spec/account-enrollment-agent-contract-2026-05-01.md
+++ b/docs/spec/account-enrollment-agent-contract-2026-05-01.md
@@ -50,11 +50,12 @@ step with `agent_safe`, `interactive`, `mutating`, and
 `spends_provider_calls`, and it explicitly reports provider-neutral enrollment
 mutation as available only where provider-owned consent flows are implemented.
 
-The first consented mutations are Codex and Claude:
+The first consented mutations are Codex, Claude, and Figma:
 
 ```bash
 oauth-mux enroll codex --account max-4 --confirm-enroll --json
 oauth-mux enroll claude --account work --confirm-enroll --json
+oauth-mux enroll figma --account design --mode pat --secret-env OMUX_FIGMA_DESIGN_PAT --confirm-enroll --json
 ```
 
 Confirmed Codex enrollment mutates only oauth-mux-owned state: active config,
@@ -66,6 +67,11 @@ Confirmed Claude enrollment follows the same boundary: active oauth-mux config,
 the `claude` profile route, and an isolated `CLAUDE_CONFIG_DIR` are scaffolded,
 then `claude auth login` is returned as a user-mediated handoff. oauth-mux does
 not run the Claude login command or rewrite Claude-owned credential state.
+
+Confirmed Figma enrollment is config-only. It adds a mode-specific Figma
+provider/profile route and an env-backed secret reference, but does not create
+token material, open OAuth, or run a proof probe. OAuth bearer, PAT, and
+plan/file metadata modes remain separate route shapes.
 
 ## User Stories
 
@@ -121,14 +127,14 @@ automatic quota repair.
 Figma needs auth-mode separation. OAuth bearer, PAT, and plan/file metadata
 routes must not collapse into one "Figma works" claim.
 
-Expected future flow:
+Expected flow:
 
 ```bash
-oauth-mux enroll figma --account work --mode oauth
-oauth-mux enroll figma --account service --mode pat
 oauth-mux enroll plan figma --account service --mode pat --json
+oauth-mux enroll figma --account service --mode pat --secret-env OMUX_FIGMA_SERVICE_PAT --confirm-enroll --json
+export OMUX_FIGMA_SERVICE_PAT=<figma-token>
 oauth-mux accounts list --provider figma --json
-oauth-mux probe --provider figma --account service --capability identity-pat --json
+oauth-mux probe --provider figma-pat --account service --capability identity-pat --json
 ```
 
 The proof gate must distinguish `scope_insufficient`, revoked token,
@@ -174,7 +180,7 @@ handoff rather than trying to run browser/device auth silently.
 - safe next commands;
 - the future provider-neutral mutation command with `available:false`.
 
-For Codex and Claude, that command is now available and points to
+For Codex, Claude, and Figma, that command is now available and points to
 `oauth-mux enroll <provider> --account <name> --confirm-enroll`.
 
 Account state is intentionally coarse:
@@ -230,10 +236,10 @@ Mutation-capable tools such as `enroll.start`, `enroll.complete`, or
 evidence. MCP tools should preserve the same action taxonomy as the CLI:
 diagnostic, handoff, probe, repair, and mutation.
 
-For the current Codex and Claude implementations, the mutation-capable tool
+For the current Codex, Claude, and Figma implementations, the mutation-capable tool
 equivalent should expose the same shape as `enroll <provider>
---confirm-enroll`: config/store scaffolding only, with provider login returned
-as a user-mediated handoff.
+--confirm-enroll`: config/store scaffolding only, with provider login, secret,
+or proof setup returned as a user-mediated handoff.
 
 ## Implementation Slices
 
@@ -244,5 +250,6 @@ as a user-mediated handoff.
    `enroll codex --account <name> --confirm-enroll`.
 4. Shipped Claude account-store enrollment as
    `enroll claude --account <name> --confirm-enroll`.
-5. Add Figma OAuth/PAT enrollment mutation planning and proof fixtures.
+5. Shipped Figma OAuth/PAT/plan enrollment scaffolding as
+   `enroll figma --account <name> --mode <oauth|pat|plan> --confirm-enroll`.
 6. Define the MCP tool schema against the same JSON surfaces.

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -113,8 +113,10 @@ second slice is `oauth-mux enroll plan <provider> --json`, which explains the
 provider-specific setup path and labels each step before any mutation. The
 third slice is Codex `oauth-mux enroll codex --account <name> --confirm-enroll
 --json`; the fourth slice is Claude `oauth-mux enroll claude --account <name>
---confirm-enroll --json`. Both mutate oauth-mux config/store scaffolding but
-return upstream login as a user-mediated handoff.
+--confirm-enroll --json`; the fifth slice is Figma `oauth-mux enroll figma
+--account <name> --mode <oauth|pat|plan> --confirm-enroll --json`. These mutate
+oauth-mux config/store scaffolding but return upstream login, secret, or proof
+setup as user-mediated handoffs.
 
 Core product docs must remain service-manager agnostic. `systemctl`,
 `launchctl`, Homebrew services, cron, and Windows Services can become wrapper
@@ -185,8 +187,8 @@ these precise provider-proof children.
 1. Keep provider-neutral account inventory and enrollment planning aligned with
    the account-enrollment contract, so agents can inspect N configured accounts
    and explain setup before route, repair, handoff, or live-proof decisions.
-2. Use the Codex and Claude confirmed enrollment paths as the consent/mutation
-   reference before adding Figma or MCP mutation tools.
+2. Use the Codex, Claude, and Figma confirmed enrollment paths as the
+   consent/mutation reference before adding MCP mutation tools.
 3. Update website/release copy to use the public `jesssullivan/omux` Homebrew
    tap and close `#66` / `TIN-858` after those surfaces are aligned.
 4. Finish `TIN-862` by adding Linear OAuth bearer proof. GitHub identity and

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -516,4 +516,61 @@ jq -e '
   and any(.accounts[]; .account == "work" and .secret_backend == "file")
 ' "$accounts_after_claude_json" >/dev/null
 
+printf 'first-run e2e: enroll figma requires explicit confirmation and mode truth\n'
+enroll_figma_preview_json="$tmp/enroll-figma-preview.json"
+run_json "$enroll_figma_preview_json" enroll figma --account design --mode pat --secret-env OMUX_FIGMA_DESIGN_PAT --json
+jq -e '
+  .ok == false
+  and .confirmation_required == true
+  and .requires == "--confirm-enroll"
+  and .provider == "figma"
+  and .account == "design"
+  and .mode == "pat"
+  and .config_provider == "figma-pat"
+  and .capability == "identity-pat"
+  and .secret_backend == "env"
+  and .secret_env == "OMUX_FIGMA_DESIGN_PAT"
+  and .spends_provider_calls == false
+  and (.confirm_command | contains("oauth-mux enroll figma --account design --mode pat --secret-env OMUX_FIGMA_DESIGN_PAT --confirm-enroll"))
+  and (.proof_command == "oauth-mux probe --provider figma-pat --account design --capability identity-pat --json")
+  and .plan.provider_neutral_mutation_supported == true
+' "$enroll_figma_preview_json" >/dev/null
+jq -e '
+  (.providers["figma-pat"] == null)
+  and (.profiles["figma-pat"] == null)
+' "$config_path" >/dev/null
+
+printf 'first-run e2e: confirmed enroll figma adds env-backed route without token creation\n'
+enroll_figma_confirmed_json="$tmp/enroll-figma-confirmed.json"
+run_json "$enroll_figma_confirmed_json" enroll figma --account design --mode pat --secret-env OMUX_FIGMA_DESIGN_PAT --confirm-enroll --json
+jq -e '
+  .ok == true
+  and .executed == true
+  and .provider == "figma"
+  and .account == "design"
+  and .mode == "pat"
+  and .config_provider == "figma-pat"
+  and .capability == "identity-pat"
+  and .secret_backend == "env"
+  and .secret_env == "OMUX_FIGMA_DESIGN_PAT"
+  and .config_changed == true
+  and .created_secret == false
+  and .ran_provider_login == false
+  and .spends_provider_calls == false
+  and .backup_config != null
+  and (.next_commands | index("export OMUX_FIGMA_DESIGN_PAT=<figma-token>") != null)
+  and (.next_commands | index("oauth-mux probe --provider figma-pat --account design --capability identity-pat --json") != null)
+' "$enroll_figma_confirmed_json" >/dev/null
+jq -e '
+  (.providers["figma-pat"].kind == "figma")
+  and (.providers["figma-pat"].accounts.design.secret.backend == "env")
+  and (.providers["figma-pat"].accounts.design.secret.variable == "OMUX_FIGMA_DESIGN_PAT")
+  and (.profiles["figma-pat"].providers | index("figma-pat:design#identity-pat") != null)
+' "$config_path" >/dev/null
+accounts_after_figma_json="$tmp/accounts-after-figma.json"
+run_json "$accounts_after_figma_json" accounts list --provider figma --json
+jq -e '
+  any(.accounts[]; .provider == "figma-pat" and .account == "design" and .secret_backend == "env")
+' "$accounts_after_figma_json" >/dev/null
+
 printf 'first-run e2e passed\n'

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -102,6 +102,7 @@ pub const Command = union(enum) {
         plan,
         codex,
         claude,
+        figma,
     };
 
     pub const EnrollArgs = struct {
@@ -110,6 +111,7 @@ pub const Command = union(enum) {
         account: ?[]const u8 = null,
         mode: ?[]const u8 = null,
         store_root: ?[]const u8 = null,
+        secret_env: ?[]const u8 = null,
         confirm_enroll: bool = false,
         json: bool = false,
     };
@@ -444,9 +446,13 @@ fn parseEnroll(args: []const []const u8) Command {
         result.action = .claude;
         result.provider = "claude";
         i = 1;
+    } else if (args.len > 0 and eql(args[0], "figma")) {
+        result.action = .figma;
+        result.provider = "figma";
+        i = 1;
     }
     if (i < args.len and !std.mem.startsWith(u8, args[i], "--")) {
-        if (result.action == .codex or result.action == .claude) {
+        if (result.action == .codex or result.action == .claude or result.action == .figma) {
             result.account = args[i];
         } else {
             result.provider = args[i];
@@ -466,6 +472,9 @@ fn parseEnroll(args: []const []const u8) Command {
         } else if (eql(args[i], "--store-root") or eql(args[i], "--config-root")) {
             i += 1;
             if (i < args.len) result.store_root = args[i];
+        } else if (eql(args[i], "--secret-env")) {
+            i += 1;
+            if (i < args.len) result.secret_env = args[i];
         } else if (eql(args[i], "--confirm-enroll") or eql(args[i], "--confirm")) {
             result.confirm_enroll = true;
         } else if (eql(args[i], "--json")) {
@@ -890,6 +899,9 @@ pub fn printUsage(writer: anytype) !void {
         \\
         \\  enroll claude --account <name> [--config-root <path>] [--confirm-enroll] [--json]
         \\      Add a Claude account config dir; does not run Claude login.
+        \\
+        \\  enroll figma --account <name> [--mode oauth|pat|plan] [--secret-env <name>] [--confirm-enroll] [--json]
+        \\      Add a Figma account secret route; does not create or validate token material.
         \\
         \\  status [--json] [--provider <name>]
         \\      Show active accounts, health scores, and circuit states.
@@ -1322,6 +1334,23 @@ test "parse enroll claude account confirmation" {
     }
 }
 
+test "parse enroll figma account mode secret env confirmation" {
+    const args = [_][]const u8{ "enroll", "figma", "service", "--mode", "pat", "--secret-env", "OMUX_FIGMA_SERVICE_PAT", "--confirm", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .enroll => |enroll| {
+            try std.testing.expect(enroll.action == .figma);
+            try std.testing.expectEqualStrings("figma", enroll.provider.?);
+            try std.testing.expectEqualStrings("service", enroll.account.?);
+            try std.testing.expectEqualStrings("pat", enroll.mode.?);
+            try std.testing.expectEqualStrings("OMUX_FIGMA_SERVICE_PAT", enroll.secret_env.?);
+            try std.testing.expect(enroll.confirm_enroll);
+            try std.testing.expect(enroll.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 test "parse repair plan with profile" {
     const args = [_][]const u8{ "repair-plan", "--profile", "codex-max", "--json" };
     const cmd = parse(&args);
@@ -1565,12 +1594,13 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from providers' -a 'list' -d 'Provider subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from accounts' -a 'list' -d 'Accounts subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from accounts' -l provider -d 'Provider name' -r
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -a 'plan codex claude' -d 'Enrollment subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -a 'plan codex claude figma' -d 'Enrollment subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -l provider -d 'Provider name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -l account -d 'Account name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -l mode -d 'Enrollment mode' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -l store-root -d 'Codex store root' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -l config-root -d 'Provider config root' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -l secret-env -d 'Secret env var name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -l confirm-enroll -d 'Confirm config/store mutation'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from enroll' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from env' -l shell -d 'Shell type' -r -a 'fish zsh bash ksh'

--- a/src/main.zig
+++ b/src/main.zig
@@ -547,6 +547,7 @@ fn runEnroll(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.En
         },
         .codex => try runEnrollCodex(allocator, writer, args),
         .claude => try runEnrollClaude(allocator, writer, args),
+        .figma => try runEnrollFigma(allocator, writer, args),
     }
 }
 
@@ -749,6 +750,107 @@ fn runEnrollClaude(allocator: std.mem.Allocator, writer: anytype, args: cli.Comm
     try writeEnrollClaudeResult(writer, allocator, result, args.json);
 }
 
+const EnrollFigmaResult = struct {
+    ok: bool,
+    reason: []const u8,
+    account: []const u8,
+    mode: []const u8,
+    provider: []const u8,
+    profile: []const u8,
+    capability: []const u8,
+    secret_env: []const u8,
+    active_config: []const u8,
+    backup_config: ?[]const u8 = null,
+    config_changed: bool = false,
+};
+
+fn runEnrollFigma(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.EnrollArgs) !void {
+    const account = args.account orelse {
+        if (args.json) {
+            try writer.writeAll("{\"ok\":false,\"error\":\"missing_account\",\"mutates\":true,\"requires\":\"--account <name>\",\"next_commands\":[");
+            try writeCommandJson(writer, "oauth-mux enroll plan figma --json");
+            try writer.writeAll("]}\n");
+        } else {
+            try writer.writeAll("oauth-mux enroll figma\n\n");
+            try writer.writeAll("  missing required --account <name>\n");
+            try writer.writeAll("  next: oauth-mux enroll plan figma --json\n");
+        }
+        return;
+    };
+
+    const mode = figmaEnrollmentMode(args.mode);
+    const provider_name = figmaProviderForMode(mode);
+    const profile_name = provider_name;
+    const capability = figmaCapabilityForMode(mode);
+    const secret_env = if (args.secret_env) |value|
+        try allocator.dupe(u8, value)
+    else
+        try figmaDefaultSecretEnv(allocator, account, mode);
+    defer allocator.free(secret_env);
+
+    const active_config_path = try paths.configFilePath(allocator);
+    defer allocator.free(active_config_path);
+
+    if (!args.confirm_enroll) {
+        try writeEnrollFigmaConfirmationRequired(writer, allocator, args, active_config_path, provider_name, profile_name, capability, secret_env);
+        return;
+    }
+
+    var active = config.loadFromPath(allocator, active_config_path) catch |e| {
+        if (args.json) {
+            try writer.writeAll("{\"ok\":false,\"error\":");
+            try std.json.stringify(@errorName(e), .{}, writer);
+            try writer.writeAll(",\"message\":\"active config is required before confirmed Figma enrollment\",\"next_commands\":[");
+            try writeCommandJson(writer, "oauth-mux init");
+            try writer.writeAll("]}\n");
+        } else {
+            try writer.writeAll("oauth-mux enroll figma\n\n");
+            try writer.print("  config unavailable: {s}\n", .{@errorName(e)});
+            try writer.writeAll("  next: oauth-mux init\n");
+        }
+        return;
+    };
+    defer active.deinit();
+    try config.validate(active.value, std.io.null_writer);
+
+    var result = EnrollFigmaResult{
+        .ok = true,
+        .reason = "enrolled_figma_account",
+        .account = account,
+        .mode = mode,
+        .provider = provider_name,
+        .profile = profile_name,
+        .capability = capability,
+        .secret_env = secret_env,
+        .active_config = active_config_path,
+    };
+
+    var backup_config: ?[]const u8 = null;
+    defer if (backup_config) |backup| allocator.free(backup);
+
+    const config_changed = !figmaEnrollmentShapeConfigured(active.value, provider_name, profile_name, account, capability);
+    if (config_changed) {
+        var config_buf = std.ArrayList(u8).init(allocator);
+        defer config_buf.deinit();
+        try writeFigmaEnrollConfigJson(config_buf.writer(), active.value, provider_name, profile_name, account, mode, capability, secret_env);
+
+        const parsed = try config.loadFromBytes(allocator, config_buf.items);
+        defer parsed.deinit();
+        try config.validate(parsed.value, std.io.null_writer);
+        if (!figmaEnrollmentShapeConfigured(parsed.value, provider_name, profile_name, account, capability)) return error.ConfigValidationError;
+
+        backup_config = try defaultCodexConfigBackupPath(allocator, active_config_path);
+        try writeActiveConfigAtomically(allocator, active_config_path, backup_config.?, config_buf.items);
+
+        result.backup_config = backup_config.?;
+        result.config_changed = true;
+    } else {
+        result.reason = "figma_account_already_configured";
+    }
+
+    try writeEnrollFigmaResult(writer, allocator, result, args.json);
+}
+
 fn writeEnrollCodexConfirmationRequired(
     writer: anytype,
     allocator: std.mem.Allocator,
@@ -829,6 +931,60 @@ fn writeEnrollClaudeConfirmationRequired(
     try writer.print("  {s}\n", .{confirm_command});
 }
 
+fn writeEnrollFigmaConfirmationRequired(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    args: cli.Command.EnrollArgs,
+    active_config_path: []const u8,
+    provider_name: []const u8,
+    profile_name: []const u8,
+    capability: []const u8,
+    secret_env: []const u8,
+) !void {
+    const account = args.account orelse "<account>";
+    const confirm_command = try enrollFigmaConfirmCommand(allocator, account, args.mode, args.secret_env, args.json);
+    defer allocator.free(confirm_command);
+    const probe_command = try enrollProbeCommand(allocator, provider_name, args.account, capability);
+    defer allocator.free(probe_command);
+
+    if (args.json) {
+        try writer.writeAll("{\"ok\":false,\"executed\":false,\"confirmation_required\":true,\"requires\":\"--confirm-enroll\",\"mutates\":true,\"interactive\":false,\"spends_provider_calls\":false,\"provider\":\"figma\",\"account\":");
+        try std.json.stringify(account, .{}, writer);
+        try writer.writeAll(",\"mode\":");
+        try std.json.stringify(figmaEnrollmentMode(args.mode), .{}, writer);
+        try writer.writeAll(",\"config_provider\":");
+        try std.json.stringify(provider_name, .{}, writer);
+        try writer.writeAll(",\"profile\":");
+        try std.json.stringify(profile_name, .{}, writer);
+        try writer.writeAll(",\"capability\":");
+        try std.json.stringify(capability, .{}, writer);
+        try writer.writeAll(",\"secret_backend\":\"env\",\"secret_env\":");
+        try std.json.stringify(secret_env, .{}, writer);
+        try writer.writeAll(",\"active_config\":");
+        try std.json.stringify(active_config_path, .{}, writer);
+        try writer.writeAll(",\"confirm_command\":");
+        try std.json.stringify(confirm_command, .{}, writer);
+        try writer.writeAll(",\"proof_command\":");
+        try std.json.stringify(probe_command, .{}, writer);
+        try writer.writeAll(",\"plan\":");
+        try writeEnrollPlanJsonInline(writer, allocator, args);
+        try writer.writeAll("}\n");
+        return;
+    }
+
+    try writer.writeAll("oauth-mux enroll figma\n\n");
+    try writer.writeAll("  confirmation required: --confirm-enroll\n");
+    try writer.writeAll("  mutates: active oauth-mux config only\n");
+    try writer.writeAll("  does not create: Figma token material, OAuth browser auth, provider probes\n\n");
+    try writer.print("  active config: {s}\n", .{active_config_path});
+    try writer.print("  provider:      {s}\n", .{provider_name});
+    try writer.print("  profile:       {s}\n", .{profile_name});
+    try writer.print("  capability:    {s}\n", .{capability});
+    try writer.print("  secret env:    {s}\n\n", .{secret_env});
+    try writer.writeAll("next:\n");
+    try writer.print("  {s}\n", .{confirm_command});
+}
+
 fn writeEnrollPlanJsonInline(writer: anytype, allocator: std.mem.Allocator, args: cli.Command.EnrollArgs) !void {
     var parsed_config: ?std.json.Parsed(config.Config) = config.load(allocator) catch null;
     defer if (parsed_config) |*parsed| parsed.deinit();
@@ -841,6 +997,7 @@ fn writeEnrollPlanJsonInline(writer: anytype, allocator: std.mem.Allocator, args
         .account = args.account,
         .mode = args.mode,
         .store_root = args.store_root,
+        .secret_env = args.secret_env,
         .json = true,
     };
 
@@ -987,6 +1144,65 @@ fn writeEnrollClaudeResult(writer: anytype, allocator: std.mem.Allocator, result
     try writer.writeAll("  oauth-mux stay-afloat refresh --profile claude --capability auth-status --json\n");
 }
 
+fn writeEnrollFigmaResult(writer: anytype, allocator: std.mem.Allocator, result: EnrollFigmaResult, json: bool) !void {
+    const accounts_command = try enrollAccountsCommand(allocator, "figma");
+    defer allocator.free(accounts_command);
+    const probe_command = try enrollProbeCommand(allocator, result.provider, result.account, result.capability);
+    defer allocator.free(probe_command);
+    const export_command = try figmaSecretExportCommand(allocator, result.secret_env);
+    defer allocator.free(export_command);
+
+    if (json) {
+        try writer.writeAll("{\"ok\":");
+        try writer.writeAll(if (result.ok) "true" else "false");
+        try writer.writeAll(",\"executed\":true,\"provider\":\"figma\",\"account\":");
+        try std.json.stringify(result.account, .{}, writer);
+        try writer.writeAll(",\"reason\":");
+        try std.json.stringify(result.reason, .{}, writer);
+        try writer.writeAll(",\"mode\":");
+        try std.json.stringify(result.mode, .{}, writer);
+        try writer.writeAll(",\"config_provider\":");
+        try std.json.stringify(result.provider, .{}, writer);
+        try writer.writeAll(",\"profile\":");
+        try std.json.stringify(result.profile, .{}, writer);
+        try writer.writeAll(",\"capability\":");
+        try std.json.stringify(result.capability, .{}, writer);
+        try writer.writeAll(",\"secret_backend\":\"env\",\"secret_env\":");
+        try std.json.stringify(result.secret_env, .{}, writer);
+        try writer.writeAll(",\"config_changed\":");
+        try writer.writeAll(if (result.config_changed) "true" else "false");
+        try writer.writeAll(",\"active_config\":");
+        try std.json.stringify(result.active_config, .{}, writer);
+        try writer.writeAll(",\"backup_config\":");
+        if (result.backup_config) |backup| try std.json.stringify(backup, .{}, writer) else try writer.writeAll("null");
+        try writer.writeAll(",\"created_secret\":false,\"ran_provider_login\":false,\"spends_provider_calls\":false,\"next_commands\":[");
+        try writeCommandJson(writer, export_command);
+        try writer.writeByte(',');
+        try writeCommandJson(writer, "oauth-mux config validate");
+        try writer.writeByte(',');
+        try writeCommandJson(writer, accounts_command);
+        try writer.writeByte(',');
+        try writeCommandJson(writer, probe_command);
+        try writer.writeAll("]}\n");
+        return;
+    }
+
+    try writer.writeAll("oauth-mux enroll figma\n\n");
+    try writer.print("  account:             {s}\n", .{result.account});
+    try writer.print("  mode:                {s}\n", .{result.mode});
+    try writer.print("  provider/profile:    {s} / {s}\n", .{ result.provider, result.profile });
+    try writer.print("  capability:          {s}\n", .{result.capability});
+    try writer.print("  secret env:          {s}\n", .{result.secret_env});
+    try writer.print("  config changed:      {s}\n", .{if (result.config_changed) "yes" else "no"});
+    if (result.backup_config) |backup| try writer.print("  backup config:       {s}\n", .{backup});
+    try writer.writeAll("  provider login run:  no\n\n");
+    try writer.writeAll("next:\n");
+    try writer.print("  {s}\n", .{export_command});
+    try writer.writeAll("  oauth-mux config validate\n");
+    try writer.print("  {s}\n", .{accounts_command});
+    try writer.print("  {s}\n", .{probe_command});
+}
+
 fn enrollCodexConfirmCommand(allocator: std.mem.Allocator, account: []const u8, store_root: ?[]const u8, json: bool) ![]const u8 {
     if (store_root) |root| {
         return try std.fmt.allocPrint(allocator, "oauth-mux enroll codex --account {s} --store-root {s} --confirm-enroll{s}", .{
@@ -1021,6 +1237,34 @@ fn enrollClaudeLoginCommand(allocator: std.mem.Allocator, account_dir: []const u
     return try std.fmt.allocPrint(allocator, "env CLAUDE_CONFIG_DIR={s} claude auth login", .{quoted_dir});
 }
 
+fn enrollFigmaConfirmCommand(
+    allocator: std.mem.Allocator,
+    account: []const u8,
+    mode: ?[]const u8,
+    secret_env: ?[]const u8,
+    json: bool,
+) ![]const u8 {
+    var command = std.ArrayList(u8).init(allocator);
+    errdefer command.deinit();
+    try command.appendSlice("oauth-mux enroll figma --account ");
+    try command.appendSlice(account);
+    if (mode) |value| {
+        try command.appendSlice(" --mode ");
+        try command.appendSlice(value);
+    }
+    if (secret_env) |value| {
+        try command.appendSlice(" --secret-env ");
+        try command.appendSlice(value);
+    }
+    try command.appendSlice(" --confirm-enroll");
+    if (json) try command.appendSlice(" --json");
+    return command.toOwnedSlice();
+}
+
+fn figmaSecretExportCommand(allocator: std.mem.Allocator, secret_env: []const u8) ![]const u8 {
+    return try std.fmt.allocPrint(allocator, "export {s}=<figma-token>", .{secret_env});
+}
+
 fn codexEnrollmentShapeConfigured(cfg: config.Config, account: []const u8) bool {
     const codex_provider = cfg.providers.map.get("codex") orelse return false;
     if (codex_provider.accounts.map.get(account) == null) return false;
@@ -1037,6 +1281,20 @@ fn claudeEnrollmentShapeConfigured(cfg: config.Config, account: []const u8) bool
 
     const route = health_mod.capabilityKey("claude", account, "auth-status");
     return profileContainsProvider(cfg, "claude", route.slice());
+}
+
+fn figmaEnrollmentShapeConfigured(
+    cfg: config.Config,
+    provider_name: []const u8,
+    profile_name: []const u8,
+    account: []const u8,
+    capability: []const u8,
+) bool {
+    const figma_provider = cfg.providers.map.get(provider_name) orelse return false;
+    if (figma_provider.accounts.map.get(account) == null) return false;
+
+    const route = health_mod.capabilityKey(provider_name, account, capability);
+    return profileContainsProvider(cfg, profile_name, route.slice());
 }
 
 fn profileContainsProvider(cfg: config.Config, profile_name: []const u8, provider_ref: []const u8) bool {
@@ -1174,6 +1432,80 @@ fn writeClaudeEnrollConfigJson(
     try writer.writeAll("}\n");
 }
 
+fn writeFigmaEnrollConfigJson(
+    writer: anytype,
+    active: config.Config,
+    provider_name: []const u8,
+    profile_name: []const u8,
+    account: []const u8,
+    mode: []const u8,
+    capability: []const u8,
+    secret_env: []const u8,
+) !void {
+    try writer.writeAll("{\"version\":");
+    try writer.print("{d}", .{active.version});
+    try writer.writeAll(",\"defaults\":");
+    try std.json.stringify(active.defaults, .{}, writer);
+    try writer.writeAll(",\"policy\":");
+    try std.json.stringify(active.policy, .{}, writer);
+    try writer.writeAll(",\"provider_definitions\":");
+    try std.json.stringify(active.provider_definitions, .{}, writer);
+    try writer.writeAll(",\"providers\":{");
+
+    var first = true;
+    var wrote_figma = false;
+    var provider_it = active.providers.map.iterator();
+    while (provider_it.next()) |entry| {
+        if (!first) try writer.writeByte(',');
+        first = false;
+        try std.json.stringify(entry.key_ptr.*, .{}, writer);
+        try writer.writeByte(':');
+        if (std.mem.eql(u8, entry.key_ptr.*, provider_name)) {
+            try writeFigmaProviderWithEnrollment(writer, entry.value_ptr.*, account, mode, secret_env);
+            wrote_figma = true;
+        } else {
+            try std.json.stringify(entry.value_ptr.*, .{}, writer);
+        }
+    }
+    if (!wrote_figma) {
+        if (!first) try writer.writeByte(',');
+        try std.json.stringify(provider_name, .{}, writer);
+        try writer.writeByte(':');
+        try writeFigmaProviderWithEnrollment(writer, null, account, mode, secret_env);
+    }
+
+    const route = health_mod.capabilityKey(provider_name, account, capability);
+    const profile_strategy = enrollmentProfileStrategy(active);
+
+    try writer.writeAll("},\"profiles\":{");
+    first = true;
+    var wrote_figma_profile = false;
+    var profile_it = active.profiles.map.iterator();
+    while (profile_it.next()) |entry| {
+        if (!first) try writer.writeByte(',');
+        first = false;
+        const current_profile_name = entry.key_ptr.*;
+        try std.json.stringify(current_profile_name, .{}, writer);
+        try writer.writeByte(':');
+        if (std.mem.eql(u8, current_profile_name, profile_name)) {
+            try writeProfileWithAddedProvider(writer, entry.value_ptr.*, route.slice());
+            wrote_figma_profile = true;
+        } else {
+            try std.json.stringify(entry.value_ptr.*, .{}, writer);
+        }
+    }
+    if (!wrote_figma_profile) {
+        if (!first) try writer.writeByte(',');
+        try std.json.stringify(profile_name, .{}, writer);
+        try writer.writeByte(':');
+        try writeSingleRouteProfile(writer, route.slice(), profile_strategy);
+    }
+
+    try writer.writeAll("},\"strategies\":");
+    try std.json.stringify(active.strategies, .{}, writer);
+    try writer.writeAll("}\n");
+}
+
 fn writeCodexProviderWithEnrollment(
     allocator: std.mem.Allocator,
     writer: anytype,
@@ -1280,6 +1612,72 @@ fn writeClaudeStarterAccount(
     try writer.writeAll(",\"secret\":{\"backend\":\"file\",\"path\":");
     try std.json.stringify(credentials_path, .{}, writer);
     try writer.writeAll("},\"tags\":[\"oauth\",\"claude\"]}");
+}
+
+fn writeFigmaProviderWithEnrollment(
+    writer: anytype,
+    active_provider: ?config.ProviderConfig,
+    account: []const u8,
+    mode: []const u8,
+    secret_env: []const u8,
+) !void {
+    try writer.writeAll("{\"kind\":");
+    if (active_provider) |provider_cfg| {
+        try std.json.stringify(provider_cfg.kind, .{}, writer);
+    } else {
+        try std.json.stringify("figma", .{}, writer);
+    }
+    try writer.writeAll(",\"config_dir_env\":");
+    if (active_provider) |provider_cfg| {
+        if (provider_cfg.config_dir_env) |config_dir_env| {
+            try std.json.stringify(config_dir_env, .{}, writer);
+        } else {
+            try writer.writeAll("null");
+        }
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"accounts\":{");
+
+    var first = true;
+    var next_priority: i32 = 10;
+    var account_present = false;
+    if (active_provider) |provider_cfg| {
+        var account_it = provider_cfg.accounts.map.iterator();
+        while (account_it.next()) |entry| {
+            if (!first) try writer.writeByte(',');
+            first = false;
+            try std.json.stringify(entry.key_ptr.*, .{}, writer);
+            try writer.writeByte(':');
+            try std.json.stringify(entry.value_ptr.*, .{}, writer);
+            if (entry.value_ptr.priority <= next_priority) next_priority = entry.value_ptr.priority - 10;
+            if (std.mem.eql(u8, entry.key_ptr.*, account)) account_present = true;
+        }
+    }
+
+    if (!account_present) {
+        if (!first) try writer.writeByte(',');
+        try writeFigmaStarterAccount(writer, account, mode, secret_env, next_priority);
+    }
+
+    try writer.writeAll("}}");
+}
+
+fn writeFigmaStarterAccount(
+    writer: anytype,
+    account: []const u8,
+    mode: []const u8,
+    secret_env: []const u8,
+    priority: i32,
+) !void {
+    try std.json.stringify(account, .{}, writer);
+    try writer.writeAll(":{\"priority\":");
+    try writer.print("{d}", .{priority});
+    try writer.writeAll(",\"secret\":{\"backend\":\"env\",\"variable\":");
+    try std.json.stringify(secret_env, .{}, writer);
+    try writer.writeAll("},\"tags\":[");
+    try std.json.stringify(mode, .{}, writer);
+    try writer.writeAll(",\"figma\"]}");
 }
 
 fn writeProfileWithAddedProvider(writer: anytype, profile: config.ProfileConfig, provider_ref: []const u8) !void {
@@ -1636,7 +2034,9 @@ fn writeEnrollFutureCommandJson(writer: anytype, allocator: std.mem.Allocator, a
     try writer.writeAll("\"available\":");
     try writer.writeAll(if (available) "true" else "false");
     try writer.writeAll(",\"command\":");
-    const command = if (available)
+    const command = if (available and isProvider(provider_name, "figma"))
+        try enrollFigmaConfirmCommand(allocator, account, args.mode, args.secret_env, false)
+    else if (available)
         try std.fmt.allocPrint(allocator, "oauth-mux enroll {s} --account {s} --confirm-enroll", .{ provider_name, account })
     else
         try std.fmt.allocPrint(allocator, "oauth-mux enroll {s} --account {s}", .{ provider_name, account });
@@ -1669,7 +2069,20 @@ fn isProvider(provider_name: []const u8, expected: []const u8) bool {
 }
 
 fn enrollMutationSupported(provider_name: []const u8) bool {
-    return isProvider(provider_name, "codex") or isProvider(provider_name, "claude");
+    return isProvider(provider_name, "codex") or isProvider(provider_name, "claude") or isProvider(provider_name, "figma");
+}
+
+fn figmaEnrollmentMode(mode: ?[]const u8) []const u8 {
+    const value = mode orelse return "oauth";
+    if (isProvider(value, "pat")) return "pat";
+    if (isProvider(value, "plan") or isProvider(value, "file") or isProvider(value, "file-metadata")) return "plan";
+    return "oauth";
+}
+
+fn figmaProviderForMode(mode: []const u8) []const u8 {
+    if (isProvider(mode, "pat")) return "figma-pat";
+    if (isProvider(mode, "plan")) return "figma-plan";
+    return "figma";
 }
 
 fn figmaCapabilityForMode(mode: ?[]const u8) []const u8 {
@@ -1677,6 +2090,25 @@ fn figmaCapabilityForMode(mode: ?[]const u8) []const u8 {
     if (isProvider(value, "pat")) return "identity-pat";
     if (isProvider(value, "plan") or isProvider(value, "file") or isProvider(value, "file-metadata")) return "file-metadata-plan";
     return "identity";
+}
+
+fn figmaDefaultSecretEnv(allocator: std.mem.Allocator, account: []const u8, mode: []const u8) ![]const u8 {
+    var normalized_account = std.ArrayList(u8).init(allocator);
+    defer normalized_account.deinit();
+    for (account) |c| {
+        if (std.ascii.isAlphanumeric(c)) {
+            try normalized_account.append(std.ascii.toUpper(c));
+        } else {
+            try normalized_account.append('_');
+        }
+    }
+    const suffix = if (isProvider(mode, "pat"))
+        "PAT"
+    else if (isProvider(mode, "plan"))
+        "PLAN_TOKEN"
+    else
+        "TOKEN";
+    return try std.fmt.allocPrint(allocator, "OMUX_FIGMA_{s}_{s}", .{ normalized_account.items, suffix });
 }
 
 fn enrollAccountsCommand(allocator: std.mem.Allocator, provider_name: ?[]const u8) ![]const u8 {


### PR DESCRIPTION
## Summary

Adds confirmed Figma enrollment as the token-provider counterpart to Codex and Claude:

- `oauth-mux enroll figma --account <name> --mode <oauth|pat|plan> [--secret-env <name>] --confirm-enroll --json`
- no-confirm mode that returns a confirmation-required plan without mutating config
- mode-specific config providers/profiles: `figma`, `figma-pat`, and `figma-plan`
- env-backed secret references only; this does not create token material
- explicit next commands for setting the env var, validating config, inventory, and the chosen proof probe

This does not open OAuth, run a Figma probe, or spend provider calls.

## Validation

- `nix develop --command zig fmt src/main.zig src/cli.zig`
- `nix develop --command zig build test`
- `nix develop --command just first-run-e2e-local`
- `nix develop --command just check-local`
