### PR TITLE
Add supervised stay-afloat daemon loop

### DIFF
--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -121,6 +121,11 @@ the socket stub as the production supervisor.
 - `oauth-mux daemon tick --loop --iterations <n> --interval-ms <ms> --json`
   as the lower-level wrapper-author spelling for the same bounded foreground
   loop.
+- `oauth-mux daemon run --stay-afloat --profile <profile> --capability
+  <capability>` as the first opt-in beta host for the same tick engine. It
+  reports `stay_afloat_loop.hosted:true` while running, but
+  `production_supported:false` and `hosts_stay_afloat:false` remain in status
+  until soak and wrapper proof promote the daemon product surface.
 - Account-scoped advisory locks during confirmed `repair run`, reported back as
   `repair_in_progress` by runtime-aware route planning.
 - Config-level daemon admission policy for route planning. The default admits

--- a/docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md
+++ b/docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md
@@ -258,6 +258,21 @@ snapshot under `stay_afloat` while still reporting
 - Reuse account locks, handoffs, event logs, and scheduler hints.
 - Prove macOS and Linux stop/status behavior.
 
+Implementation note, 2026-05-02: the beta loop is available as:
+
+```bash
+oauth-mux daemon run --stay-afloat --profile <profile> --capability <capability>
+oauth-mux daemon supervise --profile <profile> --capability <capability>
+```
+
+It writes the normal daemon pid file, records beta loop metadata under the
+runtime directory, runs the same stay-afloat tick engine with execute mode
+enabled, and updates the redacted `stay_afloat` status snapshot after each
+tick. `daemon status --json` reports `contract:"experimental_supervised_loop"`
+and `stay_afloat_loop.hosted:true` while the loop is running, but still reports
+`production_supported:false` and `hosts_stay_afloat:false` until wrapper docs
+and soak proof promote the product surface.
+
 ### D3: wrapper recipes
 
 - Add package-neutral wrapper docs first.

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -6,7 +6,7 @@ Issue context: GitHub `Jesssullivan/oauth-mux#66`, `#67`, `#68`; Linear
 `TIN-863`, `TIN-866`, `TIN-867`, `TIN-876`, `TIN-877`, `TIN-878`, and
 `TIN-879`, plus paid cohort lane `TIN-892` with children `TIN-893`,
 `TIN-894`, `TIN-895`, and `TIN-896`, plus production daemon contract
-`TIN-897`.
+`TIN-897` and supervised-loop implementation `TIN-898`.
 
 ## Baseline
 
@@ -21,7 +21,7 @@ boundaries that need separate tracking.
 | Facet | Public GitHub issue | Linear tracking | Current posture |
 | --- | --- | --- | --- |
 | Homebrew distribution | `#66` | `TIN-858`, related to `TIN-737` | Public Jess-owned tap exists and clean local install QA passes; Tinyland tap remains private/staged. Live website copy still needs to stop advertising the private tap. |
-| Stay-afloat daemon | `#67` | `TIN-738`, `TIN-859`, `TIN-860`, `TIN-866`, `TIN-867`, `TIN-897` | Foreground/agent-safe stay-afloat is shipped; production background daemon is not. Socket daemon is explicitly non-product plumbing for this release line. `TIN-897` now defines the promotion contract and the mediation boundary for seamless handoff claims. |
+| Stay-afloat daemon | `#67` | `TIN-738`, `TIN-859`, `TIN-860`, `TIN-866`, `TIN-867`, `TIN-897`, `TIN-898` | Foreground/agent-safe stay-afloat is shipped; production background daemon is not. Socket daemon is explicitly non-product plumbing for this release line. `TIN-897` defines the mediation boundary for seamless handoff claims; `TIN-898` adds the first opt-in beta supervised loop without changing default policy or production claims. |
 | Provider expansion | `#68` | `TIN-736`, `TIN-861`, `TIN-862`, `TIN-863`, `TIN-876`, `TIN-877`, `TIN-878`, `TIN-879` | Codex is live-proven; non-Codex proof is capability-level or still needs operator proof. |
 | Paid multi-account proof | `#67`, `#68` | `TIN-892`, `TIN-893`, `TIN-894`, `TIN-895`, `TIN-896` | A one-month paid cohort is now tracked for Codex lower-tier contrast, Claude subscription/billing shapes, Figma token/seat/plan shapes, and a foreground stay-afloat soak gate. |
 
@@ -115,6 +115,10 @@ product is aiming first at prepared fallback plus daemon-warmed route state.
 It must not claim hot-swap of an already-running Codex, Claude, or Figma
 harness unless that harness has a proven reload, restart, proxy, or in-agent
 mediation path.
+`TIN-898` adds `daemon run --stay-afloat` / `daemon supervise` as an opt-in
+beta host for the same foreground tick engine. Status can report
+`stay_afloat_loop.hosted:true`, but production support remains false until
+soak and wrapper proof complete.
 
 The account-enrollment artifact is
 `docs/spec/account-enrollment-agent-contract-2026-05-01.md`. It defines the

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -414,6 +414,48 @@ daemon_stopped="$(OMUX_STATE_DIR="$daemon_state" XDG_RUNTIME_DIR="$daemon_runtim
 expect_contains "$daemon_stopped" '"status":"not_running"' "daemon status reports stopped foreground daemon"
 expect_contains "$daemon_stopped" '"wrapper_contract":"foreground_tick"' "daemon status reports wrapper contract when stopped"
 
+printf 'e2e: supervised stay-afloat daemon loop reports beta host status\n'
+supervised_runtime="$tmp/supervised-runtime"
+supervised_log="$tmp/supervised-daemon.log"
+mkdir -p "$supervised_runtime"
+OMUX_CONFIG="$config" \
+  OMUX_STATE_DIR="$state_dir" \
+  XDG_RUNTIME_DIR="$supervised_runtime" \
+  "$bin" daemon run --stay-afloat --profile expensive --capability expensive --iterations 200 --interval-ms 50 >"$supervised_log" 2>&1 &
+daemon_pid=$!
+supervised_status=""
+for _ in $(seq 1 200); do
+  supervised_status="$(OMUX_STATE_DIR="$state_dir" XDG_RUNTIME_DIR="$supervised_runtime" "$bin" daemon status --json || true)"
+  case "$supervised_status" in
+    *'"status":"running"'*'"stay_afloat_loop":{"hosted":true'*'"stay_afloat":{"version":'*) break ;;
+  esac
+done
+expect_contains "$supervised_status" '"status":"running"' "supervised daemon status reports running"
+expect_contains "$supervised_status" '"contract":"experimental_supervised_loop"' "supervised daemon status reports beta contract"
+expect_contains "$supervised_status" '"hosts_stay_afloat":false' "supervised daemon does not claim production stay-afloat"
+expect_contains "$supervised_status" '"stay_afloat_loop":{"hosted":true' "supervised daemon reports hosted beta loop"
+expect_contains "$supervised_status" '"transport":"foreground_supervised_loop"' "supervised daemon status reports foreground loop transport"
+expect_contains "$supervised_status" '"socket":null' "supervised daemon does not claim a socket transport"
+expect_contains "$supervised_status" '"selected":{"provider":"toy","account":"a2"' "supervised daemon snapshot carries selected fallback route"
+OMUX_STATE_DIR="$state_dir" XDG_RUNTIME_DIR="$supervised_runtime" "$bin" daemon stop >/dev/null 2>&1
+set +e
+wait "$daemon_pid" 2>/dev/null
+supervised_wait_status=$?
+set -e
+daemon_pid=""
+case "$supervised_wait_status" in
+  0|143) ;;
+  *)
+    printf 'e2e assertion failed: supervised daemon exited unexpectedly with status %s\n' "$supervised_wait_status" >&2
+    printf 'supervised daemon log:\n%s\n' "$(cat "$supervised_log")" >&2
+    exit 1
+    ;;
+esac
+supervised_stopped="$(OMUX_STATE_DIR="$state_dir" XDG_RUNTIME_DIR="$supervised_runtime" "$bin" daemon status --json)"
+expect_contains "$supervised_stopped" '"status":"not_running"' "supervised daemon status reports stopped"
+expect_contains "$supervised_stopped" '"stay_afloat_loop":{"hosted":false' "supervised daemon clears hosted loop metadata after stop"
+expect_contains "$supervised_stopped" '"stay_afloat":{"version":' "supervised daemon leaves latest redacted snapshot visible after stop"
+
 printf 'e2e: daemon tick execute runs one admitted command probe\n'
 omux health --reset toy:a1 >/dev/null
 omux health --reset toy:a2 >/dev/null

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -25,7 +25,7 @@ pub const Command = union(enum) {
     init: InitArgs,
     codex: CodexArgs,
     completions: CompletionsArgs,
-    daemon_run,
+    daemon_run: DaemonRunArgs,
     daemon_start,
     daemon_stop,
     daemon_status: DaemonStatusArgs,
@@ -205,6 +205,11 @@ pub const Command = union(enum) {
         json: bool = false,
     };
 
+    pub const DaemonRunArgs = struct {
+        stay_afloat: bool = false,
+        tick: DaemonTickArgs = .{},
+    };
+
     pub const DaemonEventsArgs = struct {
         json: bool = false,
         limit: usize = 50,
@@ -271,7 +276,8 @@ pub fn parse(args: []const []const u8) Command {
     if (eql(cmd, "version") or eql(cmd, "--version") or eql(cmd, "-v")) return .version_cmd;
     if (eql(cmd, "daemon")) {
         if (rest.len > 0) {
-            if (eql(rest[0], "run")) return .daemon_run;
+            if (eql(rest[0], "run")) return parseDaemonRun(rest[1..]);
+            if (eql(rest[0], "supervise")) return parseDaemonSupervise(rest[1..]);
             if (eql(rest[0], "repair-plan")) return parseRepairPlan(rest[1..]);
             if (eql(rest[0], "start")) return .daemon_start;
             if (eql(rest[0], "stop")) return .daemon_stop;
@@ -612,6 +618,45 @@ fn parseDaemonStatus(args: []const []const u8) Command {
     return .{ .daemon_status = result };
 }
 
+fn parseDaemonRun(args: []const []const u8) Command {
+    var result = Command.DaemonRunArgs{};
+    result.tick = parseDaemonTickArgs(args);
+    result.tick.execute = true;
+    var bounded = false;
+    for (args) |arg| {
+        if (eql(arg, "--stay-afloat") or eql(arg, "stay-afloat")) {
+            result.stay_afloat = true;
+        } else if (eql(arg, "--iterations") or eql(arg, "--once")) {
+            bounded = true;
+        }
+    }
+    if (!bounded) {
+        result.tick.once = false;
+        result.tick.iterations = std.math.maxInt(u32);
+    }
+    if (!result.stay_afloat) {
+        result.tick = .{};
+    }
+    return .{ .daemon_run = result };
+}
+
+fn parseDaemonSupervise(args: []const []const u8) Command {
+    var result = Command.DaemonRunArgs{
+        .stay_afloat = true,
+        .tick = parseDaemonTickArgs(args),
+    };
+    result.tick.execute = true;
+    var bounded = false;
+    for (args) |arg| {
+        if (eql(arg, "--iterations") or eql(arg, "--once")) bounded = true;
+    }
+    if (!bounded) {
+        result.tick.once = false;
+        result.tick.iterations = std.math.maxInt(u32);
+    }
+    return .{ .daemon_run = result };
+}
+
 fn parseDaemonEvents(args: []const []const u8) Command {
     var result = Command.DaemonEventsArgs{};
     var i: usize = 0;
@@ -933,7 +978,10 @@ pub fn printUsage(writer: anytype) !void {
         \\  config validate    Validate the configuration file.
         \\  config path        Print the config file path.
         \\
-        \\  daemon run         Run the daemon in the foreground.
+        \\  daemon run [--stay-afloat] [stay-afloat options]
+        \\      Run the daemon in the foreground; --stay-afloat hosts the beta supervised tick loop.
+        \\  daemon supervise [stay-afloat options]
+        \\      Alias for daemon run --stay-afloat.
         \\  daemon start       Start experimental daemon stub; no automatic repair.
         \\  daemon stop        Stop the daemon.
         \\  daemon status [--json]
@@ -1420,7 +1468,11 @@ test "parse route explain with profile" {
 
 test "parse daemon run" {
     const args = [_][]const u8{ "daemon", "run" };
-    try std.testing.expect(parse(&args) == .daemon_run);
+    const cmd = parse(&args);
+    switch (cmd) {
+        .daemon_run => |run| try std.testing.expect(!run.stay_afloat),
+        else => return error.Unexpected,
+    }
 }
 
 test "parse daemon events json limit" {
@@ -1473,6 +1525,23 @@ test "parse stay-afloat once json selector" {
             try std.testing.expectEqualStrings("codex-max", tick.capability.?);
         },
         else => return error.Unexpected,
+    }
+}
+
+test "parse daemon run stay-afloat supervisor" {
+    const args = [_][]const u8{ "daemon", "run", "--stay-afloat", "--profile", "codex-max", "--capability", "codex-max", "--iterations", "2", "--interval-ms", "0" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .daemon_run => |run| {
+            try std.testing.expect(run.stay_afloat);
+            try std.testing.expect(!run.tick.once);
+            try std.testing.expect(run.tick.execute);
+            try std.testing.expectEqual(@as(u32, 2), run.tick.iterations);
+            try std.testing.expectEqual(@as(u64, 0), run.tick.interval_ms);
+            try std.testing.expectEqualStrings("codex-max", run.tick.profile.?);
+            try std.testing.expectEqualStrings("codex-max", run.tick.capability.?);
+        },
+        else => return error.TestUnexpectedResult,
     }
 }
 
@@ -1634,7 +1703,8 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary live-qa probe-all config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run start stop status events handoffs tick' -d 'Daemon subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run supervise start stop status events handoffs tick' -d 'Daemon subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l stay-afloat -d 'Host beta supervised stay-afloat loop'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l limit -d 'Limit event count' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l all -d 'Include historical handoff events'

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -15,6 +15,19 @@ pub const DaemonError = error{
     OutOfMemory,
 };
 
+pub const RunGuard = struct {
+    allocator: std.mem.Allocator,
+    pid_path: []const u8,
+    metadata_path: []const u8,
+
+    pub fn release(self: *RunGuard) void {
+        std.fs.deleteFileAbsolute(self.pid_path) catch {};
+        std.fs.deleteFileAbsolute(self.metadata_path) catch {};
+        self.allocator.free(self.pid_path);
+        self.allocator.free(self.metadata_path);
+    }
+};
+
 pub fn run(allocator: std.mem.Allocator) DaemonError!void {
     if (comptime builtin.os.tag == .windows) {
         log.err("daemon: foreground socket transport is not implemented on windows", .{});
@@ -38,6 +51,35 @@ pub fn run(allocator: std.mem.Allocator) DaemonError!void {
     defer std.fs.deleteFileAbsolute(pid_path) catch {};
 
     runLoop(allocator, sock_path) catch return error.SocketError;
+}
+
+pub fn acquireStayAfloatRunGuard(allocator: std.mem.Allocator) DaemonError!RunGuard {
+    if (comptime builtin.os.tag == .windows) {
+        log.err("daemon: foreground stay-afloat loop is not implemented on windows", .{});
+        return error.SocketError;
+    }
+
+    const pid_path = pidPath(allocator) catch return error.OutOfMemory;
+    errdefer allocator.free(pid_path);
+
+    const metadata_path = metadataPath(allocator) catch return error.OutOfMemory;
+    errdefer allocator.free(metadata_path);
+
+    if (isRunning(allocator)) {
+        log.err("daemon: already running", .{});
+        return error.AlreadyRunning;
+    }
+
+    ensureParentDir(pid_path) catch return error.SocketError;
+    writePidFile(pid_path, currentPid()) catch return error.SocketError;
+    errdefer std.fs.deleteFileAbsolute(pid_path) catch {};
+
+    writeStayAfloatMetadata(metadata_path) catch return error.SocketError;
+    return .{
+        .allocator = allocator,
+        .pid_path = pid_path,
+        .metadata_path = metadata_path,
+    };
 }
 
 pub fn start(allocator: std.mem.Allocator) DaemonError!void {
@@ -114,49 +156,81 @@ pub fn stop(allocator: std.mem.Allocator) !void {
         return;
     };
 
+    const metadata_path = metadataPath(allocator) catch null;
+    defer if (metadata_path) |path| allocator.free(path);
+
     log.info("daemon: stopped (pid {d})", .{pid});
     std.fs.deleteFileAbsolute(pid_path) catch {};
+    if (metadata_path) |path| std.fs.deleteFileAbsolute(path) catch {};
 }
 
 pub fn status(allocator: std.mem.Allocator, writer: anytype, json: bool) !void {
     const pid_path = try pidPath(allocator);
     defer allocator.free(pid_path);
 
-    if (isRunning(allocator)) {
+    const running = isRunning(allocator);
+    const loop_hosted = if (running) hasStayAfloatMetadata(allocator) else false;
+
+    if (running) {
         const pid = readPidFile(allocator, pid_path) catch 0;
         const sock = try paths.socketPath(allocator);
         defer allocator.free(sock);
         if (json) {
             try writer.writeAll("{\"status\":\"running\"");
-            try writeStatusContractJson(writer);
+            try writeStatusContractJson(writer, loop_hosted);
+            try writeStatusLoopJson(allocator, writer, loop_hosted);
             try writeStatusSnapshotJson(allocator, writer);
-            try writer.print(",\"pid\":{d},\"socket\":", .{pid});
-            try std.json.stringify(sock, .{}, writer);
+            try writer.print(",\"pid\":{d},\"transport\":", .{pid});
+            try std.json.stringify(if (loop_hosted) "foreground_supervised_loop" else "unix_socket", .{}, writer);
+            try writer.writeAll(",\"socket\":");
+            if (loop_hosted) try writer.writeAll("null") else try std.json.stringify(sock, .{}, writer);
             try writer.writeAll("}\n");
         } else {
-            try writer.print("daemon: running (pid {d}, socket {s})\n", .{ pid, sock });
-            try writer.writeAll("daemon: experimental socket stub; stay-afloat contract is the foreground tick engine\n");
+            if (loop_hosted) {
+                try writer.print("daemon: running supervised stay-afloat loop (pid {d})\n", .{pid});
+            } else {
+                try writer.print("daemon: running (pid {d}, socket {s})\n", .{ pid, sock });
+            }
+            try writer.writeAll("daemon: experimental; stay-afloat contract is the foreground tick engine\n");
         }
     } else {
         if (json) {
             try writer.writeAll("{\"status\":\"not_running\"");
-            try writeStatusContractJson(writer);
+            try writeStatusContractJson(writer, false);
+            try writeStatusLoopJson(allocator, writer, false);
             try writeStatusSnapshotJson(allocator, writer);
             try writer.writeAll("}\n");
         } else {
             try writer.writeAll("daemon: not running\n");
-            try writer.writeAll("daemon: experimental socket stub; stay-afloat contract is the foreground tick engine\n");
+            try writer.writeAll("daemon: experimental; stay-afloat contract is the foreground tick engine\n");
         }
     }
 }
 
-fn writeStatusContractJson(writer: anytype) !void {
-    try writer.writeAll(",\"contract\":\"experimental_socket_stub\"");
+fn writeStatusContractJson(writer: anytype, loop_hosted: bool) !void {
+    try writer.writeAll(",\"contract\":");
+    try std.json.stringify(if (loop_hosted) "experimental_supervised_loop" else "experimental_socket_stub", .{}, writer);
     try writer.writeAll(",\"production_supported\":false");
     try writer.writeAll(",\"hosts_stay_afloat\":false");
     try writer.writeAll(",\"wrapper_contract\":\"foreground_tick\"");
     try writer.writeAll(",\"socket_transport_supported\":");
     try writer.writeAll(if (builtin.os.tag == .windows) "false" else "true");
+}
+
+fn writeStatusLoopJson(allocator: std.mem.Allocator, writer: anytype, loop_hosted: bool) !void {
+    try writer.writeAll(",\"stay_afloat_loop\":");
+    if (loop_hosted) {
+        const metadata = try readMetadataAlloc(allocator);
+        if (metadata) |bytes| {
+            defer allocator.free(bytes);
+            const trimmed = std.mem.trim(u8, bytes, " \t\r\n");
+            if (trimmed.len != 0 and trimmed[0] == '{') {
+                try writer.writeAll(trimmed);
+                return;
+            }
+        }
+    }
+    try writer.writeAll("{\"hosted\":false,\"production_supported\":false}");
 }
 
 fn writeStatusSnapshotJson(allocator: std.mem.Allocator, writer: anytype) !void {
@@ -296,6 +370,56 @@ fn readPidFile(allocator: std.mem.Allocator, path: []const u8) !Pid {
     return std.fmt.parseInt(Pid, pid_str, 10) catch return error.InvalidCharacter;
 }
 
+fn metadataPath(allocator: std.mem.Allocator) ![]const u8 {
+    const dir = paths.runtimeDir(allocator) catch return error.OutOfMemory;
+    defer allocator.free(dir);
+    return std.fs.path.join(allocator, &.{ dir, "daemon-metadata.json" });
+}
+
+fn writeStayAfloatMetadata(path: []const u8) !void {
+    try ensureParentDir(path);
+    const file = try std.fs.createFileAbsolute(path, .{ .truncate = true, .mode = 0o600 });
+    defer file.close();
+    const writer = file.writer();
+    try writer.writeAll("{\"hosted\":true");
+    try writer.writeAll(",\"mode\":\"stay_afloat_supervisor\"");
+    try writer.writeAll(",\"contract\":\"beta_foreground_tick_host\"");
+    try writer.writeAll(",\"production_supported\":false");
+    try writer.writeAll(",\"started_at\":");
+    try writer.print("{d}", .{std.time.timestamp()});
+    try writer.writeAll("}\n");
+}
+
+fn readMetadataAlloc(allocator: std.mem.Allocator) !?[]const u8 {
+    const path = try metadataPath(allocator);
+    defer allocator.free(path);
+    const file = std.fs.openFileAbsolute(path, .{}) catch |e| switch (e) {
+        error.FileNotFound => return null,
+        else => return e,
+    };
+    defer file.close();
+    return try file.readToEndAlloc(allocator, 16 * 1024);
+}
+
+fn hasStayAfloatMetadata(allocator: std.mem.Allocator) bool {
+    const metadata = readMetadataAlloc(allocator) catch return false;
+    if (metadata) |bytes| {
+        defer allocator.free(bytes);
+        return std.mem.indexOf(u8, bytes, "\"hosted\":true") != null and
+            std.mem.indexOf(u8, bytes, "\"mode\":\"stay_afloat_supervisor\"") != null;
+    }
+    return false;
+}
+
+fn ensureParentDir(path: []const u8) !void {
+    if (std.fs.path.dirname(path)) |dir| {
+        std.fs.makeDirAbsolute(dir) catch |e| switch (e) {
+            error.PathAlreadyExists => {},
+            else => return e,
+        };
+    }
+}
+
 test "isRunning returns false when no daemon" {
     try std.testing.expect(!isRunning(std.testing.allocator));
 }
@@ -310,5 +434,6 @@ test "status json exposes socket daemon contract" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"production_supported\":false") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"hosts_stay_afloat\":false") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"wrapper_contract\":\"foreground_tick\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"stay_afloat_loop\":{\"hosted\":false") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"stay_afloat\":") != null);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -161,7 +161,14 @@ pub fn main() !void {
             try cli.printCompletions(stdout, comp_args.shell);
         },
 
-        .daemon_run => {
+        .daemon_run => |run_args| {
+            if (run_args.stay_afloat) {
+                runSupervisedStayAfloat(allocator, stdout, run_args.tick) catch |e| {
+                    log.err("daemon stay-afloat: {s}", .{@errorName(e)});
+                    std.process.exit(types.ExitCode.general_error.int());
+                };
+                return;
+            }
             daemon.run(allocator) catch |e| {
                 log.err("daemon: {s}", .{@errorName(e)});
                 std.process.exit(types.ExitCode.general_error.int());
@@ -3541,6 +3548,21 @@ fn runDaemonTick(
     if (args.json and iterations > 1) {
         try writer.writeAll("]}\n");
     }
+}
+
+fn runSupervisedStayAfloat(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    args: cli.Command.DaemonTickArgs,
+) !void {
+    var guard = try daemon.acquireStayAfloatRunGuard(allocator);
+    defer guard.release();
+
+    var tick_args = args;
+    tick_args.execute = true;
+    tick_args.json = false;
+
+    try runDaemonTick(allocator, writer, tick_args, "oauth-mux daemon run --stay-afloat");
 }
 
 fn writeDaemonTickSnapshot(


### PR DESCRIPTION
## Summary

- adds opt-in beta hosting for the foreground stay-afloat tick loop via `oauth-mux daemon run --stay-afloat` and `oauth-mux daemon supervise`
- records supervised-loop runtime metadata and exposes it through `oauth-mux daemon status --json` without promoting the socket daemon to a production surface
- extends local e2e coverage and docs for the TIN-898 daemon boundary

## Product truth

This does not claim seamless background muxing yet. The status contract remains `production_supported:false` and `hosts_stay_afloat:false`; the new loop is a beta supervised host for route-state refresh and repair handoff evidence.

## Validation

- `zig build test`
- `git diff --check`
- `nix develop --command just check-local`

Refs TIN-898. Related to #67.