### PR TITLE
Add Codex fallback drill

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-plan --pr
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-session-smoke --profile codex-max --capability codex-max --confirm-broker --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-run --profile codex-max --capability codex-max --prompt 'Reply with oauth-mux broker-run ok.' --confirm-spend --json
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-fallback-drill --profile codex-max --capability codex-max --from-account max-3 --confirm-drill --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-smoke --profile codex-max --capability codex-max --confirm-broker --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-refresh-smoke --profile codex-max --capability codex-max --confirm-broker --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-401-smoke --profile codex-max --capability codex-max --confirm-broker --json
@@ -155,6 +156,12 @@ For a bounded beta session loop, pipe line-delimited prompts to `codex
 broker-run --stdin --confirm-spend --json`; the command keeps one broker-owned
 app-server session open and reports prompt/turn counts without printing
 transcript content.
+`codex broker-fallback-drill --from-account ... --confirm-drill --json` is the
+controlled no-spend way to observe route-state fallback. It records the named
+Codex route as quota-exhausted in local oauth-mux health, then verifies the next
+broker-owned route selection chooses a distinct fallback route. This mutates
+route health and intentionally does not claim provider-originated quota
+exhaustion, same-thread quota recovery, or unmanaged TUI hot-swap.
 `codex broker-smoke --confirm-broker --json` is the next local proof: it starts
 a broker-owned Codex app-server stdio child, sends the selected route token to
 that child only, and verifies initialize/login/account-update milestones while
@@ -300,6 +307,7 @@ oauth-mux codex broker-plan --profile codex-max --capability codex-max --json
 oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json
 oauth-mux codex broker-session-smoke --profile codex-max --capability codex-max --confirm-broker --json
 oauth-mux codex broker-run --profile codex-max --capability codex-max --prompt 'Reply with oauth-mux broker-run ok.' --confirm-spend --json
+oauth-mux codex broker-fallback-drill --profile codex-max --capability codex-max --from-account max-3 --confirm-drill --json
 oauth-mux codex broker-smoke --profile codex-max --capability codex-max --confirm-broker --json
 oauth-mux codex broker-refresh-smoke --profile codex-max --capability codex-max --confirm-broker --json
 oauth-mux codex broker-401-smoke --profile codex-max --capability codex-max --confirm-broker --json

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -174,6 +174,14 @@ For a bounded beta multi-turn session, pass `--stdin` instead of `--prompt` and
 pipe one prompt per line. The session stays broker-owned and redacted; the
 output reports prompt counts and completed turns, not transcript content.
 
+`oauth-mux codex broker-fallback-drill --profile codex-max --capability
+codex-max --from-account max-3 --confirm-drill --json` is the controlled
+operator drill for observing fallback without waiting for a provider-originated
+quota event. It mutates local route health by recording the named route as
+quota-exhausted, then verifies the next broker-owned route selection chooses a
+distinct fallback. It does not spend provider calls and does not claim
+same-thread quota recovery or unmanaged TUI hot-swap.
+
 `oauth-mux stay-afloat launch -- <command>` is the matching startup command for
 users and wrappers. It executes the target only after a selectable route is
 found from recorded evidence. The delegated `exec` path still validates local

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -246,6 +246,13 @@ account ids, or raw protocol output.
 For a bounded beta broker-owned session loop, pipe line-delimited prompts and
 replace `--prompt ...` with `--stdin`. The same spend gate applies, and
 transcript content remains suppressed in normal output.
+Use
+`oauth-mux codex broker-fallback-drill --profile codex-max --capability
+codex-max --from-account max-3 --confirm-drill --json` when you need to observe
+fallback deliberately. It records the named route as quota-exhausted in local
+route health, then verifies broker-owned selection moves to a distinct fallback
+route. This is no-spend and useful for operator drills, but it is controlled
+route-state evidence, not provider-originated quota exhaustion.
 
 `stay-afloat launch -- <command>` is the user/wrapper startup boundary. It runs
 the same preflight as `stay-afloat next`, then starts the target only when a

--- a/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
+++ b/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
@@ -290,9 +290,15 @@ For quota-driven account changes, use a different action name, such as
    live Codex provider for one turn and emits redacted protocol evidence.
    A bounded beta loop form accepts line-delimited prompts via `--stdin` and
    keeps one broker-owned app-server session open across those turns.
-13. Only after topology A is green, attempt topology B with a remote TUI and
+13. Add a controlled fallback observation drill:
+   `oauth-mux codex broker-fallback-drill --profile codex-max --capability
+   codex-max --from-account max-3 --confirm-drill --json` records the named
+   route as quota-exhausted in local route health and verifies the next
+   broker-owned route selection picks a distinct fallback. This is no-spend
+   route-state evidence, not provider-originated quota evidence.
+14. Only after topology A is green, attempt topology B with a remote TUI and
    sidecar broker.
-14. Update website and README claim language only after live dogfood passes.
+15. Update website and README claim language only after live dogfood passes.
 
 ## Acceptance Criteria
 
@@ -317,6 +323,9 @@ For quota-driven account changes, use a different action name, such as
   its bounded `--stdin` beta can exercise multiple turns in one broker-owned
   app-server session. It still does not prove fallback recovery or unmanaged
   TUI hot-swap, and it reports counts without printing transcript content.
+- The broker fallback drill is no-spend but mutates local route health. It can
+  observe next-route fallback after a controlled quota-exhausted mark, while
+  explicitly not claiming provider-originated quota exhaustion.
 - Cross-account switching is blocked when forced workspace or profile policy
   forbids it.
 - Quota/rate-limit behavior is separately classified as next-turn account

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -256,6 +256,11 @@ these precise provider-proof children.
    live one-turn broker-owned session proof and remains spend-gated. Its
    bounded `--stdin` beta keeps one broker-owned app-server session open across
    line-delimited live turns while still suppressing transcript content.
+   `oauth-mux codex broker-fallback-drill --from-account ...
+   --confirm-drill` is the controlled operator drill for fallback observation:
+   it marks a route quota-exhausted in local route health and verifies the next
+   broker-owned selection moves to a distinct fallback, without claiming that
+   the quota signal came from the provider.
 10. Return to daemon background implementation only after wrapper/install
    decisions and provider proof produce enough real operator evidence. The
    current socket daemon decision is complete under `TIN-867`; future

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -811,6 +811,37 @@ expect_not_contains "$broker_session_plan" "$broker_jwt" "broker-session-plan do
 expect_not_contains "$broker_session_plan" 'broker-session-refresh-token' "broker-session-plan does not expose refresh token value"
 expect_not_contains "$broker_session_plan" 'broker-session-spare-token' "broker-session-plan does not expose spare refresh token value"
 
+printf 'e2e: codex broker-fallback-drill requires explicit confirmation before mutating route health\n'
+broker_fallback_drill_prompt="$(OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex broker-fallback-drill --profile codex-max --capability codex-max --from-account max-2 --json)"
+expect_contains "$broker_fallback_drill_prompt" '"mode":"codex_broker_fallback_drill"' "broker-fallback-drill reports drill mode"
+expect_contains "$broker_fallback_drill_prompt" '"confirmation_required":true' "broker-fallback-drill requires confirmation"
+expect_contains "$broker_fallback_drill_prompt" '"requires":"--confirm-drill"' "broker-fallback-drill reports required confirmation flag"
+expect_contains "$broker_fallback_drill_prompt" '"spends_provider_calls":false' "broker-fallback-drill confirmation reports no provider spend"
+expect_contains "$broker_fallback_drill_prompt" '"mutates_route_health":true' "broker-fallback-drill confirmation reports route-health mutation"
+
+printf 'e2e: codex broker-fallback-drill marks selected route exhausted and selects fallback route\n'
+broker_fallback_drill="$(PATH="$broker_session_bin:$PATH" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex broker-fallback-drill --profile codex-max --capability codex-max --from-account max-2 --confirm-drill --json)"
+expect_contains "$broker_fallback_drill" '"mode":"codex_broker_fallback_drill"' "broker-fallback-drill reports drill mode after confirmation"
+expect_contains "$broker_fallback_drill" '"ok":true' "broker-fallback-drill succeeds when distinct fallback exists"
+expect_contains "$broker_fallback_drill" '"spends_provider_calls":false' "broker-fallback-drill remains no-spend"
+expect_contains "$broker_fallback_drill" '"mutates_route_health":true' "broker-fallback-drill reports route-health mutation"
+expect_contains "$broker_fallback_drill" '"proof_status":"controlled_route_state_fallback_drill"' "broker-fallback-drill scopes proof status"
+expect_contains "$broker_fallback_drill" '"provider_originated_quota":false' "broker-fallback-drill does not claim provider-originated quota"
+expect_contains "$broker_fallback_drill" '"drilled":{"provider":"codex","account":"max-2","capability":"codex-max"' "broker-fallback-drill reports drilled route"
+expect_contains "$broker_fallback_drill" '"classification":"quota_exhausted"' "broker-fallback-drill records quota classification"
+expect_contains "$broker_fallback_drill" '"previous_selected":{"provider":"codex","account":"max-2","capability":"codex-max"' "broker-fallback-drill records previous selected route"
+expect_contains "$broker_fallback_drill" '"selected":{"provider":"codex","account":"max-3","capability":"codex-max"' "broker-fallback-drill selects fallback route"
+expect_contains "$broker_fallback_drill" '"fallback_route_is_distinct":true' "broker-fallback-drill reports distinct fallback"
+expect_contains "$broker_fallback_drill" '"route_role":"quota_blocked"' "broker-fallback-drill shows drilled route blocked"
+expect_contains "$broker_fallback_drill" '"route_role":"selected"' "broker-fallback-drill shows fallback route selected"
+expect_contains "$broker_fallback_drill" '"tokens_printed":false' "broker-fallback-drill redaction reports token suppression"
+expect_contains "$broker_fallback_drill" '"account_id_printed":false' "broker-fallback-drill redaction reports account id suppression"
+expect_not_contains "$broker_fallback_drill" 'acct-session-fallback' "broker-fallback-drill does not expose fallback account id value"
+expect_not_contains "$broker_fallback_drill" 'acct-session-spare' "broker-fallback-drill does not expose spare account id value"
+expect_not_contains "$broker_fallback_drill" "$broker_jwt" "broker-fallback-drill does not expose token value"
+expect_not_contains "$broker_fallback_drill" 'broker-session-refresh-token' "broker-fallback-drill does not expose refresh token value"
+expect_not_contains "$broker_fallback_drill" 'broker-session-spare-token' "broker-fallback-drill does not expose spare refresh token value"
+
 printf 'e2e: codex broker-session-smoke requires explicit confirmation before starting app-server\n'
 broker_session_smoke_prompt="$(OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex broker-session-smoke --profile codex-max --capability codex-max --json)"
 expect_contains "$broker_session_smoke_prompt" '"mode":"codex_broker_owned_session_smoke"' "broker-session-smoke reports session smoke mode"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -186,6 +186,7 @@ pub const Command = union(enum) {
         broker_session_plan,
         broker_session_smoke,
         broker_run,
+        broker_fallback_drill,
         broker_smoke,
         broker_refresh_smoke,
         broker_401_smoke,
@@ -204,9 +205,11 @@ pub const Command = union(enum) {
         live: bool = false,
         confirm_spend: bool = false,
         confirm_broker: bool = false,
+        confirm_drill: bool = false,
         json: bool = false,
         prompt: ?[]const u8 = null,
         model: ?[]const u8 = null,
+        from_account: ?[]const u8 = null,
         stdin_prompts: bool = false,
         output: ?[]const u8 = null,
         candidate: ?[]const u8 = null,
@@ -898,6 +901,8 @@ fn parseCodex(args: []const []const u8) Command {
             result.action = .broker_session_smoke;
         } else if (eql(args[0], "broker-run")) {
             result.action = .broker_run;
+        } else if (eql(args[0], "broker-fallback-drill")) {
+            result.action = .broker_fallback_drill;
         } else if (eql(args[0], "broker-smoke")) {
             result.action = .broker_smoke;
         } else if (eql(args[0], "broker-refresh-smoke")) {
@@ -951,6 +956,9 @@ fn parseCodexOptions(result: *Command.CodexArgs, args: []const []const u8, optio
         } else if (eql(args[i], "--model")) {
             i += 1;
             if (i < args.len) result.model = args[i];
+        } else if (eql(args[i], "--from-account")) {
+            i += 1;
+            if (i < args.len) result.from_account = args[i];
         } else if (eql(args[i], "--stdin")) {
             result.stdin_prompts = true;
         } else if (eql(args[i], "--device")) {
@@ -963,6 +971,8 @@ fn parseCodexOptions(result: *Command.CodexArgs, args: []const []const u8, optio
             result.confirm_spend = true;
         } else if (eql(args[i], "--confirm-broker")) {
             result.confirm_broker = true;
+        } else if (eql(args[i], "--confirm-drill")) {
+            result.confirm_drill = true;
         } else if (eql(args[i], "--json")) {
             result.json = true;
         } else if (result.account == null and !std.mem.startsWith(u8, args[i], "-")) {
@@ -1107,6 +1117,9 @@ pub fn printUsage(writer: anytype) !void {
         \\  codex broker-run [--profile name] [--capability c] (--prompt text|--stdin) --confirm-spend [--model m] [--json]
         \\      Run one or more live broker-owned Codex app-server turns from the session plan.
         \\
+        \\  codex broker-fallback-drill [--profile name] [--capability c] --from-account name --confirm-drill [--json]
+        \\      Mark one Codex route quota-exhausted locally and prove the next broker-owned route selection.
+        \\
         \\  codex broker-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\      Start a broker-owned Codex app-server stdio session and verify external auth login.
         \\
@@ -1161,6 +1174,7 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\  oauth-mux codex broker-session-plan [--profile name] [--capability c] [--json]
         \\  oauth-mux codex broker-session-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\  oauth-mux codex broker-run [--profile name] [--capability c] (--prompt text|--stdin) --confirm-spend [--model m] [--json]
+        \\  oauth-mux codex broker-fallback-drill [--profile name] [--capability c] --from-account name --confirm-drill [--json]
         \\  oauth-mux codex broker-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\  oauth-mux codex broker-refresh-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\  oauth-mux codex broker-401-smoke [--profile name] [--capability c] --confirm-broker [--json]
@@ -1181,6 +1195,8 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\  selected Codex route secret and send it only to a broker-owned
         \\  Codex app-server child process; they do not print token or
         \\  account-id values.
+        \\  broker-fallback-drill mutates only oauth-mux route health; it does
+        \\  not spend provider calls or print secrets.
         \\  live-qa and broker-run require --confirm-spend or
         \\  OMUX_LIVE_QA_CONFIRM=spend-real-calls.
         \\  --help and -h are non-mutating for every Codex subcommand.
@@ -1440,6 +1456,22 @@ test "parse codex broker run stdin" {
             try std.testing.expectEqualStrings("codex-max", codex.capabilities);
             try std.testing.expect(codex.stdin_prompts);
             try std.testing.expect(codex.confirm_spend);
+            try std.testing.expect(codex.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse codex broker fallback drill" {
+    const args = [_][]const u8{ "codex", "broker-fallback-drill", "--profile", "codex-max", "--capability", "codex-max", "--from-account", "max-3", "--confirm-drill", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex => |codex| {
+            try std.testing.expect(codex.action == .broker_fallback_drill);
+            try std.testing.expectEqualStrings("codex-max", codex.profile.?);
+            try std.testing.expectEqualStrings("codex-max", codex.capabilities);
+            try std.testing.expectEqualStrings("max-3", codex.from_account.?);
+            try std.testing.expect(codex.confirm_drill);
             try std.testing.expect(codex.json);
         },
         else => return error.Unexpected,
@@ -1991,7 +2023,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary live-qa probe-all broker-plan broker-session-plan broker-session-smoke broker-run broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary live-qa probe-all broker-plan broker-session-plan broker-session-smoke broker-run broker-fallback-drill broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run supervise start stop status events handoffs tick' -d 'Daemon subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l stay-afloat -d 'Host beta supervised stay-afloat loop'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l json -d 'JSON output'

--- a/src/main.zig
+++ b/src/main.zig
@@ -7520,6 +7520,7 @@ fn runCodex(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Cod
         .broker_session_plan => try runCodexBrokerSessionPlan(allocator, writer, args),
         .broker_session_smoke => try runCodexBrokerSessionSmoke(allocator, writer, args),
         .broker_run => try runCodexBrokerRun(allocator, writer, args),
+        .broker_fallback_drill => try runCodexBrokerFallbackDrill(allocator, writer, args),
         .broker_smoke => try runCodexBrokerSmoke(allocator, writer, args, .login),
         .broker_refresh_smoke => try runCodexBrokerSmoke(allocator, writer, args, .refresh),
         .broker_401_smoke => try runCodexBroker401Smoke(allocator, writer, args),
@@ -7960,6 +7961,309 @@ const CodexBrokerSessionSummary = struct {
     blocked_broker_routes: usize = 0,
     auth_unready_routes: usize = 0,
 };
+
+const codex_fallback_drill_retry_after_s: u32 = 7200;
+
+fn runCodexBrokerFallbackDrill(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    args: cli.Command.CodexArgs,
+) !void {
+    if (!args.confirm_drill) {
+        if (args.json) {
+            try writer.writeAll("{\"ok\":false,\"confirmation_required\":true,\"requires\":\"--confirm-drill\",\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mutates_route_health\":true,\"mode\":\"codex_broker_fallback_drill\",\"next_commands\":[");
+            try writeCommandJson(writer, "oauth-mux codex broker-session-plan --profile <profile> --capability <capability> --json");
+            try writer.writeByte(',');
+            try writeCommandJson(writer, "oauth-mux codex broker-fallback-drill --profile <profile> --capability <capability> --from-account <account> --confirm-drill --json");
+            try writer.writeAll("]}\n");
+        } else {
+            try writer.writeAll("oauth-mux Codex broker fallback drill\n\n");
+            try writer.writeAll("  confirmation required: --confirm-drill\n");
+            try writer.writeAll("  this marks one local route-health entry quota-exhausted and proves the next broker-owned route selection\n");
+        }
+        return;
+    }
+
+    const from_account = nonEmpty(args.from_account) orelse {
+        if (args.json) {
+            try writer.writeAll("{\"ok\":false,\"error\":\"from_account_required\",\"requires\":\"--from-account <account>\",\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mutates_route_health\":false,\"mode\":\"codex_broker_fallback_drill\"}\n");
+        } else {
+            try writer.writeAll("oauth-mux Codex broker fallback drill\n\n");
+            try writer.writeAll("  from account required: --from-account <account>\n");
+        }
+        return;
+    };
+
+    const capability = firstCommaValue(args.capabilities) orelse {
+        if (args.json) {
+            try writer.writeAll("{\"ok\":false,\"error\":\"capability_required\",\"requires\":\"--capability <capability>\",\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mutates_route_health\":false,\"mode\":\"codex_broker_fallback_drill\"}\n");
+        } else {
+            try writer.writeAll("oauth-mux Codex broker fallback drill\n\n");
+            try writer.writeAll("  capability required: --capability <capability>\n");
+        }
+        return;
+    };
+
+    const parsed = try config.load(allocator);
+    defer parsed.deinit();
+
+    var validation_messages = std.ArrayList(u8).init(allocator);
+    defer validation_messages.deinit();
+    try config.validate(parsed.value, validation_messages.writer());
+
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+
+    var routes = try collectRepairPlanRoutes(allocator, parsed.value, .{
+        .profile = args.profile,
+        .provider = if (args.profile == null) "codex" else null,
+        .account = null,
+        .capability = capability,
+        .json = args.json,
+    });
+    defer routes.deinit();
+
+    var before = std.ArrayList(RouteEvaluation).init(allocator);
+    defer before.deinit();
+    try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &before);
+
+    const target_index = findCodexBrokerRouteIndexForAccount(before.items, from_account, capability) orelse {
+        if (args.json) {
+            try writer.writeAll("{\"version\":");
+            try std.json.stringify(cli.version, .{}, writer);
+            try writer.writeAll(",\"mode\":\"codex_broker_fallback_drill\",\"ok\":false,\"confirmed\":true,\"reason\":\"from_account_not_in_route_set\",\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mutates_route_health\":false,\"from_account\":");
+            try std.json.stringify(from_account, .{}, writer);
+            try writer.writeAll(",\"profile\":");
+            if (args.profile) |profile| try std.json.stringify(profile, .{}, writer) else try writer.writeAll("null");
+            try writer.writeAll(",\"capability\":");
+            try std.json.stringify(capability, .{}, writer);
+            try writer.writeAll("}\n");
+        } else {
+            try writer.writeAll("oauth-mux Codex broker fallback drill\n\n");
+            try writer.print("  no matching Codex route for account {s}\n", .{from_account});
+        }
+        return;
+    };
+
+    const previous_selected_index = try firstSelectableCodexBrokerRouteIndex(allocator, parsed.value, before.items);
+    const target_route = before.items[target_index].route;
+    const target_was_selected_before = if (previous_selected_index) |idx|
+        sameRepairPlanRouteIdentity(before.items[idx].route, target_route)
+    else
+        false;
+
+    const def = config.resolveProviderDefinition(parsed.value, target_route.provider);
+    if (target_route.capability) |route_capability| {
+        store.recordCapabilityHttpStatusForProvider(
+            target_route.provider,
+            target_route.account,
+            route_capability,
+            def,
+            429,
+            codex_fallback_drill_retry_after_s,
+            "controlled codex broker fallback drill",
+        );
+    } else {
+        const key = health_mod.accountKey(target_route.provider, target_route.account);
+        store.recordHttpStatusForProvider(
+            key.slice(),
+            def,
+            429,
+            codex_fallback_drill_retry_after_s,
+            "controlled codex broker fallback drill",
+        );
+    }
+    store.persist();
+
+    var after = std.ArrayList(RouteEvaluation).init(allocator);
+    defer after.deinit();
+    try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &after);
+
+    const selected_index = try firstSelectableCodexBrokerRouteIndex(allocator, parsed.value, after.items);
+    const fallback_route_is_distinct = if (selected_index) |idx|
+        !sameRepairPlanRouteIdentity(after.items[idx].route, target_route)
+    else
+        false;
+    const ok = target_was_selected_before and fallback_route_is_distinct;
+    const reason = if (ok)
+        "controlled_fallback_selected_distinct_route"
+    else if (!target_was_selected_before)
+        "drilled_route_was_not_selected_before"
+    else if (selected_index == null)
+        "no_fallback_route_after_drill"
+    else
+        "drill_selected_same_route";
+
+    if (args.json) {
+        try writeCodexBrokerFallbackDrillJson(
+            writer,
+            allocator,
+            parsed.value,
+            before.items,
+            after.items,
+            target_route,
+            previous_selected_index,
+            selected_index,
+            args.profile,
+            capability,
+            ok,
+            reason,
+            target_was_selected_before,
+            fallback_route_is_distinct,
+        );
+    } else {
+        try writeCodexBrokerFallbackDrillText(
+            writer,
+            target_route,
+            before.items,
+            after.items,
+            previous_selected_index,
+            selected_index,
+            capability,
+            ok,
+            reason,
+            target_was_selected_before,
+            fallback_route_is_distinct,
+        );
+    }
+}
+
+fn findCodexBrokerRouteIndexForAccount(
+    evaluations: []const RouteEvaluation,
+    account: []const u8,
+    capability: []const u8,
+) ?usize {
+    for (evaluations, 0..) |evaluation, idx| {
+        if (!std.mem.eql(u8, evaluation.route.provider, "codex")) continue;
+        if (!std.mem.eql(u8, evaluation.route.account, account)) continue;
+        const route_capability = evaluation.route.capability orelse continue;
+        if (!std.mem.eql(u8, route_capability, capability)) continue;
+        return idx;
+    }
+    return null;
+}
+
+fn writeCodexBrokerFallbackDrillJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    before: []const RouteEvaluation,
+    after: []const RouteEvaluation,
+    target_route: RepairPlanRoute,
+    previous_selected_index: ?usize,
+    selected_index: ?usize,
+    profile: ?[]const u8,
+    capability: []const u8,
+    ok: bool,
+    reason: []const u8,
+    target_was_selected_before: bool,
+    fallback_route_is_distinct: bool,
+) !void {
+    const summary = try summarizeCodexBrokerSessionPlan(allocator, cfg, after, selected_index);
+
+    try writer.writeAll("{\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"mode\":\"codex_broker_fallback_drill\",\"ok\":");
+    try writer.writeAll(if (ok) "true" else "false");
+    try writer.writeAll(",\"confirmed\":true,\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mutates_route_health\":true");
+    try writer.writeAll(",\"reason\":");
+    try std.json.stringify(reason, .{}, writer);
+    try writer.writeAll(",\"claim\":{\"claim_version\":1,\"level\":\"controlled_route_health_drill\",\"proof_status\":\"controlled_route_state_fallback_drill\",\"broker_owned_session\":true,\"route_selection_source\":\"route_health_after_controlled_mutation\",\"provider_originated_quota\":false,\"next_turn_route_state_fallback\":");
+    try writer.writeAll(if (ok) "true" else "false");
+    try writer.writeAll(",\"same_turn_quota_recovery\":false,\"same_thread_quota_recovery\":false,\"supervised_restart\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
+    try writer.writeAll(",\"profile\":");
+    if (profile) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"capability\":");
+    try std.json.stringify(capability, .{}, writer);
+    try writer.writeAll(",\"drilled\":{\"provider\":");
+    try std.json.stringify(target_route.provider, .{}, writer);
+    try writer.writeAll(",\"account\":");
+    try std.json.stringify(target_route.account, .{}, writer);
+    try writer.writeAll(",\"capability\":");
+    if (target_route.capability) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"health_key\":");
+    if (target_route.capability) |route_capability| {
+        const key = health_mod.capabilityKey(target_route.provider, target_route.account, route_capability);
+        try std.json.stringify(key.slice(), .{}, writer);
+    } else {
+        const key = health_mod.accountKey(target_route.provider, target_route.account);
+        try std.json.stringify(key.slice(), .{}, writer);
+    }
+    try writer.print(",\"http_status\":429,\"retry_after_s\":{d}", .{codex_fallback_drill_retry_after_s});
+    try writer.writeAll(",\"classification\":\"quota_exhausted\",\"decision\":\"try_next_account\",\"previously_selected\":");
+    try writer.writeAll(if (target_was_selected_before) "true" else "false");
+    try writer.writeByte('}');
+    try writer.writeAll(",\"previous_selected\":");
+    if (previous_selected_index) |idx| try writeRouteSelectionJson(writer, before[idx].route) else try writer.writeAll("null");
+    try writer.writeAll(",\"selected\":");
+    if (selected_index) |idx| try writeRouteSelectionJson(writer, after[idx].route) else try writer.writeAll("null");
+    try writer.writeAll(",\"fallback_route_is_distinct\":");
+    try writer.writeAll(if (fallback_route_is_distinct) "true" else "false");
+    try writer.print(",\"summary\":{{\"routes_total\":{d},\"broker_ready_routes\":{d},\"unreadable_routes\":{d},\"selectable_routes\":{d},\"selectable_broker_routes\":{d},\"selectable_fallback_routes\":{d},\"blocked_broker_routes\":{d},\"auth_unready_routes\":{d}}}", .{
+        summary.routes_total,
+        summary.broker_ready_routes,
+        summary.unreadable_routes,
+        summary.selectable_routes,
+        summary.selectable_broker_routes,
+        summary.selectable_fallback_routes,
+        summary.blocked_broker_routes,
+        summary.auth_unready_routes,
+    });
+    try writer.writeAll(",\"routes\":[");
+    for (after, 0..) |evaluation, idx| {
+        if (idx > 0) try writer.writeByte(',');
+        const selected = if (selected_index) |selected_idx| idx == selected_idx else false;
+        const plan = try inspectCodexBrokerRoute(allocator, cfg, evaluation.route);
+        try writeCodexBrokerSessionRouteJson(writer, allocator, cfg, evaluation, selected, plan);
+    }
+    try writer.writeAll("],\"redaction\":{\"tokens_printed\":false,\"account_id_printed\":false,\"raw_protocol_printed\":false}");
+    try writer.writeAll("}\n");
+}
+
+fn writeCodexBrokerFallbackDrillText(
+    writer: anytype,
+    target_route: RepairPlanRoute,
+    before: []const RouteEvaluation,
+    after: []const RouteEvaluation,
+    previous_selected_index: ?usize,
+    selected_index: ?usize,
+    capability: []const u8,
+    ok: bool,
+    reason: []const u8,
+    target_was_selected_before: bool,
+    fallback_route_is_distinct: bool,
+) !void {
+    try writer.writeAll("oauth-mux Codex broker fallback drill\n\n");
+    try writer.print("  capability: {s}\n", .{capability});
+    try writer.print("  drilled: {s}:{s}", .{ target_route.provider, target_route.account });
+    if (target_route.capability) |value| try writer.print("#{s}", .{value});
+    try writer.print(" -> quota_exhausted retry_after_s={d}\n", .{codex_fallback_drill_retry_after_s});
+    try writer.writeAll("  previous selected: ");
+    if (previous_selected_index) |idx| {
+        const route = before[idx].route;
+        try writer.print("{s}:{s}", .{ route.provider, route.account });
+        if (route.capability) |value| try writer.print("#{s}", .{value});
+        try writer.writeByte('\n');
+    } else {
+        try writer.writeAll("none\n");
+    }
+    try writer.writeAll("  selected after drill: ");
+    if (selected_index) |idx| {
+        const route = after[idx].route;
+        try writer.print("{s}:{s}", .{ route.provider, route.account });
+        if (route.capability) |value| try writer.print("#{s}", .{value});
+        try writer.writeByte('\n');
+    } else {
+        try writer.writeAll("none\n");
+    }
+    try writer.print("  previously_selected={s} distinct_fallback={s}\n", .{
+        if (target_was_selected_before) "true" else "false",
+        if (fallback_route_is_distinct) "true" else "false",
+    });
+    try writer.print("  ok: {s}\n", .{if (ok) "true" else "false"});
+    try writer.print("  reason: {s}\n", .{reason});
+    try writer.writeAll("  boundary: controlled route-health mutation; provider-originated quota is not proven by this drill\n");
+}
 
 fn firstSelectableCodexBrokerRouteIndex(
     allocator: std.mem.Allocator,


### PR DESCRIPTION
## Summary

Adds `oauth-mux codex broker-fallback-drill` as an explicit no-spend operator drill for observing Codex route-state fallback.

The command:

- requires `--confirm-drill`
- records the named Codex route as local `quota_exhausted` route health with a 429 / retry-after signal
- re-runs broker-owned session route selection
- reports whether selection moved from the drilled route to a distinct fallback
- emits claim/redaction metadata without printing tokens, account IDs, prompts, assistant output, or raw protocol

Docs now describe this as controlled route-state evidence, not provider-originated quota exhaustion or same-thread recovery.

## Why

We now have four Codex subscriptions in different states and needed a boring way to observe fallback intentionally without waiting for the active account to exhaust in real time. This gives TIN-916/TIN-917 a safe drill path: prove the route-state handoff to the next broker-owned route, then use `broker-run` separately when live provider spend is intended.

## Validation

Local checks:

- `zig build test`
- `./scripts/e2e-local.sh`
- `just check-local`

Live controlled observation after max-4 enrollment:

- pre-drill `codex broker-session-plan --profile codex-max --capability codex-max --json` selected `max-3` with `max-4` as selectable fallback
- `codex broker-fallback-drill --profile codex-max --capability codex-max --from-account max-3 --confirm-drill --json` returned `ok:true`, `previous_selected:max-3`, `selected:max-4`, `provider_originated_quota:false`, `next_turn_route_state_fallback:true`
- post-drill `broker-session-plan`, `route explain`, and `stay-afloat --once` selected `max-4`
- spend-gated `codex broker-run --profile codex-max --capability codex-max --prompt ... --confirm-spend --json` completed one live broker-owned turn on `max-4`

Boundary: this PR does not claim same-turn recovery, same-thread quota recovery, unmanaged TUI hot-swap, or provider-originated quota exhaustion from the drill.

Refs #131
Refs #133
