### PR TITLE
[codex] Select fallback route for broker refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,10 @@ that child only, and verifies initialize/login/account-update milestones while
 still suppressing token, account-id, and raw protocol output.
 `codex broker-refresh-smoke --confirm-broker --json` proves the next app-server
 primitive: after external-auth login, oauth-mux can observe
-`account/chatgptAuthTokens/refresh` and answer it with the selected route token
-tuple. This is still a local mediated app-server protocol proof, not an
-unmanaged running Codex TUI hot-swap or quota-recovery claim.
+`account/chatgptAuthTokens/refresh` and answer it with the next ready route
+token tuple when a fallback account exists. This is still a local mediated
+app-server protocol proof, not an unmanaged running Codex TUI hot-swap or
+quota-recovery claim.
 
 `stay-afloat launch -- <command>` is the target execution boundary for new
 harness sessions. It uses the same no-spend preflight as `stay-afloat next`; if

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -132,10 +132,11 @@ account-id, and raw protocol values.
 
 `oauth-mux codex broker-refresh-smoke --profile codex-max --capability
 codex-max --confirm-broker --json` extends that local proof by answering an
-app-server `account/chatgptAuthTokens/refresh` request with the selected route
-token tuple. This proves the refresh-response primitive needed for future live
-401 repair in mediated sessions. It is still not an unmanaged current TUI
-hot-swap, per-request mux, or quota-recovery claim.
+app-server `account/chatgptAuthTokens/refresh` request with the next ready
+route token tuple when a fallback account exists. This proves the
+refresh-response selection primitive needed for future live 401 repair in
+mediated sessions. It is still not an unmanaged current TUI hot-swap,
+per-request mux, or quota-recovery claim.
 
 `oauth-mux stay-afloat launch -- <command>` is the matching startup command for
 users and wrappers. It executes the target only after a selectable route is

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -208,9 +208,10 @@ unmanaged current TUI hot-swap or quota-recovery claim.
 Use
 `oauth-mux codex broker-refresh-smoke --profile codex-max --capability
 codex-max --confirm-broker --json` to prove that the same mediated app-server
-session can answer `account/chatgptAuthTokens/refresh` after login. This is the
-first local proof for the live 401 repair primitive; it does not yet prove
-automatic repair of an already-running unmanaged Codex process.
+session can answer `account/chatgptAuthTokens/refresh` after login with the
+next ready route when a fallback account exists. This is the first local proof
+for the live 401 repair primitive; it does not yet prove automatic repair of an
+already-running unmanaged Codex process.
 
 `stay-afloat launch -- <command>` is the user/wrapper startup boundary. It runs
 the same preflight as `stay-afloat next`, then starts the target only when a

--- a/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
+++ b/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
@@ -254,8 +254,9 @@ For quota-driven account changes, use a different action name, such as
 7. Prove the local refresh-response primitive with
    `oauth-mux codex broker-refresh-smoke --profile codex-max --capability
    codex-max --confirm-broker --json`: after app-server login, observe
-   `account/chatgptAuthTokens/refresh`, respond with the selected route's
-   external-auth tuple, and report only redacted protocol milestones.
+   `account/chatgptAuthTokens/refresh`, respond with the next ready route's
+   external-auth tuple when a fallback account exists, and report only redacted
+   protocol milestones.
 8. Add a controlled 401 proof that switches from one account token to another
    and records redacted evidence.
 9. Add a no-overclaim quota proof: show that rate-limit snapshots can trigger

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -703,6 +703,51 @@ expect_not_contains "$broker_smoke" "$broker_jwt" "broker-smoke does not expose 
 expect_not_contains "$broker_smoke" 'broker-refresh-token' "broker-smoke does not expose refresh token value"
 
 printf 'e2e: codex broker-refresh-smoke answers app-server auth refresh without leaking tokens\n'
+broker_auth_fallback="$tmp/broker-auth-fallback.json"
+broker_switch_config="$tmp/broker-switch-config.json"
+cat >"$broker_auth_fallback" <<EOF
+{
+  "auth_mode": "chatgpt",
+  "tokens": {
+    "id_token": "$broker_jwt",
+    "access_token": "$broker_jwt",
+    "refresh_token": "broker-refresh-token-fallback",
+    "account_id": "acct-fallback"
+  }
+}
+EOF
+cat >"$broker_switch_config" <<EOF
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "kind": "codex",
+      "accounts": {
+        "max-1": {
+          "priority": 20,
+          "secret": {
+            "backend": "file",
+            "path": "$broker_auth"
+          }
+        },
+        "max-2": {
+          "priority": 10,
+          "secret": {
+            "backend": "file",
+            "path": "$broker_auth_fallback"
+          }
+        }
+      }
+    }
+  },
+  "profiles": {
+    "codex-max": {
+      "providers": ["codex:max-1#codex-max", "codex:max-2#codex-max"]
+    }
+  },
+  "strategies": {}
+}
+EOF
 mock_codex_refresh_app_server="$tmp/mock-codex-refresh-app-server"
 cat >"$mock_codex_refresh_app_server" <<'EOF'
 #!/bin/sh
@@ -717,23 +762,30 @@ while IFS= read -r line; do
       printf '%s\n' '{"method":"account/updated","params":{"authMode":"chatgptAuthTokens","planType":"pro"}}'
       printf '%s\n' '{"id":99,"method":"account/chatgptAuthTokens/refresh","params":{"reason":"unauthorized"}}'
       ;;
-    *'"id":99'*'"result"'*)
+    *'"id":99'*'"result"'*'acct-fallback'*)
       printf '%s\n' '{"method":"account/updated","params":{"authMode":"chatgptAuthTokens","planType":"pro"}}'
+      ;;
+    *'"id":99'*'"result"'*)
+      exit 17
       ;;
   esac
 done
 EOF
 chmod +x "$mock_codex_refresh_app_server"
-broker_refresh_smoke="$(OMUX_CONFIG="$broker_config" OMUX_STATE_DIR="$state_dir" OMUX_CODEX_APP_SERVER="$mock_codex_refresh_app_server" "$bin" codex broker-refresh-smoke --profile codex-max --capability codex-max --confirm-broker --json)"
+broker_refresh_smoke="$(OMUX_CONFIG="$broker_switch_config" OMUX_STATE_DIR="$state_dir" OMUX_CODEX_APP_SERVER="$mock_codex_refresh_app_server" "$bin" codex broker-refresh-smoke --profile codex-max --capability codex-max --confirm-broker --json)"
 expect_contains "$broker_refresh_smoke" '"mode":"codex_app_server_stdio_broker_refresh_smoke"' "broker-refresh-smoke reports refresh broker mode"
 expect_contains "$broker_refresh_smoke" '"ok":true' "broker-refresh-smoke reports success"
 expect_contains "$broker_refresh_smoke" '"proof_status":"local_refresh_protocol_smoke"' "broker-refresh-smoke reports refresh protocol proof status"
+expect_contains "$broker_refresh_smoke" '"selected":{"provider":"codex","account":"max-1","capability":"codex-max"' "broker-refresh-smoke starts from first ready route"
+expect_contains "$broker_refresh_smoke" '"refresh_selected":{"provider":"codex","account":"max-2","capability":"codex-max"' "broker-refresh-smoke answers refresh with fallback route"
+expect_contains "$broker_refresh_smoke" '"refresh_route_is_fallback":true' "broker-refresh-smoke marks refresh route as fallback"
 expect_contains "$broker_refresh_smoke" '"refresh_request_seen":true' "broker-refresh-smoke observes refresh request"
 expect_contains "$broker_refresh_smoke" '"refresh_reason_unauthorized":true' "broker-refresh-smoke classifies unauthorized refresh reason"
 expect_contains "$broker_refresh_smoke" '"refresh_response_sent":true' "broker-refresh-smoke sends refresh response"
 expect_contains "$broker_refresh_smoke" '"tokens_printed":false' "broker-refresh-smoke redaction reports token suppression"
 expect_contains "$broker_refresh_smoke" '"raw_protocol_printed":false' "broker-refresh-smoke redaction reports raw protocol suppression"
 expect_not_contains "$broker_refresh_smoke" 'acct-test' "broker-refresh-smoke does not expose account id value"
+expect_not_contains "$broker_refresh_smoke" 'acct-fallback' "broker-refresh-smoke does not expose fallback account id value"
 expect_not_contains "$broker_refresh_smoke" "$broker_jwt" "broker-refresh-smoke does not expose token value"
 expect_not_contains "$broker_refresh_smoke" 'broker-refresh-token' "broker-refresh-smoke does not expose refresh token value"
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -7718,6 +7718,44 @@ const CodexBrokerSmokeResult = struct {
     protocol: CodexBrokerProtocolObservation = .{},
 };
 
+const CodexBrokerRouteCredentials = struct {
+    route: RepairPlanRoute,
+    credentials: CodexBrokerCredentials,
+
+    fn deinit(self: *CodexBrokerRouteCredentials, allocator: std.mem.Allocator) void {
+        self.credentials.deinit(allocator);
+    }
+};
+
+fn cloneCodexBrokerCredentials(
+    allocator: std.mem.Allocator,
+    credentials: CodexBrokerCredentials,
+) !CodexBrokerCredentials {
+    const access_token = try allocator.dupe(u8, credentials.access_token);
+    errdefer allocator.free(access_token);
+    const chatgpt_account_id = try allocator.dupe(u8, credentials.chatgpt_account_id);
+    errdefer allocator.free(chatgpt_account_id);
+    const chatgpt_plan_type = if (credentials.chatgpt_plan_type) |value|
+        try allocator.dupe(u8, value)
+    else
+        null;
+    errdefer if (chatgpt_plan_type) |value| allocator.free(value);
+
+    return .{
+        .access_token = access_token,
+        .chatgpt_account_id = chatgpt_account_id,
+        .chatgpt_plan_type = chatgpt_plan_type,
+    };
+}
+
+fn sameRepairPlanRouteIdentity(a: RepairPlanRoute, b: RepairPlanRoute) bool {
+    if (!std.mem.eql(u8, a.provider, b.provider)) return false;
+    if (!std.mem.eql(u8, a.account, b.account)) return false;
+    if (a.capability == null and b.capability == null) return true;
+    if (a.capability == null or b.capability == null) return false;
+    return std.mem.eql(u8, a.capability.?, b.capability.?);
+}
+
 fn runCodexBrokerPlan(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs) !void {
     const parsed = try config.load(allocator);
     defer parsed.deinit();
@@ -7870,19 +7908,32 @@ fn runCodexBrokerSmoke(
     });
     defer routes.deinit();
 
-    var selected: ?RepairPlanRoute = null;
-    var credentials: ?CodexBrokerCredentials = null;
+    var selected: ?CodexBrokerRouteCredentials = null;
+    defer if (selected) |*value| value.deinit(allocator);
+    var refresh_selected: ?CodexBrokerRouteCredentials = null;
+    defer if (refresh_selected) |*value| value.deinit(allocator);
     for (routes.items) |route| {
         const plan = try inspectCodexBrokerRoute(allocator, parsed.value, route);
         if (!plan.can_supply) continue;
-        credentials = loadCodexBrokerCredentialsForRoute(allocator, parsed.value, route) catch null;
-        if (credentials != null) {
-            selected = route;
+        const credentials = loadCodexBrokerCredentialsForRoute(allocator, parsed.value, route) catch continue;
+        if (selected == null) {
+            selected = .{
+                .route = route,
+                .credentials = credentials,
+            };
+            continue;
+        }
+        if (mode == .refresh and refresh_selected == null and !sameRepairPlanRouteIdentity(selected.?.route, route)) {
+            refresh_selected = .{
+                .route = route,
+                .credentials = credentials,
+            };
             break;
         }
+        credentials.deinit(allocator);
     }
 
-    if (selected == null or credentials == null) {
+    if (selected == null) {
         if (args.json) {
             try writer.writeAll("{\"version\":");
             try std.json.stringify(cli.version, .{}, writer);
@@ -7900,7 +7951,13 @@ fn runCodexBrokerSmoke(
         }
         return;
     }
-    defer credentials.?.deinit(allocator);
+
+    if (mode == .refresh and refresh_selected == null) {
+        refresh_selected = .{
+            .route = selected.?.route,
+            .credentials = try cloneCodexBrokerCredentials(allocator, selected.?.credentials),
+        };
+    }
 
     const state_dir = try paths.stateDir(allocator);
     defer allocator.free(state_dir);
@@ -7908,18 +7965,21 @@ fn runCodexBrokerSmoke(
     defer allocator.free(run_dir);
     try std.fs.cwd().makePath(run_dir);
 
-    const result = try runCodexAppServerBrokerSmoke(allocator, credentials.?, run_dir, mode);
+    const refresh_route = if (refresh_selected) |value| value.route else null;
+    const refresh_credentials = if (refresh_selected) |value| value.credentials else selected.?.credentials;
+    const result = try runCodexAppServerBrokerSmoke(allocator, selected.?.credentials, refresh_credentials, run_dir, mode);
 
     if (args.json) {
-        try writeCodexBrokerSmokeJson(writer, selected.?, capability, result, mode);
+        try writeCodexBrokerSmokeJson(writer, selected.?.route, refresh_route, capability, result, mode);
     } else {
-        try writeCodexBrokerSmokeText(writer, selected.?, capability, result, mode);
+        try writeCodexBrokerSmokeText(writer, selected.?.route, refresh_route, capability, result, mode);
     }
 }
 
 fn writeCodexBrokerSmokeJson(
     writer: anytype,
     route: RepairPlanRoute,
+    refresh_route: ?RepairPlanRoute,
     capability: ?[]const u8,
     result: CodexBrokerSmokeResult,
     mode: CodexBrokerSmokeMode,
@@ -7936,6 +7996,10 @@ fn writeCodexBrokerSmokeJson(
     try writer.writeAll(",\"current_process_hotswap\":false,\"per_request_muxing\":false}");
     try writer.writeAll(",\"selected\":");
     try writeRouteSelectionJson(writer, route);
+    try writer.writeAll(",\"refresh_selected\":");
+    if (refresh_route) |value| try writeRouteSelectionJson(writer, value) else try writer.writeAll("null");
+    try writer.writeAll(",\"refresh_route_is_fallback\":");
+    try writer.writeAll(if (refresh_route != null and !sameRepairPlanRouteIdentity(route, refresh_route.?)) "true" else "false");
     try writer.writeAll(",\"capability\":");
     if (capability) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"app_server\":{\"transport\":\"stdio\",\"requires_experimental_api\":true,\"login_method\":\"account/login/start.chatgptAuthTokens\",\"refresh_method\":\"account/chatgptAuthTokens/refresh\"}");
@@ -7981,6 +8045,7 @@ fn writeCodexBrokerProtocolJson(writer: anytype, result: CodexBrokerSmokeResult)
 fn writeCodexBrokerSmokeText(
     writer: anytype,
     route: RepairPlanRoute,
+    refresh_route: ?RepairPlanRoute,
     capability: ?[]const u8,
     result: CodexBrokerSmokeResult,
     mode: CodexBrokerSmokeMode,
@@ -7989,6 +8054,11 @@ fn writeCodexBrokerSmokeText(
     try writer.print("  route: {s}:{s}", .{ route.provider, route.account });
     if (capability) |value| try writer.print("#{s}", .{value});
     try writer.writeByte('\n');
+    if (refresh_route) |value| {
+        try writer.print("  refresh route: {s}:{s}", .{ value.provider, value.account });
+        if (value.capability) |route_capability| try writer.print("#{s}", .{route_capability});
+        try writer.print(" fallback={s}\n", .{if (sameRepairPlanRouteIdentity(route, value)) "false" else "true"});
+    }
     try writer.print("  ok: {s}\n", .{if (result.ok) "true" else "false"});
     try writer.print("  reason: {s}\n", .{result.reason});
     try writer.print("  initialized: {s}\n", .{if (result.protocol.initialized) "true" else "false"});
@@ -8005,7 +8075,8 @@ fn writeCodexBrokerSmokeText(
 
 fn runCodexAppServerBrokerSmoke(
     allocator: std.mem.Allocator,
-    credentials: CodexBrokerCredentials,
+    login_credentials: CodexBrokerCredentials,
+    refresh_credentials: CodexBrokerCredentials,
     codex_home: []const u8,
     mode: CodexBrokerSmokeMode,
 ) !CodexBrokerSmokeResult {
@@ -8019,7 +8090,7 @@ fn runCodexAppServerBrokerSmoke(
 
     var login_request = std.ArrayList(u8).init(allocator);
     defer login_request.deinit();
-    try writeCodexAppServerLoginRequest(login_request.writer(), credentials);
+    try writeCodexAppServerLoginRequest(login_request.writer(), login_credentials);
     try login_request.append('\n');
 
     var env_map = try std.process.getEnvMap(allocator);
@@ -8102,7 +8173,7 @@ fn runCodexAppServerBrokerSmoke(
                 if (!request.reason_unauthorized) {
                     result.reason = "unsupported_refresh_reason";
                 } else if (child.stdin) |stdin_file| {
-                    try writeCodexAppServerRefreshResponse(stdin_file.writer(), request.id, credentials);
+                    try writeCodexAppServerRefreshResponse(stdin_file.writer(), request.id, refresh_credentials);
                     try stdin_file.writeAll("\n");
                     result.refresh_response_sent = true;
                     stdin_file.close();
@@ -8146,11 +8217,13 @@ fn runCodexAppServerBrokerSmoke(
     result.stdout_bytes = stdout_buf.items.len;
     result.stderr_bytes = stderr_buf.items.len;
     result.protocol = inspectCodexBrokerProtocolOutput(stdout_buf.items);
+    const child_exit_ok = result.exit_code != null and result.exit_code.? == 0;
     result.ok = switch (mode) {
         .login => result.protocol.initialized and
             result.protocol.login_response and
             result.protocol.login_completed and
             result.protocol.account_updated and
+            child_exit_ok and
             !result.protocol.experimental_api_required_error,
         .refresh => result.protocol.initialized and
             result.protocol.login_response and
@@ -8159,6 +8232,7 @@ fn runCodexAppServerBrokerSmoke(
             result.protocol.refresh_request_seen and
             result.protocol.refresh_reason_unauthorized and
             result.refresh_response_sent and
+            child_exit_ok and
             !result.protocol.experimental_api_required_error,
     };
     if (result.ok) {


### PR DESCRIPTION
## Summary

Extends `oauth-mux codex broker-refresh-smoke` from same-route refresh response to fallback route selection.

When a profile has multiple broker-ready Codex routes, oauth-mux now logs in the broker-owned app-server with the first ready route and answers `account/chatgptAuthTokens/refresh` with the next ready route. JSON output reports `selected`, `refresh_selected`, and `refresh_route_is_fallback` while still suppressing token, account-id, and raw protocol values.

## Why

TIN-915 needs a cross-account handoff rehearsal before the controlled live 401 proof. This PR proves the route-choice half with a mock app-server that exits nonzero unless the refresh response contains the fallback account token tuple.

## Validation

- `just check-local`
- Real Codex app-server login broker smoke still passes: `./zig-out/bin/oauth-mux codex broker-smoke --profile codex-max --capability codex-max --confirm-broker --json`
