### PR TITLE
Plan paid provider proof cohort

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -180,7 +180,9 @@ Provider authors should use `oauth-mux providers list --json` to verify whether
 their provider is currently `built_in`, `schema_modeled`, `live_proven`, or still
 waiting on `needs_operator_proof`. Capability entries can be promoted more
 narrowly with `local_live_proven` or `public_live_proven` before the whole
-provider family is proven.
+provider family is proven. The same JSON includes non-secret
+`proof_requirements`, which is the agent-safe handoff list for missing tokens,
+provider CLI logins, file keys, and live proof consent.
 
 ## Non-Tinyland Deployments
 

--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -216,6 +216,34 @@ intended auth modes have attached redacted evidence.
 - MCP `resource` with a Figma PAT as bearer candidate: HTTP 405,
   `degraded.unknown_4xx`; this is not resource-token proof.
 
+## Paid Multi-Account Proof Cohort
+
+The next dogfood lane is tracked in Linear `TIN-892` and specified in
+`docs/spec/paid-multi-account-proof-cohort-2026-05-01.md`. It is a one-month
+paid cohort, not a default CI lane.
+
+Target shapes:
+
+- Codex: existing three Max-capable accounts plus one lower-tier OAuth account
+  to prove tier and usage contrast.
+- Claude Code: three isolated account/billing shapes across Pro, Max, and a
+  team/API-billed route where available.
+- Figma: three token/resource shapes across PAT, OAuth bearer, and
+  Organization/Enterprise plan-token file metadata if that spend is approved.
+
+The cohort uses the same explicit confirmation gates as other live QA:
+
+```bash
+OMUX_LIVE_QA_CONFIRM=spend-real-calls \
+  just live-qa
+```
+
+Do not schedule the paid cohort. It is a manual artifact-producing lane for
+provider proof and foreground stay-afloat soak evidence. The pass condition is
+not "every account is available"; the pass condition is that every unavailable
+account is typed correctly and at least one route can carry the requested
+capability when the cohort is expected to stay afloat.
+
 ## GitHub Workflow
 
 `.github/workflows/live-provider-qa.yml` is manual-only. It requires the

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -453,7 +453,9 @@ paths unless the user explicitly passes `--include-paths`.
 Capability entries expose narrower proof status in `capability_budgets`:
 `live_proven` for hosted secret-scoped proof, `local_live_proven` for local
 operator proof, `public_live_proven` for no-secret public metadata proof, and
-`needs_operator_proof` for modeled-but-unproven capabilities.
+`needs_operator_proof` for modeled-but-unproven capabilities. They also expose
+non-secret `proof_requirements` so agents can ask for the right env var, CLI
+login, plan token, file key, or consent gate without guessing.
 
 ## Provider Onboarding Checklist
 

--- a/docs/spec/account-enrollment-agent-contract-2026-05-01.md
+++ b/docs/spec/account-enrollment-agent-contract-2026-05-01.md
@@ -15,6 +15,12 @@ The goal is a stable shape where users and agents can add the N+1 account,
 inspect what changed, and keep work afloat without memorizing each provider's
 storage quirks.
 
+The paid proof cohort in
+`docs/spec/paid-multi-account-proof-cohort-2026-05-01.md` is the first planned
+stress test for this contract: one lower-tier Codex account added to the
+existing Max cohort, three Claude Code account/billing shapes, and three Figma
+token/resource shapes.
+
 ## Product Contract
 
 Enrollment is a three-layer contract:
@@ -167,7 +173,7 @@ handoff rather than trying to run browser/device auth silently.
 - account-level runtime readiness;
 - writeback admission;
 - per-capability proof, runtime readiness, recorded liveness, selectability,
-  and safe action shape;
+  proof requirements, and safe action shape;
 - agent-safe next commands.
 
 `enroll plan --json` reports:

--- a/docs/spec/paid-multi-account-proof-cohort-2026-05-01.md
+++ b/docs/spec/paid-multi-account-proof-cohort-2026-05-01.md
@@ -1,0 +1,252 @@
+# Paid Multi-Account Proof Cohort
+Date: 2026-05-01
+
+Issue context: Linear `TIN-892`, with children `TIN-893`, `TIN-894`,
+`TIN-895`, and `TIN-896`; parent `TIN-736`; related to stay-afloat `TIN-738`.
+GitHub `Jesssullivan/oauth-mux#68` and `#67`.
+
+## Baseline
+
+The current product can prove Codex fallback with three configured accounts and
+can prove several non-Codex identity capabilities. That is not the same as
+being ready to tell users that oauth-mux handles their real multi-account
+subscription reality.
+
+The next proof lane should intentionally buy or allocate a one-month cohort of
+common paid account shapes, then run the same boring user story across each
+provider:
+
+1. enroll account without stealing upstream credential ownership;
+2. list accounts and proof requirements without leaking secrets;
+3. prove runtime readiness;
+4. prove liveness with typed outcomes;
+5. select a fallback route;
+6. keep work afloat through the foreground stay-afloat contract;
+7. record artifacts and update claims only for the exact shape proven.
+
+This lane is about evidence, not broad claims. A paid account only earns a
+public claim after the probe, route, repair, and stay-afloat surfaces agree.
+
+## Current Source Facts
+
+These are time-sensitive and should be rechecked before purchasing.
+
+- OpenAI's current Codex pricing page says Codex is included in ChatGPT Free,
+  Go, Plus, Pro, Business, Edu, and Enterprise. It lists Plus at $20/month and
+  Pro from $100/month, with Pro offering higher Codex usage than Plus.
+- OpenAI's Codex CLI docs say first run prompts the user to authenticate with a
+  ChatGPT account or API key, and that the CLI runs on macOS, Windows, and
+  Linux.
+- Anthropic's pricing page lists Claude Pro at $20 monthly, Max from $100
+  monthly, Team standard and premium seats, and Enterprise. It also says Pro
+  includes Claude Code; the Claude Code costs page says Pro and Max subscribers
+  see plan usage bars rather than API session dollar cost as billing truth.
+- Anthropic's enterprise pricing page says Claude Code can be used with a
+  Claude subscription or billed through an Anthropic Console account.
+- Figma's pricing page lists Professional Full, Dev, and Collab seats and says
+  Dev Mode and MCP support are plan/seat features.
+- Figma's REST auth docs separate OAuth apps, plan access tokens, and personal
+  access tokens. Plan access tokens are available for Organization and
+  Enterprise plans and are not tied to a user.
+- Figma's REST rate-limit docs say limits depend on seat type, endpoint tier,
+  and the plan/location of the requested resource. They also say OAuth limits
+  are per user, per plan, per app; plan-token limits are per token and plan;
+  PAT limits are per user and plan.
+
+Primary sources:
+
+- https://developers.openai.com/codex/pricing
+- https://developers.openai.com/codex/cli
+- https://claude.com/pricing
+- https://code.claude.com/docs/en/costs
+- https://claude.com/pricing/enterprise
+- https://www.figma.com/pricing/
+- https://developers.figma.com/docs/rest-api/authentication/
+- https://developers.figma.com/docs/rest-api/rate-limits/
+- https://developers.figma.com/docs/rest-api/plan-access-tokens/
+
+## Cohort Shape
+
+### Codex: `TIN-893`
+
+Use the existing three Max-capable accounts as the high-usage cohort. Add one
+lower-tier OAuth account to prove tier and usage contrast.
+
+Suggested labels:
+
+| Label | Intended shape | Proof value |
+| --- | --- | --- |
+| `codex-max-1` | Existing Max-capable account | Quota exhaustion, weekly reset, and fallback history. |
+| `codex-max-2` | Existing Max-capable account | Independent Max-capable route with the same capability names. |
+| `codex-max-3` | Existing active/API-backed route | Available fallback when other Max routes are exhausted. |
+| `codex-plus-1` | New lower-tier ChatGPT OAuth account | Tier/usage contrast against Max; proves lower-tier accounts do not poison Max route health. |
+
+Do not model the lower-tier account as a broken Max account. Expected outcomes
+may include `tier_insufficient`, `quota_exhausted`, or `rate_limited` for some
+capabilities and `available` for others.
+
+Required proof:
+
+```bash
+oauth-mux accounts list --provider codex --json
+oauth-mux enroll plan codex --account codex-plus-1 --json
+oauth-mux enroll codex --account codex-plus-1 --confirm-enroll --json
+# user-mediated handoff from enroll output
+oauth-mux doctor runtime --provider codex --account codex-plus-1 --capability codex-mini --json
+oauth-mux stay-afloat refresh --profile codex-mini --capability codex-mini --json
+oauth-mux route explain --profile codex-mini --capability codex-mini --json
+oauth-mux stay-afloat --once --profile codex-mini --capability codex-mini --json
+```
+
+Spendful proof remains behind explicit confirmation:
+
+```bash
+OMUX_LIVE_QA_CONFIRM=spend-real-calls \
+OMUX_LIVE_QA_PROVIDER=codex \
+OMUX_LIVE_QA_ACCOUNTS=max-1,max-2,max-3,codex-plus-1 \
+OMUX_LIVE_QA_CAPABILITIES=codex-mini,codex-max \
+  just live-qa
+```
+
+### Claude Code: `TIN-894`
+
+Use three account or billing shapes only if they produce different product
+evidence. A good one-month target is:
+
+| Label | Intended shape | Proof value |
+| --- | --- | --- |
+| `claude-pro-1` | Pro subscription | Common individual user with Claude Code included. |
+| `claude-max-1` | Max 5x or 20x | Higher usage route and priority behavior. |
+| `claude-team-or-api-1` | Team seat or Console/API-billed Claude Code | Admin/billing boundary distinct from personal subscription. |
+
+If Team minimums or account policy make the third shape too expensive or noisy,
+use API-billed Console auth for the third proof and record that Team remains
+unproven.
+
+Required proof:
+
+```bash
+oauth-mux accounts list --provider claude --json
+oauth-mux enroll plan claude --account claude-pro-1 --json
+oauth-mux enroll claude --account claude-pro-1 --confirm-enroll --json
+# user-mediated: env CLAUDE_CONFIG_DIR=<account-dir> claude auth login
+oauth-mux doctor runtime --provider claude --account claude-pro-1 --capability auth-status --json
+oauth-mux probe --provider claude --account claude-pro-1 --capability auth-status --json
+oauth-mux stay-afloat --once --profile claude --capability auth-status --json
+```
+
+The first Claude cohort gate is account-store isolation and `auth-status`.
+Usage/quota proof should come after fixtures cover logged-out, missing CLI,
+keychain/store boundary, quota/usage limited, and provider degraded states.
+
+### Figma: `TIN-896`
+
+Figma needs token and resource diversity more than three identical users.
+
+Suggested one-month target:
+
+| Label | Intended shape | Proof value |
+| --- | --- | --- |
+| `figma-full-1` | Professional Full seat with PAT and OAuth | Common designer/admin route; proves OAuth `identity` and PAT `identity-pat` separately. |
+| `figma-dev-1` | Professional Dev seat | Common engineering/Dev Mode/MCP route. |
+| `figma-plan-1` | Organization or Enterprise plan access token | User-independent automation and file metadata proof. |
+
+If an Organization/Enterprise plan is not worth the month of spend, keep
+`figma-plan-1` as explicitly unproven and do not promote
+`file-metadata-plan`.
+
+Required proof:
+
+```bash
+oauth-mux accounts list --provider figma --json
+oauth-mux enroll plan figma --account figma-full-1 --mode oauth --json
+oauth-mux enroll figma --account figma-full-1 --mode oauth --secret-env OMUX_FIGMA_FULL_OAUTH --confirm-enroll --json
+oauth-mux probe --provider figma --account figma-full-1 --capability identity --json
+
+oauth-mux enroll plan figma --account figma-dev-1 --mode pat --json
+oauth-mux enroll figma --account figma-dev-1 --mode pat --secret-env OMUX_FIGMA_DEV_PAT --confirm-enroll --json
+oauth-mux probe --provider figma-pat --account figma-dev-1 --capability identity-pat --json
+
+oauth-mux enroll plan figma --account figma-plan-1 --mode plan --json
+oauth-mux enroll figma --account figma-plan-1 --mode plan --secret-env OMUX_FIGMA_PLAN_TOKEN --confirm-enroll --json
+OMUX_FIGMA_PLAN_FILE_KEY=<file-key> \
+  oauth-mux probe --provider figma-plan --account figma-plan-1 --capability file-metadata-plan --json
+```
+
+The Figma proof must intentionally keep these states distinct:
+
+- OAuth bearer identity;
+- PAT identity;
+- plan-token file metadata;
+- Figma remote MCP bearer-resource token;
+- insufficient scope;
+- file/resource not permitted;
+- rate limit with retry/upgrade hints.
+
+## Stay-Afloat Soak Gate: `TIN-895`
+
+The paid cohort should not promote the background daemon by accident. The
+portable product contract remains foreground and wrapper-friendly:
+
+```bash
+oauth-mux route explain --profile <profile> --capability <capability> --json
+oauth-mux route select --profile <profile> --capability <capability> --json
+oauth-mux repair-plan --profile <profile> --capability <capability> --json
+oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json
+oauth-mux stay-afloat refresh --profile <profile> --capability <capability> --json
+oauth-mux stay-afloat --loop --iterations 2 --interval-ms 0 --profile <profile> --capability <capability> --json
+```
+
+Seven-day soak criteria:
+
+- no silent provider-spend probes;
+- no silent browser/device login;
+- no mutation outside oauth-mux-owned config/store scaffolding;
+- no platform-specific dependency such as `systemctl`;
+- route-state refresh stays explicit and redacted;
+- at least one planned unavailable account does not poison a separate
+  available account for the same provider;
+- every unavailable state has a typed action or handoff.
+
+Evidence should be recorded as:
+
+- hosted workflow artifact ID or local `dist/live-qa/<timestamp>`;
+- redacted command transcript;
+- `accounts list --json`;
+- `providers list --json`;
+- `route explain --json`;
+- `stay-afloat --once --json`;
+- provider-specific live probe output.
+
+## Claim Policy
+
+Allowed after this lane:
+
+- `capability_live_proven`: a specific provider/account capability has redacted
+  live proof.
+- `paid_cohort_proven`: the named cohort shape passed enrollment, routing, and
+  stay-afloat gates.
+- `foreground_stay_afloat_proven`: explicit user-run stay-afloat kept a route
+  selectable or returned the right handoff.
+
+Not allowed yet:
+
+- "Universal OAuth muxing is proven."
+- "Production background daemon keeps every provider afloat."
+- "Figma is proven" unless OAuth, PAT, plan-token, and MCP resource-token
+  claims are separately qualified.
+- "Claude is proven" beyond the specific subscription/auth-status/quota shapes
+  that have artifacts.
+
+## Immediate Work
+
+1. Land the proof-requirements JSON surface so agents can discover the missing
+   values without reading this spec.
+2. Enroll the lower-tier Codex account and run no-spend inventory/runtime
+   checks before live probes.
+3. Decide the Claude third shape: Team seat, Enterprise/self-serve path, or
+   API-billed Console auth.
+4. Decide whether Figma Organization/Enterprise spend is worth plan-token
+   proof this month.
+5. Run the seven-day foreground stay-afloat soak after all paid accounts are
+   enrolled and one live proof pass has succeeded.

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -4,7 +4,8 @@ Date: 2026-05-01
 Issue context: GitHub `Jesssullivan/oauth-mux#66`, `#67`, `#68`; Linear
 `TIN-858`, `TIN-736`, `TIN-738`, `TIN-859`, `TIN-860`, `TIN-861`, `TIN-862`,
 `TIN-863`, `TIN-866`, `TIN-867`, `TIN-876`, `TIN-877`, `TIN-878`, and
-`TIN-879`.
+`TIN-879`, plus paid cohort lane `TIN-892` with children `TIN-893`,
+`TIN-894`, `TIN-895`, and `TIN-896`.
 
 ## Baseline
 
@@ -21,6 +22,7 @@ boundaries that need separate tracking.
 | Homebrew distribution | `#66` | `TIN-858`, related to `TIN-737` | Public Jess-owned tap exists and clean local install QA passes; Tinyland tap remains private/staged. Live website copy still needs to stop advertising the private tap. |
 | Stay-afloat daemon | `#67` | `TIN-738`, `TIN-859`, `TIN-860`, `TIN-866`, `TIN-867` | Foreground/agent-safe stay-afloat is shipped; production background daemon is not. Socket daemon is explicitly non-product plumbing for this release line. |
 | Provider expansion | `#68` | `TIN-736`, `TIN-861`, `TIN-862`, `TIN-863`, `TIN-876`, `TIN-877`, `TIN-878`, `TIN-879` | Codex is live-proven; non-Codex proof is capability-level or still needs operator proof. |
+| Paid multi-account proof | `#67`, `#68` | `TIN-892`, `TIN-893`, `TIN-894`, `TIN-895`, `TIN-896` | A one-month paid cohort is now tracked for Codex lower-tier contrast, Claude subscription/billing shapes, Figma token/seat/plan shapes, and a foreground stay-afloat soak gate. |
 
 ## Homebrew Boundary
 
@@ -181,6 +183,11 @@ Next split:
 - `TIN-879`: decide and prove the Gemini CLI provider shape before any proof
   promotion; do not assume generic Google OAuth token behavior is enough for
   the harness.
+- `TIN-892`: run a paid multi-account proof cohort for common subscription and
+  token shapes. Children: `TIN-893` Codex Max plus lower-tier OAuth contrast,
+  `TIN-894` Claude Code Pro/Max/team-or-API shapes, `TIN-896` Figma PAT/OAuth/
+  plan-token seat and resource limits, and `TIN-895` the seven-day
+  foreground stay-afloat soak and public claim policy.
 
 Older broad wave tickets `TIN-818` and `TIN-816` are canceled as superseded by
 these precise provider-proof children.
@@ -199,9 +206,12 @@ these precise provider-proof children.
    `needs_operator_proof`.
 5. Continue `TIN-861` and `TIN-863` on their remaining hard shapes: Claude
    quota/repair semantics and MCP resource-bound bearer-token proof.
-6. Work provider proof in narrow slices: `TIN-876` Vercel, `TIN-877` Figma,
+6. Start `TIN-892` paid proof once billing choices are confirmed. Use
+   `docs/spec/paid-multi-account-proof-cohort-2026-05-01.md` as the cohort
+   matrix and keep provider-level promotion conservative.
+7. Work provider proof in narrow slices: `TIN-876` Vercel, `TIN-877` Figma,
    `TIN-878` FlakeHub/Determinate, and `TIN-879` Gemini.
-7. Return to daemon background scheduling only after wrapper/install decisions
+8. Return to daemon background scheduling only after wrapper/install decisions
    and provider proof produce enough real operator evidence. The current socket
    daemon decision is complete under `TIN-867`; future production daemon work
    must promote the foreground tick engine deliberately.

--- a/src/main.zig
+++ b/src/main.zig
@@ -478,6 +478,8 @@ fn writeAccountCapabilityJson(
     try std.json.stringify(capability.name, .{}, writer);
     try writer.writeAll(",\"proof_status\":");
     try std.json.stringify(capability.proof_status, .{}, writer);
+    try writer.writeAll(",\"proof_requirements\":");
+    try writeStringArrayJson(writer, capability.proof_requirements);
     try writer.writeAll(",\"budget\":");
     if (budget) |probe_budget| try std.json.stringify(@tagName(probe_budget), .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"runtime\":");
@@ -5758,6 +5760,8 @@ fn writeCapabilityBudgetsJson(writer: anytype, def: provider_schema.ProviderDefi
         try std.json.stringify(capability.name, .{}, writer);
         try writer.writeAll(",\"proof_status\":");
         try std.json.stringify(capability.proof_status, .{}, writer);
+        try writer.writeAll(",\"proof_requirements\":");
+        try writeStringArrayJson(writer, capability.proof_requirements);
         try writer.writeAll(",\"budget\":");
         if (capability.probe) |probe_def| {
             try std.json.stringify(@tagName(probe_def.budget orelse provider_schema.defaultProbeBudget(probe_def.transport)), .{}, writer);
@@ -8133,6 +8137,7 @@ test "writeProvidersListJson exposes extension and budget metadata" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"repair_owner\":\"upstream_cli_login\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"runtime\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"capability_budgets\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"proof_requirements\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"codex-max\",\"proof_status\":\"live_proven\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"auth-status\",\"proof_status\":\"local_live_proven\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"identity\",\"proof_status\":\"local_live_proven\"") != null);
@@ -8140,6 +8145,8 @@ test "writeProvidersListJson exposes extension and budget metadata" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"resource-metadata\",\"proof_status\":\"public_live_proven\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"resource\",\"proof_status\":\"needs_operator_proof\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"identity-api-key\",\"proof_status\":\"local_live_proven\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "OMUX_FIGMA_PLAN_FILE_KEY") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "OMUX_MCP_RESOURCE_TOKEN") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"budget\":\"spend_provider\"") != null);
 }
 

--- a/src/provider_schema.zig
+++ b/src/provider_schema.zig
@@ -143,6 +143,7 @@ pub const CapabilityDefinition = struct {
     name: []const u8,
     aliases: []const []const u8 = &.{},
     proof_status: []const u8 = proof_needs_operator,
+    proof_requirements: []const []const u8 = &.{},
     probe: ?ProbeDefinition = null,
 };
 
@@ -271,6 +272,11 @@ const claude_capabilities = [_]CapabilityDefinition{
         .name = "auth-status",
         .aliases = &.{ "status", "identity", "whoami" },
         .proof_status = proof_local_live,
+        .proof_requirements = &.{
+            "claude CLI installed",
+            "account-scoped CLAUDE_CONFIG_DIR",
+            "user-mediated claude auth login",
+        },
         .probe = .{
             .transport = .command,
             .auth = .none,
@@ -344,6 +350,10 @@ const mcp_capabilities = [_]CapabilityDefinition{
         .name = "resource-metadata",
         .aliases = &.{ "metadata", "protected-resource-metadata" },
         .proof_status = proof_public_live,
+        .proof_requirements = &.{
+            "OMUX_MCP_RESOURCE_METADATA_URL",
+            "public RFC 9728 protected resource metadata",
+        },
         .probe = .{
             .method = "GET",
             .url = "{{OMUX_MCP_RESOURCE_METADATA_URL}}",
@@ -355,6 +365,11 @@ const mcp_capabilities = [_]CapabilityDefinition{
     .{
         .name = "resource",
         .aliases = &.{ "resource-probe", "http" },
+        .proof_requirements = &.{
+            "OMUX_MCP_RESOURCE_TOKEN",
+            "OMUX_MCP_RESOURCE_PROBE_URL",
+            "resource-bound bearer token for the probed MCP resource",
+        },
         .probe = .{
             .method = "GET",
             .url = "{{OMUX_MCP_RESOURCE_PROBE_URL}}",
@@ -417,6 +432,10 @@ const vercel_capabilities = [_]CapabilityDefinition{
         .name = "identity",
         .aliases = &.{ "user", "whoami" },
         .proof_status = proof_local_live,
+        .proof_requirements = &.{
+            "VERCEL_TOKEN",
+            "Vercel token accepted by GET /v2/user",
+        },
         .probe = .{
             .method = "GET",
             .url = "https://api.vercel.com/v2/user",
@@ -430,6 +449,10 @@ const github_capabilities = [_]CapabilityDefinition{
         .name = "identity",
         .aliases = &.{ "user", "whoami" },
         .proof_status = proof_local_live,
+        .proof_requirements = &.{
+            "GH_TOKEN or gh auth token",
+            "GitHub token accepted by GET /user",
+        },
         .probe = .{
             .method = "GET",
             .url = "https://api.github.com/user",
@@ -460,6 +483,10 @@ const linear_capabilities = [_]CapabilityDefinition{
     .{
         .name = "identity",
         .aliases = &.{ "viewer", "whoami" },
+        .proof_requirements = &.{
+            "LINEAR_ACCESS_TOKEN",
+            "OAuth bearer token accepted by Linear GraphQL viewer query",
+        },
         .probe = .{
             .method = "POST",
             .url = "https://api.linear.app/graphql",
@@ -473,6 +500,10 @@ const linear_capabilities = [_]CapabilityDefinition{
         .name = "identity-api-key",
         .aliases = &.{ "api-key", "personal-api-key", "pat", "whoami-api-key" },
         .proof_status = proof_local_live,
+        .proof_requirements = &.{
+            "Linear personal API key",
+            "raw Authorization header accepted by Linear GraphQL viewer query",
+        },
         .probe = .{
             .method = "POST",
             .url = "https://api.linear.app/graphql",
@@ -504,6 +535,10 @@ const figma_capabilities = [_]CapabilityDefinition{
     .{
         .name = "identity",
         .aliases = &.{ "me", "whoami" },
+        .proof_requirements = &.{
+            "FIGMA_ACCESS_TOKEN",
+            "OAuth token with current_user:read",
+        },
         .probe = .{
             .method = "GET",
             .url = "https://api.figma.com/v1/me",
@@ -514,6 +549,10 @@ const figma_capabilities = [_]CapabilityDefinition{
         .name = "identity-pat",
         .aliases = &.{ "me-pat", "pat" },
         .proof_status = proof_local_live,
+        .proof_requirements = &.{
+            "OMUX_FIGMA_PAT or FIGMA_ACCESS_TOKEN",
+            "Figma personal access token accepted by X-Figma-Token",
+        },
         .probe = .{
             .method = "GET",
             .url = "https://api.figma.com/v1/me",
@@ -524,6 +563,11 @@ const figma_capabilities = [_]CapabilityDefinition{
     .{
         .name = "file-metadata-plan",
         .aliases = &.{ "plan-file-meta", "plan-file-metadata", "plan" },
+        .proof_requirements = &.{
+            "OMUX_FIGMA_PLAN_TOKEN",
+            "OMUX_FIGMA_PLAN_FILE_KEY",
+            "Organization or Enterprise plan access token with file metadata scope",
+        },
         .probe = .{
             .method = "GET",
             .url = "https://api.figma.com/v1/files/{{OMUX_FIGMA_PLAN_FILE_KEY}}/meta",
@@ -560,6 +604,10 @@ const flakehub_capabilities = [_]CapabilityDefinition{
         .name = "status",
         .aliases = &.{ "identity", "whoami" },
         .proof_status = proof_local_live,
+        .proof_requirements = &.{
+            "determinate-nixd installed",
+            "local Determinate/FlakeHub auth state",
+        },
         .probe = .{
             .transport = .command,
             .auth = .none,
@@ -575,6 +623,12 @@ const codex_capabilities = [_]CapabilityDefinition{
         .name = "codex-max",
         .aliases = &.{ "max", "gpt-5.3-codex", "gpt-5.1-codex-max" },
         .proof_status = proof_live,
+        .proof_requirements = &.{
+            "codex CLI installed",
+            "account-scoped CODEX_HOME",
+            "ChatGPT account with Codex Max-capable subscription or API path",
+            "OMUX_LIVE_QA_CONFIRM=spend-real-calls for live proof",
+        },
         .probe = .{
             .transport = .command,
             .auth = .none,
@@ -596,6 +650,12 @@ const codex_capabilities = [_]CapabilityDefinition{
         .name = "codex-mini",
         .aliases = &.{ "mini", "spark", "gpt-5.3-codex-spark", "gpt-5.1-codex-mini" },
         .proof_status = proof_live,
+        .proof_requirements = &.{
+            "codex CLI installed",
+            "account-scoped CODEX_HOME",
+            "ChatGPT account with Codex CLI access",
+            "OMUX_LIVE_QA_CONFIRM=spend-real-calls for live proof",
+        },
         .probe = .{
             .transport = .command,
             .auth = .none,
@@ -1718,6 +1778,17 @@ test "figma pat identity capability uses explicit token header" {
 }
 
 test "figma plan capability uses resource scoped file metadata probe" {
+    var proof_requirement_found = false;
+    for (figma_def.capabilities) |capability| {
+        if (std.mem.eql(u8, capability.name, "file-metadata-plan")) {
+            for (capability.proof_requirements) |requirement| {
+                if (std.mem.eql(u8, requirement, "OMUX_FIGMA_PLAN_FILE_KEY")) proof_requirement_found = true;
+            }
+            break;
+        }
+    }
+    try std.testing.expect(proof_requirement_found);
+
     const plan = probePlanForCapability(figma_def, "plan-file-meta").?;
     try std.testing.expectEqual(ProbeTransport.http, plan.transport);
     try std.testing.expectEqualStrings("file-metadata-plan", plan.capability);


### PR DESCRIPTION
## Summary

- add non-secret capability proof requirements to provider/account JSON surfaces
- document the paid multi-account proof cohort across Codex, Claude Code, and Figma
- align live QA, onboarding, adoption, and product-gap docs with Linear TIN-892 through TIN-896

## Validation

- nix develop --command just check-local
- git diff --check
- providers/account JSON smoke checks for proof_requirements

## Tracking

- Linear: TIN-892, TIN-893, TIN-894, TIN-895, TIN-896
- GitHub: #67, #68