### PR TITLE
Add Codex broker session smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux accounts list --provid
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-plan --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-session-smoke --profile codex-max --capability codex-max --confirm-broker --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-smoke --profile codex-max --capability codex-max --confirm-broker --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-refresh-smoke --profile codex-max --capability codex-max --confirm-broker --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-401-smoke --profile codex-max --capability codex-max --confirm-broker --json
@@ -140,6 +141,10 @@ ids, credential paths, or provider-call evidence.
 route liveness. It reports the selected broker-owned session route, immediate
 selectable fallback routes, quota-blocked routes, and the explicit claim
 boundary without starting Codex or probing providers.
+`codex broker-session-smoke --confirm-broker --json` takes the next no-spend UX
+step: it uses the session plan's selected and fallback routes, starts a local
+broker-owned app-server session against mocked Responses/ChatGPT endpoints, and
+proves new-thread fallback after simulated quota exhaustion.
 `codex broker-smoke --confirm-broker --json` is the next local proof: it starts
 a broker-owned Codex app-server stdio child, sends the selected route token to
 that child only, and verifies initialize/login/account-update milestones while
@@ -283,6 +288,7 @@ oauth-mux codex live-qa
 oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 oauth-mux codex broker-plan --profile codex-max --capability codex-max --json
 oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json
+oauth-mux codex broker-session-smoke --profile codex-max --capability codex-max --confirm-broker --json
 oauth-mux codex broker-smoke --profile codex-max --capability codex-max --confirm-broker --json
 oauth-mux codex broker-refresh-smoke --profile codex-max --capability codex-max --confirm-broker --json
 oauth-mux codex broker-401-smoke --profile codex-max --capability codex-max --confirm-broker --json

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -159,6 +159,12 @@ combines recorded route liveness with app-server auth-broker readiness, then
 reports the selected route, immediate selectable fallbacks, quota-blocked broker
 routes, and the same explicit no-hot-swap/no-same-thread quota boundary.
 
+`oauth-mux codex broker-session-smoke --profile codex-max --capability codex-max
+--confirm-broker --json` is the matching no-spend multi-turn UX smoke. It uses
+the session plan's selected and fallback routes, starts a broker-owned
+app-server against local mocked backend endpoints, simulates quota exhaustion on
+turn one, and verifies a new brokered thread uses the fallback route.
+
 `oauth-mux stay-afloat launch -- <command>` is the matching startup command for
 users and wrappers. It executes the target only after a selectable route is
 found from recorded evidence. The delegated `exec` path still validates local

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -231,6 +231,12 @@ Use
 Codex or spending provider calls. It joins route liveness with broker token
 readiness and reports which route would start the session plus which broker-ready
 routes are immediate fallbacks.
+Use
+`oauth-mux codex broker-session-smoke --profile codex-max --capability codex-max
+--confirm-broker --json` to exercise that plan as a local multi-turn
+broker-owned app-server session. It keeps provider traffic mocked, simulates
+quota exhaustion on the first turn, and verifies fallback Authorization on a new
+brokered thread selected from the session plan.
 
 `stay-afloat launch -- <command>` is the user/wrapper startup boundary. It runs
 the same preflight as `stay-afloat next`, then starts the target only when a

--- a/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
+++ b/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
@@ -278,9 +278,15 @@ For quota-driven account changes, use a different action name, such as
    codex-max --json` joins recorded route liveness with broker auth readiness
    and reports selected, fallback, quota-blocked, and auth-unready routes for
    the future broker-owned session UX.
-11. Only after topology A is green, attempt topology B with a remote TUI and
+11. Add a no-spend broker-owned session smoke:
+   `oauth-mux codex broker-session-smoke --profile codex-max --capability
+   codex-max --confirm-broker --json` uses the session plan's selected and
+   fallback routes, starts a local app-server session against mocked backend
+   endpoints, simulates quota exhaustion on turn one, and verifies a new
+   brokered thread uses fallback Authorization.
+12. Only after topology A is green, attempt topology B with a remote TUI and
    sidecar broker.
-12. Update website and README claim language only after live dogfood passes.
+13. Update website and README claim language only after live dogfood passes.
 
 ## Acceptance Criteria
 
@@ -298,6 +304,9 @@ For quota-driven account changes, use a different action name, such as
 - The broker session plan is no-spend and planning-only. It can report a
   broker-owned session start route plus immediate selectable fallbacks, but it
   does not start Codex, spend provider calls, or claim unmanaged TUI hot-swap.
+- The broker session smoke is no-spend and local. It can prove a multi-turn
+  broker-owned app-server handoff using session-plan route selection, but it
+  still does not prove same-thread quota recovery or unmanaged TUI hot-swap.
 - Cross-account switching is blocked when forced workspace or profile policy
   forbids it.
 - Quota/rate-limit behavior is separately classified as next-turn account

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -249,7 +249,9 @@ these precise provider-proof children.
    fallback login, while same-turn and same-thread quota recovery remain
    unclaimed. `oauth-mux codex broker-session-plan` is the next UX slice: it
    combines route liveness with broker readiness to plan a broker-owned Codex
-   session without spending provider calls.
+   session without spending provider calls. `oauth-mux codex
+   broker-session-smoke --confirm-broker` exercises that plan as a local
+   multi-turn broker-owned app-server session against mocked backend endpoints.
 10. Return to daemon background implementation only after wrapper/install
    decisions and provider proof produce enough real operator evidence. The
    current socket daemon decision is complete under `TIN-867`; future

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -811,6 +811,13 @@ expect_not_contains "$broker_session_plan" "$broker_jwt" "broker-session-plan do
 expect_not_contains "$broker_session_plan" 'broker-session-refresh-token' "broker-session-plan does not expose refresh token value"
 expect_not_contains "$broker_session_plan" 'broker-session-spare-token' "broker-session-plan does not expose spare refresh token value"
 
+printf 'e2e: codex broker-session-smoke requires explicit confirmation before starting app-server\n'
+broker_session_smoke_prompt="$(OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex broker-session-smoke --profile codex-max --capability codex-max --json)"
+expect_contains "$broker_session_smoke_prompt" '"mode":"codex_broker_owned_session_smoke"' "broker-session-smoke reports session smoke mode"
+expect_contains "$broker_session_smoke_prompt" '"confirmation_required":true' "broker-session-smoke requires confirmation"
+expect_contains "$broker_session_smoke_prompt" '"requires":"--confirm-broker"' "broker-session-smoke reports required confirmation flag"
+expect_contains "$broker_session_smoke_prompt" '"spends_provider_calls":false' "broker-session-smoke confirmation prompt reports no provider spend"
+
 printf 'e2e: codex broker-smoke verifies app-server stdio login without leaking tokens\n'
 mock_codex_app_server="$tmp/mock-codex-app-server"
 cat >"$mock_codex_app_server" <<'EOF'

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -184,6 +184,7 @@ pub const Command = union(enum) {
         config_merge,
         broker_plan,
         broker_session_plan,
+        broker_session_smoke,
         broker_smoke,
         broker_refresh_smoke,
         broker_401_smoke,
@@ -889,6 +890,8 @@ fn parseCodex(args: []const []const u8) Command {
             result.action = .broker_plan;
         } else if (eql(args[0], "broker-session-plan")) {
             result.action = .broker_session_plan;
+        } else if (eql(args[0], "broker-session-smoke")) {
+            result.action = .broker_session_smoke;
         } else if (eql(args[0], "broker-smoke")) {
             result.action = .broker_smoke;
         } else if (eql(args[0], "broker-refresh-smoke")) {
@@ -1084,6 +1087,9 @@ pub fn printUsage(writer: anytype) !void {
         \\  codex broker-session-plan [--profile name] [--capability c] [--json]
         \\      Plan a broker-owned Codex session from route liveness and auth-broker readiness.
         \\
+        \\  codex broker-session-smoke [--profile name] [--capability c] --confirm-broker [--json]
+        \\      Run a local multi-turn broker-owned Codex session smoke from the session plan.
+        \\
         \\  codex broker-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\      Start a broker-owned Codex app-server stdio session and verify external auth login.
         \\
@@ -1136,6 +1142,7 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\  oauth-mux codex probe-all [--accounts a,b,c] [--capability c] [--json]
         \\  oauth-mux codex broker-plan [--profile name] [--capability c] [--json]
         \\  oauth-mux codex broker-session-plan [--profile name] [--capability c] [--json]
+        \\  oauth-mux codex broker-session-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\  oauth-mux codex broker-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\  oauth-mux codex broker-refresh-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\  oauth-mux codex broker-401-smoke [--profile name] [--capability c] --confirm-broker [--json]
@@ -1365,6 +1372,21 @@ test "parse codex broker session plan" {
             try std.testing.expect(codex.action == .broker_session_plan);
             try std.testing.expectEqualStrings("codex-max", codex.profile.?);
             try std.testing.expectEqualStrings("codex-max", codex.capabilities);
+            try std.testing.expect(codex.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse codex broker session smoke" {
+    const args = [_][]const u8{ "codex", "broker-session-smoke", "--profile", "codex-max", "--capability", "codex-max", "--confirm-broker", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex => |codex| {
+            try std.testing.expect(codex.action == .broker_session_smoke);
+            try std.testing.expectEqualStrings("codex-max", codex.profile.?);
+            try std.testing.expectEqualStrings("codex-max", codex.capabilities);
+            try std.testing.expect(codex.confirm_broker);
             try std.testing.expect(codex.json);
         },
         else => return error.Unexpected,
@@ -1916,7 +1938,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary live-qa probe-all broker-plan broker-session-plan broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary live-qa probe-all broker-plan broker-session-plan broker-session-smoke broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run supervise start stop status events handoffs tick' -d 'Daemon subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l stay-afloat -d 'Host beta supervised stay-afloat loop'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l json -d 'JSON output'

--- a/src/main.zig
+++ b/src/main.zig
@@ -7518,6 +7518,7 @@ fn runCodex(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Cod
         .config_merge => try runCodexConfigMerge(allocator, writer, args),
         .broker_plan => try runCodexBrokerPlan(allocator, writer, args),
         .broker_session_plan => try runCodexBrokerSessionPlan(allocator, writer, args),
+        .broker_session_smoke => try runCodexBrokerSessionSmoke(allocator, writer, args),
         .broker_smoke => try runCodexBrokerSmoke(allocator, writer, args, .login),
         .broker_refresh_smoke => try runCodexBrokerSmoke(allocator, writer, args, .refresh),
         .broker_401_smoke => try runCodexBroker401Smoke(allocator, writer, args),
@@ -8158,6 +8159,189 @@ fn codexBrokerSessionRouteRole(evaluation: RouteEvaluation, selected: bool, plan
     if (std.mem.eql(u8, evaluation.skip_reason, "rate_limited")) return "rate_limited";
     if (std.mem.eql(u8, evaluation.skip_reason, "unrecorded")) return "probe_needed";
     return "not_selectable";
+}
+
+fn runCodexBrokerSessionSmoke(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    args: cli.Command.CodexArgs,
+) !void {
+    if (!args.confirm_broker) {
+        if (args.json) {
+            try writer.writeAll("{\"ok\":false,\"confirmation_required\":true,\"requires\":\"--confirm-broker\",\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mode\":\"codex_broker_owned_session_smoke\",\"next_commands\":[");
+            try writeCommandJson(writer, "oauth-mux codex broker-session-plan --profile <profile> --capability <capability> --json");
+            try writer.writeByte(',');
+            try writeCommandJson(writer, "oauth-mux codex broker-session-smoke --profile <profile> --capability <capability> --confirm-broker --json");
+            try writer.writeAll("]}\n");
+        } else {
+            try writer.writeAll("oauth-mux Codex broker-owned session smoke\n\n");
+            try writer.writeAll("  confirmation required: --confirm-broker\n");
+            try writer.writeAll("  this starts a broker-owned Codex app-server child plus a local no-spend Responses mock using broker-session-plan route semantics\n");
+        }
+        return;
+    }
+
+    const parsed = try config.load(allocator);
+    defer parsed.deinit();
+
+    var validation_messages = std.ArrayList(u8).init(allocator);
+    defer validation_messages.deinit();
+    try config.validate(parsed.value, validation_messages.writer());
+
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+
+    const capability = firstCommaValue(args.capabilities);
+    var routes = try collectRepairPlanRoutes(allocator, parsed.value, .{
+        .profile = args.profile,
+        .provider = if (args.profile == null) "codex" else null,
+        .account = args.account,
+        .capability = capability,
+        .json = args.json,
+    });
+    defer routes.deinit();
+
+    var evaluations = std.ArrayList(RouteEvaluation).init(allocator);
+    defer evaluations.deinit();
+    try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &evaluations);
+
+    const selected_index = try firstSelectableCodexBrokerRouteIndex(allocator, parsed.value, evaluations.items);
+    var selected: ?CodexBrokerRouteCredentials = null;
+    defer if (selected) |*value| value.deinit(allocator);
+    var fallback_selected: ?CodexBrokerRouteCredentials = null;
+    defer if (fallback_selected) |*value| value.deinit(allocator);
+
+    if (selected_index) |idx| {
+        const route = evaluations.items[idx].route;
+        selected = .{
+            .route = route,
+            .credentials = try loadCodexBrokerCredentialsForRoute(allocator, parsed.value, route),
+        };
+
+        for (evaluations.items, 0..) |evaluation, fallback_idx| {
+            if (fallback_idx == idx or !evaluation.selectable) continue;
+            const plan = try inspectCodexBrokerRoute(allocator, parsed.value, evaluation.route);
+            if (!plan.can_supply) continue;
+            fallback_selected = .{
+                .route = evaluation.route,
+                .credentials = try loadCodexBrokerCredentialsForRoute(allocator, parsed.value, evaluation.route),
+            };
+            break;
+        }
+    }
+
+    if (selected == null or fallback_selected == null) {
+        const reason = if (selected == null) "no_session_start_ready_route" else "no_selectable_broker_fallback_route";
+        if (args.json) {
+            try writer.writeAll("{\"version\":");
+            try std.json.stringify(cli.version, .{}, writer);
+            try writer.writeAll(",\"mode\":\"codex_broker_owned_session_smoke\",\"ok\":false,\"confirmed\":true,\"reason\":");
+            try std.json.stringify(reason, .{}, writer);
+            try writer.writeAll(",\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mutates_route_health\":false,\"routes_total\":");
+            try writer.print("{d}", .{evaluations.items.len});
+            try writer.writeAll(",\"next_commands\":[");
+            try writeCommandJson(writer, "oauth-mux codex broker-session-plan --profile <profile> --capability <capability> --json");
+            try writer.writeAll("]}\n");
+        } else {
+            try writer.writeAll("oauth-mux Codex broker-owned session smoke\n\n");
+            try writer.print("  {s}\n", .{reason});
+            try writer.writeAll("  next: oauth-mux codex broker-session-plan --profile <profile> --capability <capability> --json\n");
+        }
+        return;
+    }
+
+    const state_dir = try paths.stateDir(allocator);
+    defer allocator.free(state_dir);
+    const run_dir = try std.fmt.allocPrint(allocator, "{s}/codex-broker-session-smoke-{d}", .{ state_dir, std.time.milliTimestamp() });
+    defer allocator.free(run_dir);
+    try std.fs.cwd().makePath(run_dir);
+
+    var mock_server = try startCodexBrokerQuotaMockServer(allocator, selected.?.credentials.access_token, fallback_selected.?.credentials.access_token);
+    defer mock_server.destroy();
+
+    const mock_origin = try std.fmt.allocPrint(allocator, "http://127.0.0.1:{d}", .{mock_server.port});
+    defer allocator.free(mock_origin);
+    const base_url = try std.fmt.allocPrint(allocator, "{s}/v1", .{mock_origin});
+    defer allocator.free(base_url);
+    const chatgpt_base_url = try std.fmt.allocPrint(allocator, "{s}/backend-api", .{mock_origin});
+    defer allocator.free(chatgpt_base_url);
+    try writeCodexBroker401AppServerFiles(allocator, run_dir, base_url, chatgpt_base_url);
+
+    var result = CodexBrokerQuotaSmokeResult{
+        .broker = try runCodexAppServerQuotaBrokerSmoke(
+            allocator,
+            selected.?.credentials,
+            fallback_selected.?.credentials,
+            run_dir,
+        ),
+    };
+    result.http = mock_server.finish();
+
+    if (args.json) {
+        try writeCodexBrokerSessionSmokeJson(writer, selected.?.route, fallback_selected.?.route, capability, result);
+    } else {
+        try writeCodexBrokerSessionSmokeText(writer, selected.?.route, fallback_selected.?.route, capability, result);
+    }
+}
+
+fn codexBrokerSessionSmokeReason(result: CodexBrokerQuotaSmokeResult) []const u8 {
+    if (codexBrokerQuotaSmokeOk(result)) return "broker_session_next_thread_fallback_completed";
+    return codexBrokerQuotaSmokeReason(result);
+}
+
+fn writeCodexBrokerSessionSmokeJson(
+    writer: anytype,
+    route: RepairPlanRoute,
+    fallback_route: RepairPlanRoute,
+    capability: ?[]const u8,
+    result: CodexBrokerQuotaSmokeResult,
+) !void {
+    try writer.writeAll("{\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"mode\":\"codex_broker_owned_session_smoke\",\"ok\":");
+    try writer.writeAll(if (codexBrokerQuotaSmokeOk(result)) "true" else "false");
+    try writer.writeAll(",\"confirmed\":true,\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mutates_route_health\":false");
+    try writer.writeAll(",\"reason\":");
+    try std.json.stringify(codexBrokerSessionSmokeReason(result), .{}, writer);
+    try writer.writeAll(",\"claim\":{\"claim_version\":1,\"level\":\"current_process_auth_broker\",\"proof_status\":\"local_broker_owned_session_smoke\",\"broker_owned_session\":true,\"route_selection_source\":\"broker_session_plan\",\"session_start_ready\":true,\"prepared_fallback\":true,\"next_thread_quota_fallback\":true,\"same_turn_quota_recovery\":false,\"same_thread_quota_recovery\":false,\"supervised_restart\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
+    try writer.writeAll(",\"selected\":");
+    try writeRouteSelectionJson(writer, route);
+    try writer.writeAll(",\"fallback_selected\":");
+    try writeRouteSelectionJson(writer, fallback_route);
+    try writer.writeAll(",\"fallback_route_is_distinct\":");
+    try writer.writeAll(if (!sameRepairPlanRouteIdentity(route, fallback_route)) "true" else "false");
+    try writer.writeAll(",\"simulated_route_state\":{\"first_turn_classification\":\"quota_exhausted\",\"decision\":\"try_next_account\",\"retry_after_s\":7200}");
+    try writer.writeAll(",\"capability\":");
+    if (capability) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"app_server\":{\"transport\":\"stdio\",\"requires_experimental_api\":true,\"login_method\":\"account/login/start.chatgptAuthTokens\",\"mock_provider\":\"local_responses_429_then_new_thread_fallback_sse\"}");
+    try writer.writeAll(",\"protocol\":");
+    try writeCodexBrokerProtocolJson(writer, result.broker);
+    try writer.writeAll(",\"http_mock\":");
+    try writeCodexBrokerQuotaHttpJson(writer, result.http);
+    try writer.writeAll(",\"redaction\":{\"tokens_printed\":false,\"account_id_printed\":false,\"raw_protocol_printed\":false}");
+    try writer.writeAll("}\n");
+}
+
+fn writeCodexBrokerSessionSmokeText(
+    writer: anytype,
+    route: RepairPlanRoute,
+    fallback_route: RepairPlanRoute,
+    capability: ?[]const u8,
+    result: CodexBrokerQuotaSmokeResult,
+) !void {
+    try writer.writeAll("oauth-mux Codex broker-owned session smoke\n\n");
+    try writer.print("  route: {s}:{s}", .{ route.provider, route.account });
+    if (capability) |value| try writer.print("#{s}", .{value});
+    try writer.writeByte('\n');
+    try writer.print("  fallback route: {s}:{s}", .{ fallback_route.provider, fallback_route.account });
+    if (fallback_route.capability) |route_capability| try writer.print("#{s}", .{route_capability});
+    try writer.print(" distinct={s}\n", .{if (sameRepairPlanRouteIdentity(route, fallback_route)) "false" else "true"});
+    try writer.print("  ok: {s}\n", .{if (codexBrokerQuotaSmokeOk(result)) "true" else "false"});
+    try writer.print("  reason: {s}\n", .{codexBrokerSessionSmokeReason(result)});
+    try writer.print("  quota_response_sent: {s}\n", .{if (result.http.quota_response_sent) "true" else "false"});
+    try writer.print("  next_turn_used_fallback: {s}\n", .{if (result.http.next_turn_used_fallback) "true" else "false"});
+    try writer.print("  same_turn_refresh_request_seen: {s}\n", .{if (result.broker.protocol.refresh_request_seen) "true" else "false"});
+    try writer.writeAll("  redaction: tokens/account ids/raw protocol not printed\n");
 }
 
 fn runCodexBrokerSmoke(


### PR DESCRIPTION
## Summary

Adds `oauth-mux codex broker-session-smoke` as a no-spend multi-turn broker-owned Codex app-server session proof. The command uses `broker-session-plan` route semantics, starts the session with the selected route, simulates quota exhaustion on the first turn, applies fallback `account/login/start` credentials, starts a new brokered thread, and verifies the next Responses request uses fallback Authorization.

The command keeps the claim scoped to broker-owned app-server sessions. It explicitly does not claim same-turn quota recovery, same-thread quota recovery, unmanaged TUI hot-swap, or per-request muxing.

## Why

TIN-917 / GitHub #133 needs the next UX-shaped proof after `broker-session-plan`. This moves from a planning surface to a local session-shaped smoke that demonstrates turn 1 and fallback turn 2 behavior without spending provider calls.

It also distinguishes planner-selected live routes from the older raw quota smoke: with the current four Codex subscriptions, the live no-spend smoke starts on `max-3` and falls back to distinct route `max-4`, while `max-1` and `max-2` remain quota-blocked.

## Validation

- `zig build test`
- `./scripts/e2e-local.sh`
- `just check-local`
- `./zig-out/bin/oauth-mux codex broker-session-smoke --profile codex-max --capability codex-max --confirm-broker --json`

Live no-spend smoke passed with `ok:true`, selected route `max-3`, fallback route `max-4`, `fallback_route_is_distinct:true`, `quota_response_sent:true`, and `next_turn_used_fallback:true`. Tokens, account IDs, and raw protocol output are not printed.

Refs #133.
