### PR TITLE
Surface stay-afloat claim levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,11 @@ portable foreground tick for dogfood and wrappers. No `systemctl`, `launchctl`,
 service manager, browser auth, provider spend, or secret mutation is assumed
 unless policy and CLI flags explicitly admit it. Tick JSON includes route-level
 `next_tick_after` and `schedule_reason` fields, plus top-level summary wake-up
-hints, so wrappers can sleep or back off without guessing.
+hints, so wrappers can sleep or back off without guessing. Tick JSON and the
+latest `daemon status --json` snapshot also include `claim.level`. A
+`prepared_fallback` claim means the next mediated `stay-afloat launch` can pick
+a route; it does not claim current-process hot-swap, supervised restart, or
+per-request muxing.
 
 Secret read and writeback are also separate. Route and runtime JSON expose a
 `writeback` object with the secret backend capability and whether automatic

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -75,6 +75,12 @@ rather than introducing separate behavior.
 includes the latest redacted stay-afloat tick snapshot under `stay_afloat` when
 one exists, so wrappers can inspect prepared fallback state without treating
 the socket stub as the production supervisor.
+That snapshot includes `claim.level`. `prepared_fallback` means the next
+mediated launch can select an account; it does not mean an already-running
+harness process will be hot-swapped. The same claim object keeps
+`current_process_hotswap:false`, `supervised_restart:false`, and
+`per_request_muxing:false` until a specific wrapper, restart path, proxy, or
+in-agent adapter proves those stronger levels.
 
 ## Allowed Now
 
@@ -125,6 +131,10 @@ the socket stub as the production supervisor.
 - `oauth-mux daemon tick --loop --iterations <n> --interval-ms <ms> --json`
   as the lower-level wrapper-author spelling for the same bounded foreground
   loop.
+- `claim.level:"prepared_fallback"` in `stay-afloat` / `daemon tick` JSON and
+  in the latest `daemon status --json` snapshot when a route is selectable.
+  Wrappers should pair that with the emitted `claim.launch_argv` and should not
+  infer current-process hot-swap or per-request muxing.
 - `oauth-mux daemon run --stay-afloat --profile <profile> --capability
   <capability>` as the first opt-in beta host for the same tick engine. It
   reports `stay_afloat_loop.hosted:true` while running, but

--- a/docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md
+++ b/docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md
@@ -249,6 +249,12 @@ Implementation note, 2026-05-02: this slice now writes
 stay-afloat/daemon tick. `oauth-mux daemon status --json` exposes the latest
 snapshot under `stay_afloat` while still reporting
 `production_supported:false` and `hosts_stay_afloat:false`.
+The snapshot now includes a `claim` object. `claim.level:"prepared_fallback"`
+is Level 1: route state is warm enough for the next mediated
+`stay-afloat launch` / `exec` boundary. The object explicitly keeps
+`current_process_hotswap:false`, `supervised_restart:false`, and
+`per_request_muxing:false` so agents and websites do not overclaim daemon
+behavior from a healthy snapshot.
 
 ### D2: supervised stay-afloat loop
 
@@ -287,6 +293,12 @@ and soak proof promote the product surface.
 - Add MCP/in-agent tools for route visibility and handoff surfacing.
 - Consider request-level proxying only where the harness protocol can support
   Level 3 per-request muxing.
+
+Implementation note, 2026-05-02: `oauth-mux stay-afloat launch` is now the
+Level 1 startup boundary. It preflights from recorded evidence, delegates to
+`exec` for normal validation, retries the next selectable route if launch-time
+validation reclassifies the first route, and refuses to start the target when
+no route remains selectable.
 
 ### D5: paid cohort soak
 

--- a/docs/stay-afloat-wrappers.md
+++ b/docs/stay-afloat-wrappers.md
@@ -54,13 +54,23 @@ fields shaped like:
   },
   "transport": "foreground_supervised_loop",
   "socket": null,
-  "stay_afloat": {}
+  "stay_afloat": {
+    "claim": {
+      "level": "prepared_fallback",
+      "current_process_hotswap": false,
+      "supervised_restart": false,
+      "per_request_muxing": false
+    }
+  }
 }
 ```
 
 `production_supported:false` and `hosts_stay_afloat:false` are intentional. The
 beta loop is useful for dogfooding, wrapper integration, and soak proof, but it
 is not yet the production background daemon claim tracked by GitHub #67.
+`claim.level:"prepared_fallback"` means the next mediated launch can select an
+account through `stay-afloat launch`; it does not claim current-process
+hot-swap, supervised restart, or per-request muxing.
 
 ## Smoke And Soak
 

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -385,6 +385,11 @@ expect_contains "$daemon_tick" '"mode":"once"' "daemon tick reports one-shot mod
 expect_contains "$daemon_tick" '"executed":false' "daemon tick does not execute probes or repair"
 expect_contains "$daemon_tick" '"afloat":true' "daemon tick reports profile afloat"
 expect_contains "$daemon_tick" '"selected":{"provider":"toy","account":"a2"' "daemon tick selects fallback account a2"
+expect_contains "$daemon_tick" '"claim":{"claim_version":1,"level":"prepared_fallback"' "daemon tick reports prepared fallback claim"
+expect_contains "$daemon_tick" '"max_supported_level":"prepared_fallback"' "daemon tick reports maximum supported claim level"
+expect_contains "$daemon_tick" '"current_process_hotswap":false' "daemon tick refuses current-process hot-swap claim"
+expect_contains "$daemon_tick" '"per_request_muxing":false' "daemon tick refuses per-request muxing claim"
+expect_contains "$daemon_tick" '"launch_argv":["oauth-mux","stay-afloat","launch","--profile","expensive","--capability","expensive","--","<command>"]' "daemon tick reports wrapper launch argv"
 expect_contains "$daemon_tick" '"action":"wait_for_quota"' "daemon tick includes wait action for exhausted route"
 expect_contains "$daemon_tick" '"schedule_reason":"wait_until"' "daemon tick exposes quota reset schedule reason"
 expect_contains "$daemon_tick" '"next_tick_reason":"wait_until"' "daemon tick summary exposes earliest schedule reason"
@@ -405,6 +410,8 @@ expect_contains "$daemon_status_snapshot" '"status":"not_running"' "daemon statu
 expect_contains "$daemon_status_snapshot" '"hosts_stay_afloat":false' "daemon status still does not claim to host stay-afloat"
 expect_contains "$daemon_status_snapshot" '"stay_afloat":{"version":' "daemon status includes latest stay-afloat snapshot"
 expect_contains "$daemon_status_snapshot" '"contract":"foreground_tick_snapshot"' "daemon snapshot reports foreground tick contract"
+expect_contains "$daemon_status_snapshot" '"claim":{"claim_version":1,"level":"prepared_fallback"' "daemon status exposes latest stay-afloat claim"
+expect_contains "$daemon_status_snapshot" '"current_process_hotswap":false' "daemon status refuses hot-swap claim"
 expect_contains "$daemon_status_snapshot" '"selected":{"provider":"toy","account":"a2"' "daemon snapshot carries selected fallback route"
 
 printf 'e2e: bounded daemon tick loop emits repeated planning snapshots\n'

--- a/src/main.zig
+++ b/src/main.zig
@@ -3848,11 +3848,70 @@ fn writeDaemonTickSnapshot(
     } else {
         try writer.writeAll("null");
     }
+    try writer.writeAll(",\"claim\":");
+    try writeStayAfloatClaimJson(writer, args, selectedRoute(evaluations, selected_index));
     try writer.writeAll(",\"summary\":");
     try writeDaemonTickStatsJson(writer, stats);
     try writer.writeByte('}');
 
     try repair_state.writeDaemonSnapshot(allocator, snapshot.items);
+}
+
+fn selectedRoute(evaluations: []const RouteEvaluation, selected_index: ?usize) ?RepairPlanRoute {
+    if (selected_index) |idx| {
+        if (idx < evaluations.len) return evaluations[idx].route;
+    }
+    return null;
+}
+
+fn writeStayAfloatClaimJson(
+    writer: anytype,
+    args: cli.Command.DaemonTickArgs,
+    route: ?RepairPlanRoute,
+) !void {
+    const prepared = route != null;
+    try writer.writeAll("{\"claim_version\":1");
+    try writer.writeAll(",\"level\":");
+    try std.json.stringify(if (prepared) "prepared_fallback" else "mediation_required", .{}, writer);
+    try writer.writeAll(",\"max_supported_level\":\"prepared_fallback\"");
+    try writer.writeAll(",\"prepared_fallback\":");
+    try writer.writeAll(if (prepared) "true" else "false");
+    try writer.writeAll(",\"requires_mediation\":true");
+    try writer.writeAll(",\"mediation_point\":\"stay-afloat launch\"");
+    try writer.writeAll(",\"target_boundary\":\"process_start\"");
+    try writer.writeAll(",\"current_process_hotswap\":false");
+    try writer.writeAll(",\"supervised_restart\":false");
+    try writer.writeAll(",\"per_request_muxing\":false");
+    try writer.writeAll(",\"launch_argv\":");
+    try writeStayAfloatLaunchArgvJson(writer, args);
+    try writer.writeByte('}');
+}
+
+fn writeStayAfloatLaunchArgvJson(writer: anytype, args: cli.Command.DaemonTickArgs) !void {
+    var first = true;
+    try writer.writeByte('[');
+    try writeJsonArrayString(writer, &first, "oauth-mux");
+    try writeJsonArrayString(writer, &first, "stay-afloat");
+    try writeJsonArrayString(writer, &first, "launch");
+    if (args.profile) |profile_name| {
+        try writeJsonArrayString(writer, &first, "--profile");
+        try writeJsonArrayString(writer, &first, profile_name);
+    }
+    if (args.provider) |provider_name| {
+        try writeJsonArrayString(writer, &first, "--provider");
+        try writeJsonArrayString(writer, &first, provider_name);
+    }
+    if (args.account) |account| {
+        try writeJsonArrayString(writer, &first, "--account");
+        try writeJsonArrayString(writer, &first, account);
+    }
+    if (args.capability) |capability| {
+        try writeJsonArrayString(writer, &first, "--capability");
+        try writeJsonArrayString(writer, &first, capability);
+    }
+    try writeJsonArrayString(writer, &first, "--");
+    try writeJsonArrayString(writer, &first, "<command>");
+    try writer.writeByte(']');
 }
 
 fn daemonTickArgsToPlanArgs(args: cli.Command.DaemonTickArgs) cli.Command.RepairPlanArgs {
@@ -4698,6 +4757,8 @@ fn writeDaemonTickJsonObject(
     } else {
         try writer.writeAll("null");
     }
+    try writer.writeAll(",\"claim\":");
+    try writeStayAfloatClaimJson(writer, args, selectedRoute(evaluations, selected_index));
     try writer.writeAll(",\"summary\":");
     try writeDaemonTickStatsJson(writer, stats);
     try writer.writeAll(",\"executions\":");


### PR DESCRIPTION
## Summary

- Add a machine-readable stay-afloat `claim` object to tick JSON and daemon snapshots.
- Report Level 1 `prepared_fallback` when a route is selectable, with wrapper-friendly `stay-afloat launch ... -- <command>` argv.
- Explicitly keep `current_process_hotswap`, `supervised_restart`, and `per_request_muxing` false until separately proven.
- Document the claim boundary in daemon docs, wrapper docs, and README.
- Assert the claim object in local E2E and daemon status snapshot checks.

## Tracking

Refs TIN-905.
Closes #113.
Related to #67.

## Validation

- `zig build test`
- `nix develop --command just check-local`
- Live no-spend dogfood: `stay-afloat --once --profile codex-max --capability codex-max --json` reported `claim.level=prepared_fallback` for `codex:max-3`.
- Live no-spend dogfood: `daemon status --json` exposed the same latest snapshot claim while `hosts_stay_afloat=false`.
