### PR TITLE
Define background stay-afloat daemon contract

### DIFF
--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -39,6 +39,9 @@ the portable foreground supervisor contract tracked by `TIN-859`. See
 `docs/spec/stay-afloat-permission-broker-contract-2026-05-01.md` for how agents
 and wrappers should handle `action.diagnostic_command` without promoting the
 socket daemon.
+See `docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md` for the
+`TIN-897` production-daemon contract and the distinction between prepared
+fallback, supervised restart, and true per-request muxing.
 
 ## Supervisor Contract
 
@@ -64,7 +67,10 @@ containers, and CI wrappers must preserve the foreground command contract
 rather than introducing separate behavior.
 `oauth-mux daemon status --json` reports this boundary directly with
 `contract:"experimental_socket_stub"`, `production_supported:false`,
-`hosts_stay_afloat:false`, and `wrapper_contract:"foreground_tick"`.
+`hosts_stay_afloat:false`, and `wrapper_contract:"foreground_tick"`. It also
+includes the latest redacted stay-afloat tick snapshot under `stay_afloat` when
+one exists, so wrappers can inspect prepared fallback state without treating
+the socket stub as the production supervisor.
 
 ## Allowed Now
 
@@ -158,6 +164,14 @@ The daemon can become a supported operator feature when:
    docs;
 9. live-provider QA covers timeout, auth failure, quota exhaustion, and
    transient rate-limit behavior.
+
+The stronger "seamless muxing" claim also requires a mediation point. A
+background daemon can keep route state and reauth handoffs warm, but it cannot
+hot-swap credentials already loaded into an upstream harness process unless
+that harness supports live reload, supervised restart, proxying, or an
+oauth-mux-aware in-agent adapter. Until that proof exists, user-facing copy
+should describe prepared fallback for the next mediated action, not transparent
+replacement of the current process.
 
 Until then, user and agent onboarding should use one-shot commands:
 

--- a/docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md
+++ b/docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md
@@ -1,0 +1,313 @@
+# Background Stay-Afloat Daemon Contract
+Date: 2026-05-02
+
+Issue context: Linear `TIN-897`, child of `TIN-738`; GitHub
+`Jesssullivan/oauth-mux#67`. This builds on
+`docs/spec/stay-afloat-supervisor-contract-2026-05-01.md`,
+`docs/spec/stay-afloat-permission-broker-contract-2026-05-01.md`, and
+`docs/spec/paid-multi-account-proof-cohort-2026-05-01.md`.
+
+## Baseline
+
+`oauth-mux` can already keep a route set understandable and selectable through
+foreground commands:
+
+```bash
+oauth-mux route explain --profile <profile> --capability <capability> --json
+oauth-mux route select --profile <profile> --capability <capability> --json
+oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json
+oauth-mux stay-afloat --loop --iterations <n> --interval-ms <ms> --profile <profile> --capability <capability> --json
+```
+
+The current Codex dogfood state proves that route-scoped fallback works:
+`codex:max-1#codex-max` is parked as quota exhausted until its reset window,
+`codex:max-2#codex-max` is selected, and `codex:max-3#codex-max` remains a
+selectable fallback. That is real product evidence.
+
+The stronger product goal is not proven yet:
+
+> install oauth-mux, enroll N accounts, and have user or agent work stay afloat
+> while subscriptions pass through quota, rate limit, logged-out, stale-token,
+> runtime-boundary, and reauth states.
+
+That goal needs a background daemon, but it also needs a precise definition of
+"seamless." A daemon can keep route state, schedules, events, and reauth
+handoffs warm. It cannot transparently rewrite credentials already loaded in an
+upstream harness process unless the harness supports live reload or the harness
+request path is mediated by oauth-mux.
+
+## Decision
+
+The production daemon should promote the existing foreground tick engine. It
+must not introduce a second muxing model.
+
+The daemon's stable responsibilities are:
+
+- run the same policy-gated stay-afloat tick loop in the background;
+- keep the latest route snapshot available for users, wrappers, and agents;
+- maintain redacted event, handoff, and execution evidence;
+- honor route-level `next_tick_after` and `schedule_reason`;
+- run only admitted background actions;
+- surface user-mediated auth and runtime diagnostics as handoffs;
+- expose status without depending on any one service manager.
+
+The daemon's non-responsibilities are equally important:
+
+- no silent provider-spend probes by default;
+- no silent browser/device login;
+- no silent mutation of upstream CLI-owned stores;
+- no assumption that `systemctl`, `launchctl`, Homebrew services, cron, or
+  Windows Services define product semantics;
+- no claim that an already-running harness process can be hot-swapped unless
+  that harness has a proven reload, restart, proxy, or in-agent mediation path.
+
+## Seamless Handoff Model
+
+There are three levels of "seamless" support. Public docs and demos must name
+the level being shown.
+
+### Level 1: prepared fallback
+
+The daemon keeps route state fresh enough that the next mediated action can
+pick a healthy account without a user re-running diagnostics.
+
+This is what the product can realistically support first for Codex, Claude,
+Figma, GitHub, Linear, Vercel, FlakeHub, and MCP-like providers.
+
+Required mediation point:
+
+- `oauth-mux exec`;
+- a shell wrapper;
+- an agent calling `route select` or `stay-afloat --once`;
+- a package wrapper that calls the foreground tick contract.
+
+If an account caps out during a long-running upstream process, Level 1 prepares
+the next launch or command. It does not mutate the already-running process.
+
+### Level 2: supervised restart or relaunch
+
+The wrapper owns the harness process and can restart it with a new selected
+route when the current route becomes unusable.
+
+Required mediation point:
+
+- an oauth-mux-owned command wrapper;
+- an editor/agent integration that can restart a child harness;
+- a CLI launcher that treats route selection as part of process startup.
+
+This can feel seamless to a user when the harness session is restart-tolerant.
+It is still not hot credential reload.
+
+### Level 3: per-request muxing
+
+Every provider request passes through oauth-mux or an oauth-mux-aware protocol
+surface. The mux can reroute a single request without restarting the harness.
+
+Required mediation point:
+
+- an HTTP/API proxy;
+- an MCP tool/resource server;
+- an in-agent provider adapter;
+- a harness-native credential reload or account-switch API.
+
+This is the strongest product shape, but it is provider and harness specific.
+Codex and Claude command-owned sessions should not be advertised at Level 3
+until their reload or proxy semantics are explicitly proven.
+
+## Background Daemon Shape
+
+The beta background daemon should be a portable foreground process first. A
+service manager may keep it alive, but service managers remain wrappers.
+
+Core daemon loop:
+
+1. load config, health, runtime state, locks, and event state;
+2. expand configured profiles into routes;
+3. run one `stay-afloat` execute tick under daemon policy;
+4. write a redacted route snapshot;
+5. expose status, events, and handoffs;
+6. sleep until the earliest admitted `next_tick_after`, bounded by policy;
+7. stop cleanly on signal or explicit stop command.
+
+Default policy:
+
+```json
+{
+  "allowed_budgets": ["free_local", "free_command"],
+  "allow_interactive": false,
+  "allow_mutating": false
+}
+```
+
+Provider-spend probes, interactive auth, and credential mutation require
+explicit operator policy plus redacted evidence.
+
+## Cross-Platform Requirements
+
+Core behavior must work without platform-specific assumptions:
+
+- no required `systemctl`;
+- no required `launchctl`;
+- no required Homebrew services;
+- no required cron;
+- no required Windows Services;
+- no shell-specific startup requirement.
+
+The core process should be runnable as:
+
+```bash
+oauth-mux daemon run --stay-afloat --profile <profile> --capability <capability>
+```
+
+The exact flag spelling can change during implementation, but the product
+boundary should not: a foreground process hosts the same stay-afloat tick
+engine and optional service wrappers only keep that process running.
+
+Wrapper examples can come later:
+
+- Homebrew service wrapper;
+- macOS launchd plist;
+- Linux systemd user unit;
+- Windows scheduled task or service wrapper;
+- container/CI wrapper;
+- shell hook for agents and terminal sessions.
+
+Each wrapper must preserve daemon policy, event logging, handoff visibility,
+and stop/status inspection.
+
+## Harness Mediation Contracts
+
+### Codex
+
+Codex currently behaves as a command-owned session. `CODEX_HOME` selection is
+the main route injection boundary.
+
+Supported near-term product shape:
+
+- daemon keeps Codex route evidence and handoffs warm;
+- `oauth-mux exec --profile codex-max -- codex ...` launches future Codex
+  commands with the selected account;
+- a Codex-specific wrapper can relaunch a child Codex process when the selected
+  route changes;
+- direct hot-swap inside this already-running Codex session is not promised.
+
+### Claude
+
+Claude is also command-owned. `CLAUDE_CONFIG_DIR` isolation and `claude auth
+status` are the first proven surfaces.
+
+Supported near-term product shape:
+
+- daemon keeps account-store readiness and auth-status evidence warm;
+- login remains user-mediated through Claude CLI handoff;
+- quota and usage behavior need paid cohort proof before background claims.
+
+### Figma
+
+Figma has multiple auth shapes: OAuth bearer, PAT, plan token, and MCP remote
+resource auth. These must stay separate.
+
+Supported near-term product shape:
+
+- daemon can keep low-impact identity/resource status warm when policy admits;
+- PAT and plan-token stores can become stronger candidates for automatic
+  refresh or rotation only when ownership is explicit;
+- OAuth/browser flows remain user-mediated until a safe app flow is proven.
+
+### MCP and in-agent surfaces
+
+MCP should expose visibility before mutation:
+
+- `accounts.list`;
+- `providers.list`;
+- `route.explain`;
+- `stay_afloat.once`;
+- `handoffs.list`;
+- `enroll.plan`.
+
+Mutation-capable tools must require explicit user consent and return redacted
+evidence. They should not silently run browser/device auth or spend provider
+quota.
+
+## Implementation Slices
+
+### D0: contract and tracking
+
+- Create this production daemon contract.
+- Link it from the daemon boundary and product gap map.
+- Attach it to `TIN-897` and GitHub `#67`.
+
+### D1: daemon snapshot status
+
+- Persist the latest stay-afloat tick summary as a redacted daemon snapshot.
+- Add status JSON fields for `last_tick_at`, `next_tick_after`,
+  `next_tick_reason`, `afloat`, `selected`, and `handoff_pending`.
+- Keep `production_supported:false` until a supervised loop exists.
+
+Implementation note, 2026-05-02: this slice now writes
+`daemon-snapshot.json` under the oauth-mux state directory after each
+stay-afloat/daemon tick. `oauth-mux daemon status --json` exposes the latest
+snapshot under `stay_afloat` while still reporting
+`production_supported:false` and `hosts_stay_afloat:false`.
+
+### D2: supervised stay-afloat loop
+
+- Add an opt-in daemon mode that hosts the foreground tick engine.
+- Stop cleanly.
+- Run no provider-spend probes by default.
+- Reuse account locks, handoffs, event logs, and scheduler hints.
+- Prove macOS and Linux stop/status behavior.
+
+### D3: wrapper recipes
+
+- Add package-neutral wrapper docs first.
+- Add Homebrew service, launchd, systemd user, Windows, and container examples
+  only as optional wrappers.
+- Prove each wrapper preserves policy and event/handoff visibility.
+
+### D4: mediation adapters
+
+- Promote `oauth-mux exec` and shell wrappers as Level 1 mediation.
+- Add a Codex wrapper story for selected-account launch and supervised restart.
+- Add MCP/in-agent tools for route visibility and handoff surfacing.
+- Consider request-level proxying only where the harness protocol can support
+  Level 3 per-request muxing.
+
+### D5: paid cohort soak
+
+- Run the `TIN-895` seven-day foreground soak first.
+- Then run daemon beta soak on the same cohort.
+- Public claims graduate only for the exact provider, account shape, and
+  mediation level proven.
+
+## Claim Policy
+
+Allowed now:
+
+- foreground stay-afloat selects a usable route from recorded liveness and
+  runtime readiness;
+- Codex multi-account fallback is proven for the current dogfood state;
+- daemon work is in progress toward background supervision.
+
+Allowed after D2 and soak evidence:
+
+- background daemon keeps route state and handoffs warm for proven profiles;
+- optional wrappers can keep the daemon process running on tested platforms.
+
+Not allowed without Level 2 or Level 3 proof:
+
+- "oauth-mux will seamlessly hot-swap this already-running Codex session";
+- "background daemon silently reauths provider-owned CLI sessions";
+- "universal OAuth muxing is proven for every AI harness";
+- "Figma" or "Claude" are fully proven without naming the exact capability and
+  account/billing shape.
+
+## Immediate Product Answer
+
+If the current Codex session caps out, oauth-mux should be able to identify the
+next selectable Codex route from recorded evidence. It will not automatically
+replace the credentials inside this already-running Codex process unless this
+session was launched through a mediation layer that can relaunch, reload, or
+proxy requests through oauth-mux.
+
+That is the gap this contract exists to close.

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -5,7 +5,8 @@ Issue context: GitHub `Jesssullivan/oauth-mux#66`, `#67`, `#68`; Linear
 `TIN-858`, `TIN-736`, `TIN-738`, `TIN-859`, `TIN-860`, `TIN-861`, `TIN-862`,
 `TIN-863`, `TIN-866`, `TIN-867`, `TIN-876`, `TIN-877`, `TIN-878`, and
 `TIN-879`, plus paid cohort lane `TIN-892` with children `TIN-893`,
-`TIN-894`, `TIN-895`, and `TIN-896`.
+`TIN-894`, `TIN-895`, and `TIN-896`, plus production daemon contract
+`TIN-897`.
 
 ## Baseline
 
@@ -20,7 +21,7 @@ boundaries that need separate tracking.
 | Facet | Public GitHub issue | Linear tracking | Current posture |
 | --- | --- | --- | --- |
 | Homebrew distribution | `#66` | `TIN-858`, related to `TIN-737` | Public Jess-owned tap exists and clean local install QA passes; Tinyland tap remains private/staged. Live website copy still needs to stop advertising the private tap. |
-| Stay-afloat daemon | `#67` | `TIN-738`, `TIN-859`, `TIN-860`, `TIN-866`, `TIN-867` | Foreground/agent-safe stay-afloat is shipped; production background daemon is not. Socket daemon is explicitly non-product plumbing for this release line. |
+| Stay-afloat daemon | `#67` | `TIN-738`, `TIN-859`, `TIN-860`, `TIN-866`, `TIN-867`, `TIN-897` | Foreground/agent-safe stay-afloat is shipped; production background daemon is not. Socket daemon is explicitly non-product plumbing for this release line. `TIN-897` now defines the promotion contract and the mediation boundary for seamless handoff claims. |
 | Provider expansion | `#68` | `TIN-736`, `TIN-861`, `TIN-862`, `TIN-863`, `TIN-876`, `TIN-877`, `TIN-878`, `TIN-879` | Codex is live-proven; non-Codex proof is capability-level or still needs operator proof. |
 | Paid multi-account proof | `#67`, `#68` | `TIN-892`, `TIN-893`, `TIN-894`, `TIN-895`, `TIN-896` | A one-month paid cohort is now tracked for Codex lower-tier contrast, Claude subscription/billing shapes, Figma token/seat/plan shapes, and a foreground stay-afloat soak gate. |
 
@@ -105,6 +106,15 @@ The `TIN-891` permission-broker artifact is
 how agents, shells, CI jobs, and optional service wrappers should handle
 `action.diagnostic_command` in the right process boundary without turning
 runtime diagnostics into OAuth liveness or automatic repair evidence.
+
+The `TIN-897` background-daemon artifact is
+`docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md`. It defines
+three levels of seamless muxing: prepared fallback for the next mediated
+action, supervised restart/relaunch, and true per-request muxing. The current
+product is aiming first at prepared fallback plus daemon-warmed route state.
+It must not claim hot-swap of an already-running Codex, Claude, or Figma
+harness unless that harness has a proven reload, restart, proxy, or in-agent
+mediation path.
 
 The account-enrollment artifact is
 `docs/spec/account-enrollment-agent-contract-2026-05-01.md`. It defines the
@@ -211,15 +221,20 @@ these precise provider-proof children.
    matrix and keep provider-level promotion conservative.
 7. Work provider proof in narrow slices: `TIN-876` Vercel, `TIN-877` Figma,
    `TIN-878` FlakeHub/Determinate, and `TIN-879` Gemini.
-8. Return to daemon background scheduling only after wrapper/install decisions
-   and provider proof produce enough real operator evidence. The current socket
-   daemon decision is complete under `TIN-867`; future production daemon work
-   must promote the foreground tick engine deliberately.
+8. Work `TIN-897` as the daemon promotion contract: define daemon snapshot
+   status, supervised tick loop, wrapper recipes, and mediation adapters before
+   making seamless handoff claims.
+9. Return to daemon background implementation only after wrapper/install
+   decisions and provider proof produce enough real operator evidence. The
+   current socket daemon decision is complete under `TIN-867`; future
+   production daemon work must promote the foreground tick engine deliberately.
 
 ## Guardrails
 
 - Do not describe the public tap as Homebrew core.
 - Do not make daemon execution a first-run or release gate.
+- Do not claim hot-swap inside an already-running harness without a proven
+  reload, supervised restart, proxy, or in-agent mediation path.
 - Do not run live probes by default.
 - Do not mutate upstream CLI-owned credential stores.
 - Do not promote a provider to `live_proven` without redacted fixtures and an

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -358,6 +358,14 @@ expect_contains "$stay_afloat" '"afloat":true' "stay-afloat reports profile aflo
 expect_contains "$stay_afloat" '"selected":{"provider":"toy","account":"a2"' "stay-afloat selects fallback account a2"
 expect_contains "$stay_afloat" '"next_tick_reason":"wait_until"' "stay-afloat exposes scheduler summary"
 
+printf 'e2e: daemon status exposes latest stay-afloat snapshot without promoting socket daemon\n'
+daemon_status_snapshot="$(omux daemon status --json)"
+expect_contains "$daemon_status_snapshot" '"status":"not_running"' "daemon status remains stopped after foreground tick"
+expect_contains "$daemon_status_snapshot" '"hosts_stay_afloat":false' "daemon status still does not claim to host stay-afloat"
+expect_contains "$daemon_status_snapshot" '"stay_afloat":{"version":' "daemon status includes latest stay-afloat snapshot"
+expect_contains "$daemon_status_snapshot" '"contract":"foreground_tick_snapshot"' "daemon snapshot reports foreground tick contract"
+expect_contains "$daemon_status_snapshot" '"selected":{"provider":"toy","account":"a2"' "daemon snapshot carries selected fallback route"
+
 printf 'e2e: bounded daemon tick loop emits repeated planning snapshots\n'
 daemon_loop="$(omux daemon tick --loop --iterations 2 --interval-ms 0 --profile expensive --capability expensive --json)"
 expect_contains "$daemon_loop" '"mode":"loop"' "daemon tick loop reports loop mode"

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const health_mod = @import("health.zig");
 const paths = @import("paths.zig");
 const log = @import("log.zig");
+const repair_state = @import("repair_state.zig");
 const builtin = @import("builtin");
 
 const Pid = if (builtin.os.tag == .windows) u32 else std.posix.pid_t;
@@ -128,6 +129,7 @@ pub fn status(allocator: std.mem.Allocator, writer: anytype, json: bool) !void {
         if (json) {
             try writer.writeAll("{\"status\":\"running\"");
             try writeStatusContractJson(writer);
+            try writeStatusSnapshotJson(allocator, writer);
             try writer.print(",\"pid\":{d},\"socket\":", .{pid});
             try std.json.stringify(sock, .{}, writer);
             try writer.writeAll("}\n");
@@ -139,6 +141,7 @@ pub fn status(allocator: std.mem.Allocator, writer: anytype, json: bool) !void {
         if (json) {
             try writer.writeAll("{\"status\":\"not_running\"");
             try writeStatusContractJson(writer);
+            try writeStatusSnapshotJson(allocator, writer);
             try writer.writeAll("}\n");
         } else {
             try writer.writeAll("daemon: not running\n");
@@ -154,6 +157,22 @@ fn writeStatusContractJson(writer: anytype) !void {
     try writer.writeAll(",\"wrapper_contract\":\"foreground_tick\"");
     try writer.writeAll(",\"socket_transport_supported\":");
     try writer.writeAll(if (builtin.os.tag == .windows) "false" else "true");
+}
+
+fn writeStatusSnapshotJson(allocator: std.mem.Allocator, writer: anytype) !void {
+    try writer.writeAll(",\"stay_afloat\":");
+    const snapshot = try repair_state.readDaemonSnapshotAlloc(allocator);
+    if (snapshot) |bytes| {
+        defer allocator.free(bytes);
+        const trimmed = std.mem.trim(u8, bytes, " \t\r\n");
+        if (trimmed.len == 0) {
+            try writer.writeAll("null");
+        } else {
+            try writer.writeAll(trimmed);
+        }
+    } else {
+        try writer.writeAll("null");
+    }
 }
 
 fn isRunning(allocator: std.mem.Allocator) bool {
@@ -291,4 +310,5 @@ test "status json exposes socket daemon contract" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"production_supported\":false") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"hosts_stay_afloat\":false") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"wrapper_contract\":\"foreground_tick\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"stay_afloat\":") != null);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -3519,6 +3519,8 @@ fn runDaemonTick(
             selected_index = firstSelectableRoute(evaluations.items);
         }
 
+        writeDaemonTickSnapshot(allocator, parsed.value, evaluations.items, selected_index, executions.items, args, observed_at) catch {};
+
         if (args.json) {
             if (iterations > 1) {
                 if (idx > 0) try writer.writeByte(',');
@@ -3539,6 +3541,54 @@ fn runDaemonTick(
     if (args.json and iterations > 1) {
         try writer.writeAll("]}\n");
     }
+}
+
+fn writeDaemonTickSnapshot(
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+    executions: []const DaemonTickExecution,
+    args: cli.Command.DaemonTickArgs,
+    observed_at: i64,
+) !void {
+    var snapshot = std.ArrayList(u8).init(allocator);
+    defer snapshot.deinit();
+    const writer = snapshot.writer();
+    const stats = daemonTickStats(cfg.policy.daemon, evaluations, observed_at);
+
+    try writer.writeAll("{\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"contract\":\"foreground_tick_snapshot\"");
+    try writer.writeAll(",\"last_tick_at\":");
+    try writer.print("{d}", .{observed_at});
+    try writer.writeAll(",\"profile\":");
+    if (args.profile) |profile_name| try std.json.stringify(profile_name, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"capability\":");
+    if (args.capability) |capability| try std.json.stringify(capability, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"mode\":");
+    try std.json.stringify(if (args.once) "once" else "loop", .{}, writer);
+    try writer.writeAll(",\"execution_mode\":");
+    try std.json.stringify(if (args.execute) "execute" else "plan", .{}, writer);
+    try writer.writeAll(",\"executed\":");
+    try writer.writeAll(if (daemonTickExecutionsRan(executions)) "true" else "false");
+    try writer.writeAll(",\"handoff_queued\":");
+    try writer.writeAll(if (daemonTickHandoffQueued(executions)) "true" else "false");
+    try writer.writeAll(",\"handoff_pending\":");
+    try writer.writeAll(if (daemonTickHandoffPending(executions)) "true" else "false");
+    try writer.writeAll(",\"afloat\":");
+    try writer.writeAll(if (selected_index != null) "true" else "false");
+    try writer.writeAll(",\"selected\":");
+    if (selected_index) |idx| {
+        try writeRouteSelectionJson(writer, evaluations[idx].route);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"summary\":");
+    try writeDaemonTickStatsJson(writer, stats);
+    try writer.writeByte('}');
+
+    try repair_state.writeDaemonSnapshot(allocator, snapshot.items);
 }
 
 fn daemonTickArgsToPlanArgs(args: cli.Command.DaemonTickArgs) cli.Command.RepairPlanArgs {

--- a/src/repair_state.zig
+++ b/src/repair_state.zig
@@ -69,6 +69,32 @@ pub fn writeHandoffs(allocator: std.mem.Allocator, writer: anytype, json: bool, 
     try writePendingHandoffView(allocator, writer, json, limit);
 }
 
+pub fn writeDaemonSnapshot(allocator: std.mem.Allocator, bytes: []const u8) !void {
+    const path = try daemonSnapshotPath(allocator);
+    defer allocator.free(path);
+    try ensureParentDir(path);
+
+    const file = try std.fs.createFileAbsolute(path, .{
+        .truncate = true,
+        .mode = 0o600,
+    });
+    defer file.close();
+    try file.writeAll(bytes);
+    if (bytes.len == 0 or bytes[bytes.len - 1] != '\n') try file.writeAll("\n");
+}
+
+pub fn readDaemonSnapshotAlloc(allocator: std.mem.Allocator) !?[]const u8 {
+    const path = try daemonSnapshotPath(allocator);
+    defer allocator.free(path);
+
+    const file = std.fs.openFileAbsolute(path, .{}) catch |e| switch (e) {
+        error.FileNotFound => return null,
+        else => return e,
+    };
+    defer file.close();
+    return try file.readToEndAlloc(allocator, 64 * 1024);
+}
+
 pub fn hasPendingHandoff(allocator: std.mem.Allocator, key: HandoffKey) !bool {
     const path = try eventsPath(allocator);
     defer allocator.free(path);
@@ -395,6 +421,12 @@ fn eventsPath(allocator: std.mem.Allocator) ![]const u8 {
     const dir = try paths.stateDir(allocator);
     defer allocator.free(dir);
     return std.fs.path.join(allocator, &.{ dir, "repair-events.jsonl" });
+}
+
+fn daemonSnapshotPath(allocator: std.mem.Allocator) ![]const u8 {
+    const dir = try paths.stateDir(allocator);
+    defer allocator.free(dir);
+    return std.fs.path.join(allocator, &.{ dir, "daemon-snapshot.json" });
 }
 
 fn locksDir(allocator: std.mem.Allocator) ![]const u8 {


### PR DESCRIPTION
## Summary

- adds the TIN-897 background stay-afloat daemon contract
- defines prepared fallback, supervised restart, and per-request muxing as separate claim levels
- updates the daemon boundary and product gap map so seamless handoff claims require a proven mediation point
- adds the first D1 implementation slice: stay-afloat ticks write a redacted daemon snapshot, and `daemon status --json` exposes it under `stay_afloat` while keeping `production_supported:false`

## Why

The foreground stay-afloat supervisor is real, but a production daemon must not imply hot-swapping credentials inside an already-running harness process. This locks the next implementation arc around route-state supervision, handoff readiness, and explicit mediation layers.

## Validation

- git diff --check
- zig build test
- nix develop --command just check-local
- smoke: `stay-afloat --once --profile codex-max --capability codex-max --json` followed by `daemon status --json` shows `stay_afloat.contract=foreground_tick_snapshot`, `afloat=true`, selected `codex:max-2#codex-max`, while socket daemon remains not running and not production-supported

Refs TIN-897, #67