### PR TITLE
[codex] Harden stay-afloat broker e2e contract

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -144,6 +144,24 @@ The account enrollment and agent inventory contract lives in
 `docs/spec/account-enrollment-agent-contract-2026-05-01.md`. Use that contract
 before broadening provider-neutral enrollment commands or MCP mutation tools.
 
+## Wrapper Author Experience
+
+Wrappers should call the foreground command contract, not the socket daemon:
+
+```bash
+oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json
+oauth-mux stay-afloat --loop --iterations <n> --interval-ms <ms> --profile <profile> --capability <capability> --json
+```
+
+A wrapper may act automatically only on admitted, non-interactive,
+non-mutating work. When JSON reports `action.kind:"fix_runtime"` with
+`action.command:null`, the wrapper should display or broker
+`action.diagnostic_command` in the user-owned process boundary, then rerun
+`stay-afloat` or `route explain`. It must not infer credential liveness from a
+runtime diagnostic, rewrite provider stores, or treat `systemd`, `launchd`,
+Homebrew services, cron, Windows Services, containers, or CI as product
+semantics.
+
 ## Provider Author Experience
 
 A new provider should usually start as data, not Zig:

--- a/docs/spec/stay-afloat-permission-broker-contract-2026-05-01.md
+++ b/docs/spec/stay-afloat-permission-broker-contract-2026-05-01.md
@@ -173,3 +173,8 @@ service managers as optional wrapper examples.
 The next implementation slice should add a small wrapper-author section to the
 public docs and one fixture/E2E case that asserts `diagnostic_command` remains
 present for runtime repair while `command` remains `null`.
+
+Implementation note, 2026-05-01: the public adoption doc now includes the
+wrapper-author contract, and the clean first-run E2E asserts that
+`repair-plan`, `route explain`, and `stay-afloat --once` keep runtime repair
+as `command:null` plus a user/broker-visible `diagnostic_command`.

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -251,6 +251,11 @@ jq -e '
   and (.routes | length) == 3
   and all(.routes[]; .provider == "codex" and .capability == "codex-max" and .action.mutating == false)
   and all(.routes[]; .action.kind == "fix_runtime" or .action.kind == "probe_needed" or .action.kind == "none" or .action.kind == "wait_and_retry" or .action.kind == "wait_for_quota" or .action.kind == "wait_for_cooldown")
+  and all(.routes[]; if .action.kind == "fix_runtime" then
+    .action.command == null
+    and (.action.diagnostic_command | startswith("oauth-mux doctor runtime --provider codex --account "))
+    and (.action.diagnostic_command | endswith(" --capability codex-max --json"))
+  else true end)
 ' "$repair_plan_json" >/dev/null
 
 printf 'first-run e2e: route explain reports no recorded health without mutation\n'
@@ -265,7 +270,32 @@ jq -e '
   and (.routes | length) == 3
   and all(.routes[]; .provider == "codex" and .capability == "codex-max" and .action.mutating == false)
   and all(.routes[]; .action.kind == "fix_runtime" or .action.kind == "probe_needed")
+  and all(.routes[]; if .action.kind == "fix_runtime" then
+    .action.command == null
+    and (.action.diagnostic_command | startswith("oauth-mux doctor runtime --provider codex --account "))
+    and (.action.diagnostic_command | endswith(" --capability codex-max --json"))
+  else true end)
 ' "$route_explain_json" >/dev/null
+
+printf 'first-run e2e: stay-afloat exposes runtime diagnostics without automatic repair\n'
+stay_afloat_json="$tmp/stay-afloat-codex-max.json"
+run_json "$stay_afloat_json" stay-afloat --once --profile codex-max --capability codex-max --json
+jq -e '
+  .mode == "once"
+  and .execution_mode == "plan"
+  and .executed == false
+  and .afloat == false
+  and .selected == null
+  and (.routes | length) == 3
+  and all(.routes[]; .route.provider == "codex" and .route.capability == "codex-max")
+  and all(.routes[]; if .route.action.kind == "fix_runtime" then
+    .route.action.command == null
+    and (.route.action.diagnostic_command | startswith("oauth-mux doctor runtime --provider codex --account "))
+    and (.route.action.diagnostic_command | endswith(" --capability codex-max --json"))
+  else true end)
+' "$stay_afloat_json" >/dev/null
+test ! -e "$store_root"
+test ! -e "$legacy_store_root"
 
 printf 'first-run e2e: route select refuses unrecorded health evidence\n'
 route_select_json="$tmp/route-select-codex-max.json"


### PR DESCRIPTION
## Summary

- add a wrapper-author section to the public adoption doc for the foreground stay-afloat contract
- record the permission-broker implementation note in the stay-afloat contract spec
- tighten clean first-run E2E so runtime repair keeps `command:null` and exposes `diagnostic_command` through `repair-plan`, `route explain`, and `stay-afloat --once`

## Why

Dogfooding showed the important distinction between OAuth liveness and runtime/process-boundary readiness. This locks that boundary into the no-secret first-run path so wrappers and agents do not treat runtime diagnostics as automatic credential repair.

## Validation

- `just first-run-e2e-local`
- `nix develop --command just check-local`
