### PR TITLE
[codex] Expose stay-afloat snapshot freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,10 +207,14 @@ uses the earliest summary wake-up hint between ticks, bounded by
 latest `daemon status --json` snapshot also include `claim.level`. A
 `prepared_fallback` claim means the next mediated `stay-afloat launch` can pick
 a route; it does not claim current-process hot-swap, supervised restart, or
-per-request muxing. When `daemon run --stay-afloat` is active,
-`daemon status --json` also reports `stay_afloat_loop.selector`,
-`interval_ms`, `iterations`, and `execution_mode` so operators can verify which
-profile/capability the beta host is actually supervising.
+per-request muxing. `daemon status --json` also reports
+`stay_afloat_snapshot` metadata with presence, parseability, `last_tick_at`,
+`age_seconds`, active-loop correlation, a 300 second staleness threshold, and a
+fresh/stale reason so wrappers can reject old prepared-fallback claims. When
+`daemon run --stay-afloat` is active, `daemon status --json` also reports
+`stay_afloat_loop.selector`, `interval_ms`, `iterations`, and `execution_mode`
+so operators can verify which profile/capability the beta host is actually
+supervising.
 
 Secret read and writeback are also separate. Route and runtime JSON expose a
 `writeback` object with the secret backend capability and whether automatic

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -74,7 +74,13 @@ rather than introducing separate behavior.
 `hosts_stay_afloat:false`, and `wrapper_contract:"foreground_tick"`. It also
 includes the latest redacted stay-afloat tick snapshot under `stay_afloat` when
 one exists, so wrappers can inspect prepared fallback state without treating
-the socket stub as the production supervisor.
+the socket stub as the production supervisor. The sibling
+`stay_afloat_snapshot` object reports whether that snapshot is present,
+parseable, when it was last ticked, its age in seconds, the 300 second staleness
+threshold, active-loop correlation, and a fresh/stale reason. Wrappers should
+treat stale, missing, empty, malformed, or `before_current_loop` snapshots as
+evidence to run or wait for a new foreground tick instead of trusting an old
+prepared-fallback claim.
 That snapshot includes `claim.level`. `prepared_fallback` means the next
 mediated launch can select an account; it does not mean an already-running
 harness process will be hot-swapped. The same claim object keeps

--- a/docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md
+++ b/docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md
@@ -249,6 +249,12 @@ Implementation note, 2026-05-02: this slice now writes
 stay-afloat/daemon tick. `oauth-mux daemon status --json` exposes the latest
 snapshot under `stay_afloat` while still reporting
 `production_supported:false` and `hosts_stay_afloat:false`.
+Status also emits a sibling `stay_afloat_snapshot` metadata object with
+presence, parseability, `last_tick_at`, `age_seconds`, a 300 second staleness
+threshold, active-loop correlation, `stale`, and `reason`. This lets wrappers
+and agents distinguish a fresh prepared-fallback claim from a missing,
+malformed, stale, or pre-current-loop local snapshot before making launch or
+repair decisions.
 The snapshot now includes a `claim` object. `claim.level:"prepared_fallback"`
 is Level 1: route state is warm enough for the next mediated
 `stay-afloat launch` / `exec` boundary. The object explicitly keeps

--- a/docs/stay-afloat-wrappers.md
+++ b/docs/stay-afloat-wrappers.md
@@ -70,6 +70,17 @@ fields shaped like:
   },
   "transport": "foreground_supervised_loop",
   "socket": null,
+  "stay_afloat_snapshot": {
+    "present": true,
+    "parseable": true,
+    "last_tick_at": 1777752000,
+    "age_seconds": 2,
+    "loop_started_at": 1777751998,
+    "current_loop_observed": true,
+    "stale_after_seconds": 300,
+    "stale": false,
+    "reason": "fresh"
+  },
   "stay_afloat": {
     "claim": {
       "level": "prepared_fallback",
@@ -131,6 +142,11 @@ Good soak evidence includes:
 - `transport:"foreground_supervised_loop"` and `socket:null`.
 - A redacted `stay_afloat` snapshot with selected route, fallback, repair, or
   handoff state.
+- `stay_afloat_snapshot.present:true`, `parseable:true`, `stale:false`, and
+  `current_loop_observed:true` while the beta loop is active. Missing, empty,
+  malformed, stale, or `before_current_loop` metadata means the wrapper should
+  run or wait for a fresh foreground tick before trusting prepared fallback
+  state.
 - `status:"not_running"` after `oauth-mux daemon stop`.
 - No hidden browser/device auth.
 - No provider-spend probes unless the operator opted into a spend-capable

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -412,6 +412,12 @@ daemon_status_snapshot="$(omux daemon status --json)"
 expect_contains "$daemon_status_snapshot" '"status":"not_running"' "daemon status remains stopped after foreground tick"
 expect_contains "$daemon_status_snapshot" '"hosts_stay_afloat":false' "daemon status still does not claim to host stay-afloat"
 expect_contains "$daemon_status_snapshot" '"stay_afloat":{"version":' "daemon status includes latest stay-afloat snapshot"
+expect_contains "$daemon_status_snapshot" '"stay_afloat_snapshot":{"present":true,"parseable":true' "daemon status reports parseable stay-afloat snapshot metadata"
+expect_contains "$daemon_status_snapshot" '"stale_after_seconds":300' "daemon status reports snapshot staleness threshold"
+expect_contains "$daemon_status_snapshot" '"stale":false' "daemon status reports fresh stay-afloat snapshot"
+expect_contains "$daemon_status_snapshot" '"reason":"fresh"' "daemon status reports fresh snapshot reason"
+expect_contains "$daemon_status_snapshot" '"loop_started_at":null' "daemon status reports no active loop correlation while stopped"
+expect_contains "$daemon_status_snapshot" '"current_loop_observed":null' "daemon status reports no active loop observation while stopped"
 expect_contains "$daemon_status_snapshot" '"contract":"foreground_tick_snapshot"' "daemon snapshot reports foreground tick contract"
 expect_contains "$daemon_status_snapshot" '"claim":{"claim_version":1,"level":"prepared_fallback"' "daemon status exposes latest stay-afloat claim"
 expect_contains "$daemon_status_snapshot" '"current_process_hotswap":false' "daemon status refuses hot-swap claim"
@@ -478,13 +484,17 @@ supervised_status=""
 for _ in $(seq 1 200); do
   supervised_status="$(OMUX_STATE_DIR="$state_dir" XDG_RUNTIME_DIR="$supervised_runtime" "$bin" daemon status --json || true)"
   case "$supervised_status" in
-    *'"status":"running"'*'"stay_afloat_loop":{"hosted":true'*'"stay_afloat":{"version":'*) break ;;
+    *'"status":"running"'*'"stay_afloat_loop":{"hosted":true'*'"stay_afloat":{"version":'*'"current_loop_observed":true'*) break ;;
   esac
 done
 expect_contains "$supervised_status" '"status":"running"' "supervised daemon status reports running"
 expect_contains "$supervised_status" '"contract":"experimental_supervised_loop"' "supervised daemon status reports beta contract"
 expect_contains "$supervised_status" '"hosts_stay_afloat":false' "supervised daemon does not claim production stay-afloat"
 expect_contains "$supervised_status" '"stay_afloat_loop":{"hosted":true' "supervised daemon reports hosted beta loop"
+expect_contains "$supervised_status" '"stay_afloat_snapshot":{"present":true,"parseable":true' "supervised daemon reports parseable stay-afloat snapshot metadata"
+expect_contains "$supervised_status" '"current_loop_observed":true' "supervised daemon status proves active loop has written a snapshot"
+expect_contains "$supervised_status" '"stale":false' "supervised daemon reports fresh stay-afloat snapshot"
+expect_contains "$supervised_status" '"reason":"fresh"' "supervised daemon reports fresh snapshot reason"
 expect_contains "$supervised_status" '"selector":{"profile":"expensive","provider":null,"account":null,"capability":"expensive"}' "supervised daemon reports hosted selector"
 expect_contains "$supervised_status" '"once":false' "supervised daemon reports loop mode metadata"
 expect_contains "$supervised_status" '"iterations":200' "supervised daemon reports requested iteration bound"
@@ -511,6 +521,7 @@ supervised_stopped="$(OMUX_STATE_DIR="$state_dir" XDG_RUNTIME_DIR="$supervised_r
 expect_contains "$supervised_stopped" '"status":"not_running"' "supervised daemon status reports stopped"
 expect_contains "$supervised_stopped" '"stay_afloat_loop":{"hosted":false' "supervised daemon clears hosted loop metadata after stop"
 expect_contains "$supervised_stopped" '"stay_afloat":{"version":' "supervised daemon leaves latest redacted snapshot visible after stop"
+expect_contains "$supervised_stopped" '"stay_afloat_snapshot":{"present":true,"parseable":true' "supervised daemon leaves snapshot metadata visible after stop"
 
 printf 'e2e: daemon tick execute runs one admitted command probe\n'
 omux health --reset toy:a1 >/dev/null

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -6,6 +6,7 @@ const repair_state = @import("repair_state.zig");
 const builtin = @import("builtin");
 
 const Pid = if (builtin.os.tag == .windows) u32 else std.posix.pid_t;
+const stay_afloat_snapshot_stale_after_s: i64 = 300;
 
 pub const DaemonError = error{
     AlreadyRunning,
@@ -37,6 +38,22 @@ pub const StayAfloatRunMetadata = struct {
     iterations: u32 = 1,
     interval_ms: u64 = 60_000,
     execute: bool = true,
+};
+
+const SnapshotFreshness = struct {
+    present: bool,
+    parseable: bool,
+    last_tick_at: ?i64 = null,
+    age_seconds: ?i64 = null,
+    loop_started_at: ?i64 = null,
+    current_loop_observed: ?bool = null,
+    stale_after_seconds: i64 = stay_afloat_snapshot_stale_after_s,
+    stale: bool = true,
+    reason: []const u8,
+};
+
+const StatusLoopInfo = struct {
+    started_at: ?i64 = null,
 };
 
 pub fn run(allocator: std.mem.Allocator) DaemonError!void {
@@ -189,8 +206,8 @@ pub fn status(allocator: std.mem.Allocator, writer: anytype, json: bool) !void {
         if (json) {
             try writer.writeAll("{\"status\":\"running\"");
             try writeStatusContractJson(writer, loop_hosted);
-            try writeStatusLoopJson(allocator, writer, loop_hosted);
-            try writeStatusSnapshotJson(allocator, writer);
+            const loop_info = try writeStatusLoopJson(allocator, writer, loop_hosted);
+            try writeStatusSnapshotJson(allocator, writer, loop_info.started_at);
             try writer.print(",\"pid\":{d},\"transport\":", .{pid});
             try std.json.stringify(if (loop_hosted) "foreground_supervised_loop" else "unix_socket", .{}, writer);
             try writer.writeAll(",\"socket\":");
@@ -208,8 +225,8 @@ pub fn status(allocator: std.mem.Allocator, writer: anytype, json: bool) !void {
         if (json) {
             try writer.writeAll("{\"status\":\"not_running\"");
             try writeStatusContractJson(writer, false);
-            try writeStatusLoopJson(allocator, writer, false);
-            try writeStatusSnapshotJson(allocator, writer);
+            const loop_info = try writeStatusLoopJson(allocator, writer, false);
+            try writeStatusSnapshotJson(allocator, writer, loop_info.started_at);
             try writer.writeAll("}\n");
         } else {
             try writer.writeAll("daemon: not running\n");
@@ -228,7 +245,7 @@ fn writeStatusContractJson(writer: anytype, loop_hosted: bool) !void {
     try writer.writeAll(if (builtin.os.tag == .windows) "false" else "true");
 }
 
-fn writeStatusLoopJson(allocator: std.mem.Allocator, writer: anytype, loop_hosted: bool) !void {
+fn writeStatusLoopJson(allocator: std.mem.Allocator, writer: anytype, loop_hosted: bool) !StatusLoopInfo {
     try writer.writeAll(",\"stay_afloat_loop\":");
     if (loop_hosted) {
         const metadata = try readMetadataAlloc(allocator);
@@ -237,27 +254,146 @@ fn writeStatusLoopJson(allocator: std.mem.Allocator, writer: anytype, loop_hoste
             const trimmed = std.mem.trim(u8, bytes, " \t\r\n");
             if (trimmed.len != 0 and trimmed[0] == '{') {
                 try writer.writeAll(trimmed);
-                return;
+                return .{ .started_at = jsonObjectI64(allocator, trimmed, "started_at") };
             }
         }
     }
     try writer.writeAll("{\"hosted\":false,\"production_supported\":false}");
+    return .{};
 }
 
-fn writeStatusSnapshotJson(allocator: std.mem.Allocator, writer: anytype) !void {
+fn writeStatusSnapshotJson(allocator: std.mem.Allocator, writer: anytype, loop_started_at: ?i64) !void {
     try writer.writeAll(",\"stay_afloat\":");
+    const now = std.time.timestamp();
     const snapshot = try repair_state.readDaemonSnapshotAlloc(allocator);
-    if (snapshot) |bytes| {
+    const freshness = if (snapshot) |bytes| blk: {
         defer allocator.free(bytes);
         const trimmed = std.mem.trim(u8, bytes, " \t\r\n");
-        if (trimmed.len == 0) {
-            try writer.writeAll("null");
-        } else {
+        const classified = snapshotFreshnessFromBytes(allocator, trimmed, now, loop_started_at);
+        if (trimmed.len != 0 and classified.parseable) {
             try writer.writeAll(trimmed);
+        } else {
+            try writer.writeAll("null");
         }
-    } else {
+        break :blk classified;
+    } else blk: {
         try writer.writeAll("null");
-    }
+        break :blk missingSnapshotFreshness();
+    };
+
+    try writer.writeAll(",\"stay_afloat_snapshot\":");
+    try writeSnapshotFreshnessJson(writer, freshness);
+}
+
+fn snapshotFreshnessFromBytes(
+    allocator: std.mem.Allocator,
+    trimmed: []const u8,
+    now: i64,
+    loop_started_at: ?i64,
+) SnapshotFreshness {
+    if (trimmed.len == 0) return .{
+        .present = false,
+        .parseable = false,
+        .loop_started_at = loop_started_at,
+        .current_loop_observed = if (loop_started_at == null) null else false,
+        .reason = "empty",
+    };
+
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, trimmed, .{}) catch {
+        return .{
+            .present = true,
+            .parseable = false,
+            .loop_started_at = loop_started_at,
+            .current_loop_observed = if (loop_started_at == null) null else false,
+            .reason = "malformed",
+        };
+    };
+    defer parsed.deinit();
+
+    const obj = switch (parsed.value) {
+        .object => |obj| obj,
+        else => return .{
+            .present = true,
+            .parseable = true,
+            .loop_started_at = loop_started_at,
+            .current_loop_observed = if (loop_started_at == null) null else false,
+            .reason = "missing_last_tick_at",
+        },
+    };
+
+    const last_tick_at = switch (obj.get("last_tick_at") orelse return .{
+        .present = true,
+        .parseable = true,
+        .loop_started_at = loop_started_at,
+        .current_loop_observed = if (loop_started_at == null) null else false,
+        .reason = "missing_last_tick_at",
+    }) {
+        .integer => |value| value,
+        else => return .{
+            .present = true,
+            .parseable = true,
+            .loop_started_at = loop_started_at,
+            .current_loop_observed = if (loop_started_at == null) null else false,
+            .reason = "invalid_last_tick_at",
+        },
+    };
+
+    const age = if (last_tick_at > now) 0 else now - last_tick_at;
+    const stale = age > stay_afloat_snapshot_stale_after_s;
+    const current_loop_observed = if (loop_started_at) |started_at| last_tick_at >= started_at else null;
+    return .{
+        .present = true,
+        .parseable = true,
+        .last_tick_at = last_tick_at,
+        .age_seconds = age,
+        .loop_started_at = loop_started_at,
+        .current_loop_observed = current_loop_observed,
+        .stale = stale,
+        .reason = if (stale) "stale" else if (current_loop_observed == false) "before_current_loop" else "fresh",
+    };
+}
+
+fn missingSnapshotFreshness() SnapshotFreshness {
+    return .{
+        .present = false,
+        .parseable = false,
+        .reason = "missing",
+    };
+}
+
+fn writeSnapshotFreshnessJson(writer: anytype, freshness: SnapshotFreshness) !void {
+    try writer.writeAll("{\"present\":");
+    try writer.writeAll(if (freshness.present) "true" else "false");
+    try writer.writeAll(",\"parseable\":");
+    try writer.writeAll(if (freshness.parseable) "true" else "false");
+    try writer.writeAll(",\"last_tick_at\":");
+    if (freshness.last_tick_at) |last_tick_at| try writer.print("{d}", .{last_tick_at}) else try writer.writeAll("null");
+    try writer.writeAll(",\"age_seconds\":");
+    if (freshness.age_seconds) |age_seconds| try writer.print("{d}", .{age_seconds}) else try writer.writeAll("null");
+    try writer.writeAll(",\"loop_started_at\":");
+    if (freshness.loop_started_at) |started_at| try writer.print("{d}", .{started_at}) else try writer.writeAll("null");
+    try writer.writeAll(",\"current_loop_observed\":");
+    if (freshness.current_loop_observed) |observed| try writer.writeAll(if (observed) "true" else "false") else try writer.writeAll("null");
+    try writer.writeAll(",\"stale_after_seconds\":");
+    try writer.print("{d}", .{freshness.stale_after_seconds});
+    try writer.writeAll(",\"stale\":");
+    try writer.writeAll(if (freshness.stale) "true" else "false");
+    try writer.writeAll(",\"reason\":");
+    try std.json.stringify(freshness.reason, .{}, writer);
+    try writer.writeAll("}");
+}
+
+fn jsonObjectI64(allocator: std.mem.Allocator, bytes: []const u8, field: []const u8) ?i64 {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, bytes, .{}) catch return null;
+    defer parsed.deinit();
+    const obj = switch (parsed.value) {
+        .object => |obj| obj,
+        else => return null,
+    };
+    return switch (obj.get(field) orelse return null) {
+        .integer => |value| value,
+        else => null,
+    };
 }
 
 fn isRunning(allocator: std.mem.Allocator) bool {
@@ -468,6 +604,77 @@ test "status json exposes socket daemon contract" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"wrapper_contract\":\"foreground_tick\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"stay_afloat_loop\":{\"hosted\":false") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"stay_afloat\":") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"stay_afloat_snapshot\":") != null);
+}
+
+test "stay-afloat snapshot freshness reports fresh and stale snapshots" {
+    const fresh = snapshotFreshnessFromBytes(std.testing.allocator, "{\"last_tick_at\":1000}", 1100, null);
+    try std.testing.expect(fresh.present);
+    try std.testing.expect(fresh.parseable);
+    try std.testing.expectEqual(@as(?i64, 1000), fresh.last_tick_at);
+    try std.testing.expectEqual(@as(?i64, 100), fresh.age_seconds);
+    try std.testing.expect(!fresh.stale);
+    try std.testing.expectEqualStrings("fresh", fresh.reason);
+
+    const stale = snapshotFreshnessFromBytes(std.testing.allocator, "{\"last_tick_at\":1000}", 1301, null);
+    try std.testing.expect(stale.present);
+    try std.testing.expect(stale.parseable);
+    try std.testing.expectEqual(@as(?i64, 301), stale.age_seconds);
+    try std.testing.expect(stale.stale);
+    try std.testing.expectEqualStrings("stale", stale.reason);
+
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+    try writeSnapshotFreshnessJson(buf.writer(), fresh);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"present\":true,\"parseable\":true,\"last_tick_at\":1000") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"age_seconds\":100") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"loop_started_at\":null") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"current_loop_observed\":null") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"stale_after_seconds\":300") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"stale\":false") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"reason\":\"fresh\"") != null);
+}
+
+test "stay-afloat snapshot freshness reports missing and malformed snapshots" {
+    const missing = missingSnapshotFreshness();
+    try std.testing.expect(!missing.present);
+    try std.testing.expect(!missing.parseable);
+    try std.testing.expect(missing.stale);
+    try std.testing.expectEqualStrings("missing", missing.reason);
+
+    const empty = snapshotFreshnessFromBytes(std.testing.allocator, "", 1100, null);
+    try std.testing.expect(!empty.present);
+    try std.testing.expect(!empty.parseable);
+    try std.testing.expect(empty.stale);
+    try std.testing.expectEqualStrings("empty", empty.reason);
+
+    const malformed = snapshotFreshnessFromBytes(std.testing.allocator, "{\"last_tick_at\":", 1100, null);
+    try std.testing.expect(malformed.present);
+    try std.testing.expect(!malformed.parseable);
+    try std.testing.expect(malformed.stale);
+    try std.testing.expectEqualStrings("malformed", malformed.reason);
+
+    const missing_tick = snapshotFreshnessFromBytes(std.testing.allocator, "{\"version\":\"test\"}", 1100, null);
+    try std.testing.expect(missing_tick.present);
+    try std.testing.expect(missing_tick.parseable);
+    try std.testing.expect(missing_tick.stale);
+    try std.testing.expectEqualStrings("missing_last_tick_at", missing_tick.reason);
+}
+
+test "stay-afloat snapshot freshness identifies snapshots before active loop" {
+    const before_loop = snapshotFreshnessFromBytes(std.testing.allocator, "{\"last_tick_at\":1000}", 1100, 1050);
+    try std.testing.expect(before_loop.present);
+    try std.testing.expect(before_loop.parseable);
+    try std.testing.expectEqual(@as(?i64, 1050), before_loop.loop_started_at);
+    try std.testing.expectEqual(@as(?bool, false), before_loop.current_loop_observed);
+    try std.testing.expect(!before_loop.stale);
+    try std.testing.expectEqualStrings("before_current_loop", before_loop.reason);
+
+    const current_loop = snapshotFreshnessFromBytes(std.testing.allocator, "{\"last_tick_at\":1100}", 1100, 1050);
+    try std.testing.expectEqual(@as(?i64, 1050), current_loop.loop_started_at);
+    try std.testing.expectEqual(@as(?bool, true), current_loop.current_loop_observed);
+    try std.testing.expect(!current_loop.stale);
+    try std.testing.expectEqualStrings("fresh", current_loop.reason);
 }
 
 test "stay-afloat metadata json exposes selector and cadence" {


### PR DESCRIPTION
## What changed

- Adds `stay_afloat_snapshot` metadata to `daemon status --json` alongside the existing redacted `stay_afloat` snapshot.
- Reports snapshot presence, parseability, `last_tick_at`, `age_seconds`, `loop_started_at`, `current_loop_observed`, staleness threshold, stale state, and reason.
- Keeps the existing embedded `stay_afloat` snapshot contract intact for valid snapshots, while malformed or empty snapshots are surfaced as `stay_afloat:null` plus explicit metadata.
- Updates local E2E coverage and stay-afloat wrapper/operator docs.

## Why

Dogfooding showed that `daemon status --json` could expose a `prepared_fallback` snapshot that was either stale or from before the currently running supervised loop. Wrappers and agents need to reject that state instead of treating any embedded snapshot as usable stay-afloat proof.

## Validation

- `zig build test`
- `nix develop --command just check-local`
- Live Codex beta-host dogfood: `daemon supervise --profile codex-max --capability codex-max` reported `current_loop_observed:true`, `stale:false`, selected `codex:max-3`, and kept `current_process_hotswap:false` / `supervised_restart:false` / `per_request_muxing:false`.

Fixes #121
Tracking: TIN-910 / TIN-738 / #67
