### PR TITLE
Add Codex broker session plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair-plan --profile 
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux accounts list --provider codex --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-plan --profile codex-max --capability codex-max --json
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-smoke --profile codex-max --capability codex-max --confirm-broker --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-refresh-smoke --profile codex-max --capability codex-max --confirm-broker --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-401-smoke --profile codex-max --capability codex-max --confirm-broker --json
@@ -135,6 +136,10 @@ sessions, not a current public claim.
 configured Codex stores locally and reports whether each route can supply the
 external-auth tuple Codex app-server expects, without printing tokens, account
 ids, credential paths, or provider-call evidence.
+`codex broker-session-plan --json` combines that broker readiness with recorded
+route liveness. It reports the selected broker-owned session route, immediate
+selectable fallback routes, quota-blocked routes, and the explicit claim
+boundary without starting Codex or probing providers.
 `codex broker-smoke --confirm-broker --json` is the next local proof: it starts
 a broker-owned Codex app-server stdio child, sends the selected route token to
 that child only, and verifies initialize/login/account-update milestones while
@@ -277,6 +282,7 @@ oauth-mux codex canary
 oauth-mux codex live-qa
 oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 oauth-mux codex broker-plan --profile codex-max --capability codex-max --json
+oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json
 oauth-mux codex broker-smoke --profile codex-max --capability codex-max --confirm-broker --json
 oauth-mux codex broker-refresh-smoke --profile codex-max --capability codex-max --confirm-broker --json
 oauth-mux codex broker-401-smoke --profile codex-max --capability codex-max --confirm-broker --json

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -153,6 +153,12 @@ auth-refresh hook, applies a fallback app-server login, and verifies a new
 brokered thread uses fallback Authorization. Same-thread quota recovery remains
 explicitly unproven.
 
+`oauth-mux codex broker-session-plan --profile codex-max --capability codex-max
+--json` is the no-spend UX planning surface for broker-owned Codex sessions. It
+combines recorded route liveness with app-server auth-broker readiness, then
+reports the selected route, immediate selectable fallbacks, quota-blocked broker
+routes, and the same explicit no-hot-swap/no-same-thread quota boundary.
+
 `oauth-mux stay-afloat launch -- <command>` is the matching startup command for
 users and wrappers. It executes the target only after a selectable route is
 found from recorded evidence. The delegated `exec` path still validates local

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -225,6 +225,12 @@ Use
 simulates usage-limit 429, confirms that this is not the same hook as 401
 auth-refresh, then verifies fallback Authorization on a new brokered thread.
 That is useful stay-afloat evidence, but not same-thread quota recovery.
+Use
+`oauth-mux codex broker-session-plan --profile codex-max --capability codex-max
+--json` when you need the user-facing broker-owned session plan without running
+Codex or spending provider calls. It joins route liveness with broker token
+readiness and reports which route would start the session plus which broker-ready
+routes are immediate fallbacks.
 
 `stay-afloat launch -- <command>` is the user/wrapper startup boundary. It runs
 the same preflight as `stay-afloat next`, then starts the target only when a

--- a/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
+++ b/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
@@ -76,9 +76,10 @@ There are now four distinct stay-afloat claim levels:
    healthy account.
 2. `supervised_restart`: not implemented. oauth-mux owns a child process and
    can restart it under another route after typed failure evidence.
-3. `current_process_auth_broker`: not implemented. The upstream harness exposes
-   a reload, external-auth, or account-switch protocol that oauth-mux can
-   drive while the harness process remains alive.
+3. `current_process_auth_broker`: implemented only for broker-owned Codex
+   app-server proof paths. The upstream harness exposes a reload, external-auth,
+   or account-switch protocol that oauth-mux can drive while the harness process
+   remains alive.
 4. `per_request_muxing`: not implemented. Every model/provider request passes
    through oauth-mux or an oauth-mux-aware adapter.
 
@@ -272,9 +273,14 @@ For quota-driven account changes, use a different action name, such as
    proves the first no-spend version: local usage-limit 429 does not produce
    the 401 refresh hook, fallback app-server login is accepted, and a new
    brokered thread uses fallback Authorization.
-10. Only after topology A is green, attempt topology B with a remote TUI and
+10. Add a no-spend session planning surface:
+   `oauth-mux codex broker-session-plan --profile codex-max --capability
+   codex-max --json` joins recorded route liveness with broker auth readiness
+   and reports selected, fallback, quota-blocked, and auth-unready routes for
+   the future broker-owned session UX.
+11. Only after topology A is green, attempt topology B with a remote TUI and
    sidecar broker.
-11. Update website and README claim language only after live dogfood passes.
+12. Update website and README claim language only after live dogfood passes.
 
 ## Acceptance Criteria
 
@@ -289,6 +295,9 @@ For quota-driven account changes, use a different action name, such as
 - The controlled quota smoke proves new-thread fallback after local
   usage-limit classification. It also records the negative evidence:
   same-turn and same-thread quota recovery are not proven.
+- The broker session plan is no-spend and planning-only. It can report a
+  broker-owned session start route plus immediate selectable fallbacks, but it
+  does not start Codex, spend provider calls, or claim unmanaged TUI hot-swap.
 - Cross-account switching is blocked when forced workspace or profile policy
   forbids it.
 - Quota/rate-limit behavior is separately classified as next-turn account

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -247,7 +247,9 @@ these precise provider-proof children.
    route. `oauth-mux codex broker-quota-smoke --confirm-broker` proves the
    local no-spend quota boundary: new brokered thread fallback works after
    fallback login, while same-turn and same-thread quota recovery remain
-   unclaimed.
+   unclaimed. `oauth-mux codex broker-session-plan` is the next UX slice: it
+   combines route liveness with broker readiness to plan a broker-owned Codex
+   session without spending provider calls.
 10. Return to daemon background implementation only after wrapper/install
    decisions and provider proof produce enough real operator evidence. The
    current socket daemon decision is complete under `TIN-867`; future

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -670,6 +670,147 @@ expect_not_contains "$broker_plan" 'acct-test' "broker-plan does not expose acco
 expect_not_contains "$broker_plan" "$broker_jwt" "broker-plan does not expose token value"
 expect_not_contains "$broker_plan" 'broker-refresh-token' "broker-plan does not expose refresh token value"
 
+printf 'e2e: codex broker-session-plan combines route liveness with broker readiness\n'
+broker_auth_session_fallback="$tmp/broker-auth-session-fallback.json"
+broker_auth_session_spare="$tmp/broker-auth-session-spare.json"
+broker_session_config="$tmp/broker-session-config.json"
+broker_session_state="$tmp/broker-session-state"
+broker_session_max1_home="$tmp/broker-session-max-1"
+broker_session_max2_home="$tmp/broker-session-max-2"
+broker_session_max3_home="$tmp/broker-session-max-3"
+broker_session_bin="$tmp/broker-session-bin"
+mkdir -p "$broker_session_state" "$broker_session_max1_home" "$broker_session_max2_home" "$broker_session_max3_home" "$broker_session_bin"
+cat >"$broker_session_bin/codex" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+chmod +x "$broker_session_bin/codex"
+cp "$broker_auth" "$broker_session_max1_home/auth.json"
+cat >"$broker_auth_session_fallback" <<EOF
+{
+  "auth_mode": "chatgpt",
+  "tokens": {
+    "id_token": "$broker_jwt",
+    "access_token": "$broker_jwt",
+    "refresh_token": "broker-session-refresh-token",
+    "account_id": "acct-session-fallback"
+  }
+}
+EOF
+cat >"$broker_auth_session_spare" <<EOF
+{
+  "auth_mode": "chatgpt",
+  "tokens": {
+    "id_token": "$broker_jwt",
+    "access_token": "$broker_jwt",
+    "refresh_token": "broker-session-spare-token",
+    "account_id": "acct-session-spare"
+  }
+}
+EOF
+cp "$broker_auth_session_fallback" "$broker_session_max2_home/auth.json"
+cp "$broker_auth_session_spare" "$broker_session_max3_home/auth.json"
+cat >"$broker_session_config" <<EOF
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "kind": "codex",
+      "accounts": {
+        "max-1": {
+          "config_dir": "$broker_session_max1_home",
+          "secret": {
+            "backend": "file",
+            "path": "$broker_session_max1_home/auth.json"
+          }
+        },
+        "max-2": {
+          "config_dir": "$broker_session_max2_home",
+          "secret": {
+            "backend": "file",
+            "path": "$broker_auth_session_fallback"
+          }
+        },
+        "max-3": {
+          "config_dir": "$broker_session_max3_home",
+          "secret": {
+            "backend": "file",
+            "path": "$broker_auth_session_spare"
+          }
+        }
+      }
+    }
+  },
+  "profiles": {
+    "codex-max": {
+      "providers": ["codex:max-1#codex-max", "codex:max-2#codex-max", "codex:max-3#codex-max"]
+    }
+  },
+  "strategies": {}
+}
+EOF
+cat >"$broker_session_state/health.json" <<'EOF'
+{
+  "version": 2,
+  "accounts": [
+    {
+      "key": "codex:max-1#codex-max",
+      "last_probe_source": "capability_probe",
+      "last_probe_hint_class": "quota_exhausted",
+      "last_probe_decision": "try_next_account",
+      "liveness": {
+        "state": "live",
+        "availability": "quota_exhausted",
+        "window_resets_at": 1999999999
+      }
+    },
+    {
+      "key": "codex:max-2#codex-max",
+      "last_probe_source": "capability_probe",
+      "last_probe_hint_class": "none",
+      "last_probe_decision": "use_this",
+      "liveness": {
+        "state": "live",
+        "availability": "available"
+      }
+    },
+    {
+      "key": "codex:max-3#codex-max",
+      "last_probe_source": "capability_probe",
+      "last_probe_hint_class": "none",
+      "last_probe_decision": "use_this",
+      "liveness": {
+        "state": "live",
+        "availability": "available"
+      }
+    }
+  ]
+}
+EOF
+broker_session_plan="$(PATH="$broker_session_bin:$PATH" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex broker-session-plan --profile codex-max --capability codex-max --json)"
+expect_contains "$broker_session_plan" '"mode":"codex_broker_owned_session_plan"' "broker-session-plan reports session mode"
+expect_contains "$broker_session_plan" '"spends_provider_calls":false' "broker-session-plan reports no provider spend"
+expect_contains "$broker_session_plan" '"mutates_route_health":false' "broker-session-plan reports no route-health mutation"
+expect_contains "$broker_session_plan" '"proof_status":"session_planning_only"' "broker-session-plan refuses execution proof claim"
+expect_contains "$broker_session_plan" '"broker_owned_session":true' "broker-session-plan scopes claim to broker-owned session"
+expect_contains "$broker_session_plan" '"session_start_ready":true' "broker-session-plan reports start-ready selected route"
+expect_contains "$broker_session_plan" '"prepared_fallback":true' "broker-session-plan reports selectable broker fallback"
+expect_contains "$broker_session_plan" '"same_thread_quota_recovery":false' "broker-session-plan keeps same-thread quota boundary explicit"
+expect_contains "$broker_session_plan" '"routes_total":3' "broker-session-plan counts routes"
+expect_contains "$broker_session_plan" '"broker_ready_routes":3' "broker-session-plan counts broker-ready routes"
+expect_contains "$broker_session_plan" '"selectable_broker_routes":2' "broker-session-plan counts selectable broker routes"
+expect_contains "$broker_session_plan" '"selectable_fallback_routes":1' "broker-session-plan counts immediate fallback route"
+expect_contains "$broker_session_plan" '"blocked_broker_routes":1' "broker-session-plan counts quota-blocked broker route"
+expect_contains "$broker_session_plan" '"selected":{"provider":"codex","account":"max-2","capability":"codex-max"' "broker-session-plan selects first selectable broker route"
+expect_contains "$broker_session_plan" '"route_role":"quota_blocked"' "broker-session-plan marks exhausted broker route"
+expect_contains "$broker_session_plan" '"route_role":"selected"' "broker-session-plan marks selected route"
+expect_contains "$broker_session_plan" '"route_role":"selectable_fallback"' "broker-session-plan marks fallback route"
+expect_not_contains "$broker_session_plan" 'acct-session-fallback' "broker-session-plan does not expose fallback account id value"
+expect_not_contains "$broker_session_plan" 'acct-session-spare' "broker-session-plan does not expose spare account id value"
+expect_not_contains "$broker_session_plan" "$broker_jwt" "broker-session-plan does not expose token value"
+expect_not_contains "$broker_session_plan" 'broker-session-refresh-token' "broker-session-plan does not expose refresh token value"
+expect_not_contains "$broker_session_plan" 'broker-session-spare-token' "broker-session-plan does not expose spare refresh token value"
+
 printf 'e2e: codex broker-smoke verifies app-server stdio login without leaking tokens\n'
 mock_codex_app_server="$tmp/mock-codex-app-server"
 cat >"$mock_codex_app_server" <<'EOF'

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -183,6 +183,7 @@ pub const Command = union(enum) {
         config_candidate,
         config_merge,
         broker_plan,
+        broker_session_plan,
         broker_smoke,
         broker_refresh_smoke,
         broker_401_smoke,
@@ -886,6 +887,8 @@ fn parseCodex(args: []const []const u8) Command {
             result.action = .config_merge;
         } else if (eql(args[0], "broker-plan")) {
             result.action = .broker_plan;
+        } else if (eql(args[0], "broker-session-plan")) {
+            result.action = .broker_session_plan;
         } else if (eql(args[0], "broker-smoke")) {
             result.action = .broker_smoke;
         } else if (eql(args[0], "broker-refresh-smoke")) {
@@ -1078,6 +1081,9 @@ pub fn printUsage(writer: anytype) !void {
         \\  codex broker-plan [--profile name] [--capability c] [--json]
         \\      Inspect whether Codex routes can supply app-server external auth tokens.
         \\
+        \\  codex broker-session-plan [--profile name] [--capability c] [--json]
+        \\      Plan a broker-owned Codex session from route liveness and auth-broker readiness.
+        \\
         \\  codex broker-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\      Start a broker-owned Codex app-server stdio session and verify external auth login.
         \\
@@ -1129,6 +1135,7 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\  oauth-mux codex live-qa [--accounts a,b,c] [--capabilities c1,c2] [--confirm-spend] [--json]
         \\  oauth-mux codex probe-all [--accounts a,b,c] [--capability c] [--json]
         \\  oauth-mux codex broker-plan [--profile name] [--capability c] [--json]
+        \\  oauth-mux codex broker-session-plan [--profile name] [--capability c] [--json]
         \\  oauth-mux codex broker-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\  oauth-mux codex broker-refresh-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\  oauth-mux codex broker-401-smoke [--profile name] [--capability c] --confirm-broker [--json]
@@ -1342,6 +1349,20 @@ test "parse codex broker plan" {
     switch (cmd) {
         .codex => |codex| {
             try std.testing.expect(codex.action == .broker_plan);
+            try std.testing.expectEqualStrings("codex-max", codex.profile.?);
+            try std.testing.expectEqualStrings("codex-max", codex.capabilities);
+            try std.testing.expect(codex.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse codex broker session plan" {
+    const args = [_][]const u8{ "codex", "broker-session-plan", "--profile", "codex-max", "--capability", "codex-max", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex => |codex| {
+            try std.testing.expect(codex.action == .broker_session_plan);
             try std.testing.expectEqualStrings("codex-max", codex.profile.?);
             try std.testing.expectEqualStrings("codex-max", codex.capabilities);
             try std.testing.expect(codex.json);
@@ -1895,7 +1916,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary live-qa probe-all broker-plan broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary live-qa probe-all broker-plan broker-session-plan broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run supervise start stop status events handoffs tick' -d 'Daemon subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l stay-afloat -d 'Host beta supervised stay-afloat loop'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l json -d 'JSON output'

--- a/src/main.zig
+++ b/src/main.zig
@@ -7517,6 +7517,7 @@ fn runCodex(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Cod
         .config_candidate => try runCodexConfigCandidate(allocator, writer, args, root),
         .config_merge => try runCodexConfigMerge(allocator, writer, args),
         .broker_plan => try runCodexBrokerPlan(allocator, writer, args),
+        .broker_session_plan => try runCodexBrokerSessionPlan(allocator, writer, args),
         .broker_smoke => try runCodexBrokerSmoke(allocator, writer, args, .login),
         .broker_refresh_smoke => try runCodexBrokerSmoke(allocator, writer, args, .refresh),
         .broker_401_smoke => try runCodexBroker401Smoke(allocator, writer, args),
@@ -7911,6 +7912,252 @@ fn writeCodexBrokerPlanText(
         try writer.print(" account_id={s}", .{if (plan.chatgpt_account_id_present) "yes" else "no"});
         try writer.print(" plan_type={s}\n", .{if (plan.chatgpt_plan_type_present) "yes" else "no"});
     }
+}
+
+fn runCodexBrokerSessionPlan(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs) !void {
+    const parsed = try config.load(allocator);
+    defer parsed.deinit();
+
+    var validation_messages = std.ArrayList(u8).init(allocator);
+    defer validation_messages.deinit();
+    try config.validate(parsed.value, validation_messages.writer());
+
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+
+    const capability = firstCommaValue(args.capabilities);
+    var routes = try collectRepairPlanRoutes(allocator, parsed.value, .{
+        .profile = args.profile,
+        .provider = if (args.profile == null) "codex" else null,
+        .account = args.account,
+        .capability = capability,
+        .json = args.json,
+    });
+    defer routes.deinit();
+
+    var evaluations = std.ArrayList(RouteEvaluation).init(allocator);
+    defer evaluations.deinit();
+    try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &evaluations);
+
+    const selected_index = try firstSelectableCodexBrokerRouteIndex(allocator, parsed.value, evaluations.items);
+
+    if (args.json) {
+        try writeCodexBrokerSessionPlanJson(writer, allocator, parsed.value, evaluations.items, selected_index, args.profile, capability);
+    } else {
+        try writeCodexBrokerSessionPlanText(writer, allocator, parsed.value, evaluations.items, selected_index, args.profile, capability);
+    }
+}
+
+const CodexBrokerSessionSummary = struct {
+    routes_total: usize = 0,
+    broker_ready_routes: usize = 0,
+    unreadable_routes: usize = 0,
+    selectable_routes: usize = 0,
+    selectable_broker_routes: usize = 0,
+    selectable_fallback_routes: usize = 0,
+    blocked_broker_routes: usize = 0,
+    auth_unready_routes: usize = 0,
+};
+
+fn firstSelectableCodexBrokerRouteIndex(
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluations: []const RouteEvaluation,
+) !?usize {
+    for (evaluations, 0..) |evaluation, idx| {
+        if (!evaluation.selectable) continue;
+        const plan = try inspectCodexBrokerRoute(allocator, cfg, evaluation.route);
+        if (plan.can_supply) return idx;
+    }
+    return null;
+}
+
+fn summarizeCodexBrokerSessionPlan(
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+) !CodexBrokerSessionSummary {
+    var summary = CodexBrokerSessionSummary{};
+    for (evaluations, 0..) |evaluation, idx| {
+        const plan = try inspectCodexBrokerRoute(allocator, cfg, evaluation.route);
+        summary.routes_total += 1;
+        if (evaluation.selectable) summary.selectable_routes += 1;
+        if (plan.can_supply) {
+            summary.broker_ready_routes += 1;
+            if (evaluation.selectable) {
+                summary.selectable_broker_routes += 1;
+                if (selected_index == null or idx != selected_index.?) summary.selectable_fallback_routes += 1;
+            } else {
+                summary.blocked_broker_routes += 1;
+            }
+        } else {
+            summary.auth_unready_routes += 1;
+            if (!plan.secret_readable) summary.unreadable_routes += 1;
+        }
+    }
+    return summary;
+}
+
+fn writeCodexBrokerSessionPlanJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+    profile: ?[]const u8,
+    capability: ?[]const u8,
+) !void {
+    const summary = try summarizeCodexBrokerSessionPlan(allocator, cfg, evaluations, selected_index);
+    const session_start_ready = selected_index != null;
+    const prepared_fallback = summary.selectable_fallback_routes > 0;
+
+    try writer.writeAll("{\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"mode\":\"codex_broker_owned_session_plan\"");
+    try writer.writeAll(",\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mutates_route_health\":false");
+    try writer.writeAll(",\"app_server\":{\"transport\":\"stdio\",\"requires_experimental_api\":true,\"login_method\":\"account/login/start.chatgptAuthTokens\",\"refresh_method\":\"account/chatgptAuthTokens/refresh\"}");
+    try writer.writeAll(",\"ok\":");
+    try writer.writeAll(if (session_start_ready) "true" else "false");
+    try writer.writeAll(",\"claim\":{\"claim_version\":1,\"level\":\"current_process_auth_broker\",\"proof_status\":\"session_planning_only\",\"broker_owned_session\":true,\"session_start_ready\":");
+    try writer.writeAll(if (session_start_ready) "true" else "false");
+    try writer.writeAll(",\"prepared_fallback\":");
+    try writer.writeAll(if (prepared_fallback) "true" else "false");
+    try writer.writeAll(",\"next_thread_quota_fallback\":");
+    try writer.writeAll(if (prepared_fallback) "true" else "false");
+    try writer.writeAll(",\"same_turn_quota_recovery\":false,\"same_thread_quota_recovery\":false,\"supervised_restart\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
+    try writer.writeAll(",\"policy\":");
+    try writePolicyJson(writer, cfg.policy);
+    try writer.writeAll(",\"profile\":");
+    if (profile) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"capability\":");
+    if (capability) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.print(",\"summary\":{{\"routes_total\":{d},\"broker_ready_routes\":{d},\"unreadable_routes\":{d},\"selectable_routes\":{d},\"selectable_broker_routes\":{d},\"selectable_fallback_routes\":{d},\"blocked_broker_routes\":{d},\"auth_unready_routes\":{d}}}", .{
+        summary.routes_total,
+        summary.broker_ready_routes,
+        summary.unreadable_routes,
+        summary.selectable_routes,
+        summary.selectable_broker_routes,
+        summary.selectable_fallback_routes,
+        summary.blocked_broker_routes,
+        summary.auth_unready_routes,
+    });
+    try writer.writeAll(",\"selected\":");
+    if (selected_index) |idx| {
+        try writeRouteSelectionJson(writer, evaluations[idx].route);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"routes\":[");
+    for (evaluations, 0..) |evaluation, idx| {
+        if (idx > 0) try writer.writeByte(',');
+        const selected = if (selected_index) |selected_idx| idx == selected_idx else false;
+        const plan = try inspectCodexBrokerRoute(allocator, cfg, evaluation.route);
+        try writeCodexBrokerSessionRouteJson(writer, allocator, cfg, evaluation, selected, plan);
+    }
+    try writer.writeAll("]}\n");
+}
+
+fn writeCodexBrokerSessionPlanText(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+    profile: ?[]const u8,
+    capability: ?[]const u8,
+) !void {
+    const summary = try summarizeCodexBrokerSessionPlan(allocator, cfg, evaluations, selected_index);
+    try writer.writeAll("oauth-mux Codex broker-owned session plan\n\n");
+    if (profile) |value| try writer.print("  profile: {s}\n", .{value});
+    if (capability) |value| try writer.print("  capability: {s}\n", .{value});
+    try writer.writeAll("  claim: planning-only current_process_auth_broker for broker-owned app-server sessions\n");
+    try writer.print("  broker_ready_routes: {d}\n", .{summary.broker_ready_routes});
+    try writer.print("  selectable_broker_routes: {d}\n", .{summary.selectable_broker_routes});
+    try writer.print("  selectable_fallback_routes: {d}\n", .{summary.selectable_fallback_routes});
+
+    if (selected_index) |idx| {
+        const selected = evaluations[idx].route;
+        try writer.print("  selected: {s}:{s}", .{ selected.provider, selected.account });
+        if (selected.capability) |value| try writer.print("#{s}", .{value});
+        try writer.writeByte('\n');
+    } else {
+        try writer.writeAll("  selected: none\n");
+    }
+
+    if (evaluations.len == 0) {
+        try writer.writeAll("\n  no matching Codex routes\n");
+        return;
+    }
+
+    try writer.writeAll("\n  routes:\n");
+    for (evaluations, 0..) |evaluation, idx| {
+        const selected = if (selected_index) |selected_idx| idx == selected_idx else false;
+        const plan = try inspectCodexBrokerRoute(allocator, cfg, evaluation.route);
+        const role = codexBrokerSessionRouteRole(evaluation, selected, plan);
+        try writer.print("    {s}:{s}", .{ evaluation.route.provider, evaluation.route.account });
+        if (evaluation.route.capability) |value| try writer.print("#{s}", .{value});
+        try writer.print(" role={s} selectable={s} broker_ready={s} reason={s} broker_reason={s}\n", .{
+            role,
+            if (evaluation.selectable) "true" else "false",
+            if (plan.can_supply) "true" else "false",
+            evaluation.skip_reason,
+            plan.reason,
+        });
+    }
+}
+
+fn writeCodexBrokerSessionRouteJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluation: RouteEvaluation,
+    selected: bool,
+    plan: CodexBrokerTokenPlan,
+) !void {
+    const fallback_candidate = plan.can_supply and evaluation.selectable and !selected;
+    try writer.writeByte('{');
+    try writer.writeAll("\"provider\":");
+    try std.json.stringify(evaluation.route.provider, .{}, writer);
+    try writer.writeAll(",\"account\":");
+    try std.json.stringify(evaluation.route.account, .{}, writer);
+    try writer.writeAll(",\"capability\":");
+    if (evaluation.route.capability) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"selected\":");
+    try writer.writeAll(if (selected) "true" else "false");
+    try writer.writeAll(",\"selectable\":");
+    try writer.writeAll(if (evaluation.selectable) "true" else "false");
+    try writer.writeAll(",\"broker_ready\":");
+    try writer.writeAll(if (plan.can_supply) "true" else "false");
+    try writer.writeAll(",\"session_ready\":");
+    try writer.writeAll(if (plan.can_supply and evaluation.selectable) "true" else "false");
+    try writer.writeAll(",\"fallback_candidate\":");
+    try writer.writeAll(if (fallback_candidate) "true" else "false");
+    try writer.writeAll(",\"route_role\":");
+    try std.json.stringify(codexBrokerSessionRouteRole(evaluation, selected, plan), .{}, writer);
+    try writer.writeAll(",\"skip_reason\":");
+    try std.json.stringify(evaluation.skip_reason, .{}, writer);
+    try writer.writeAll(",\"runtime\":");
+    try writeRuntimeReadinessJson(writer, evaluation.runtime);
+    try writer.writeAll(",\"liveness\":");
+    if (evaluation.health) |health| try writeLivenessJson(writer, health.liveness) else try writer.writeAll("null");
+    try writer.writeAll(",\"last_probe\":");
+    if (evaluation.health) |health| try writeProbeEvidenceJson(writer, health) else try writer.writeAll("null");
+    try writer.writeAll(",\"action\":");
+    try writeRepairActionJson(writer, allocator, evaluation.action, evaluation.route);
+    try writer.writeAll(",\"auth_broker\":");
+    try writeCodexBrokerRouteJson(writer, evaluation.route, cfg, plan);
+    try writer.writeByte('}');
+}
+
+fn codexBrokerSessionRouteRole(evaluation: RouteEvaluation, selected: bool, plan: CodexBrokerTokenPlan) []const u8 {
+    if (!plan.can_supply) return "auth_broker_unready";
+    if (selected) return "selected";
+    if (evaluation.selectable) return "selectable_fallback";
+    if (std.mem.eql(u8, evaluation.skip_reason, "quota_exhausted")) return "quota_blocked";
+    if (std.mem.eql(u8, evaluation.skip_reason, "rate_limited")) return "rate_limited";
+    if (std.mem.eql(u8, evaluation.skip_reason, "unrecorded")) return "probe_needed";
+    return "not_selectable";
 }
 
 fn runCodexBrokerSmoke(


### PR DESCRIPTION
## Summary

Adds `oauth-mux codex broker-session-plan` as the first no-spend UX planning surface for broker-owned Codex sessions. The command combines recorded route liveness with app-server auth-broker readiness, then reports the selected session route, immediate selectable fallback routes, quota-blocked broker routes, and auth-broker readiness without starting Codex or probing providers.

The JSON claim remains deliberately bounded: broker-owned app-server session planning only, no unmanaged TUI hot-swap, no per-request muxing, and no same-turn or same-thread quota recovery claim.

## Why

TIN-917 / GitHub #133 needs a user-facing bridge from the proof commands to an eventual broker-owned session surface. PR #132 proved the quota primitive; this PR makes the current route matrix actionable for session planning without spending provider calls.

## Validation

- `zig build test`
- `./scripts/e2e-local.sh`
- `just check-local`
- `./zig-out/bin/oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json`

Live no-spend planner output against the current four-subscription Codex profile reports: 4 broker-ready routes, 2 selectable broker routes, max-3 selected, max-4 as immediate fallback, and max-1/max-2 quota-blocked. Tokens, account IDs, JWTs, refresh tokens, raw protocol output, and credential paths are not printed.

Refs #133. Related #131.
