### PR TITLE
Add Codex broker live run

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux doctor runtime --profi
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-plan --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-session-smoke --profile codex-max --capability codex-max --confirm-broker --json
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-run --profile codex-max --capability codex-max --prompt 'Reply with oauth-mux broker-run ok.' --confirm-spend --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-smoke --profile codex-max --capability codex-max --confirm-broker --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-refresh-smoke --profile codex-max --capability codex-max --confirm-broker --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-401-smoke --profile codex-max --capability codex-max --confirm-broker --json
@@ -145,6 +146,11 @@ boundary without starting Codex or probing providers.
 step: it uses the session plan's selected and fallback routes, starts a local
 broker-owned app-server session against mocked Responses/ChatGPT endpoints, and
 proves new-thread fallback after simulated quota exhaustion.
+`codex broker-run --prompt ... --confirm-spend --json` is the explicit live
+one-turn proof for that UX path. It uses the session plan's selected route,
+starts a broker-owned app-server against Codex's default live provider, sends
+one prompt, and reports only redacted protocol evidence; prompt text, assistant
+output, tokens, account ids, and raw protocol output are not printed.
 `codex broker-smoke --confirm-broker --json` is the next local proof: it starts
 a broker-owned Codex app-server stdio child, sends the selected route token to
 that child only, and verifies initialize/login/account-update milestones while
@@ -289,6 +295,7 @@ oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 oauth-mux codex broker-plan --profile codex-max --capability codex-max --json
 oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json
 oauth-mux codex broker-session-smoke --profile codex-max --capability codex-max --confirm-broker --json
+oauth-mux codex broker-run --profile codex-max --capability codex-max --prompt 'Reply with oauth-mux broker-run ok.' --confirm-spend --json
 oauth-mux codex broker-smoke --profile codex-max --capability codex-max --confirm-broker --json
 oauth-mux codex broker-refresh-smoke --profile codex-max --capability codex-max --confirm-broker --json
 oauth-mux codex broker-401-smoke --profile codex-max --capability codex-max --confirm-broker --json

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -165,6 +165,12 @@ the session plan's selected and fallback routes, starts a broker-owned
 app-server against local mocked backend endpoints, simulates quota exhaustion on
 turn one, and verifies a new brokered thread uses the fallback route.
 
+`oauth-mux codex broker-run --profile codex-max --capability codex-max --prompt
+... --confirm-spend --json` is the explicit live one-turn proof for the same
+broker-owned UX. It starts the selected route against Codex's default live
+provider and emits redacted protocol evidence without printing prompt text,
+assistant output, tokens, account ids, or raw app-server protocol.
+
 `oauth-mux stay-afloat launch -- <command>` is the matching startup command for
 users and wrappers. It executes the target only after a selectable route is
 found from recorded evidence. The delegated `exec` path still validates local

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -237,6 +237,12 @@ Use
 broker-owned app-server session. It keeps provider traffic mocked, simulates
 quota exhaustion on the first turn, and verifies fallback Authorization on a new
 brokered thread selected from the session plan.
+Use
+`oauth-mux codex broker-run --profile codex-max --capability codex-max --prompt
+... --confirm-spend --json` only after the operator explicitly approves live
+provider spend. It runs one real broker-owned app-server turn from the session
+plan and prints redacted evidence, not prompt text, assistant output, tokens,
+account ids, or raw protocol output.
 
 `stay-afloat launch -- <command>` is the user/wrapper startup boundary. It runs
 the same preflight as `stay-afloat next`, then starts the target only when a

--- a/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
+++ b/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
@@ -284,9 +284,13 @@ For quota-driven account changes, use a different action name, such as
    fallback routes, starts a local app-server session against mocked backend
    endpoints, simulates quota exhaustion on turn one, and verifies a new
    brokered thread uses fallback Authorization.
-12. Only after topology A is green, attempt topology B with a remote TUI and
+12. Add the first spend-gated live broker-owned session proof:
+   `oauth-mux codex broker-run --profile codex-max --capability codex-max
+   --prompt ... --confirm-spend --json` starts the selected route against the
+   live Codex provider for one turn and emits redacted protocol evidence.
+13. Only after topology A is green, attempt topology B with a remote TUI and
    sidecar broker.
-13. Update website and README claim language only after live dogfood passes.
+14. Update website and README claim language only after live dogfood passes.
 
 ## Acceptance Criteria
 
@@ -307,6 +311,10 @@ For quota-driven account changes, use a different action name, such as
 - The broker session smoke is no-spend and local. It can prove a multi-turn
   broker-owned app-server handoff using session-plan route selection, but it
   still does not prove same-thread quota recovery or unmanaged TUI hot-swap.
+- The broker live run is spend-gated and one-turn only. It can prove a
+  broker-owned app-server session reaches Codex's live provider with the
+  selected route, but it still does not prove fallback recovery or unmanaged
+  TUI hot-swap.
 - Cross-account switching is blocked when forced workspace or profile policy
   forbids it.
 - Quota/rate-limit behavior is separately classified as next-turn account

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -252,6 +252,8 @@ these precise provider-proof children.
    session without spending provider calls. `oauth-mux codex
    broker-session-smoke --confirm-broker` exercises that plan as a local
    multi-turn broker-owned app-server session against mocked backend endpoints.
+   `oauth-mux codex broker-run --prompt ... --confirm-spend` is the matching
+   live one-turn broker-owned session proof and remains spend-gated.
 10. Return to daemon background implementation only after wrapper/install
    decisions and provider proof produce enough real operator evidence. The
    current socket daemon decision is complete under `TIN-867`; future

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -818,6 +818,13 @@ expect_contains "$broker_session_smoke_prompt" '"confirmation_required":true' "b
 expect_contains "$broker_session_smoke_prompt" '"requires":"--confirm-broker"' "broker-session-smoke reports required confirmation flag"
 expect_contains "$broker_session_smoke_prompt" '"spends_provider_calls":false' "broker-session-smoke confirmation prompt reports no provider spend"
 
+printf 'e2e: codex broker-run requires explicit spend confirmation before live app-server turn\n'
+broker_run_prompt="$(OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex broker-run --profile codex-max --capability codex-max --prompt 'hello' --json 2>/dev/null || true)"
+expect_contains "$broker_run_prompt" '"mode":"codex_broker_owned_session_live_run"' "broker-run reports live broker mode"
+expect_contains "$broker_run_prompt" '"confirmation_required":true' "broker-run requires confirmation"
+expect_contains "$broker_run_prompt" '"requires":"--confirm-spend or OMUX_LIVE_QA_CONFIRM=spend-real-calls"' "broker-run reports spend confirmation gate"
+expect_contains "$broker_run_prompt" '"spends_provider_calls":true' "broker-run confirmation prompt reports provider spend"
+
 printf 'e2e: codex broker-smoke verifies app-server stdio login without leaking tokens\n'
 mock_codex_app_server="$tmp/mock-codex-app-server"
 cat >"$mock_codex_app_server" <<'EOF'

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -185,6 +185,7 @@ pub const Command = union(enum) {
         broker_plan,
         broker_session_plan,
         broker_session_smoke,
+        broker_run,
         broker_smoke,
         broker_refresh_smoke,
         broker_401_smoke,
@@ -204,6 +205,8 @@ pub const Command = union(enum) {
         confirm_spend: bool = false,
         confirm_broker: bool = false,
         json: bool = false,
+        prompt: ?[]const u8 = null,
+        model: ?[]const u8 = null,
         output: ?[]const u8 = null,
         candidate: ?[]const u8 = null,
         backup: ?[]const u8 = null,
@@ -892,6 +895,8 @@ fn parseCodex(args: []const []const u8) Command {
             result.action = .broker_session_plan;
         } else if (eql(args[0], "broker-session-smoke")) {
             result.action = .broker_session_smoke;
+        } else if (eql(args[0], "broker-run")) {
+            result.action = .broker_run;
         } else if (eql(args[0], "broker-smoke")) {
             result.action = .broker_smoke;
         } else if (eql(args[0], "broker-refresh-smoke")) {
@@ -939,6 +944,12 @@ fn parseCodexOptions(result: *Command.CodexArgs, args: []const []const u8, optio
         } else if (eql(args[i], "--backup")) {
             i += 1;
             if (i < args.len) result.backup = args[i];
+        } else if (eql(args[i], "--prompt")) {
+            i += 1;
+            if (i < args.len) result.prompt = args[i];
+        } else if (eql(args[i], "--model")) {
+            i += 1;
+            if (i < args.len) result.model = args[i];
         } else if (eql(args[i], "--device")) {
             result.device = true;
         } else if (eql(args[i], "--status-only")) {
@@ -1090,6 +1101,9 @@ pub fn printUsage(writer: anytype) !void {
         \\  codex broker-session-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\      Run a local multi-turn broker-owned Codex session smoke from the session plan.
         \\
+        \\  codex broker-run [--profile name] [--capability c] --prompt text --confirm-spend [--model m] [--json]
+        \\      Run one live broker-owned Codex app-server turn from the session plan.
+        \\
         \\  codex broker-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\      Start a broker-owned Codex app-server stdio session and verify external auth login.
         \\
@@ -1143,6 +1157,7 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\  oauth-mux codex broker-plan [--profile name] [--capability c] [--json]
         \\  oauth-mux codex broker-session-plan [--profile name] [--capability c] [--json]
         \\  oauth-mux codex broker-session-smoke [--profile name] [--capability c] --confirm-broker [--json]
+        \\  oauth-mux codex broker-run [--profile name] [--capability c] --prompt text --confirm-spend [--model m] [--json]
         \\  oauth-mux codex broker-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\  oauth-mux codex broker-refresh-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\  oauth-mux codex broker-401-smoke [--profile name] [--capability c] --confirm-broker [--json]
@@ -1158,11 +1173,13 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\Safety:
         \\  canary is no-spend unless --live is provided.
         \\  live-qa, probe-all, and canary --live run real provider probes.
-        \\  broker-smoke, broker-refresh-smoke, broker-401-smoke, and
-        \\  broker-quota-smoke read a selected Codex route secret and send it
-        \\  only to a broker-owned Codex app-server child process; they do not
-        \\  print token or account-id values.
-        \\  live-qa requires --confirm-spend or OMUX_LIVE_QA_CONFIRM=spend-real-calls.
+        \\  broker-smoke, broker-refresh-smoke, broker-401-smoke,
+        \\  broker-quota-smoke, broker-session-smoke, and broker-run read a
+        \\  selected Codex route secret and send it only to a broker-owned
+        \\  Codex app-server child process; they do not print token or
+        \\  account-id values.
+        \\  live-qa and broker-run require --confirm-spend or
+        \\  OMUX_LIVE_QA_CONFIRM=spend-real-calls.
         \\  --help and -h are non-mutating for every Codex subcommand.
         \\
         \\Defaults:
@@ -1387,6 +1404,23 @@ test "parse codex broker session smoke" {
             try std.testing.expectEqualStrings("codex-max", codex.profile.?);
             try std.testing.expectEqualStrings("codex-max", codex.capabilities);
             try std.testing.expect(codex.confirm_broker);
+            try std.testing.expect(codex.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse codex broker run" {
+    const args = [_][]const u8{ "codex", "broker-run", "--profile", "codex-max", "--capability", "codex-max", "--prompt", "hello", "--model", "gpt-5.5", "--confirm-spend", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex => |codex| {
+            try std.testing.expect(codex.action == .broker_run);
+            try std.testing.expectEqualStrings("codex-max", codex.profile.?);
+            try std.testing.expectEqualStrings("codex-max", codex.capabilities);
+            try std.testing.expectEqualStrings("hello", codex.prompt.?);
+            try std.testing.expectEqualStrings("gpt-5.5", codex.model.?);
+            try std.testing.expect(codex.confirm_spend);
             try std.testing.expect(codex.json);
         },
         else => return error.Unexpected,
@@ -1938,7 +1972,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary live-qa probe-all broker-plan broker-session-plan broker-session-smoke broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary live-qa probe-all broker-plan broker-session-plan broker-session-smoke broker-run broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run supervise start stop status events handoffs tick' -d 'Daemon subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l stay-afloat -d 'Host beta supervised stay-afloat loop'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l json -d 'JSON output'

--- a/src/main.zig
+++ b/src/main.zig
@@ -7519,6 +7519,7 @@ fn runCodex(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Cod
         .broker_plan => try runCodexBrokerPlan(allocator, writer, args),
         .broker_session_plan => try runCodexBrokerSessionPlan(allocator, writer, args),
         .broker_session_smoke => try runCodexBrokerSessionSmoke(allocator, writer, args),
+        .broker_run => try runCodexBrokerRun(allocator, writer, args),
         .broker_smoke => try runCodexBrokerSmoke(allocator, writer, args, .login),
         .broker_refresh_smoke => try runCodexBrokerSmoke(allocator, writer, args, .refresh),
         .broker_401_smoke => try runCodexBroker401Smoke(allocator, writer, args),
@@ -8342,6 +8343,207 @@ fn writeCodexBrokerSessionSmokeText(
     try writer.print("  next_turn_used_fallback: {s}\n", .{if (result.http.next_turn_used_fallback) "true" else "false"});
     try writer.print("  same_turn_refresh_request_seen: {s}\n", .{if (result.broker.protocol.refresh_request_seen) "true" else "false"});
     try writer.writeAll("  redaction: tokens/account ids/raw protocol not printed\n");
+}
+
+fn runCodexBrokerRun(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    args: cli.Command.CodexArgs,
+) !void {
+    if (!codexLiveQaConfirmed(args)) {
+        if (args.json) {
+            try writer.writeAll("{\"ok\":false,\"error\":\"confirmation_required\",\"confirmation_required\":true,\"requires\":\"--confirm-spend or OMUX_LIVE_QA_CONFIRM=spend-real-calls\",\"spends_provider_calls\":true,\"mutates_user_config\":false,\"mode\":\"codex_broker_owned_session_live_run\",\"next_commands\":[");
+            try writeCommandJson(writer, "oauth-mux codex broker-session-plan --profile <profile> --capability <capability> --json");
+            try writer.writeByte(',');
+            try writeCommandJson(writer, "oauth-mux codex broker-run --profile <profile> --capability <capability> --prompt <prompt> --confirm-spend --json");
+            try writer.writeAll("]}\n");
+        } else {
+            try writer.writeAll("oauth-mux Codex broker-owned live run is disabled.\n\n");
+            try writer.writeAll("This command starts a broker-owned Codex app-server and sends one real Codex turn.\n");
+            try writer.writeAll("Re-run with --confirm-spend or OMUX_LIVE_QA_CONFIRM=spend-real-calls.\n");
+        }
+        return error.CodexLiveQaConfirmationRequired;
+    }
+
+    const prompt = args.prompt orelse {
+        if (args.json) {
+            try writer.writeAll("{\"ok\":false,\"error\":\"prompt_required\",\"requires\":\"--prompt\",\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mode\":\"codex_broker_owned_session_live_run\"}\n");
+        } else {
+            try writer.writeAll("oauth-mux Codex broker-owned live run\n\n");
+            try writer.writeAll("  prompt required: --prompt <text>\n");
+        }
+        return;
+    };
+
+    const model = try codexBrokerRunModel(allocator, args);
+    defer allocator.free(model);
+
+    const parsed = try config.load(allocator);
+    defer parsed.deinit();
+
+    var validation_messages = std.ArrayList(u8).init(allocator);
+    defer validation_messages.deinit();
+    try config.validate(parsed.value, validation_messages.writer());
+
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+
+    const capability = firstCommaValue(args.capabilities);
+    var routes = try collectRepairPlanRoutes(allocator, parsed.value, .{
+        .profile = args.profile,
+        .provider = if (args.profile == null) "codex" else null,
+        .account = args.account,
+        .capability = capability,
+        .json = args.json,
+    });
+    defer routes.deinit();
+
+    var evaluations = std.ArrayList(RouteEvaluation).init(allocator);
+    defer evaluations.deinit();
+    try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &evaluations);
+
+    const selected_index = try firstSelectableCodexBrokerRouteIndex(allocator, parsed.value, evaluations.items);
+    const summary = try summarizeCodexBrokerSessionPlan(allocator, parsed.value, evaluations.items, selected_index);
+
+    var selected: ?CodexBrokerRouteCredentials = null;
+    defer if (selected) |*value| value.deinit(allocator);
+
+    if (selected_index) |idx| {
+        const route = evaluations.items[idx].route;
+        selected = .{
+            .route = route,
+            .credentials = try loadCodexBrokerCredentialsForRoute(allocator, parsed.value, route),
+        };
+    }
+
+    if (selected == null) {
+        if (args.json) {
+            try writer.writeAll("{\"version\":");
+            try std.json.stringify(cli.version, .{}, writer);
+            try writer.writeAll(",\"mode\":\"codex_broker_owned_session_live_run\",\"ok\":false,\"confirmed\":true,\"reason\":\"no_session_start_ready_route\",\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mutates_route_health\":false,\"routes_total\":");
+            try writer.print("{d}", .{evaluations.items.len});
+            try writer.writeAll(",\"next_commands\":[");
+            try writeCommandJson(writer, "oauth-mux codex broker-session-plan --profile <profile> --capability <capability> --json");
+            try writer.writeAll("]}\n");
+        } else {
+            try writer.writeAll("oauth-mux Codex broker-owned live run\n\n");
+            try writer.writeAll("  no session-start-ready Codex route found\n");
+            try writer.writeAll("  next: oauth-mux codex broker-session-plan --profile <profile> --capability <capability> --json\n");
+        }
+        return;
+    }
+
+    const state_dir = try paths.stateDir(allocator);
+    defer allocator.free(state_dir);
+    const run_dir = try std.fmt.allocPrint(allocator, "{s}/codex-broker-run-{d}", .{ state_dir, std.time.milliTimestamp() });
+    defer allocator.free(run_dir);
+    try std.fs.cwd().makePath(run_dir);
+    try writeCodexBrokerLiveAppServerFiles(allocator, run_dir, model);
+
+    const result = try runCodexAppServerLiveBrokerRun(
+        allocator,
+        selected.?.credentials,
+        run_dir,
+        model,
+        prompt,
+    );
+
+    if (args.json) {
+        try writeCodexBrokerRunJson(writer, selected.?.route, capability, model, prompt, summary, result);
+    } else {
+        try writeCodexBrokerRunText(writer, selected.?.route, capability, model, prompt, summary, result);
+    }
+}
+
+fn codexBrokerRunModel(allocator: std.mem.Allocator, args: cli.Command.CodexArgs) ![]const u8 {
+    if (args.model) |model| return try allocator.dupe(u8, model);
+    if (try getEnvOwnedOrNull(allocator, "OMUX_CODEX_BROKER_MODEL")) |model| return model;
+    return try allocator.dupe(u8, "gpt-5.5");
+}
+
+fn codexBrokerRunOk(result: CodexBrokerSmokeResult) bool {
+    return result.protocol.initialized and
+        result.protocol.login_response and
+        result.protocol.login_completed and
+        result.protocol.account_updated and
+        result.protocol.thread_started and
+        result.protocol.turn_started and
+        result.protocol.turn_completed and
+        result.exit_code != null and
+        result.exit_code.? == 0 and
+        !result.protocol.experimental_api_required_error;
+}
+
+fn codexBrokerRunReason(result: CodexBrokerSmokeResult) []const u8 {
+    if (codexBrokerRunOk(result)) return "live_turn_completed";
+    return result.reason;
+}
+
+fn writeCodexBrokerRunJson(
+    writer: anytype,
+    route: RepairPlanRoute,
+    capability: ?[]const u8,
+    model: []const u8,
+    prompt: []const u8,
+    summary: CodexBrokerSessionSummary,
+    result: CodexBrokerSmokeResult,
+) !void {
+    const prepared_fallback = summary.selectable_fallback_routes > 0;
+    try writer.writeAll("{\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"mode\":\"codex_broker_owned_session_live_run\",\"ok\":");
+    try writer.writeAll(if (codexBrokerRunOk(result)) "true" else "false");
+    try writer.writeAll(",\"confirmed\":true,\"spends_provider_calls\":true,\"mutates_user_config\":false,\"mutates_route_health\":false");
+    try writer.writeAll(",\"reason\":");
+    try std.json.stringify(codexBrokerRunReason(result), .{}, writer);
+    try writer.writeAll(",\"claim\":{\"claim_version\":1,\"level\":\"current_process_auth_broker\",\"proof_status\":\"live_broker_owned_session_one_turn\",\"broker_owned_session\":true,\"route_selection_source\":\"broker_session_plan\",\"session_start_ready\":true,\"live_provider_turn\":true,\"prepared_fallback\":");
+    try writer.writeAll(if (prepared_fallback) "true" else "false");
+    try writer.writeAll(",\"next_thread_quota_fallback\":false,\"same_turn_quota_recovery\":false,\"same_thread_quota_recovery\":false,\"supervised_restart\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
+    try writer.writeAll(",\"selected\":");
+    try writeRouteSelectionJson(writer, route);
+    try writer.writeAll(",\"capability\":");
+    if (capability) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"model\":");
+    try std.json.stringify(model, .{}, writer);
+    try writer.print(",\"prompt_chars\":{d}", .{prompt.len});
+    try writer.print(",\"summary\":{{\"routes_total\":{d},\"broker_ready_routes\":{d},\"selectable_broker_routes\":{d},\"selectable_fallback_routes\":{d},\"blocked_broker_routes\":{d},\"auth_unready_routes\":{d}}}", .{
+        summary.routes_total,
+        summary.broker_ready_routes,
+        summary.selectable_broker_routes,
+        summary.selectable_fallback_routes,
+        summary.blocked_broker_routes,
+        summary.auth_unready_routes,
+    });
+    try writer.writeAll(",\"app_server\":{\"transport\":\"stdio\",\"requires_experimental_api\":true,\"login_method\":\"account/login/start.chatgptAuthTokens\",\"provider\":\"default_codex_provider\"}");
+    try writer.writeAll(",\"live\":{\"turns_requested\":1,\"turns_completed\":");
+    try writer.print("{d}", .{result.protocol.turn_completed_count});
+    try writer.writeAll(",\"transcript_printed\":false}");
+    try writer.writeAll(",\"protocol\":");
+    try writeCodexBrokerProtocolJson(writer, result);
+    try writer.writeAll(",\"redaction\":{\"tokens_printed\":false,\"account_id_printed\":false,\"raw_protocol_printed\":false,\"prompt_printed\":false,\"assistant_output_printed\":false}");
+    try writer.writeAll("}\n");
+}
+
+fn writeCodexBrokerRunText(
+    writer: anytype,
+    route: RepairPlanRoute,
+    capability: ?[]const u8,
+    model: []const u8,
+    prompt: []const u8,
+    summary: CodexBrokerSessionSummary,
+    result: CodexBrokerSmokeResult,
+) !void {
+    try writer.writeAll("oauth-mux Codex broker-owned live run\n\n");
+    try writer.print("  route: {s}:{s}", .{ route.provider, route.account });
+    if (capability) |value| try writer.print("#{s}", .{value});
+    try writer.writeByte('\n');
+    try writer.print("  model: {s}\n", .{model});
+    try writer.print("  prompt chars: {d}\n", .{prompt.len});
+    try writer.print("  prepared fallback: {s}\n", .{if (summary.selectable_fallback_routes > 0) "true" else "false"});
+    try writer.print("  ok: {s}\n", .{if (codexBrokerRunOk(result)) "true" else "false"});
+    try writer.print("  reason: {s}\n", .{codexBrokerRunReason(result)});
+    try writer.print("  turn_completed: {s}\n", .{if (result.protocol.turn_completed) "true" else "false"});
+    try writer.writeAll("  redaction: tokens/account ids/raw protocol/prompt/assistant output not printed\n");
 }
 
 fn runCodexBrokerSmoke(
@@ -9568,6 +9770,167 @@ fn runCodexAppServerQuotaBrokerSmoke(
     return result;
 }
 
+fn runCodexAppServerLiveBrokerRun(
+    allocator: std.mem.Allocator,
+    login_credentials: CodexBrokerCredentials,
+    codex_home: []const u8,
+    model: []const u8,
+    prompt: []const u8,
+) !CodexBrokerSmokeResult {
+    const app_server_bin = std.process.getEnvVarOwned(allocator, "OMUX_CODEX_APP_SERVER") catch try allocator.dupe(u8, "codex");
+    defer allocator.free(app_server_bin);
+
+    var initialize_request = std.ArrayList(u8).init(allocator);
+    defer initialize_request.deinit();
+    try writeCodexAppServerInitializeRequest(initialize_request.writer());
+    try initialize_request.append('\n');
+
+    var login_request = std.ArrayList(u8).init(allocator);
+    defer login_request.deinit();
+    try writeCodexAppServerLoginRequest(login_request.writer(), login_credentials);
+    try login_request.append('\n');
+
+    var thread_request = std.ArrayList(u8).init(allocator);
+    defer thread_request.deinit();
+    try writeCodexAppServerThreadStartRequestWithModel(thread_request.writer(), model);
+    try thread_request.append('\n');
+
+    var env_map = try std.process.getEnvMap(allocator);
+    defer env_map.deinit();
+    try env_map.put("CODEX_HOME", codex_home);
+    env_map.remove("OPENAI_API_KEY");
+
+    const argv = [_][]const u8{ app_server_bin, "app-server", "--listen", "stdio://" };
+    var child = std.process.Child.init(&argv, allocator);
+    child.stdin_behavior = .Pipe;
+    child.stdout_behavior = .Pipe;
+    child.stderr_behavior = .Pipe;
+    child.env_map = &env_map;
+
+    child.spawn() catch |e| {
+        return .{ .ok = false, .reason = @errorName(e), .spawned = false };
+    };
+
+    var result = CodexBrokerSmokeResult{ .spawned = true };
+    var stdout_buf = std.ArrayListUnmanaged(u8){};
+    defer stdout_buf.deinit(allocator);
+    var stderr_buf = std.ArrayListUnmanaged(u8){};
+    defer stderr_buf.deinit(allocator);
+    var thread_request_sent = false;
+    var login_sent = false;
+    var turn_sent = false;
+
+    if (child.stdin) |stdin_file| {
+        try stdin_file.writeAll(initialize_request.items);
+    }
+
+    var poller = std.io.poll(allocator, enum { stdout, stderr }, .{
+        .stdout = child.stdout.?,
+        .stderr = child.stderr.?,
+    });
+    defer poller.deinit();
+
+    var term: ?std.process.Child.Term = null;
+    const max_output_bytes: usize = 2 * 1024 * 1024;
+    const deadline_ns = std.time.nanoTimestamp() + (90 * std.time.ns_per_s);
+    while (true) {
+        if (poller.fifo(.stdout).readableLength() > max_output_bytes or
+            poller.fifo(.stderr).readableLength() > max_output_bytes)
+        {
+            term = child.kill() catch null;
+            result.reason = "output_too_large";
+            break;
+        }
+
+        const now = std.time.nanoTimestamp();
+        if (now >= deadline_ns) {
+            try appendCodexBrokerPollFifo(allocator, &stdout_buf, poller.fifo(.stdout));
+            try appendCodexBrokerPollFifo(allocator, &stderr_buf, poller.fifo(.stderr));
+            term = child.kill() catch null;
+            result.reason = "timeout";
+            break;
+        }
+
+        const remaining_ns = deadline_ns - now;
+        const poll_ns_i = @min(remaining_ns, @as(i128, 50 * std.time.ns_per_ms));
+        const keep_polling = poller.pollTimeout(@intCast(poll_ns_i)) catch |e| {
+            term = child.kill() catch null;
+            result.reason = @errorName(e);
+            break;
+        };
+        try appendCodexBrokerPollFifo(allocator, &stdout_buf, poller.fifo(.stdout));
+        try appendCodexBrokerPollFifo(allocator, &stderr_buf, poller.fifo(.stderr));
+
+        const observation = inspectCodexBrokerProtocolOutput(stdout_buf.items);
+        if (!login_sent and observation.initialized) {
+            if (child.stdin) |stdin_file| {
+                try stdin_file.writeAll(login_request.items);
+                login_sent = true;
+            }
+        }
+
+        if (!thread_request_sent and observation.login_completed and observation.account_updated) {
+            if (child.stdin) |stdin_file| {
+                try stdin_file.writeAll(thread_request.items);
+                thread_request_sent = true;
+            }
+        }
+
+        const thread_id = try findCodexBrokerThreadId(allocator, stdout_buf.items);
+        defer if (thread_id) |id| allocator.free(id);
+        if (!turn_sent) {
+            if (thread_id) |id| {
+                if (child.stdin) |stdin_file| {
+                    try writeCodexAppServerTurnStartRequestWithId(stdin_file.writer(), 4, id, prompt);
+                    try stdin_file.writeAll("\n");
+                    turn_sent = true;
+                }
+            }
+        }
+
+        if (turn_sent and observation.turn_completed_count >= 1 and !result.stdin_closed) {
+            if (child.stdin) |stdin_file| {
+                stdin_file.close();
+                child.stdin = null;
+                result.stdin_closed = true;
+            }
+        }
+
+        if (!keep_polling) break;
+    }
+
+    if (!result.stdin_closed) {
+        if (child.stdin) |stdin_file| {
+            stdin_file.close();
+            child.stdin = null;
+            result.stdin_closed = true;
+        }
+    }
+
+    if (term == null) {
+        term = child.wait() catch |e| {
+            result.reason = @errorName(e);
+            return result;
+        };
+    }
+
+    result.exited = true;
+    result.exit_code = switch (term.?) {
+        .Exited => |code| code,
+        else => null,
+    };
+    result.stdout_bytes = stdout_buf.items.len;
+    result.stderr_bytes = stderr_buf.items.len;
+    result.protocol = inspectCodexBrokerProtocolOutput(stdout_buf.items);
+    result.ok = codexBrokerRunOk(result);
+    if (result.ok) {
+        result.reason = "live_turn_completed";
+    } else if (std.mem.eql(u8, result.reason, "unknown")) {
+        result.reason = "protocol_incomplete";
+    }
+    return result;
+}
+
 const CodexBroker401MockServerState = struct {
     mutex: std.Thread.Mutex = .{},
     observation: CodexBroker401HttpObservation = .{},
@@ -10091,7 +10454,17 @@ fn writeCodexAppServerThreadStartRequest(writer: anytype) !void {
 }
 
 fn writeCodexAppServerThreadStartRequestWithId(writer: anytype, id: i64) !void {
-    try writer.print("{{\"id\":{d},\"method\":\"thread/start\",\"params\":{{\"model\":\"mock-model\"}}}}", .{id});
+    try writeCodexAppServerThreadStartRequestWithIdAndModel(writer, id, "mock-model");
+}
+
+fn writeCodexAppServerThreadStartRequestWithModel(writer: anytype, model: []const u8) !void {
+    try writeCodexAppServerThreadStartRequestWithIdAndModel(writer, 3, model);
+}
+
+fn writeCodexAppServerThreadStartRequestWithIdAndModel(writer: anytype, id: i64, model: []const u8) !void {
+    try writer.print("{{\"id\":{d},\"method\":\"thread/start\",\"params\":{{\"model\":", .{id});
+    try std.json.stringify(model, .{}, writer);
+    try writer.writeAll("}}");
 }
 
 fn writeCodexAppServerTurnStartRequest(writer: anytype, thread_id: []const u8) !void {
@@ -10184,6 +10557,29 @@ fn writeCodexBroker401AppServerFiles(
         \\    }
         \\  ]
         \\}
+    );
+}
+
+fn writeCodexBrokerLiveAppServerFiles(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    model: []const u8,
+) !void {
+    const config_path = try std.fs.path.join(allocator, &.{ codex_home, "config.toml" });
+    defer allocator.free(config_path);
+    const config_file = try std.fs.createFileAbsolute(config_path, .{ .truncate = true, .mode = 0o600 });
+    defer config_file.close();
+    try config_file.writer().writeAll("model = ");
+    try std.json.stringify(model, .{}, config_file.writer());
+    try config_file.writer().writeAll(
+        \\
+        \\approval_policy = "never"
+        \\sandbox_mode = "read-only"
+        \\model_reasoning_effort = "low"
+        \\
+        \\[features]
+        \\shell_snapshot = false
+        \\
     );
 }
 


### PR DESCRIPTION
## Summary

Adds `oauth-mux codex broker-run` as the first explicit-spend live proof for broker-owned Codex app-server sessions. The command uses `broker-session-plan` route selection, starts a broker-owned Codex app-server with selected ChatGPT auth tokens, sends one prompt to the live provider, and emits redacted protocol evidence.

The output intentionally does not print prompt text, assistant output, access tokens, account IDs, raw JWTs, credential paths, or raw app-server protocol. The claim stays scoped to one broker-owned live turn and does not claim fallback recovery, unmanaged TUI hot-swap, same-thread quota recovery, or per-request muxing.

## Why

TIN-917 / GitHub #133 has moved from no-spend planning and local smoke proofs to live dogfood with four Codex subscriptions. This gives operators a precise spend-gated command for proving the broker-owned mediation point against the live Codex provider.

## Validation

- `zig build`
- `zig build test`
- `./scripts/e2e-local.sh`
- `just check-local`
- `./zig-out/bin/oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json`
- `./zig-out/bin/oauth-mux codex broker-run --profile codex-max --capability codex-max --prompt 'Reply exactly: oauth-mux broker-run live ok.' --confirm-spend --json`

Live evidence from the current four-account setup:

- `broker-session-plan` reported 4 broker-ready routes.
- `max-1` and `max-2` are quota-blocked.
- `max-3` is selected and `max-4` is the selectable fallback.
- `broker-run` completed one live provider turn with `ok:true`, `reason:"live_turn_completed"`, `turns_completed:1`, `model:"gpt-5.5"`, and `stderr_bytes:0`.
- Redaction flags report no token, account-id, prompt, assistant output, or raw protocol printing.

Refs #133.
