### PR TITLE
Add stay-afloat launch boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ mutating auth state:
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux route explain --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux route select --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux stay-afloat next --profile codex-max --capability codex-max --json
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux stay-afloat launch --profile codex-max --capability codex-max -- codex
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair-plan --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux accounts list --provider codex --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux doctor runtime --profile codex-max --capability codex-max --json
@@ -120,6 +121,13 @@ When a route is selectable, it returns `ready_for_exec:true` plus an exact
 selectable, it returns `ready_for_exec:false` plus the typed repair or handoff
 action without running probes, auth flows, provider calls, target commands, or
 secret mutation.
+
+`stay-afloat launch -- <command>` is the target execution boundary for new
+harness sessions. It uses the same no-spend preflight as `stay-afloat next`; if
+a route is selectable, it launches the target through `oauth-mux exec` with the
+selected provider/account/capability pinned. If no route is selectable, it
+prints the mediated repair/handoff text and exits nonzero without running the
+target.
 
 `doctor runtime --json` is also no-spend. It checks local runtime prerequisites
 such as upstream binaries, configured account store directories, write access,

--- a/README.md
+++ b/README.md
@@ -125,9 +125,13 @@ secret mutation.
 `stay-afloat launch -- <command>` is the target execution boundary for new
 harness sessions. It uses the same no-spend preflight as `stay-afloat next`; if
 a route is selectable, it launches the target through `oauth-mux exec` with the
-selected provider/account/capability pinned. If no route is selectable, it
-prints the mediated repair/handoff text and exits nonzero without running the
-target.
+selected provider/account/capability pinned. `exec` still performs normal
+token/runtime validation before the target starts; if that validation
+reclassifies the selected route, launch re-runs selection and tries the next
+selectable account. If no route remains selectable, launch prints the refreshed
+mediation text and exits nonzero without running the target. If no route is
+selectable at preflight, launch also prints the mediated repair/handoff text
+and exits nonzero without running the target.
 
 `doctor runtime --json` is also no-spend. It checks local runtime prerequisites
 such as upstream binaries, configured account store directories, write access,

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -110,8 +110,12 @@ or user-handoff action to mediate before retrying.
 
 `oauth-mux stay-afloat launch -- <command>` is the matching startup command for
 users and wrappers. It executes the target only after a selectable route is
-found from recorded evidence; otherwise it prints the mediation text and exits
-nonzero without starting the target.
+found from recorded evidence. The delegated `exec` path still validates local
+runtime and token state before the target starts; if that reclassifies the
+selected route, launch re-runs selection and tries the next selectable account.
+If no route remains selectable, launch prints refreshed mediation text and exits
+nonzero without starting the target. If no route is selectable at preflight, it
+also prints mediation text and exits nonzero without starting the target.
 
 `oauth-mux accounts list --json` is the provider-neutral account inventory
 surface. It reports configured accounts, runtime readiness, capability proof,

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -43,6 +43,7 @@ oauth-mux discover --json
 oauth-mux doctor runtime --json
 oauth-mux route explain --profile <profile> --capability <capability> --json
 oauth-mux stay-afloat next --profile <profile> --capability <capability> --json
+oauth-mux stay-afloat launch --profile <profile> --capability <capability> -- <command>
 oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json
 oauth-mux stay-afloat handoffs --json
 oauth-mux stay-afloat refresh --profile <profile> --capability <capability> --json
@@ -106,6 +107,11 @@ useful for support bundles and full-machine cleanup.
 `oauth-mux stay-afloat next --json` is the simplest agent handoff: it returns
 an exact `exec_argv` when already afloat, otherwise it returns the typed repair
 or user-handoff action to mediate before retrying.
+
+`oauth-mux stay-afloat launch -- <command>` is the matching startup command for
+users and wrappers. It executes the target only after a selectable route is
+found from recorded evidence; otherwise it prints the mediation text and exits
+nonzero without starting the target.
 
 `oauth-mux accounts list --json` is the provider-neutral account inventory
 surface. It reports configured accounts, runtime readiness, capability proof,

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -191,9 +191,14 @@ repair owner, and any user-facing command to run.
 `stay-afloat launch -- <command>` is the user/wrapper startup boundary. It runs
 the same preflight as `stay-afloat next`, then starts the target only when a
 route is selectable. The launched command receives credentials through
-`oauth-mux exec` with the selected provider, account, and capability pinned. If
-the route needs reauth, quota wait, runtime repair, or another handoff, launch
-prints the mediation text and exits nonzero without starting the target.
+`oauth-mux exec` with the selected provider, account, and capability pinned.
+That exec path still validates token and runtime state before target startup;
+if validation reclassifies the selected route, launch re-runs selection and
+tries the next selectable account. If no route remains selectable, launch prints
+refreshed mediation text and exits nonzero without starting the target. If the
+route needs reauth, quota wait, runtime repair, or another handoff at
+preflight, launch also prints mediation text and exits nonzero without starting
+the target.
 
 `oauth-mux repair run` is the explicit repair execution gate. It refuses
 mutation unless `--confirm-repair` is present. Without confirmation, it is safe

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -171,6 +171,7 @@ To inspect the stay-afloat decision loop without running a canary:
 oauth-mux route explain --profile codex-max --capability codex-max --json
 oauth-mux route select --profile codex-max --capability codex-max --json
 oauth-mux stay-afloat next --profile codex-max --capability codex-max --json
+oauth-mux stay-afloat launch --profile codex-max --capability codex-max -- codex
 oauth-mux repair-plan --profile codex-max --capability codex-max --json
 oauth-mux repair-plan --profile codex-mini --capability codex-mini --json
 ```
@@ -186,6 +187,13 @@ does not probe or mutate. If a route is selectable, it returns
 capability for `oauth-mux exec`. If no route is selectable, it returns
 `ready_for_exec:false` and embeds the typed repair action, mediation mode,
 repair owner, and any user-facing command to run.
+
+`stay-afloat launch -- <command>` is the user/wrapper startup boundary. It runs
+the same preflight as `stay-afloat next`, then starts the target only when a
+route is selectable. The launched command receives credentials through
+`oauth-mux exec` with the selected provider, account, and capability pinned. If
+the route needs reauth, quota wait, runtime repair, or another handoff, launch
+prints the mediation text and exits nonzero without starting the target.
 
 `oauth-mux repair run` is the explicit repair execution gate. It refuses
 mutation unless `--confirm-repair` is present. Without confirmation, it is safe

--- a/docs/stay-afloat-wrappers.md
+++ b/docs/stay-afloat-wrappers.md
@@ -26,7 +26,11 @@ typed repair/handoff action to mediate first.
 Use `stay-afloat launch -- <command>` when the wrapper should actually start a
 new harness session. It runs the same route preflight, pins the selected account
 for `oauth-mux exec`, and refuses to run the target when repair or user handoff
-is needed.
+is needed. Because the delegated exec path still validates token and runtime
+state before startup, launch can refresh route evidence and try the next
+selectable account when a route that looked selectable at preflight is
+reclassified before the target starts. If no selectable account remains, it
+prints the refreshed mediation text and exits nonzero.
 
 The beta supervised daemon host wraps that same engine:
 

--- a/docs/stay-afloat-wrappers.md
+++ b/docs/stay-afloat-wrappers.md
@@ -13,6 +13,7 @@ The supported contract is still the portable tick engine:
 
 ```bash
 oauth-mux stay-afloat next --profile codex-max --capability codex-max --json
+oauth-mux stay-afloat launch --profile codex-max --capability codex-max -- codex
 oauth-mux stay-afloat --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
 oauth-mux daemon tick --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
 ```
@@ -21,6 +22,11 @@ Use `stay-afloat next --json` before launching a harness from an agent or
 wrapper. It does not spend provider calls or mutate auth state; it either
 returns an exact `oauth-mux exec` argv for the selected route or returns the
 typed repair/handoff action to mediate first.
+
+Use `stay-afloat launch -- <command>` when the wrapper should actually start a
+new harness session. It runs the same route preflight, pins the selected account
+for `oauth-mux exec`, and refuses to run the target when repair or user handoff
+is needed.
 
 The beta supervised daemon host wraps that same engine:
 

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -346,6 +346,12 @@ expect_contains "$stay_next" '"selected":{"provider":"toy","account":"a2"' "stay
 expect_contains "$stay_next" '"next_action":{"kind":"exec"' "stay-afloat next returns exec mediation"
 expect_contains "$stay_next" '"exec_argv":["oauth-mux","exec","--provider","toy","--account","a2","--capability","expensive","--","<command>"]' "stay-afloat next returns exact exec argv"
 
+printf 'e2e: stay-afloat launch executes target with selected fallback account\n'
+launch_out="$tmp/stay-launch.out"
+OMUX_E2E_EXEC_OUT="$launch_out" omux stay-afloat launch --profile expensive --capability expensive -- sh -c 'printf "%s:%s" "$OMUX_ACTIVE_ACCOUNT" "$TOY_TOKEN" > "$OMUX_E2E_EXEC_OUT"'
+launch_result="$(cat "$launch_out")"
+expect_contains "$launch_result" 'a2:omux-e2e-a2' "stay-afloat launch target receives selected fallback account"
+
 printf 'e2e: daemon tick plans stay-afloat without executing work\n'
 daemon_tick="$(omux daemon tick --once --profile expensive --capability expensive --json)"
 expect_contains "$daemon_tick" '"mode":"once"' "daemon tick reports one-shot mode"
@@ -573,6 +579,26 @@ expect_contains "$stay_next_reauth" '"kind":"reauth"' "stay-afloat next reauth r
 expect_contains "$stay_next_reauth" '"mediation":"user_handoff"' "stay-afloat next reauth reports user handoff"
 expect_contains "$stay_next_reauth" '"repair_owner":"upstream_cli_login"' "stay-afloat next reauth reports upstream owner"
 expect_contains "$stay_next_reauth" '"command":"oauth-mux codex login-device max-1"' "stay-afloat next reauth reports upstream command"
+test ! -e "$tmp/reauth-home/auth.json"
+
+printf 'e2e: stay-afloat launch refuses target when user-mediated reauth is needed\n'
+stay_launch_reauth_out="$tmp/stay-launch-reauth.out"
+stay_launch_should_not_run="$tmp/stay-launch-should-not-run"
+set +e
+OMUX_CONFIG="$reauth_config" \
+  OMUX_STATE_DIR="$state_dir" \
+  "$bin" stay-afloat launch --profile needs-reauth --capability codex-max -- sh -c "touch '$stay_launch_should_not_run'" >"$stay_launch_reauth_out" 2>"$tmp/stay-launch-reauth.stderr"
+stay_launch_reauth_status=$?
+set -e
+if [ "$stay_launch_reauth_status" -eq 0 ]; then
+  printf 'e2e assertion failed: stay-afloat launch should refuse a reauth-needed route\n' >&2
+  exit 1
+fi
+stay_launch_reauth="$(cat "$stay_launch_reauth_out")"
+expect_contains "$stay_launch_reauth" 'ready_for_exec: false' "stay-afloat launch refusal reports not ready"
+expect_contains "$stay_launch_reauth" 'next_action: reauth' "stay-afloat launch refusal reports reauth action"
+expect_contains "$stay_launch_reauth" 'command: oauth-mux codex login-device max-1' "stay-afloat launch refusal reports upstream command"
+test ! -e "$stay_launch_should_not_run"
 test ! -e "$tmp/reauth-home/auth.json"
 
 printf 'e2e: daemon tick execute queues interactive reauth handoff\n'

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -27,6 +27,7 @@ config="$tmp/config.json"
 state_dir="$tmp/state"
 exec_out="$tmp/exec.out"
 probe_cmd="$tmp/probe-harness.sh"
+probe_mode_file="$tmp/probe-mode"
 reauth_probe_cmd="$tmp/reauth-probe-harness.sh"
 
 mkdir -p "$state_dir" "$tmp/a1-home" "$tmp/a2-home"
@@ -39,6 +40,15 @@ capability="${1:-}"
 
 case "${capability}:${OMUX_ACTIVE_ACCOUNT:-}" in
   expensive:a1)
+    if [ -n "${OMUX_E2E_PROBE_MODE_FILE:-}" ] &&
+      [ -f "$OMUX_E2E_PROBE_MODE_FILE" ] &&
+      grep -q '^expensive:a1:ok$' "$OMUX_E2E_PROBE_MODE_FILE"; then
+      printf 'ok provider=%s account=%s capability=%s\n' \
+        "${OMUX_ACTIVE_PROVIDER:-}" \
+        "${OMUX_ACTIVE_ACCOUNT:-}" \
+        "${OMUX_ACTIVE_CAPABILITY:-}"
+      exit 0
+    fi
     printf '%s\n' 'quota_exhausted: simulated monthly route limit'
     exit 1
     ;;
@@ -197,6 +207,7 @@ omux() {
     OMUX_STATE_DIR="$state_dir" \
     OMUX_E2E_A1_AUTH="$auth_a1" \
     OMUX_E2E_A2_AUTH="$auth_a2" \
+    OMUX_E2E_PROBE_MODE_FILE="$probe_mode_file" \
     "$bin" "$@"
 }
 
@@ -351,6 +362,22 @@ launch_out="$tmp/stay-launch.out"
 OMUX_E2E_EXEC_OUT="$launch_out" omux stay-afloat launch --profile expensive --capability expensive -- sh -c 'printf "%s:%s" "$OMUX_ACTIVE_ACCOUNT" "$TOY_TOKEN" > "$OMUX_E2E_EXEC_OUT"'
 launch_result="$(cat "$launch_out")"
 expect_contains "$launch_result" 'a2:omux-e2e-a2' "stay-afloat launch target receives selected fallback account"
+
+printf 'e2e: stay-afloat launch retries next route when exec reclassifies selected account\n'
+printf '%s\n' 'expensive:a1:ok' >"$probe_mode_file"
+omux health --reset toy:a1#expensive >/dev/null
+omux health --reset toy:a2#expensive >/dev/null
+stale_a1_probe="$(omux probe --provider toy --account a1 --capability expensive --json)"
+expect_contains "$stale_a1_probe" '"account":"a1"' "stale launch setup records a1 as available"
+stale_a2_probe="$(omux probe --provider toy --account a2 --capability expensive --json)"
+expect_contains "$stale_a2_probe" '"account":"a2"' "stale launch setup records a2 as available"
+rm -f "$probe_mode_file"
+stale_next="$(omux stay-afloat next --profile expensive --capability expensive --json)"
+expect_contains "$stale_next" '"selected":{"provider":"toy","account":"a1"' "stale launch preflight selects a1 from recorded evidence"
+stale_launch_out="$tmp/stay-launch-stale.out"
+OMUX_E2E_EXEC_OUT="$stale_launch_out" omux stay-afloat launch --profile expensive --capability expensive -- sh -c 'printf "%s:%s" "$OMUX_ACTIVE_ACCOUNT" "$TOY_TOKEN" > "$OMUX_E2E_EXEC_OUT"'
+stale_launch_result="$(cat "$stale_launch_out")"
+expect_contains "$stale_launch_result" 'a2:omux-e2e-a2' "stay-afloat launch falls through to a2 after a1 reclassification"
 
 printf 'e2e: daemon tick plans stay-afloat without executing work\n'
 daemon_tick="$(omux daemon tick --once --profile expensive --capability expensive --json)"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -19,6 +19,7 @@ pub const Command = union(enum) {
     repair_run: RepairRunArgs,
     route: RouteArgs,
     stay_afloat_next: RouteArgs,
+    stay_afloat_launch: ExecArgs,
     stay_afloat: DaemonTickArgs,
     stay_afloat_handoff: HandoffArgs,
     config_validate,
@@ -300,6 +301,10 @@ pub fn parse(args: []const []const u8) Command {
 }
 
 fn parseExec(args: []const []const u8) Command {
+    return .{ .exec = parseExecArgs(args) };
+}
+
+fn parseExecArgs(args: []const []const u8) Command.ExecArgs {
     var result = Command.ExecArgs{};
     var i: usize = 0;
     while (i < args.len) : (i += 1) {
@@ -326,7 +331,7 @@ fn parseExec(args: []const []const u8) Command {
             if (i < args.len) result.strategy = args[i];
         }
     }
-    return .{ .exec = result };
+    return result;
 }
 
 fn parseEnv(args: []const []const u8) Command {
@@ -701,6 +706,7 @@ fn parseDaemonTick(args: []const []const u8) Command {
 }
 
 fn parseStayAfloat(args: []const []const u8) Command {
+    if (args.len > 0 and eql(args[0], "launch")) return .{ .stay_afloat_launch = parseExecArgs(args[1..]) };
     if (args.len > 0 and eql(args[0], "next")) return parseStayAfloatNext(args[1..]);
     if (args.len > 0 and eql(args[0], "handoffs")) return parseDaemonHandoffs(args[1..]);
     if (args.len > 0 and eql(args[0], "handoff")) return parseStayAfloatHandoff(args[1..]);
@@ -999,6 +1005,8 @@ pub fn printUsage(writer: anytype) !void {
         \\      Run the portable stay-afloat planner/executor without service-manager assumptions.
         \\  stay-afloat next [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
         \\      Show the next mediated action: exec argv when afloat, otherwise typed repair/handoff.
+        \\  stay-afloat launch [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] -- <cmd> [args...]
+        \\      Launch a target only when route evidence selects an exact account; otherwise print mediation and exit nonzero.
         \\  stay-afloat refresh [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
         \\      Run one execute tick to refresh route evidence after user-mediated auth.
         \\  stay-afloat handoffs [--json] [--limit <n>] [--all]
@@ -1576,6 +1584,23 @@ test "parse stay-afloat next json selector" {
     }
 }
 
+test "parse stay-afloat launch selector and target" {
+    const args = [_][]const u8{ "stay-afloat", "launch", "--profile", "codex-max", "--provider", "codex", "--account", "max-2", "--capability", "codex-max", "--", "codex", "--ask-for-approval=never" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .stay_afloat_launch => |launch| {
+            try std.testing.expectEqualStrings("codex-max", launch.profile.?);
+            try std.testing.expectEqualStrings("codex", launch.provider.?);
+            try std.testing.expectEqualStrings("max-2", launch.account.?);
+            try std.testing.expectEqualStrings("codex-max", launch.capability.?);
+            try std.testing.expectEqual(@as(usize, 2), launch.target_argv.len);
+            try std.testing.expectEqualStrings("codex", launch.target_argv[0]);
+            try std.testing.expectEqualStrings("--ask-for-approval=never", launch.target_argv[1]);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 test "parse daemon run stay-afloat supervisor" {
     const args = [_][]const u8{ "daemon", "run", "--stay-afloat", "--profile", "codex-max", "--capability", "codex-max", "--iterations", "2", "--interval-ms", "0" };
     const cmd = parse(&args);
@@ -1738,7 +1763,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from route' -a 'select explain' -d 'Route subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from route' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l json -d 'JSON output'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -a 'next handoffs handoff refresh' -d 'Stay-afloat subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -a 'next launch handoffs handoff refresh' -d 'Stay-afloat subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from handoff' -a 'ack clear' -d 'Handoff action'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l once -d 'Run one stay-afloat tick'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l loop -d 'Run bounded foreground stay-afloat ticks'

--- a/src/main.zig
+++ b/src/main.zig
@@ -3591,9 +3591,6 @@ fn runStayAfloatLaunch(allocator: std.mem.Allocator, writer: anytype, args: cli.
     defer validation_messages.deinit();
     try config.validate(parsed.value, validation_messages.writer());
 
-    var store = health_mod.HealthStore.load(allocator, .{});
-    defer store.deinit();
-
     const selector = cli.Command.RouteArgs{
         .action = .explain,
         .profile = args.profile,
@@ -3609,24 +3606,109 @@ fn runStayAfloatLaunch(allocator: std.mem.Allocator, writer: anytype, args: cli.
     });
     defer routes.deinit();
 
-    var evaluations = std.ArrayList(RouteEvaluation).init(allocator);
-    defer evaluations.deinit();
-    try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &evaluations);
+    var attempted_routes = std.ArrayList(RepairPlanRoute).init(allocator);
+    defer attempted_routes.deinit();
 
-    const selected_index = firstSelectableRoute(evaluations.items);
-    if (selected_index == null) {
-        const candidate_index = firstActionableRoute(evaluations.items);
-        try writeStayAfloatMediationText(writer, allocator, evaluations.items, null, candidate_index, selector, "oauth-mux stay-afloat launch");
-        return error.AllAccountsExhausted;
+    var last_exec_error: ?anyerror = null;
+    while (attempted_routes.items.len < routes.items.len) {
+        var store = health_mod.HealthStore.load(allocator, .{});
+        defer store.deinit();
+
+        var evaluations = std.ArrayList(RouteEvaluation).init(allocator);
+        defer evaluations.deinit();
+        try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &evaluations);
+
+        const selected_index = firstSelectableRouteNotAttempted(evaluations.items, attempted_routes.items);
+        if (selected_index == null) {
+            const candidate_index = firstActionableRoute(evaluations.items);
+            try writeStayAfloatMediationText(writer, allocator, evaluations.items, null, candidate_index, selector, "oauth-mux stay-afloat launch");
+            if (last_exec_error) |err| return err;
+            return error.AllAccountsExhausted;
+        }
+
+        const selected = evaluations.items[selected_index.?].route;
+        try attempted_routes.append(selected);
+
+        var exec_args = args;
+        exec_args.profile = null;
+        exec_args.provider = selected.provider;
+        exec_args.account = selected.account;
+        exec_args.capability = selected.capability orelse args.capability;
+        runExec(allocator, exec_args) catch |e| {
+            last_exec_error = e;
+            continue;
+        };
     }
 
-    const selected = evaluations.items[selected_index.?].route;
-    var exec_args = args;
-    exec_args.profile = null;
-    exec_args.provider = selected.provider;
-    exec_args.account = selected.account;
-    exec_args.capability = selected.capability orelse args.capability;
-    try runExec(allocator, exec_args);
+    try writeStayAfloatLaunchMediationFromCurrentState(
+        allocator,
+        writer,
+        parsed.value,
+        routes.items,
+        selector,
+    );
+    if (last_exec_error) |err| return err;
+    return error.AllAccountsExhausted;
+}
+
+fn firstSelectableRouteNotAttempted(
+    evaluations: []const RouteEvaluation,
+    attempted_routes: []const RepairPlanRoute,
+) ?usize {
+    for (evaluations, 0..) |evaluation, idx| {
+        if (!evaluation.selectable) continue;
+        if (routeWasAttempted(evaluation.route, attempted_routes)) continue;
+        return idx;
+    }
+    return null;
+}
+
+fn routeWasAttempted(route: RepairPlanRoute, attempted_routes: []const RepairPlanRoute) bool {
+    for (attempted_routes) |attempted| {
+        if (routesEqual(route, attempted)) return true;
+    }
+    return false;
+}
+
+fn routesEqual(a: RepairPlanRoute, b: RepairPlanRoute) bool {
+    return std.mem.eql(u8, a.provider, b.provider) and
+        std.mem.eql(u8, a.account, b.account) and
+        optionalStringsEqual(a.capability, b.capability);
+}
+
+fn optionalStringsEqual(a: ?[]const u8, b: ?[]const u8) bool {
+    if (a) |a_value| {
+        const b_value = b orelse return false;
+        return std.mem.eql(u8, a_value, b_value);
+    }
+    return b == null;
+}
+
+fn writeStayAfloatLaunchMediationFromCurrentState(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    cfg: config.Config,
+    routes: []const RepairPlanRoute,
+    selector: cli.Command.RouteArgs,
+) !void {
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+
+    var evaluations = std.ArrayList(RouteEvaluation).init(allocator);
+    defer evaluations.deinit();
+    try collectRouteEvaluations(allocator, cfg, &store, routes, &evaluations);
+
+    const selected_index = firstSelectableRoute(evaluations.items);
+    const candidate_index = if (selected_index == null) firstActionableRoute(evaluations.items) else null;
+    try writeStayAfloatMediationText(
+        writer,
+        allocator,
+        evaluations.items,
+        selected_index,
+        candidate_index,
+        selector,
+        "oauth-mux stay-afloat launch",
+    );
 }
 
 fn runDaemonTick(

--- a/src/main.zig
+++ b/src/main.zig
@@ -150,6 +150,13 @@ pub fn main() !void {
             };
         },
 
+        .stay_afloat_launch => |launch_args| {
+            runStayAfloatLaunch(allocator, stdout, launch_args) catch |e| {
+                log.err("stay-afloat launch: {s}", .{@errorName(e)});
+                std.process.exit(exitCodeFromPipelineError(e));
+            };
+        },
+
         .stay_afloat => |tick_args| {
             runDaemonTick(allocator, stdout, tick_args, "oauth-mux stay-afloat") catch |e| {
                 log.err("stay-afloat: {s}", .{@errorName(e)});
@@ -3571,6 +3578,57 @@ fn runStayAfloatNext(allocator: std.mem.Allocator, writer: anytype, args: cli.Co
     }
 }
 
+fn runStayAfloatLaunch(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.ExecArgs) !void {
+    if (args.target_argv.len == 0) {
+        log.err("stay-afloat launch: no target command specified (use -- before the command)", .{});
+        return error.ConfigValidationError;
+    }
+
+    const parsed = try config.load(allocator);
+    defer parsed.deinit();
+
+    var validation_messages = std.ArrayList(u8).init(allocator);
+    defer validation_messages.deinit();
+    try config.validate(parsed.value, validation_messages.writer());
+
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+
+    const selector = cli.Command.RouteArgs{
+        .action = .explain,
+        .profile = args.profile,
+        .provider = args.provider,
+        .account = args.account,
+        .capability = args.capability,
+    };
+    var routes = try collectRepairPlanRoutes(allocator, parsed.value, .{
+        .profile = selector.profile,
+        .provider = selector.provider,
+        .account = selector.account,
+        .capability = selector.capability,
+    });
+    defer routes.deinit();
+
+    var evaluations = std.ArrayList(RouteEvaluation).init(allocator);
+    defer evaluations.deinit();
+    try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &evaluations);
+
+    const selected_index = firstSelectableRoute(evaluations.items);
+    if (selected_index == null) {
+        const candidate_index = firstActionableRoute(evaluations.items);
+        try writeStayAfloatMediationText(writer, allocator, evaluations.items, null, candidate_index, selector, "oauth-mux stay-afloat launch");
+        return error.AllAccountsExhausted;
+    }
+
+    const selected = evaluations.items[selected_index.?].route;
+    var exec_args = args;
+    exec_args.profile = null;
+    exec_args.provider = selected.provider;
+    exec_args.account = selected.account;
+    exec_args.capability = selected.capability orelse args.capability;
+    try runExec(allocator, exec_args);
+}
+
 fn runDaemonTick(
     allocator: std.mem.Allocator,
     writer: anytype,
@@ -4146,7 +4204,19 @@ fn writeStayAfloatNextText(
     candidate_index: ?usize,
     args: cli.Command.RouteArgs,
 ) !void {
-    try writer.writeAll("oauth-mux stay-afloat next\n\n");
+    try writeStayAfloatMediationText(writer, allocator, evaluations, selected_index, candidate_index, args, "oauth-mux stay-afloat next");
+}
+
+fn writeStayAfloatMediationText(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+    candidate_index: ?usize,
+    args: cli.Command.RouteArgs,
+    command_name: []const u8,
+) !void {
+    try writer.print("{s}\n\n", .{command_name});
     if (args.profile) |profile_name| try writer.print("  profile: {s}\n", .{profile_name});
     if (args.provider) |provider_name| try writer.print("  provider: {s}\n", .{provider_name});
     if (args.account) |account| try writer.print("  account: {s}\n", .{account});


### PR DESCRIPTION
## Summary

- Add `oauth-mux stay-afloat launch` as the startup execution boundary for new harness sessions.
- Reuse route/runtime/liveness evidence to select a route before target launch.
- Pin provider/account/capability into `oauth-mux exec` when a route is selectable.
- Retry the next selectable route when launch-time exec validation reclassifies the selected account before the target starts.
- Refuse to run the target and print typed mediation when repair or user handoff is needed.
- Cover selected fallback launch, launch-time reclassification fallback, and reauth-needed launch refusal in local e2e.

## Tracking

Refs TIN-904.
Closes #111.
Related to #67.

## Validation

- `zig build test`
- `nix develop --command just check-local`
- Live dogfood: `./zig-out/bin/oauth-mux stay-afloat next --profile codex-max --capability codex-max --json` selected `codex:max-3` while `max-1` and `max-2` were quota-exhausted.
- Live dogfood: `./zig-out/bin/oauth-mux stay-afloat launch --profile codex-max --capability codex-max -- sh -c 'printf ...'` started target under `codex:max-3`.