### PR TITLE
Add stay-afloat next action mediation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ mutating auth state:
 ```bash
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux route explain --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux route select --profile codex-max --capability codex-max --json
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux stay-afloat next --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair-plan --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux accounts list --provider codex --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux doctor runtime --profile codex-max --capability codex-max --json
@@ -112,6 +113,13 @@ oauth-mux daemon events --json
 `route select` and `route explain` are no-spend stay-afloat commands. They use
 recorded route liveness plus runtime readiness; unrecorded routes are reported
 as `probe_needed` instead of being treated as available.
+
+`stay-afloat next --json` is the agent-facing bridge from route state to action.
+When a route is selectable, it returns `ready_for_exec:true` plus an exact
+`exec_argv` pinned to provider, account, and capability. When no route is
+selectable, it returns `ready_for_exec:false` plus the typed repair or handoff
+action without running probes, auth flows, provider calls, target commands, or
+secret mutation.
 
 `doctor runtime --json` is also no-spend. It checks local runtime prerequisites
 such as upstream binaries, configured account store directories, write access,

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -42,6 +42,7 @@ oauth-mux config validate
 oauth-mux discover --json
 oauth-mux doctor runtime --json
 oauth-mux route explain --profile <profile> --capability <capability> --json
+oauth-mux stay-afloat next --profile <profile> --capability <capability> --json
 oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json
 oauth-mux stay-afloat handoffs --json
 oauth-mux stay-afloat refresh --profile <profile> --capability <capability> --json
@@ -91,16 +92,21 @@ oauth-mux codex live-qa --confirm-spend
 oauth-mux codex probe-all --capability codex-mini --json
 ```
 
-`doctor runtime`, `route explain`, `route select`, `stay-afloat --once`, and
-bounded `stay-afloat --loop` are no-spend surfaces when run without
-`--execute`. They only use local runtime checks plus recorded liveness, so they
-are safe for agents to run before deciding whether a live probe or user-driven
-reauth is warranted. `stay-afloat --execute` is the beta foreground execution
-boundary: it can run one admitted non-interactive action or queue an interactive
-handoff event. Prefer scoped runtime checks such as
+`doctor runtime`, `route explain`, `route select`, `stay-afloat next`,
+`stay-afloat --once`, and bounded `stay-afloat --loop` are no-spend surfaces
+when run without `--execute`. They only use local runtime checks plus recorded
+liveness, so they are safe for agents to run before deciding whether a live
+probe or user-driven reauth is warranted. `stay-afloat --execute` is the beta
+foreground execution boundary: it can run one admitted non-interactive action
+or queue an interactive handoff event. Prefer scoped runtime checks such as
 `oauth-mux doctor runtime --profile codex-max --capability codex-max --json`
 when dogfooding a specific stay-afloat route; global runtime doctor is still
 useful for support bundles and full-machine cleanup.
+
+`oauth-mux stay-afloat next --json` is the simplest agent handoff: it returns
+an exact `exec_argv` when already afloat, otherwise it returns the typed repair
+or user-handoff action to mediate before retrying.
+
 `oauth-mux accounts list --json` is the provider-neutral account inventory
 surface. It reports configured accounts, runtime readiness, capability proof,
 recorded liveness, and safe next commands without reading credential values.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -170,6 +170,7 @@ To inspect the stay-afloat decision loop without running a canary:
 ```bash
 oauth-mux route explain --profile codex-max --capability codex-max --json
 oauth-mux route select --profile codex-max --capability codex-max --json
+oauth-mux stay-afloat next --profile codex-max --capability codex-max --json
 oauth-mux repair-plan --profile codex-max --capability codex-max --json
 oauth-mux repair-plan --profile codex-mini --capability codex-mini --json
 ```
@@ -178,6 +179,13 @@ oauth-mux repair-plan --profile codex-mini --capability codex-mini --json
 readiness plus recorded route liveness and do not probe providers or mutate auth
 state. Unrecorded routes are reported as `probe_needed`, and `route select`
 exits nonzero when no route has enough evidence to be selected.
+
+`stay-afloat next --json` is the preferred agent mediation surface. It also
+does not probe or mutate. If a route is selectable, it returns
+`ready_for_exec:true` and an exact `exec_argv` that pins provider, account, and
+capability for `oauth-mux exec`. If no route is selectable, it returns
+`ready_for_exec:false` and embeds the typed repair action, mediation mode,
+repair owner, and any user-facing command to run.
 
 `oauth-mux repair run` is the explicit repair execution gate. It refuses
 mutation unless `--confirm-repair` is present. Without confirmation, it is safe

--- a/docs/provider-repair-contracts.md
+++ b/docs/provider-repair-contracts.md
@@ -10,9 +10,9 @@ into one generic failure.
 
 ## JSON Contract
 
-`repair-plan`, `route explain`, `daemon tick`, `stay-afloat`, and
-`daemon supervise` route objects expose an `action` object. The action now has
-three distinct identity fields:
+`repair-plan`, `route explain`, `stay-afloat next`, `daemon tick`,
+`stay-afloat`, and `daemon supervise` route objects expose an `action` object.
+The action now has three distinct identity fields:
 
 ```json
 {
@@ -30,6 +30,11 @@ three distinct identity fields:
 - `kind` is the precise route action.
 - `mediation` is how an agent, wrapper, or user should handle the action.
 - `repair_owner` identifies who owns credential repair when there is one.
+
+`stay-afloat next --json` wraps the same action contract in a single
+agent-facing decision. Selectable routes return `ready_for_exec:true` with an
+exact `exec_argv`; non-selectable routes return `ready_for_exec:false` with the
+typed repair action, mediation, owner, and command fields shown above.
 
 The repair owner values are:
 

--- a/docs/stay-afloat-wrappers.md
+++ b/docs/stay-afloat-wrappers.md
@@ -12,9 +12,15 @@ already-running upstream harness process.
 The supported contract is still the portable tick engine:
 
 ```bash
+oauth-mux stay-afloat next --profile codex-max --capability codex-max --json
 oauth-mux stay-afloat --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
 oauth-mux daemon tick --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
 ```
+
+Use `stay-afloat next --json` before launching a harness from an agent or
+wrapper. It does not spend provider calls or mutate auth state; it either
+returns an exact `oauth-mux exec` argv for the selected route or returns the
+typed repair/handoff action to mediate first.
 
 The beta supervised daemon host wraps that same engine:
 

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -338,6 +338,14 @@ expect_contains "$route_select" '"action":"select"' "route select reports action
 expect_contains "$route_select" '"ok":true' "route select reports available selection"
 expect_contains "$route_select" '"selected":{"provider":"toy","account":"a2"' "route select selects fallback account a2"
 
+printf 'e2e: stay-afloat next returns exact executable mediation for selected fallback\n'
+stay_next="$(omux stay-afloat next --profile expensive --capability expensive --json)"
+expect_contains "$stay_next" '"action":"next"' "stay-afloat next reports action"
+expect_contains "$stay_next" '"ready_for_exec":true' "stay-afloat next reports executable route"
+expect_contains "$stay_next" '"selected":{"provider":"toy","account":"a2"' "stay-afloat next selects fallback account a2"
+expect_contains "$stay_next" '"next_action":{"kind":"exec"' "stay-afloat next returns exec mediation"
+expect_contains "$stay_next" '"exec_argv":["oauth-mux","exec","--provider","toy","--account","a2","--capability","expensive","--","<command>"]' "stay-afloat next returns exact exec argv"
+
 printf 'e2e: daemon tick plans stay-afloat without executing work\n'
 daemon_tick="$(omux daemon tick --once --profile expensive --capability expensive --json)"
 expect_contains "$daemon_tick" '"mode":"once"' "daemon tick reports one-shot mode"
@@ -554,6 +562,17 @@ expect_contains "$repair_reauth" '"requires":"--confirm-repair"' "repair run rep
 expect_contains "$repair_reauth" '"command":"oauth-mux codex login-device max-1"' "repair run reports upstream command"
 expect_contains "$repair_reauth" '"daemon_repair":{"admitted":false,"reason":"interactive_not_allowed","budget":"interactive"}' "repair run reports daemon policy refusal"
 expect_contains "$repair_reauth" '"writeback":{"capability":"replace_file","automatic_refresh_admitted":false,"reason":"provider_repair_owned_by_upstream_cli"}' "repair run reports upstream-owned file writeback boundary"
+test ! -e "$tmp/reauth-home/auth.json"
+
+printf 'e2e: stay-afloat next returns provider-mediated handoff when not afloat\n'
+stay_next_reauth="$(OMUX_CONFIG="$reauth_config" OMUX_STATE_DIR="$state_dir" "$bin" stay-afloat next --profile needs-reauth --capability codex-max --json)"
+expect_contains "$stay_next_reauth" '"action":"next"' "stay-afloat next reauth reports action"
+expect_contains "$stay_next_reauth" '"ready_for_exec":false' "stay-afloat next reauth refuses exec readiness"
+expect_contains "$stay_next_reauth" '"next_action":{"kind":"repair"' "stay-afloat next reauth returns repair mediation"
+expect_contains "$stay_next_reauth" '"kind":"reauth"' "stay-afloat next reauth reports reauth action"
+expect_contains "$stay_next_reauth" '"mediation":"user_handoff"' "stay-afloat next reauth reports user handoff"
+expect_contains "$stay_next_reauth" '"repair_owner":"upstream_cli_login"' "stay-afloat next reauth reports upstream owner"
+expect_contains "$stay_next_reauth" '"command":"oauth-mux codex login-device max-1"' "stay-afloat next reauth reports upstream command"
 test ! -e "$tmp/reauth-home/auth.json"
 
 printf 'e2e: daemon tick execute queues interactive reauth handoff\n'

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -18,6 +18,7 @@ pub const Command = union(enum) {
     repair_plan: RepairPlanArgs,
     repair_run: RepairRunArgs,
     route: RouteArgs,
+    stay_afloat_next: RouteArgs,
     stay_afloat: DaemonTickArgs,
     stay_afloat_handoff: HandoffArgs,
     config_validate,
@@ -39,6 +40,7 @@ pub const Command = union(enum) {
     pub const ExecArgs = struct {
         profile: ?[]const u8 = null,
         provider: ?[]const u8 = null,
+        account: ?[]const u8 = null,
         capability: ?[]const u8 = null,
         strategy: ?[]const u8 = null,
         target_argv: []const []const u8 = &.{},
@@ -313,6 +315,9 @@ fn parseExec(args: []const []const u8) Command {
         } else if (eql(args[i], "--provider")) {
             i += 1;
             if (i < args.len) result.provider = args[i];
+        } else if (eql(args[i], "--account")) {
+            i += 1;
+            if (i < args.len) result.account = args[i];
         } else if (eql(args[i], "--capability")) {
             i += 1;
             if (i < args.len) result.capability = args[i];
@@ -696,6 +701,7 @@ fn parseDaemonTick(args: []const []const u8) Command {
 }
 
 fn parseStayAfloat(args: []const []const u8) Command {
+    if (args.len > 0 and eql(args[0], "next")) return parseStayAfloatNext(args[1..]);
     if (args.len > 0 and eql(args[0], "handoffs")) return parseDaemonHandoffs(args[1..]);
     if (args.len > 0 and eql(args[0], "handoff")) return parseStayAfloatHandoff(args[1..]);
     if (args.len > 0 and eql(args[0], "refresh")) {
@@ -706,6 +712,29 @@ fn parseStayAfloat(args: []const []const u8) Command {
         return .{ .stay_afloat = tick };
     }
     return .{ .stay_afloat = parseDaemonTickArgs(args) };
+}
+
+fn parseStayAfloatNext(args: []const []const u8) Command {
+    var result = Command.RouteArgs{ .action = .explain };
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        if (eql(args[i], "--profile") or eql(args[i], "-p")) {
+            i += 1;
+            if (i < args.len) result.profile = args[i];
+        } else if (eql(args[i], "--provider")) {
+            i += 1;
+            if (i < args.len) result.provider = args[i];
+        } else if (eql(args[i], "--account")) {
+            i += 1;
+            if (i < args.len) result.account = args[i];
+        } else if (eql(args[i], "--capability")) {
+            i += 1;
+            if (i < args.len) result.capability = args[i];
+        } else if (eql(args[i], "--json")) {
+            result.json = true;
+        }
+    }
+    return .{ .stay_afloat_next = result };
 }
 
 fn parseStayAfloatHandoff(args: []const []const u8) Command {
@@ -912,7 +941,7 @@ pub fn printUsage(writer: anytype) !void {
         \\Usage: oauth-mux <command> [options]
         \\
         \\Commands:
-        \\  exec [--profile <name>] [--provider <name>] [--capability <name>] -- <cmd> [args...]
+        \\  exec [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] -- <cmd> [args...]
         \\      Execute a command with muxed OAuth credentials injected.
         \\
         \\  env [--profile <name>] [--provider <name>] [--capability <name>] [--shell fish|zsh|bash|ksh]
@@ -968,6 +997,8 @@ pub fn printUsage(writer: anytype) !void {
         \\
         \\  stay-afloat [--once|--loop] [--execute] [--iterations <n>] [--interval-ms <ms>] [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
         \\      Run the portable stay-afloat planner/executor without service-manager assumptions.
+        \\  stay-afloat next [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
+        \\      Show the next mediated action: exec argv when afloat, otherwise typed repair/handoff.
         \\  stay-afloat refresh [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
         \\      Run one execute tick to refresh route evidence after user-mediated auth.
         \\  stay-afloat handoffs [--json] [--limit <n>] [--all]
@@ -1075,11 +1106,13 @@ pub fn printCodexUsage(writer: anytype) !void {
 }
 
 test "parse exec with profile and target" {
-    const args = [_][]const u8{ "exec", "--profile", "work", "--capability", "codex-max", "--", "claude", "chat" };
+    const args = [_][]const u8{ "exec", "--profile", "work", "--provider", "codex", "--account", "max-2", "--capability", "codex-max", "--", "claude", "chat" };
     const cmd = parse(&args);
     switch (cmd) {
         .exec => |exec| {
             try std.testing.expectEqualStrings("work", exec.profile.?);
+            try std.testing.expectEqualStrings("codex", exec.provider.?);
+            try std.testing.expectEqualStrings("max-2", exec.account.?);
             try std.testing.expectEqualStrings("codex-max", exec.capability.?);
             try std.testing.expectEqual(@as(usize, 2), exec.target_argv.len);
             try std.testing.expectEqualStrings("claude", exec.target_argv[0]);
@@ -1528,6 +1561,21 @@ test "parse stay-afloat once json selector" {
     }
 }
 
+test "parse stay-afloat next json selector" {
+    const args = [_][]const u8{ "stay-afloat", "next", "--profile", "codex-max", "--account", "max-2", "--capability", "codex-max", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .stay_afloat_next => |route| {
+            try std.testing.expect(route.action == .explain);
+            try std.testing.expectEqualStrings("codex-max", route.profile.?);
+            try std.testing.expectEqualStrings("max-2", route.account.?);
+            try std.testing.expectEqualStrings("codex-max", route.capability.?);
+            try std.testing.expect(route.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 test "parse daemon run stay-afloat supervisor" {
     const args = [_][]const u8{ "daemon", "run", "--stay-afloat", "--profile", "codex-max", "--capability", "codex-max", "--iterations", "2", "--interval-ms", "0" };
     const cmd = parse(&args);
@@ -1648,7 +1696,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n __fish_use_subcommand -a completions -d 'Generate completions'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route stay-afloat' -l profile -s p -d 'Profile name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route stay-afloat' -l provider -d 'Provider name' -r
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from probe route stay-afloat' -l account -d 'Account name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec probe route stay-afloat' -l account -d 'Account name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route stay-afloat' -l capability -d 'Route capability' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from probe' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -a runtime -d 'Runtime readiness checks'
@@ -1690,7 +1738,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from route' -a 'select explain' -d 'Route subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from route' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l json -d 'JSON output'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -a 'handoffs handoff refresh' -d 'Stay-afloat subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -a 'next handoffs handoff refresh' -d 'Stay-afloat subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from handoff' -a 'ack clear' -d 'Handoff action'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l once -d 'Run one stay-afloat tick'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l loop -d 'Run bounded foreground stay-afloat ticks'

--- a/src/main.zig
+++ b/src/main.zig
@@ -143,6 +143,13 @@ pub fn main() !void {
             };
         },
 
+        .stay_afloat_next => |route_args| {
+            runStayAfloatNext(allocator, stdout, route_args) catch |e| {
+                log.err("stay-afloat next: {s}", .{@errorName(e)});
+                std.process.exit(exitCodeFromPipelineError(e));
+            };
+        },
+
         .stay_afloat => |tick_args| {
             runDaemonTick(allocator, stdout, tick_args, "oauth-mux stay-afloat") catch |e| {
                 log.err("stay-afloat: {s}", .{@errorName(e)});
@@ -2408,6 +2415,7 @@ fn writeDiscoverJson(writer: anytype, cfg: config.Config, config_path: []const u
         "oauth-mux probe --profile <profile> --capability <capability> --json",
         "oauth-mux route explain --profile <profile> --capability <capability> --json",
         "oauth-mux route select --profile <profile> --capability <capability> --json",
+        "oauth-mux stay-afloat next --profile <profile> --capability <capability> --json",
         "oauth-mux repair-plan --profile <profile> --capability <capability> --json",
         "oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json",
         "oauth-mux repair run --profile <profile> --capability <capability> --json",
@@ -3529,6 +3537,40 @@ fn runRoute(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Rou
     if (args.action == .select and selected_index == null) return error.AllAccountsExhausted;
 }
 
+fn runStayAfloatNext(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.RouteArgs) !void {
+    const parsed = try config.load(allocator);
+    defer parsed.deinit();
+
+    var validation_messages = std.ArrayList(u8).init(allocator);
+    defer validation_messages.deinit();
+    try config.validate(parsed.value, validation_messages.writer());
+
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+
+    var routes = try collectRepairPlanRoutes(allocator, parsed.value, .{
+        .profile = args.profile,
+        .provider = args.provider,
+        .account = args.account,
+        .capability = args.capability,
+        .json = args.json,
+    });
+    defer routes.deinit();
+
+    var evaluations = std.ArrayList(RouteEvaluation).init(allocator);
+    defer evaluations.deinit();
+    try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &evaluations);
+
+    const selected_index = firstSelectableRoute(evaluations.items);
+    const candidate_index = if (selected_index == null) firstActionableRoute(evaluations.items) else null;
+
+    if (args.json) {
+        try writeStayAfloatNextJson(writer, allocator, parsed.value, evaluations.items, selected_index, candidate_index, args);
+    } else {
+        try writeStayAfloatNextText(writer, allocator, evaluations.items, selected_index, candidate_index, args);
+    }
+}
+
 fn runDaemonTick(
     allocator: std.mem.Allocator,
     writer: anytype,
@@ -4013,6 +4055,14 @@ fn firstSelectableRoute(evaluations: []const RouteEvaluation) ?usize {
     return null;
 }
 
+fn firstActionableRoute(evaluations: []const RouteEvaluation) ?usize {
+    for (evaluations, 0..) |evaluation, idx| {
+        if (evaluation.action.kind != .none) return idx;
+    }
+    if (evaluations.len > 0) return 0;
+    return null;
+}
+
 fn routeSelectable(runtime: types.RuntimeReadiness, health: ?health_mod.AccountHealth) bool {
     const current = health orelse return false;
     return types.selectable(current.liveness, runtime);
@@ -4088,6 +4138,48 @@ fn writeRouteText(
     }
 }
 
+fn writeStayAfloatNextText(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+    candidate_index: ?usize,
+    args: cli.Command.RouteArgs,
+) !void {
+    try writer.writeAll("oauth-mux stay-afloat next\n\n");
+    if (args.profile) |profile_name| try writer.print("  profile: {s}\n", .{profile_name});
+    if (args.provider) |provider_name| try writer.print("  provider: {s}\n", .{provider_name});
+    if (args.account) |account| try writer.print("  account: {s}\n", .{account});
+    if (args.capability) |capability| try writer.print("  capability: {s}\n", .{capability});
+
+    if (selected_index) |idx| {
+        const selected = evaluations[idx].route;
+        try writer.writeAll("  ready_for_exec: true\n");
+        try writer.print("  selected: {s}:{s}", .{ selected.provider, selected.account });
+        if (selected.capability) |capability| try writer.print("#{s}", .{capability});
+        try writer.writeAll("\n  exec: ");
+        try writeStayAfloatExecCommandText(writer, selected);
+        try writer.writeByte('\n');
+        return;
+    }
+
+    try writer.writeAll("  ready_for_exec: false\n");
+    if (candidate_index) |idx| {
+        const candidate = evaluations[idx];
+        try writer.print("  next_action: {s} {s}\n", .{ @tagName(candidate.action.kind), candidate.action.message });
+        if (try repairCommandAlloc(allocator, candidate.action.command, candidate.route)) |command| {
+            defer allocator.free(command);
+            try writer.print("  command: {s}\n", .{command});
+        }
+        if (try runtimeDiagnosticCommandAlloc(allocator, candidate.action, candidate.route)) |command| {
+            defer allocator.free(command);
+            try writer.print("  diagnostic: {s}\n", .{command});
+        }
+    } else {
+        try writer.writeAll("  next_action: none no matching routes\n");
+    }
+}
+
 fn writeRouteJson(
     writer: anytype,
     allocator: std.mem.Allocator,
@@ -4121,6 +4213,109 @@ fn writeRouteJson(
         try writeRouteEvaluationJson(writer, allocator, cfg, evaluation, selected);
     }
     try writer.writeAll("]}\n");
+}
+
+fn writeStayAfloatNextJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+    candidate_index: ?usize,
+    args: cli.Command.RouteArgs,
+) !void {
+    try writer.writeAll("{\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"action\":\"next\"");
+    try writer.writeAll(",\"policy\":");
+    try writePolicyJson(writer, cfg.policy);
+    try writer.writeAll(",\"profile\":");
+    if (args.profile) |profile_name| try std.json.stringify(profile_name, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"provider\":");
+    if (args.provider) |provider_name| try std.json.stringify(provider_name, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"account\":");
+    if (args.account) |account| try std.json.stringify(account, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"capability\":");
+    if (args.capability) |capability| try std.json.stringify(capability, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"ok\":");
+    try writer.writeAll(if (selected_index != null) "true" else "false");
+    try writer.writeAll(",\"ready_for_exec\":");
+    try writer.writeAll(if (selected_index != null) "true" else "false");
+    try writer.writeAll(",\"selected\":");
+    if (selected_index) |idx| {
+        try writeRouteSelectionJson(writer, evaluations[idx].route);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"next_action\":");
+    try writeStayAfloatNextActionJson(writer, allocator, evaluations, selected_index, candidate_index);
+    try writer.writeAll(",\"routes\":[");
+    for (evaluations, 0..) |evaluation, idx| {
+        if (idx > 0) try writer.writeByte(',');
+        const selected = if (selected_index) |selected| idx == selected else false;
+        try writeRouteEvaluationJson(writer, allocator, cfg, evaluation, selected);
+    }
+    try writer.writeAll("]}\n");
+}
+
+fn writeStayAfloatNextActionJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+    candidate_index: ?usize,
+) !void {
+    if (selected_index) |idx| {
+        const route = evaluations[idx].route;
+        try writer.writeAll("{\"kind\":\"exec\",\"reason\":\"route_selectable\",\"agent_safe\":true,\"runs_target\":false,\"route\":");
+        try writeRouteSelectionJson(writer, route);
+        try writer.writeAll(",\"exec_argv\":");
+        try writeStayAfloatExecArgvJson(writer, route);
+        try writer.writeAll(",\"target_placeholder\":\"<command>\"}");
+        return;
+    }
+
+    if (candidate_index) |idx| {
+        const evaluation = evaluations[idx];
+        try writer.writeAll("{\"kind\":\"repair\",\"reason\":\"no_selectable_route\",\"agent_safe\":true,\"runs_target\":false,\"route\":");
+        try writeRouteSelectionJson(writer, evaluation.route);
+        try writer.writeAll(",\"action\":");
+        try writeRepairActionJson(writer, allocator, evaluation.action, evaluation.route);
+        try writer.writeByte('}');
+        return;
+    }
+
+    try writer.writeAll("{\"kind\":\"none\",\"reason\":\"no_matching_routes\",\"agent_safe\":true,\"runs_target\":false}");
+}
+
+fn writeStayAfloatExecArgvJson(writer: anytype, route: RepairPlanRoute) !void {
+    var first = true;
+    try writer.writeByte('[');
+    try writeJsonArrayString(writer, &first, "oauth-mux");
+    try writeJsonArrayString(writer, &first, "exec");
+    try writeJsonArrayString(writer, &first, "--provider");
+    try writeJsonArrayString(writer, &first, route.provider);
+    try writeJsonArrayString(writer, &first, "--account");
+    try writeJsonArrayString(writer, &first, route.account);
+    if (route.capability) |capability| {
+        try writeJsonArrayString(writer, &first, "--capability");
+        try writeJsonArrayString(writer, &first, capability);
+    }
+    try writeJsonArrayString(writer, &first, "--");
+    try writeJsonArrayString(writer, &first, "<command>");
+    try writer.writeByte(']');
+}
+
+fn writeJsonArrayString(writer: anytype, first: *bool, value: []const u8) !void {
+    if (!first.*) try writer.writeByte(',');
+    first.* = false;
+    try std.json.stringify(value, .{}, writer);
+}
+
+fn writeStayAfloatExecCommandText(writer: anytype, route: RepairPlanRoute) !void {
+    try writer.print("oauth-mux exec --provider {s} --account {s}", .{ route.provider, route.account });
+    if (route.capability) |capability| try writer.print(" --capability {s}", .{capability});
+    try writer.writeAll(" -- <command>");
 }
 
 fn writeRouteSelectionJson(writer: anytype, route: RepairPlanRoute) !void {
@@ -6373,6 +6568,7 @@ fn runExec(allocator: std.mem.Allocator, args: cli.Command.ExecArgs) !void {
 
     ctx.profile_name = args.profile;
     ctx.provider_name = args.provider;
+    ctx.account_name = args.account;
     ctx.capability_name = args.capability;
     ctx.target_argv = args.target_argv;
 
@@ -8890,6 +9086,113 @@ test "route select picks first ready live route and explains skipped quota route
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"selected\":{\"provider\":\"toy\",\"account\":\"a2\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"skip_reason\":\"quota_exhausted\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"skip_reason\":\"available\"") != null);
+}
+
+test "stay-afloat next emits exact exec argv for selected fallback" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "provider_definitions": {
+        \\    "toy": { "name": "toy", "display_name": "Toy Provider" }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "a1": { "secret": { "backend": "env", "variable": "TOY_A1" } },
+        \\        "a2": { "secret": { "backend": "env", "variable": "TOY_A2" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "work": {
+        \\      "providers": ["toy:a1#chat", "toy:a2#chat"]
+        \\    }
+        \\  },
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try config.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    store.recordCapabilityHttpStatus("toy", "a1", "chat", 429, 7200);
+    _ = try store.getOrCreate("toy:a2#chat");
+
+    var routes = try collectRepairPlanRoutes(std.testing.allocator, parsed.value, .{ .profile = "work" });
+    defer routes.deinit();
+
+    var evaluations = std.ArrayList(RouteEvaluation).init(std.testing.allocator);
+    defer evaluations.deinit();
+    try collectRouteEvaluations(std.testing.allocator, parsed.value, &store, routes.items, &evaluations);
+
+    const selected = firstSelectableRoute(evaluations.items).?;
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+    try writeStayAfloatNextJson(buf.writer(), std.testing.allocator, parsed.value, evaluations.items, selected, null, .{
+        .profile = "work",
+        .capability = "chat",
+        .json = true,
+    });
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"action\":\"next\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"ready_for_exec\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"next_action\":{\"kind\":\"exec\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"exec_argv\":[\"oauth-mux\",\"exec\",\"--provider\",\"toy\",\"--account\",\"a2\",\"--capability\",\"chat\",\"--\",\"<command>\"]") != null);
+}
+
+test "stay-afloat next emits mediated repair action when no route is selectable" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": {
+        \\          "config_dir": "/tmp/oauth-mux-test/max-1",
+        \\          "secret": { "backend": "file", "path": "/tmp/oauth-mux-test/max-1/auth.json" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "needs-reauth": {
+        \\      "providers": ["codex:max-1#codex-max"]
+        \\    }
+        \\  },
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try config.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    const route = RepairPlanRoute{ .provider = "codex", .account = "max-1", .capability = "codex-max" };
+    const evaluations = [_]RouteEvaluation{.{
+        .route = route,
+        .runtime = .{ .needs_reauth = .{ .methods = &.{"upstream_cli_login"}, .reason = "session_file_missing" } },
+        .health = null,
+        .budget = .spend_provider,
+        .action = reauthAction(route, provider_schema.codex_def),
+        .selectable = false,
+        .skip_reason = "needs_reauth",
+    }};
+
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+    try writeStayAfloatNextJson(buf.writer(), std.testing.allocator, parsed.value, &evaluations, null, 0, .{
+        .profile = "needs-reauth",
+        .capability = "codex-max",
+        .json = true,
+    });
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"ready_for_exec\":false") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"next_action\":{\"kind\":\"repair\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"kind\":\"reauth\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"mediation\":\"user_handoff\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"repair_owner\":\"upstream_cli_login\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"command\":\"oauth-mux codex login-device max-1\"") != null);
 }
 
 test "route explain treats unrecorded health as probe needed" {


### PR DESCRIPTION
## Summary

- Add `oauth-mux stay-afloat next` as a no-spend agent mediation surface.
- Return exact `oauth-mux exec --provider ... --account ... --capability ... -- <command>` argv when a route is selectable.
- Return typed repair/handoff mediation when no route is selectable, reusing the provider repair contract.
- Add `exec --account` so mediated argv can pin the selected account exactly.
- Update docs and local e2e coverage for selectable fallback and upstream-login handoff cases.

## Tracking

Refs TIN-901.
Closes #109.
Related to #67.

## Validation

- `zig build test`
- `nix develop --command just check-local`
