### PR TITLE
[codex] Prove Figma PAT and normalize config paths

### DIFF
--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -156,6 +156,15 @@ OMUX_CONFIG=$PWD/examples/linear-api-key.config.json \
   ./zig-out/bin/oauth-mux probe --profile linear-api-key --capability identity-api-key --json
 ```
 
+Figma PAT identity uses `X-Figma-Token`, not bearer auth. Use the explicit PAT
+profile when proving that mode:
+
+```bash
+OMUX_CONFIG=$PWD/examples/figma-pat.config.json \
+OMUX_FIGMA_PAT="$FIGMA_ACCESS_TOKEN" \
+  ./zig-out/bin/oauth-mux probe --profile figma-pat --capability identity-pat --json
+```
+
 To capture local artifacts through the same wrapper used by hosted provider QA:
 
 ```bash
@@ -178,13 +187,34 @@ OMUX_CONFIG=$PWD/examples/linear-api-key.config.json \
 OMUX_LIVE_QA_PROFILE=linear-api-key \
 OMUX_LIVE_QA_CAPABILITIES=identity-api-key \
   just live-qa
+
+OMUX_LIVE_QA_CONFIRM=spend-real-calls \
+OMUX_CONFIG=$PWD/examples/figma-pat.config.json \
+OMUX_FIGMA_PAT="$FIGMA_ACCESS_TOKEN" \
+OMUX_LIVE_QA_PROFILE=figma-pat \
+OMUX_LIVE_QA_CAPABILITIES=identity-pat \
+  just live-qa
 ```
 
 These probes are still explicit live provider calls. Keep them out of default
 checks and scheduled daemon loops. A successful local artifact may promote the
 specific capability to `local_live_proven`, but do not promote the whole GitHub
-or Linear provider from `needs_operator_proof` until the provider's intended
-auth modes have attached redacted evidence.
+Linear, or Figma provider from `needs_operator_proof` until the provider's
+intended auth modes have attached redacted evidence.
+
+2026-05-01 local SOPS-backed evidence:
+
+- GitHub `identity`: HTTP 200, `live.available`, `decision=use_this`.
+- Vercel `identity`: HTTP 200, `live.available`, `decision=use_this`.
+- Linear `identity-api-key`: HTTP 200, `live.available`, `decision=use_this`.
+- Linear OAuth bearer `identity`: using the personal API key as bearer returned
+  HTTP 400 and stays `needs_operator_proof`.
+- Figma PAT `identity-pat`: HTTP 200, `live.available`,
+  `decision=use_this`.
+- MCP `resource-metadata`: HTTP 200, valid RFC 9728/MCP metadata,
+  `live.available`.
+- MCP `resource` with a Figma PAT as bearer candidate: HTTP 405,
+  `degraded.unknown_4xx`; this is not resource-token proof.
 
 ## GitHub Workflow
 

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -168,7 +168,10 @@ Next split:
   `identity`, `identity-pat`, and `file-metadata-plan` must not collapse into a
   single generic "Figma works" claim. A 2026-05-01 OAuth bearer attempt
   returned HTTP 403 and correctly classified as `degraded.scope_insufficient`;
-  that is classifier evidence, not live proof.
+  that is classifier evidence, not live proof. A later SOPS-backed PAT proof
+  returned HTTP 200 and `live.available` for `identity-pat`, so only that
+  capability is `local_live_proven`; OAuth bearer identity, plan/file metadata,
+  and MCP resource-token proof remain open.
 - `TIN-878`: prove FlakeHub/Determinate as command-first status. A low-impact
   local proof now shows `flakehub:work#status` through `determinate-nixd
   status` returning HTTP-shaped status 200 and `live.available`; the capability

--- a/docs/spec/provider-proof-figma-rest-2026-05-01.md
+++ b/docs/spec/provider-proof-figma-rest-2026-05-01.md
@@ -1,0 +1,82 @@
+# Provider Proof: Figma REST Auth Shapes
+Date: 2026-05-01
+
+Issue context: Linear `TIN-877`, parent `TIN-736`; GitHub
+`Jesssullivan/oauth-mux#68`.
+
+## Baseline
+
+Figma must not be modeled as one generic "Figma works" route. oauth-mux carries
+three separate REST proof shapes:
+
+- OAuth bearer `identity`, using `Authorization: Bearer <token>` against
+  `GET https://api.figma.com/v1/me`.
+- PAT `identity-pat`, using `X-Figma-Token: <token>` against the same endpoint.
+- Plan/file-token `file-metadata-plan`, using `X-Figma-Token` against
+  `GET /v1/files/{{OMUX_FIGMA_PLAN_FILE_KEY}}/meta`.
+
+Those capabilities have different secret formats, scopes, and failure modes.
+Provider-level status should stay conservative until all intended Figma modes
+have redacted evidence.
+
+## Local Proof
+
+A low-impact PAT identity proof passed locally using the global SOPS-managed
+`api.figma_token` value, injected only into the probe environment:
+
+```bash
+OMUX_STATE_DIR=dist/live-qa/local-20260501T222732Z/state \
+OMUX_CONFIG=examples/figma-pat.config.json \
+OMUX_FIGMA_PAT=<redacted> \
+  ./zig-out/bin/oauth-mux probe --profile figma-pat \
+    --capability identity-pat --json
+```
+
+Redacted result:
+
+```json
+{
+  "provider": "figma-pat",
+  "account": "work",
+  "capability": "identity-pat",
+  "ok": true,
+  "probe_executed": true,
+  "probe_status": 200,
+  "decision": "use_this",
+  "liveness": {
+    "summary": "available",
+    "state": "live",
+    "availability": "available"
+  }
+}
+```
+
+The Figma `identity-pat` capability can now report `local_live_proven`.
+
+## Negative Evidence
+
+Earlier local proof attempted a Figma OAuth bearer token through
+`examples/figma.config.json`. That route returned HTTP 403 and classified as
+`degraded.scope_insufficient`. That is useful classifier evidence, but it is
+not OAuth bearer live proof.
+
+The same SOPS-managed Figma PAT was also tried against the Figma remote MCP
+resource endpoint as an MCP bearer-resource candidate. The route returned HTTP
+405 and classified as `degraded.unknown_4xx`. That confirms the PAT must not be
+treated as a resource-bound MCP OAuth token.
+
+## Current Proof Status
+
+- Figma REST `identity-pat`: `local_live_proven`.
+- Figma REST `identity`: `needs_operator_proof`.
+- Figma REST `file-metadata-plan`: `needs_operator_proof`.
+- MCP bearer-resource for `https://mcp.figma.com/mcp`: `needs_operator_proof`.
+
+## Next
+
+- Prove Figma OAuth bearer `identity` with a correctly scoped OAuth access
+  token.
+- Prove `file-metadata-plan` with an explicit file key and a token with
+  file-metadata scope.
+- Keep Figma PAT and Figma MCP resource tokens separate in docs, provider
+  examples, and enrollment output.

--- a/docs/spec/provider-proof-mcp-http-authorization-2026-05-01.md
+++ b/docs/spec/provider-proof-mcp-http-authorization-2026-05-01.md
@@ -114,6 +114,15 @@ resource-bound access token. The metadata capability can be reported as
 `public_live_proven`, while the bearer-token `resource` capability remains
 `needs_operator_proof`.
 
+## Negative Resource Proof
+
+The 2026-05-01 SOPS-backed Figma PAT was intentionally tried as an MCP
+resource bearer candidate against `https://mcp.figma.com/mcp`. The probe
+returned HTTP 405 and classified as `degraded.unknown_4xx`.
+
+That is useful boundary evidence: a Figma REST PAT must not be treated as a
+resource-bound MCP OAuth token. It does not promote MCP `resource` proof.
+
 ## Remaining Work
 
 - Add a resource-token proof only with a scoped MCP token minted for

--- a/docs/spec/provider-proof-vercel-2026-05-01.md
+++ b/docs/spec/provider-proof-vercel-2026-05-01.md
@@ -67,15 +67,20 @@ The Vercel `identity` capability can now report `local_live_proven`. Provider
 level status should remain conservative until broader Vercel token, team,
 scope, and project/resource failure shapes have redacted fixture coverage.
 
-## Adjacent Figma Finding
+## Adjacent Figma Findings
 
-The same proof pass also tested a Figma OAuth bearer identity token through
+An earlier proof pass also tested a Figma OAuth bearer identity token through
 `examples/figma.config.json`. That route returned HTTP 403 and correctly
 classified as `degraded.scope_insufficient`.
 
 That is useful evidence for the Figma classifier, but it is not a Figma live
-proof and does not promote any Figma capability. `TIN-877` remains open for
-Figma OAuth, PAT, and plan-token proof.
+proof and does not promote OAuth bearer identity.
+
+A later SOPS-backed proof tested the Figma PAT route through
+`examples/figma-pat.config.json`. That route returned HTTP 200,
+`live.available`, and `decision=use_this`, so only `identity-pat` can now be
+reported as `local_live_proven`. `TIN-877` remains open for Figma OAuth bearer
+identity and plan/file-token metadata proof.
 
 ## Next
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -83,7 +83,10 @@ pub fn load(allocator: std.mem.Allocator) !std.json.Parsed(Config) {
 }
 
 pub fn loadFromPath(allocator: std.mem.Allocator, path: []const u8) !std.json.Parsed(Config) {
-    const file = std.fs.openFileAbsolute(path, .{}) catch |e| switch (e) {
+    const file = (if (std.fs.path.isAbsolute(path))
+        std.fs.openFileAbsolute(path, .{})
+    else
+        std.fs.cwd().openFile(path, .{})) catch |e| switch (e) {
         error.FileNotFound => return error.FileNotFound,
         else => return error.Unexpected,
     };
@@ -1666,6 +1669,38 @@ test "validate rejects empty failure rule hint" {
     defer out.deinit();
     try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
     try std.testing.expect(std.mem.indexOf(u8, out.items, "failure_rules[0].hint_contains must not be empty") != null);
+}
+
+test "loadFromPath accepts relative config paths" {
+    const allocator = std.testing.allocator;
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    {
+        const file = try tmp.dir.createFile("config.json", .{});
+        defer file.close();
+        try file.writeAll(
+            \\{
+            \\  "version": 1,
+            \\  "providers": {},
+            \\  "profiles": {},
+            \\  "strategies": {}
+            \\}
+        );
+    }
+
+    const cwd_path = try std.fs.cwd().realpathAlloc(allocator, ".");
+    defer allocator.free(cwd_path);
+    const config_path = try tmp.dir.realpathAlloc(allocator, "config.json");
+    defer allocator.free(config_path);
+    const relative_path = try std.fs.path.relative(allocator, cwd_path, config_path);
+    defer allocator.free(relative_path);
+
+    const parsed = try loadFromPath(allocator, relative_path);
+    defer parsed.deinit();
+
+    try std.testing.expectEqual(@as(u32, 1), parsed.value.version);
 }
 
 test "resolveSecretBackend keychain" {

--- a/src/paths.zig
+++ b/src/paths.zig
@@ -5,12 +5,18 @@ const env = @import("env.zig");
 pub const app_name = "oauth-mux";
 
 pub fn configDir(allocator: std.mem.Allocator) ![]const u8 {
-    if (try env.get(allocator, "OMUX_CONFIG_DIR")) |dir| return dir;
+    if (try env.get(allocator, "OMUX_CONFIG_DIR")) |dir| {
+        defer allocator.free(dir);
+        return absolutePath(allocator, dir);
+    }
     return xdgOrMacOS(allocator, "XDG_CONFIG_HOME", ".config", "Application Support");
 }
 
 pub fn stateDir(allocator: std.mem.Allocator) ![]const u8 {
-    if (try env.get(allocator, "OMUX_STATE_DIR")) |dir| return dir;
+    if (try env.get(allocator, "OMUX_STATE_DIR")) |dir| {
+        defer allocator.free(dir);
+        return absolutePath(allocator, dir);
+    }
     return xdgOrMacOS(allocator, "XDG_STATE_HOME", ".local/state", "Application Support");
 }
 
@@ -30,7 +36,10 @@ pub fn runtimeDir(allocator: std.mem.Allocator) ![]const u8 {
 }
 
 pub fn configFilePath(allocator: std.mem.Allocator) ![]const u8 {
-    if (try env.get(allocator, "OMUX_CONFIG")) |path| return path;
+    if (try env.get(allocator, "OMUX_CONFIG")) |path| {
+        defer allocator.free(path);
+        return absolutePath(allocator, path);
+    }
     const dir = try configDir(allocator);
     defer allocator.free(dir);
     return std.fs.path.join(allocator, &.{ dir, "config.json" });
@@ -56,7 +65,9 @@ fn xdgOrMacOS(
 ) ![]const u8 {
     if (try env.get(allocator, xdg_env)) |base| {
         defer allocator.free(base);
-        return std.fs.path.join(allocator, &.{ base, app_name });
+        const joined = try std.fs.path.join(allocator, &.{ base, app_name });
+        defer allocator.free(joined);
+        return absolutePath(allocator, joined);
     }
     const home = (try env.get(allocator, "HOME")) orelse return error.OutOfMemory;
     defer allocator.free(home);
@@ -64,6 +75,16 @@ fn xdgOrMacOS(
         return std.fs.path.join(allocator, &.{ home, "Library", macos_dir_name, app_name });
     }
     return std.fs.path.join(allocator, &.{ home, linux_default_suffix, app_name });
+}
+
+pub fn absolutePath(allocator: std.mem.Allocator, path: []const u8) ![]const u8 {
+    const expanded = try expandTilde(allocator, path);
+    defer allocator.free(expanded);
+    if (std.fs.path.isAbsolute(expanded)) return try allocator.dupe(u8, expanded);
+
+    const cwd = try std.fs.cwd().realpathAlloc(allocator, ".");
+    defer allocator.free(cwd);
+    return std.fs.path.join(allocator, &.{ cwd, expanded });
 }
 
 pub fn expandTilde(allocator: std.mem.Allocator, path: []const u8) ![]const u8 {
@@ -86,5 +107,20 @@ test "expandTilde" {
         const result = try expandTilde(allocator, "");
         defer allocator.free(result);
         try std.testing.expectEqualStrings("", result);
+    }
+}
+
+test "absolutePath keeps absolute and expands relative paths" {
+    const allocator = std.testing.allocator;
+    {
+        const result = try absolutePath(allocator, "/absolute/path");
+        defer allocator.free(result);
+        try std.testing.expectEqualStrings("/absolute/path", result);
+    }
+    {
+        const result = try absolutePath(allocator, "relative/path");
+        defer allocator.free(result);
+        try std.testing.expect(std.fs.path.isAbsolute(result));
+        try std.testing.expect(std.mem.endsWith(u8, result, "relative/path"));
     }
 }

--- a/src/provider_schema.zig
+++ b/src/provider_schema.zig
@@ -513,6 +513,7 @@ const figma_capabilities = [_]CapabilityDefinition{
     .{
         .name = "identity-pat",
         .aliases = &.{ "me-pat", "pat" },
+        .proof_status = proof_local_live,
         .probe = .{
             .method = "GET",
             .url = "https://api.figma.com/v1/me",
@@ -1698,6 +1699,15 @@ test "figma identity capability uses OAuth me probe" {
 }
 
 test "figma pat identity capability uses explicit token header" {
+    var proof_status: ?[]const u8 = null;
+    for (figma_def.capabilities) |capability| {
+        if (std.mem.eql(u8, capability.name, "identity-pat")) {
+            proof_status = capability.proof_status;
+            break;
+        }
+    }
+    try std.testing.expectEqualStrings(proof_local_live, proof_status.?);
+
     const plan = probePlanForCapability(figma_def, "me-pat").?;
     try std.testing.expectEqual(ProbeTransport.http, plan.transport);
     try std.testing.expectEqualStrings("identity-pat", plan.capability);


### PR DESCRIPTION
## What changed

- Normalize relative `OMUX_CONFIG`, `OMUX_CONFIG_DIR`, and `OMUX_STATE_DIR` paths before use.
- Keep `loadFromPath` tolerant of direct relative config paths.
- Promote only Figma REST `identity-pat` to `local_live_proven` after local SOPS-backed proof.
- Add the Figma REST proof note and update provider-proof docs for Figma, MCP, Vercel, and the live QA matrix.

## Why

Dogfooding low-impact provider proof found a real crash before provider calls: relative `OMUX_CONFIG` and `OMUX_STATE_DIR` paths reached `openFileAbsolute` and panicked. The repo docs and QA commands intentionally use relative paths, so the CLI should accept them.

The same proof pass showed useful narrow provider truth: Figma PAT identity is live, but Figma OAuth bearer, Figma plan/file metadata, and MCP bearer-resource remain unproven.

## Validation

- `nix develop --command just check-local`
- Local SOPS-backed proof summaries:
  - GitHub identity: HTTP 200, `live.available`
  - Vercel identity: HTTP 200, `live.available`
  - Linear API-key identity: HTTP 200, `live.available`
  - Figma PAT identity: HTTP 200, `live.available`
  - MCP metadata: HTTP 200, `live.available`
  - Linear OAuth bearer with API-key candidate: HTTP 400, not promoted
  - MCP resource with Figma PAT candidate: HTTP 405, not promoted

Closes no issue; advances #68 / TIN-736 / TIN-877.