### PR TITLE
Honor stay-afloat scheduler hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,9 @@ portable foreground tick for dogfood and wrappers. No `systemctl`, `launchctl`,
 service manager, browser auth, provider spend, or secret mutation is assumed
 unless policy and CLI flags explicitly admit it. Tick JSON includes route-level
 `next_tick_after` and `schedule_reason` fields, plus top-level summary wake-up
-hints, so wrappers can sleep or back off without guessing. Tick JSON and the
+hints, so wrappers can sleep or back off without guessing. The built-in loop
+uses the earliest summary wake-up hint between ticks, bounded by
+`--interval-ms`, without changing daemon admission policy. Tick JSON and the
 latest `daemon status --json` snapshot also include `claim.level`. A
 `prepared_fallback` claim means the next mediated `stay-afloat launch` can pick
 a route; it does not claim current-process hot-swap, supervised restart, or

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -127,7 +127,10 @@ in-agent adapter proves those stronger levels.
   tick and remains service-manager agnostic. Route ticks expose
   `next_tick_after` plus `schedule_reason`, and the summary exposes the
   earliest `next_tick_after` plus `next_tick_reason`, so wrappers can back off
-  without inventing separate scheduler semantics.
+  without inventing separate scheduler semantics. The built-in loop also uses
+  that earliest wake-up hint when sleeping between ticks, bounded by
+  `--interval-ms`; the hint does not admit provider-spend probes, interactive
+  auth, or mutation by itself.
 - `oauth-mux daemon tick --loop --iterations <n> --interval-ms <ms> --json`
   as the lower-level wrapper-author spelling for the same bounded foreground
   loop.

--- a/docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md
+++ b/docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md
@@ -279,6 +279,13 @@ and `stay_afloat_loop.hosted:true` while the loop is running, but still reports
 `production_supported:false` and `hosts_stay_afloat:false` until wrapper docs
 and soak proof promote the product surface.
 
+Implementation note, 2026-05-02: the loop sleep path now honors the earliest
+summary `next_tick_after` emitted by route decisions, bounded by the operator's
+`--interval-ms`. A due or overdue route wakes the next tick immediately; a
+far-future reset still respects the configured maximum cadence. This is only a
+scheduler improvement and does not grant provider-spend, interactive, or
+mutating admission.
+
 ### D3: wrapper recipes
 
 - Add package-neutral wrapper docs first.

--- a/docs/stay-afloat-wrappers.md
+++ b/docs/stay-afloat-wrappers.md
@@ -39,6 +39,12 @@ oauth-mux daemon run --stay-afloat --profile codex-max --capability codex-max --
 oauth-mux daemon supervise --profile codex-max --capability codex-max --interval-ms 60000
 ```
 
+The loop uses route scheduler hints when sleeping: the earliest
+`next_tick_after` in the tick summary can wake the next pass before the fixed
+cadence, while `--interval-ms` remains the maximum sleep. This keeps quota reset,
+handoff, and runtime repair rechecks responsive without granting extra provider
+budget or mutation rights.
+
 While the beta loop is running, `oauth-mux daemon status --json` should report
 fields shaped like:
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -3784,7 +3784,8 @@ fn runDaemonTick(
             if (iterations > 1 and idx + 1 < iterations) try writer.writeByte('\n');
         }
 
-        sleepBetweenDaemonTicks(args, idx, iterations);
+        const stats = daemonTickStats(parsed.value.policy.daemon, evaluations.items, observed_at);
+        sleepBetweenDaemonTicks(args, idx, iterations, stats, observed_at);
     }
 
     if (args.json and iterations > 1) {
@@ -3954,12 +3955,29 @@ fn normalizedDaemonTickIterations(args: cli.Command.DaemonTickArgs) u32 {
     return @max(args.iterations, 1);
 }
 
-fn sleepBetweenDaemonTicks(args: cli.Command.DaemonTickArgs, idx: u32, iterations: u32) void {
-    if (idx + 1 >= iterations) return;
-    if (args.interval_ms == 0) return;
+fn sleepBetweenDaemonTicks(args: cli.Command.DaemonTickArgs, idx: u32, iterations: u32, stats: DaemonTickStats, observed_at: i64) void {
+    const sleep_ms = daemonTickSleepMs(args, idx, iterations, stats, observed_at);
+    if (sleep_ms == 0) return;
+    std.time.sleep(sleep_ms * std.time.ns_per_ms);
+}
+
+fn daemonTickSleepMs(args: cli.Command.DaemonTickArgs, idx: u32, iterations: u32, stats: DaemonTickStats, observed_at: i64) u64 {
+    if (idx + 1 >= iterations) return 0;
+    if (args.interval_ms == 0) return 0;
     const max_ms = std.math.maxInt(u64) / std.time.ns_per_ms;
-    const bounded_ms = @min(args.interval_ms, max_ms);
-    std.time.sleep(bounded_ms * std.time.ns_per_ms);
+    var sleep_ms = @min(args.interval_ms, max_ms);
+
+    if (stats.next_tick_after) |next_tick_after| {
+        if (next_tick_after <= observed_at) return 0;
+        const seconds_until: u64 = @intCast(next_tick_after - observed_at);
+        const hint_ms = if (seconds_until > max_ms / 1000)
+            max_ms
+        else
+            seconds_until * 1000;
+        sleep_ms = @min(sleep_ms, hint_ms);
+    }
+
+    return sleep_ms;
 }
 
 fn runStayAfloatHandoff(
@@ -9053,6 +9071,45 @@ test "daemon tick stats carries earliest schedule reason" {
     try std.testing.expectEqual(@as(?i64, 1300), stats.next_tick_after);
     try std.testing.expect(stats.next_tick_reason != null);
     try std.testing.expectEqualStrings("runtime_recheck", stats.next_tick_reason.?);
+}
+
+test "daemon tick sleep honors earlier route wake-up hint" {
+    const sleep_ms = daemonTickSleepMs(
+        .{ .interval_ms = 60_000 },
+        0,
+        2,
+        .{ .next_tick_after = 1030, .next_tick_reason = "rate_limit" },
+        1000,
+    );
+
+    try std.testing.expectEqual(@as(u64, 30_000), sleep_ms);
+}
+
+test "daemon tick sleep is bounded by configured interval" {
+    const sleep_ms = daemonTickSleepMs(
+        .{ .interval_ms = 5_000 },
+        0,
+        2,
+        .{ .next_tick_after = 1300, .next_tick_reason = "quota_reset" },
+        1000,
+    );
+
+    try std.testing.expectEqual(@as(u64, 5_000), sleep_ms);
+}
+
+test "daemon tick sleep handles immediate and final wake-up cases" {
+    try std.testing.expectEqual(
+        @as(u64, 0),
+        daemonTickSleepMs(.{ .interval_ms = 60_000 }, 0, 2, .{ .next_tick_after = 1000 }, 1000),
+    );
+    try std.testing.expectEqual(
+        @as(u64, 0),
+        daemonTickSleepMs(.{ .interval_ms = 60_000 }, 1, 2, .{ .next_tick_after = 1030 }, 1000),
+    );
+    try std.testing.expectEqual(
+        @as(u64, 0),
+        daemonTickSleepMs(.{ .interval_ms = 0 }, 0, 2, .{ .next_tick_after = 1030 }, 1000),
+    );
 }
 
 test "repairActionFor classifies quota exhaustion as wait action" {


### PR DESCRIPTION
## Summary

- Makes the stay-afloat/daemon loop sleep from the earliest `next_tick_after` summary hint, bounded by `--interval-ms`.
- Adds unit coverage for early wake-up, configured interval bounds, immediate due ticks, final iteration, and zero interval behavior.
- Updates daemon/wrapper docs so the scheduler truth matches the runtime behavior.

## Product impact

The beta foreground/background tick host now uses the same route wake-up hints it publishes. This makes quota reset, runtime repair, and handoff recheck loops more responsive without introducing service-manager assumptions or changing daemon admission policy.

## Boundaries

- No provider-spend probes are admitted by the scheduler hint.
- No interactive auth or mutation behavior changes.
- No current-process hotswap, supervised restart, or per-request muxing claim.

## Validation

- `zig fmt src/main.zig`
- `git diff --check`
- `zig build test`
- `nix develop --command just check-local`

Fixes #117
Tracking: TIN-907, TIN-738 / #67
