### PR TITLE
Add Codex broker run session loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ one-turn proof for that UX path. It uses the session plan's selected route,
 starts a broker-owned app-server against Codex's default live provider, sends
 one prompt, and reports only redacted protocol evidence; prompt text, assistant
 output, tokens, account ids, and raw protocol output are not printed.
+For a bounded beta session loop, pipe line-delimited prompts to `codex
+broker-run --stdin --confirm-spend --json`; the command keeps one broker-owned
+app-server session open and reports prompt/turn counts without printing
+transcript content.
 `codex broker-smoke --confirm-broker --json` is the next local proof: it starts
 a broker-owned Codex app-server stdio child, sends the selected route token to
 that child only, and verifies initialize/login/account-update milestones while

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -170,6 +170,9 @@ turn one, and verifies a new brokered thread uses the fallback route.
 broker-owned UX. It starts the selected route against Codex's default live
 provider and emits redacted protocol evidence without printing prompt text,
 assistant output, tokens, account ids, or raw app-server protocol.
+For a bounded beta multi-turn session, pass `--stdin` instead of `--prompt` and
+pipe one prompt per line. The session stays broker-owned and redacted; the
+output reports prompt counts and completed turns, not transcript content.
 
 `oauth-mux stay-afloat launch -- <command>` is the matching startup command for
 users and wrappers. It executes the target only after a selectable route is

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -243,6 +243,9 @@ Use
 provider spend. It runs one real broker-owned app-server turn from the session
 plan and prints redacted evidence, not prompt text, assistant output, tokens,
 account ids, or raw protocol output.
+For a bounded beta broker-owned session loop, pipe line-delimited prompts and
+replace `--prompt ...` with `--stdin`. The same spend gate applies, and
+transcript content remains suppressed in normal output.
 
 `stay-afloat launch -- <command>` is the user/wrapper startup boundary. It runs
 the same preflight as `stay-afloat next`, then starts the target only when a

--- a/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
+++ b/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
@@ -288,6 +288,8 @@ For quota-driven account changes, use a different action name, such as
    `oauth-mux codex broker-run --profile codex-max --capability codex-max
    --prompt ... --confirm-spend --json` starts the selected route against the
    live Codex provider for one turn and emits redacted protocol evidence.
+   A bounded beta loop form accepts line-delimited prompts via `--stdin` and
+   keeps one broker-owned app-server session open across those turns.
 13. Only after topology A is green, attempt topology B with a remote TUI and
    sidecar broker.
 14. Update website and README claim language only after live dogfood passes.
@@ -311,10 +313,10 @@ For quota-driven account changes, use a different action name, such as
 - The broker session smoke is no-spend and local. It can prove a multi-turn
   broker-owned app-server handoff using session-plan route selection, but it
   still does not prove same-thread quota recovery or unmanaged TUI hot-swap.
-- The broker live run is spend-gated and one-turn only. It can prove a
-  broker-owned app-server session reaches Codex's live provider with the
-  selected route, but it still does not prove fallback recovery or unmanaged
-  TUI hot-swap.
+- The broker live run is spend-gated. Its `--prompt` form proves one live turn;
+  its bounded `--stdin` beta can exercise multiple turns in one broker-owned
+  app-server session. It still does not prove fallback recovery or unmanaged
+  TUI hot-swap, and it reports counts without printing transcript content.
 - Cross-account switching is blocked when forced workspace or profile policy
   forbids it.
 - Quota/rate-limit behavior is separately classified as next-turn account

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -253,7 +253,9 @@ these precise provider-proof children.
    broker-session-smoke --confirm-broker` exercises that plan as a local
    multi-turn broker-owned app-server session against mocked backend endpoints.
    `oauth-mux codex broker-run --prompt ... --confirm-spend` is the matching
-   live one-turn broker-owned session proof and remains spend-gated.
+   live one-turn broker-owned session proof and remains spend-gated. Its
+   bounded `--stdin` beta keeps one broker-owned app-server session open across
+   line-delimited live turns while still suppressing transcript content.
 10. Return to daemon background implementation only after wrapper/install
    decisions and provider proof produce enough real operator evidence. The
    current socket daemon decision is complete under `TIN-867`; future

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -824,6 +824,9 @@ expect_contains "$broker_run_prompt" '"mode":"codex_broker_owned_session_live_ru
 expect_contains "$broker_run_prompt" '"confirmation_required":true' "broker-run requires confirmation"
 expect_contains "$broker_run_prompt" '"requires":"--confirm-spend or OMUX_LIVE_QA_CONFIRM=spend-real-calls"' "broker-run reports spend confirmation gate"
 expect_contains "$broker_run_prompt" '"spends_provider_calls":true' "broker-run confirmation prompt reports provider spend"
+broker_run_stdin_prompt="$(printf 'one\ntwo\n' | OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex broker-run --profile codex-max --capability codex-max --stdin --json 2>/dev/null || true)"
+expect_contains "$broker_run_stdin_prompt" '"mode":"codex_broker_owned_session_live_run"' "broker-run stdin reports live broker mode"
+expect_contains "$broker_run_stdin_prompt" '"confirmation_required":true' "broker-run stdin requires confirmation before reading live prompts"
 
 printf 'e2e: codex broker-smoke verifies app-server stdio login without leaking tokens\n'
 mock_codex_app_server="$tmp/mock-codex-app-server"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -207,6 +207,7 @@ pub const Command = union(enum) {
         json: bool = false,
         prompt: ?[]const u8 = null,
         model: ?[]const u8 = null,
+        stdin_prompts: bool = false,
         output: ?[]const u8 = null,
         candidate: ?[]const u8 = null,
         backup: ?[]const u8 = null,
@@ -950,6 +951,8 @@ fn parseCodexOptions(result: *Command.CodexArgs, args: []const []const u8, optio
         } else if (eql(args[i], "--model")) {
             i += 1;
             if (i < args.len) result.model = args[i];
+        } else if (eql(args[i], "--stdin")) {
+            result.stdin_prompts = true;
         } else if (eql(args[i], "--device")) {
             result.device = true;
         } else if (eql(args[i], "--status-only")) {
@@ -1101,8 +1104,8 @@ pub fn printUsage(writer: anytype) !void {
         \\  codex broker-session-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\      Run a local multi-turn broker-owned Codex session smoke from the session plan.
         \\
-        \\  codex broker-run [--profile name] [--capability c] --prompt text --confirm-spend [--model m] [--json]
-        \\      Run one live broker-owned Codex app-server turn from the session plan.
+        \\  codex broker-run [--profile name] [--capability c] (--prompt text|--stdin) --confirm-spend [--model m] [--json]
+        \\      Run one or more live broker-owned Codex app-server turns from the session plan.
         \\
         \\  codex broker-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\      Start a broker-owned Codex app-server stdio session and verify external auth login.
@@ -1157,7 +1160,7 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\  oauth-mux codex broker-plan [--profile name] [--capability c] [--json]
         \\  oauth-mux codex broker-session-plan [--profile name] [--capability c] [--json]
         \\  oauth-mux codex broker-session-smoke [--profile name] [--capability c] --confirm-broker [--json]
-        \\  oauth-mux codex broker-run [--profile name] [--capability c] --prompt text --confirm-spend [--model m] [--json]
+        \\  oauth-mux codex broker-run [--profile name] [--capability c] (--prompt text|--stdin) --confirm-spend [--model m] [--json]
         \\  oauth-mux codex broker-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\  oauth-mux codex broker-refresh-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\  oauth-mux codex broker-401-smoke [--profile name] [--capability c] --confirm-broker [--json]
@@ -1420,6 +1423,22 @@ test "parse codex broker run" {
             try std.testing.expectEqualStrings("codex-max", codex.capabilities);
             try std.testing.expectEqualStrings("hello", codex.prompt.?);
             try std.testing.expectEqualStrings("gpt-5.5", codex.model.?);
+            try std.testing.expect(codex.confirm_spend);
+            try std.testing.expect(codex.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse codex broker run stdin" {
+    const args = [_][]const u8{ "codex", "broker-run", "--profile", "codex-max", "--capability", "codex-max", "--stdin", "--confirm-spend", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex => |codex| {
+            try std.testing.expect(codex.action == .broker_run);
+            try std.testing.expectEqualStrings("codex-max", codex.profile.?);
+            try std.testing.expectEqualStrings("codex-max", codex.capabilities);
+            try std.testing.expect(codex.stdin_prompts);
             try std.testing.expect(codex.confirm_spend);
             try std.testing.expect(codex.json);
         },

--- a/src/main.zig
+++ b/src/main.zig
@@ -8359,21 +8359,61 @@ fn runCodexBrokerRun(
             try writer.writeAll("]}\n");
         } else {
             try writer.writeAll("oauth-mux Codex broker-owned live run is disabled.\n\n");
-            try writer.writeAll("This command starts a broker-owned Codex app-server and sends one real Codex turn.\n");
+            try writer.writeAll("This command starts a broker-owned Codex app-server and sends live Codex turns.\n");
             try writer.writeAll("Re-run with --confirm-spend or OMUX_LIVE_QA_CONFIRM=spend-real-calls.\n");
         }
         return error.CodexLiveQaConfirmationRequired;
     }
 
-    const prompt = args.prompt orelse {
+    if (args.prompt != null and args.stdin_prompts) {
         if (args.json) {
-            try writer.writeAll("{\"ok\":false,\"error\":\"prompt_required\",\"requires\":\"--prompt\",\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mode\":\"codex_broker_owned_session_live_run\"}\n");
+            try writer.writeAll("{\"ok\":false,\"error\":\"prompt_source_conflict\",\"requires\":\"exactly one of --prompt or --stdin\",\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mode\":\"codex_broker_owned_session_live_run\"}\n");
         } else {
             try writer.writeAll("oauth-mux Codex broker-owned live run\n\n");
-            try writer.writeAll("  prompt required: --prompt <text>\n");
+            try writer.writeAll("  choose exactly one prompt source: --prompt <text> or --stdin\n");
         }
         return;
-    };
+    }
+
+    var stdin_prompt_input: ?[]u8 = null;
+    defer if (stdin_prompt_input) |value| allocator.free(value);
+    var prompts = std.ArrayList([]const u8).init(allocator);
+    defer prompts.deinit();
+    const max_broker_run_prompts: usize = 8;
+
+    if (args.stdin_prompts) {
+        stdin_prompt_input = try std.io.getStdIn().reader().readAllAlloc(allocator, 64 * 1024);
+        var lines = std.mem.splitScalar(u8, stdin_prompt_input.?, '\n');
+        while (lines.next()) |line| {
+            const prompt = std.mem.trim(u8, line, " \t\r\n");
+            if (prompt.len == 0) continue;
+            try prompts.append(prompt);
+        }
+    } else if (args.prompt) |prompt| {
+        try prompts.append(prompt);
+    }
+
+    if (prompts.items.len == 0) {
+        if (args.json) {
+            try writer.writeAll("{\"ok\":false,\"error\":\"prompt_required\",\"requires\":\"--prompt or --stdin\",\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mode\":\"codex_broker_owned_session_live_run\"}\n");
+        } else {
+            try writer.writeAll("oauth-mux Codex broker-owned live run\n\n");
+            try writer.writeAll("  prompt required: --prompt <text> or line-delimited --stdin\n");
+        }
+        return;
+    }
+    if (prompts.items.len > max_broker_run_prompts) {
+        if (args.json) {
+            try writer.writeAll("{\"ok\":false,\"error\":\"prompt_count_limit_exceeded\",\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mode\":\"codex_broker_owned_session_live_run\",\"max_prompts\":");
+            try writer.print("{d}", .{max_broker_run_prompts});
+            try writer.print(",\"prompt_count\":{d}", .{prompts.items.len});
+            try writer.writeAll("}\n");
+        } else {
+            try writer.writeAll("oauth-mux Codex broker-owned live run\n\n");
+            try writer.print("  too many prompts: max {d}, got {d}\n", .{ max_broker_run_prompts, prompts.items.len });
+        }
+        return;
+    }
 
     const model = try codexBrokerRunModel(allocator, args);
     defer allocator.free(model);
@@ -8445,13 +8485,13 @@ fn runCodexBrokerRun(
         selected.?.credentials,
         run_dir,
         model,
-        prompt,
+        prompts.items,
     );
 
     if (args.json) {
-        try writeCodexBrokerRunJson(writer, selected.?.route, capability, model, prompt, summary, result);
+        try writeCodexBrokerRunJson(writer, selected.?.route, capability, model, if (args.stdin_prompts) "stdin" else "prompt", prompts.items, summary, result);
     } else {
-        try writeCodexBrokerRunText(writer, selected.?.route, capability, model, prompt, summary, result);
+        try writeCodexBrokerRunText(writer, selected.?.route, capability, model, if (args.stdin_prompts) "stdin" else "prompt", prompts.items, summary, result);
     }
 }
 
@@ -8461,7 +8501,7 @@ fn codexBrokerRunModel(allocator: std.mem.Allocator, args: cli.Command.CodexArgs
     return try allocator.dupe(u8, "gpt-5.5");
 }
 
-fn codexBrokerRunOk(result: CodexBrokerSmokeResult) bool {
+fn codexBrokerRunOk(result: CodexBrokerSmokeResult, expected_turns: usize) bool {
     return result.protocol.initialized and
         result.protocol.login_response and
         result.protocol.login_completed and
@@ -8469,14 +8509,23 @@ fn codexBrokerRunOk(result: CodexBrokerSmokeResult) bool {
         result.protocol.thread_started and
         result.protocol.turn_started and
         result.protocol.turn_completed and
+        result.protocol.turn_completed_count >= expected_turns and
         result.exit_code != null and
         result.exit_code.? == 0 and
         !result.protocol.experimental_api_required_error;
 }
 
-fn codexBrokerRunReason(result: CodexBrokerSmokeResult) []const u8 {
-    if (codexBrokerRunOk(result)) return "live_turn_completed";
+fn codexBrokerRunReason(result: CodexBrokerSmokeResult, expected_turns: usize) []const u8 {
+    if (codexBrokerRunOk(result, expected_turns)) {
+        return if (expected_turns == 1) "live_turn_completed" else "live_session_turns_completed";
+    }
     return result.reason;
+}
+
+fn codexBrokerPromptsTotalChars(prompts: []const []const u8) usize {
+    var total: usize = 0;
+    for (prompts) |prompt| total += prompt.len;
+    return total;
 }
 
 fn writeCodexBrokerRunJson(
@@ -8484,19 +8533,25 @@ fn writeCodexBrokerRunJson(
     route: RepairPlanRoute,
     capability: ?[]const u8,
     model: []const u8,
-    prompt: []const u8,
+    prompt_source: []const u8,
+    prompts: []const []const u8,
     summary: CodexBrokerSessionSummary,
     result: CodexBrokerSmokeResult,
 ) !void {
     const prepared_fallback = summary.selectable_fallback_routes > 0;
+    const prompt_chars_total = codexBrokerPromptsTotalChars(prompts);
     try writer.writeAll("{\"version\":");
     try std.json.stringify(cli.version, .{}, writer);
     try writer.writeAll(",\"mode\":\"codex_broker_owned_session_live_run\",\"ok\":");
-    try writer.writeAll(if (codexBrokerRunOk(result)) "true" else "false");
+    try writer.writeAll(if (codexBrokerRunOk(result, prompts.len)) "true" else "false");
     try writer.writeAll(",\"confirmed\":true,\"spends_provider_calls\":true,\"mutates_user_config\":false,\"mutates_route_health\":false");
     try writer.writeAll(",\"reason\":");
-    try std.json.stringify(codexBrokerRunReason(result), .{}, writer);
-    try writer.writeAll(",\"claim\":{\"claim_version\":1,\"level\":\"current_process_auth_broker\",\"proof_status\":\"live_broker_owned_session_one_turn\",\"broker_owned_session\":true,\"route_selection_source\":\"broker_session_plan\",\"session_start_ready\":true,\"live_provider_turn\":true,\"prepared_fallback\":");
+    try std.json.stringify(codexBrokerRunReason(result, prompts.len), .{}, writer);
+    try writer.writeAll(",\"claim\":{\"claim_version\":1,\"level\":\"current_process_auth_broker\",\"proof_status\":");
+    try std.json.stringify(if (prompts.len == 1) "live_broker_owned_session_one_turn" else "live_broker_owned_session_loop", .{}, writer);
+    try writer.writeAll(",\"broker_owned_session\":true,\"route_selection_source\":\"broker_session_plan\",\"session_start_ready\":true,\"live_provider_turn\":true,\"session_loop\":");
+    try writer.writeAll(if (prompts.len > 1) "true" else "false");
+    try writer.writeAll(",\"prepared_fallback\":");
     try writer.writeAll(if (prepared_fallback) "true" else "false");
     try writer.writeAll(",\"next_thread_quota_fallback\":false,\"same_turn_quota_recovery\":false,\"same_thread_quota_recovery\":false,\"supervised_restart\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
     try writer.writeAll(",\"selected\":");
@@ -8505,7 +8560,9 @@ fn writeCodexBrokerRunJson(
     if (capability) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"model\":");
     try std.json.stringify(model, .{}, writer);
-    try writer.print(",\"prompt_chars\":{d}", .{prompt.len});
+    try writer.writeAll(",\"prompt_source\":");
+    try std.json.stringify(prompt_source, .{}, writer);
+    try writer.print(",\"prompt_count\":{d},\"prompt_chars_total\":{d}", .{ prompts.len, prompt_chars_total });
     try writer.print(",\"summary\":{{\"routes_total\":{d},\"broker_ready_routes\":{d},\"selectable_broker_routes\":{d},\"selectable_fallback_routes\":{d},\"blocked_broker_routes\":{d},\"auth_unready_routes\":{d}}}", .{
         summary.routes_total,
         summary.broker_ready_routes,
@@ -8515,7 +8572,9 @@ fn writeCodexBrokerRunJson(
         summary.auth_unready_routes,
     });
     try writer.writeAll(",\"app_server\":{\"transport\":\"stdio\",\"requires_experimental_api\":true,\"login_method\":\"account/login/start.chatgptAuthTokens\",\"provider\":\"default_codex_provider\"}");
-    try writer.writeAll(",\"live\":{\"turns_requested\":1,\"turns_completed\":");
+    try writer.writeAll(",\"live\":{\"turns_requested\":");
+    try writer.print("{d}", .{prompts.len});
+    try writer.writeAll(",\"turns_completed\":");
     try writer.print("{d}", .{result.protocol.turn_completed_count});
     try writer.writeAll(",\"transcript_printed\":false}");
     try writer.writeAll(",\"protocol\":");
@@ -8529,19 +8588,23 @@ fn writeCodexBrokerRunText(
     route: RepairPlanRoute,
     capability: ?[]const u8,
     model: []const u8,
-    prompt: []const u8,
+    prompt_source: []const u8,
+    prompts: []const []const u8,
     summary: CodexBrokerSessionSummary,
     result: CodexBrokerSmokeResult,
 ) !void {
+    const prompt_chars_total = codexBrokerPromptsTotalChars(prompts);
     try writer.writeAll("oauth-mux Codex broker-owned live run\n\n");
     try writer.print("  route: {s}:{s}", .{ route.provider, route.account });
     if (capability) |value| try writer.print("#{s}", .{value});
     try writer.writeByte('\n');
     try writer.print("  model: {s}\n", .{model});
-    try writer.print("  prompt chars: {d}\n", .{prompt.len});
+    try writer.print("  prompt source: {s}\n", .{prompt_source});
+    try writer.print("  prompt count: {d}\n", .{prompts.len});
+    try writer.print("  prompt chars total: {d}\n", .{prompt_chars_total});
     try writer.print("  prepared fallback: {s}\n", .{if (summary.selectable_fallback_routes > 0) "true" else "false"});
-    try writer.print("  ok: {s}\n", .{if (codexBrokerRunOk(result)) "true" else "false"});
-    try writer.print("  reason: {s}\n", .{codexBrokerRunReason(result)});
+    try writer.print("  ok: {s}\n", .{if (codexBrokerRunOk(result, prompts.len)) "true" else "false"});
+    try writer.print("  reason: {s}\n", .{codexBrokerRunReason(result, prompts.len)});
     try writer.print("  turn_completed: {s}\n", .{if (result.protocol.turn_completed) "true" else "false"});
     try writer.writeAll("  redaction: tokens/account ids/raw protocol/prompt/assistant output not printed\n");
 }
@@ -9775,7 +9838,7 @@ fn runCodexAppServerLiveBrokerRun(
     login_credentials: CodexBrokerCredentials,
     codex_home: []const u8,
     model: []const u8,
-    prompt: []const u8,
+    prompts: []const []const u8,
 ) !CodexBrokerSmokeResult {
     const app_server_bin = std.process.getEnvVarOwned(allocator, "OMUX_CODEX_APP_SERVER") catch try allocator.dupe(u8, "codex");
     defer allocator.free(app_server_bin);
@@ -9818,7 +9881,7 @@ fn runCodexAppServerLiveBrokerRun(
     defer stderr_buf.deinit(allocator);
     var thread_request_sent = false;
     var login_sent = false;
-    var turn_sent = false;
+    var turns_sent: usize = 0;
 
     if (child.stdin) |stdin_file| {
         try stdin_file.writeAll(initialize_request.items);
@@ -9878,17 +9941,17 @@ fn runCodexAppServerLiveBrokerRun(
 
         const thread_id = try findCodexBrokerThreadId(allocator, stdout_buf.items);
         defer if (thread_id) |id| allocator.free(id);
-        if (!turn_sent) {
+        if (turns_sent < prompts.len and observation.turn_completed_count >= turns_sent) {
             if (thread_id) |id| {
                 if (child.stdin) |stdin_file| {
-                    try writeCodexAppServerTurnStartRequestWithId(stdin_file.writer(), 4, id, prompt);
+                    try writeCodexAppServerTurnStartRequestWithId(stdin_file.writer(), @intCast(4 + turns_sent), id, prompts[turns_sent]);
                     try stdin_file.writeAll("\n");
-                    turn_sent = true;
+                    turns_sent += 1;
                 }
             }
         }
 
-        if (turn_sent and observation.turn_completed_count >= 1 and !result.stdin_closed) {
+        if (turns_sent >= prompts.len and observation.turn_completed_count >= prompts.len and !result.stdin_closed) {
             if (child.stdin) |stdin_file| {
                 stdin_file.close();
                 child.stdin = null;
@@ -9922,9 +9985,9 @@ fn runCodexAppServerLiveBrokerRun(
     result.stdout_bytes = stdout_buf.items.len;
     result.stderr_bytes = stderr_buf.items.len;
     result.protocol = inspectCodexBrokerProtocolOutput(stdout_buf.items);
-    result.ok = codexBrokerRunOk(result);
+    result.ok = codexBrokerRunOk(result, prompts.len);
     if (result.ok) {
-        result.reason = "live_turn_completed";
+        result.reason = if (prompts.len == 1) "live_turn_completed" else "live_session_turns_completed";
     } else if (std.mem.eql(u8, result.reason, "unknown")) {
         result.reason = "protocol_incomplete";
     }


### PR DESCRIPTION
## Summary

Extends `oauth-mux codex broker-run` with a bounded `--stdin` beta session loop. The existing `--prompt` form remains the one-turn live proof; `--stdin` accepts line-delimited prompts, keeps one broker-owned Codex app-server session open, sends each prompt as a turn, and reports aggregate redacted evidence.

The spend and redaction boundaries stay intact: `--stdin` still requires `--confirm-spend` or `OMUX_LIVE_QA_CONFIRM=spend-real-calls`; normal output reports prompt counts and completed turns, not prompt text, assistant output, tokens, account IDs, raw JWTs, credential paths, or raw app-server protocol. The beta loop is bounded to avoid accidental large live-spend batches.

## Why

TIN-917 / GitHub #133 listed interactive broker-run beta as the next step after the one-turn live proof. This gives us a real broker-owned multi-turn app-server session surface without claiming unmanaged TUI hot-swap or fallback recovery.

## Validation

- `zig build`
- `zig build test`
- `./scripts/e2e-local.sh`
- `just check-local`
- Live two-turn loop:
  `printf 'Reply exactly: oauth-mux broker-run loop turn one ok.\nReply exactly: oauth-mux broker-run loop turn two ok.\n' | ./zig-out/bin/oauth-mux codex broker-run --profile codex-max --capability codex-max --stdin --confirm-spend --json`

Live evidence:

- Selected route: `max-3`.
- `prompt_source:"stdin"`.
- `prompt_count:2`.
- `turns_completed:2`.
- `reason:"live_session_turns_completed"`.
- `proof_status:"live_broker_owned_session_loop"`.
- `stderr_bytes:0`.
- Redaction flags remained false for tokens, account IDs, raw protocol, prompt text, and assistant output.

Still not claimed: fallback recovery, same-thread quota recovery, unmanaged TUI hot-swap, or per-request muxing.

Refs #133.
