### PR TITLE
[codex] Add exhausted route revalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-plan --pr
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-session-smoke --profile codex-max --capability codex-max --confirm-broker --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-run --profile codex-max --capability codex-max --prompt 'Reply with oauth-mux broker-run ok.' --confirm-spend --json
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex revalidate-exhausted --profile codex-max --capability codex-max --confirm-spend --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-fallback-drill --profile codex-max --capability codex-max --from-account max-3 --confirm-drill --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-smoke --profile codex-max --capability codex-max --confirm-broker --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-refresh-smoke --profile codex-max --capability codex-max --confirm-broker --json
@@ -156,6 +157,12 @@ For a bounded beta session loop, pipe line-delimited prompts to `codex
 broker-run --stdin --confirm-spend --json`; the command keeps one broker-owned
 app-server session open and reports prompt/turn counts without printing
 transcript content.
+`codex revalidate-exhausted --confirm-spend --json` is the spend-gated
+post-billing-change check. It finds recorded exhausted Codex routes for the
+selected profile/capability, bypasses only those local health blocks, runs fresh
+provider probes, and records the new evidence. Use it after credits, plan, or
+billing state changes; it removes the need to hand-reset route health, but still
+does not claim same-turn or same-thread quota recovery.
 `codex broker-fallback-drill --from-account ... --confirm-drill --json` is the
 controlled no-spend way to observe route-state fallback. It records the named
 Codex route as quota-exhausted in local oauth-mux health, then verifies the next
@@ -307,6 +314,7 @@ oauth-mux codex broker-plan --profile codex-max --capability codex-max --json
 oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json
 oauth-mux codex broker-session-smoke --profile codex-max --capability codex-max --confirm-broker --json
 oauth-mux codex broker-run --profile codex-max --capability codex-max --prompt 'Reply with oauth-mux broker-run ok.' --confirm-spend --json
+oauth-mux codex revalidate-exhausted --profile codex-max --capability codex-max --confirm-spend --json
 oauth-mux codex broker-fallback-drill --profile codex-max --capability codex-max --from-account max-3 --confirm-drill --json
 oauth-mux codex broker-smoke --profile codex-max --capability codex-max --confirm-broker --json
 oauth-mux codex broker-refresh-smoke --profile codex-max --capability codex-max --confirm-broker --json

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -174,6 +174,15 @@ For a bounded beta multi-turn session, pass `--stdin` instead of `--prompt` and
 pipe one prompt per line. The session stays broker-owned and redacted; the
 output reports prompt counts and completed turns, not transcript content.
 
+`oauth-mux codex revalidate-exhausted --profile codex-max --capability
+codex-max --confirm-spend --json` is the operator-safe post-billing-change
+refresh. It targets Codex routes already recorded as quota-exhausted or
+rate-limited, bypasses only those local route-health blocks, spends confirmed
+provider probes, and persists the fresh provider evidence. Use it after credits
+or plan changes instead of manually resetting health keys. It may make a route
+selectable again, or it may confirm that the provider still rejects that exact
+capability.
+
 `oauth-mux codex broker-fallback-drill --profile codex-max --capability
 codex-max --from-account max-3 --confirm-drill --json` is the controlled
 operator drill for observing fallback without waiting for a provider-originated

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -247,6 +247,13 @@ For a bounded beta broker-owned session loop, pipe line-delimited prompts and
 replace `--prompt ...` with `--stdin`. The same spend gate applies, and
 transcript content remains suppressed in normal output.
 Use
+`oauth-mux codex revalidate-exhausted --profile codex-max --capability
+codex-max --confirm-spend --json` after credits, plan, or billing changes. It
+re-probes only routes already recorded as exhausted or rate-limited for that
+capability, updates route health from provider evidence, and avoids hand-resetting
+health keys. If the provider still returns quota exhaustion, the route remains
+blocked even if dashboard copy suggests credits are available elsewhere.
+Use
 `oauth-mux codex broker-fallback-drill --profile codex-max --capability
 codex-max --from-account max-3 --confirm-drill --json` when you need to observe
 fallback deliberately. It records the named route as quota-exhausted in local

--- a/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
+++ b/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
@@ -323,6 +323,11 @@ For quota-driven account changes, use a different action name, such as
   its bounded `--stdin` beta can exercise multiple turns in one broker-owned
   app-server session. It still does not prove fallback recovery or unmanaged
   TUI hot-swap, and it reports counts without printing transcript content.
+- Exhausted route revalidation is spend-gated. It exists for external billing,
+  plan, or credit changes: bypass only recorded exhausted route-health blocks,
+  re-probe the provider, and persist the fresh capability evidence. It removes
+  the manual health-reset step, but it does not imply dashboard credits make a
+  route available for every Codex capability.
 - The broker fallback drill is no-spend but mutates local route health. It can
   observe next-route fallback after a controlled quota-exhausted mark, while
   explicitly not claiming provider-originated quota exhaustion.

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -256,6 +256,10 @@ these precise provider-proof children.
    live one-turn broker-owned session proof and remains spend-gated. Its
    bounded `--stdin` beta keeps one broker-owned app-server session open across
    line-delimited live turns while still suppressing transcript content.
+   `oauth-mux codex revalidate-exhausted --confirm-spend` is the spend-gated
+   hygiene path after billing or credit changes: it re-probes only routes
+   already blocked by recorded quota/rate evidence and persists the new provider
+   result, instead of requiring a manual health reset.
    `oauth-mux codex broker-fallback-drill --from-account ...
    --confirm-drill` is the controlled operator drill for fallback observation:
    it marks a route quota-exhausted in local route health and verifies the next

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -811,6 +811,38 @@ expect_not_contains "$broker_session_plan" "$broker_jwt" "broker-session-plan do
 expect_not_contains "$broker_session_plan" 'broker-session-refresh-token' "broker-session-plan does not expose refresh token value"
 expect_not_contains "$broker_session_plan" 'broker-session-spare-token' "broker-session-plan does not expose spare refresh token value"
 
+printf 'e2e: codex revalidate-exhausted requires spend confirmation before mutating route health\n'
+broker_revalidate_prompt="$(OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex revalidate-exhausted --profile codex-max --capability codex-max --account max-1 --json 2>/dev/null || true)"
+expect_contains "$broker_revalidate_prompt" '"mode":"codex_exhausted_route_revalidation"' "revalidate-exhausted reports mode"
+expect_contains "$broker_revalidate_prompt" '"confirmation_required":true' "revalidate-exhausted requires confirmation"
+expect_contains "$broker_revalidate_prompt" '"spends_provider_calls":true' "revalidate-exhausted reports provider spend"
+expect_contains "$broker_revalidate_prompt" '"mutates_route_health":true' "revalidate-exhausted reports route-health mutation"
+
+printf 'e2e: codex revalidate-exhausted re-probes an exhausted route without manual health reset\n'
+broker_revalidate_state="$tmp/broker-revalidate-state"
+mkdir -p "$broker_revalidate_state"
+cp "$broker_session_state/health.json" "$broker_revalidate_state/health.json"
+broker_revalidate="$(PATH="$broker_session_bin:$PATH" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_revalidate_state" "$bin" codex revalidate-exhausted --profile codex-max --capability codex-max --account max-1 --confirm-spend --json)"
+expect_contains "$broker_revalidate" '"mode":"codex_exhausted_route_revalidation"' "revalidate-exhausted reports mode after confirmation"
+expect_contains "$broker_revalidate" '"ok":true' "revalidate-exhausted succeeds with provider evidence"
+expect_contains "$broker_revalidate" '"proof_status":"spend_gated_exhausted_route_revalidation"' "revalidate-exhausted scopes proof status"
+expect_contains "$broker_revalidate" '"provider_originated_evidence":true' "revalidate-exhausted records provider-originated evidence"
+expect_contains "$broker_revalidate" '"manual_health_reset_required":false' "revalidate-exhausted avoids manual reset requirement"
+expect_contains "$broker_revalidate" '"next_turn_route_selection_refreshed":true' "revalidate-exhausted reports route selection refresh"
+expect_contains "$broker_revalidate" '"next_turn_route_state_fallback":false' "revalidate-exhausted does not overclaim fallback proof"
+expect_contains "$broker_revalidate" '"routes_probed":1' "revalidate-exhausted probes one targeted route"
+expect_contains "$broker_revalidate" '"routes_available_after":1' "revalidate-exhausted records available route after probe"
+expect_contains "$broker_revalidate" '"previous_selected":{"provider":"codex","account":"max-2","capability":"codex-max"' "revalidate-exhausted records previous selection"
+expect_contains "$broker_revalidate" '"selected":{"provider":"codex","account":"max-1","capability":"codex-max"' "revalidate-exhausted selects newly available route"
+expect_contains "$broker_revalidate" '"health_key":"codex:max-1#codex-max"' "revalidate-exhausted reports health key"
+expect_contains "$broker_revalidate" '"availability":"available"' "revalidate-exhausted stores availability"
+expect_contains "$broker_revalidate" '"tokens_printed":false' "revalidate-exhausted redaction reports token suppression"
+expect_not_contains "$broker_revalidate" 'acct-session-fallback' "revalidate-exhausted does not expose fallback account id value"
+expect_not_contains "$broker_revalidate" 'acct-session-spare' "revalidate-exhausted does not expose spare account id value"
+expect_not_contains "$broker_revalidate" "$broker_jwt" "revalidate-exhausted does not expose token value"
+expect_not_contains "$broker_revalidate" 'broker-session-refresh-token' "revalidate-exhausted does not expose refresh token value"
+expect_not_contains "$broker_revalidate" 'broker-session-spare-token' "revalidate-exhausted does not expose spare refresh token value"
+
 printf 'e2e: codex broker-fallback-drill requires explicit confirmation before mutating route health\n'
 broker_fallback_drill_prompt="$(OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex broker-fallback-drill --profile codex-max --capability codex-max --from-account max-2 --json)"
 expect_contains "$broker_fallback_drill_prompt" '"mode":"codex_broker_fallback_drill"' "broker-fallback-drill reports drill mode"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -179,6 +179,7 @@ pub const Command = union(enum) {
         onboard,
         canary,
         live_qa,
+        revalidate_exhausted,
         probe_all,
         config_candidate,
         config_merge,
@@ -887,6 +888,8 @@ fn parseCodex(args: []const []const u8) Command {
             result.action = .canary;
         } else if (eql(args[0], "live-qa")) {
             result.action = .live_qa;
+        } else if (eql(args[0], "revalidate-exhausted")) {
+            result.action = .revalidate_exhausted;
         } else if (eql(args[0], "probe-all")) {
             result.action = .probe_all;
         } else if (eql(args[0], "config-candidate")) {
@@ -1102,6 +1105,9 @@ pub fn printUsage(writer: anytype) !void {
         \\  codex live-qa [--accounts a,b,c] [--capabilities c1,c2] [--confirm-spend] [--json]
         \\      Run confirmed Codex route probes and record route evidence.
         \\
+        \\  codex revalidate-exhausted [--profile name] [--capability c] [--account a] --confirm-spend [--json]
+        \\      Re-probe exhausted Codex routes after external billing or credit changes.
+        \\
         \\  codex probe-all [--accounts a,b,c] [--capabilities c1,c2] [--json]
         \\      Probe every selected Codex account/capability route.
         \\
@@ -1169,6 +1175,7 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\  oauth-mux codex setup|onboard [--accounts a,b,c] [--device|--status-only] [--live]
         \\  oauth-mux codex canary [--accounts a,b,c] [--capabilities c1,c2] [--live]
         \\  oauth-mux codex live-qa [--accounts a,b,c] [--capabilities c1,c2] [--confirm-spend] [--json]
+        \\  oauth-mux codex revalidate-exhausted [--profile name] [--capability c] [--account a] --confirm-spend [--json]
         \\  oauth-mux codex probe-all [--accounts a,b,c] [--capability c] [--json]
         \\  oauth-mux codex broker-plan [--profile name] [--capability c] [--json]
         \\  oauth-mux codex broker-session-plan [--profile name] [--capability c] [--json]
@@ -1189,7 +1196,7 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\
         \\Safety:
         \\  canary is no-spend unless --live is provided.
-        \\  live-qa, probe-all, and canary --live run real provider probes.
+        \\  live-qa, revalidate-exhausted, probe-all, and canary --live run real provider probes.
         \\  broker-smoke, broker-refresh-smoke, broker-401-smoke,
         \\  broker-quota-smoke, broker-session-smoke, and broker-run read a
         \\  selected Codex route secret and send it only to a broker-owned
@@ -1197,7 +1204,7 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\  account-id values.
         \\  broker-fallback-drill mutates only oauth-mux route health; it does
         \\  not spend provider calls or print secrets.
-        \\  live-qa and broker-run require --confirm-spend or
+        \\  live-qa, revalidate-exhausted, and broker-run require --confirm-spend or
         \\  OMUX_LIVE_QA_CONFIRM=spend-real-calls.
         \\  --help and -h are non-mutating for every Codex subcommand.
         \\
@@ -1341,6 +1348,22 @@ test "parse codex live qa confirmation" {
             try std.testing.expect(codex.action == .live_qa);
             try std.testing.expectEqualStrings("max-1,max-3", codex.accounts);
             try std.testing.expectEqualStrings("codex-mini", codex.capabilities);
+            try std.testing.expect(codex.confirm_spend);
+            try std.testing.expect(codex.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse codex revalidate exhausted" {
+    const args = [_][]const u8{ "codex", "revalidate-exhausted", "--profile", "codex-max", "--capability", "codex-max", "--account", "max-3", "--confirm-spend", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex => |codex| {
+            try std.testing.expect(codex.action == .revalidate_exhausted);
+            try std.testing.expectEqualStrings("codex-max", codex.profile.?);
+            try std.testing.expectEqualStrings("codex-max", codex.capabilities);
+            try std.testing.expectEqualStrings("max-3", codex.account.?);
             try std.testing.expect(codex.confirm_spend);
             try std.testing.expect(codex.json);
         },
@@ -2023,7 +2046,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary live-qa probe-all broker-plan broker-session-plan broker-session-smoke broker-run broker-fallback-drill broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary live-qa revalidate-exhausted probe-all broker-plan broker-session-plan broker-session-smoke broker-run broker-fallback-drill broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run supervise start stop status events handoffs tick' -d 'Daemon subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l stay-afloat -d 'Host beta supervised stay-afloat loop'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l json -d 'JSON output'

--- a/src/main.zig
+++ b/src/main.zig
@@ -7513,6 +7513,7 @@ fn runCodex(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Cod
         .onboard => try runCodexOnboard(allocator, writer, args, root),
         .canary => try runCodexCanary(allocator, writer, args, root),
         .live_qa => try runCodexLiveQa(allocator, writer, args, root),
+        .revalidate_exhausted => try runCodexRevalidateExhausted(allocator, writer, args),
         .probe_all => try runCodexProbeAll(allocator, writer, args),
         .config_candidate => try runCodexConfigCandidate(allocator, writer, args, root),
         .config_merge => try runCodexConfigMerge(allocator, writer, args),
@@ -7622,6 +7623,352 @@ fn runCodexProbeAll(allocator: std.mem.Allocator, writer: anytype, args: cli.Com
         try writer.writeAll("\n=== live probes ===\n");
     }
     try runCodexLiveProbes(allocator, writer, args, !args.json);
+}
+
+const CodexRevalidateExhaustedSummary = struct {
+    routes_total: usize = 0,
+    candidates: usize = 0,
+    routes_probed: usize = 0,
+    provider_evidence_routes: usize = 0,
+    routes_available_after: usize = 0,
+    routes_blocked_after: usize = 0,
+    probe_errors: usize = 0,
+};
+
+fn runCodexRevalidateExhausted(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    args: cli.Command.CodexArgs,
+) !void {
+    if (!codexLiveQaConfirmed(args)) {
+        if (args.json) {
+            try writer.writeAll("{\"ok\":false,\"error\":\"confirmation_required\",\"confirmation_required\":true,\"requires\":\"--confirm-spend or OMUX_LIVE_QA_CONFIRM=spend-real-calls\",\"spends_provider_calls\":true,\"mutates_user_config\":false,\"mutates_route_health\":true,\"mode\":\"codex_exhausted_route_revalidation\",\"next_commands\":[");
+            try writeCommandJson(writer, "oauth-mux codex revalidate-exhausted --profile <profile> --capability <capability> --confirm-spend --json");
+            try writer.writeAll("]}\n");
+        } else {
+            try writer.writeAll("oauth-mux Codex exhausted route revalidation is disabled.\n\n");
+            try writer.writeAll("This command re-probes exhausted Codex routes and can spend subscription quota.\n");
+            try writer.writeAll("Re-run with --confirm-spend or OMUX_LIVE_QA_CONFIRM=spend-real-calls.\n");
+        }
+        return error.CodexLiveQaConfirmationRequired;
+    }
+
+    const capability = firstCommaValue(args.capabilities) orelse {
+        if (args.json) {
+            try writer.writeAll("{\"ok\":false,\"error\":\"capability_required\",\"requires\":\"--capability <capability>\",\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mutates_route_health\":false,\"mode\":\"codex_exhausted_route_revalidation\"}\n");
+        } else {
+            try writer.writeAll("oauth-mux Codex exhausted route revalidation\n\n");
+            try writer.writeAll("  capability required: --capability <capability>\n");
+        }
+        return;
+    };
+
+    const parsed = try config.load(allocator);
+    defer parsed.deinit();
+
+    var validation_messages = std.ArrayList(u8).init(allocator);
+    defer validation_messages.deinit();
+    try config.validate(parsed.value, validation_messages.writer());
+
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+
+    var routes = try collectRepairPlanRoutes(allocator, parsed.value, .{
+        .profile = args.profile,
+        .provider = if (args.profile == null) "codex" else null,
+        .account = if (args.profile == null) args.account else null,
+        .capability = capability,
+        .json = args.json,
+    });
+    defer routes.deinit();
+
+    var before = std.ArrayList(RouteEvaluation).init(allocator);
+    defer before.deinit();
+    try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &before);
+
+    const before_selected_index = try firstSelectableCodexBrokerRouteIndex(allocator, parsed.value, before.items);
+
+    var summary = CodexRevalidateExhaustedSummary{
+        .routes_total = before.items.len,
+    };
+
+    var route_results = std.ArrayList(u8).init(allocator);
+    defer route_results.deinit();
+    var first_result = true;
+
+    for (before.items) |evaluation| {
+        if (!isCodexExhaustedRevalidationCandidate(evaluation, capability, args.account)) continue;
+        summary.candidates += 1;
+        summary.routes_probed += 1;
+
+        const route = evaluation.route;
+        const key = repairPlanRouteHealthKey(route);
+        const previous_health = takeHealthEntry(&store, key.slice());
+        var restored_previous = false;
+
+        var ctx = pipeline.Context.init(allocator, parsed.value, &store);
+        defer ctx.deinit();
+        ctx.provider_name = route.provider;
+        ctx.account_name = route.account;
+        ctx.capability_name = route.capability;
+
+        const probe_result = pipeline.runProbe(&ctx);
+        var probe_error: ?types.PipelineError = null;
+        if (probe_result) |_| {} else |e| {
+            probe_error = e;
+        }
+
+        const recorded_provider_evidence = probe_error == null or liveQaErrorIsRecordedEvidence(probe_error.?);
+        if (!recorded_provider_evidence) {
+            summary.probe_errors += 1;
+            if (store.accounts.get(key.slice()) == null) {
+                if (previous_health) |health| {
+                    try putHealthEntryCopy(&store, key.slice(), health);
+                    restored_previous = true;
+                }
+            }
+        } else {
+            summary.provider_evidence_routes += 1;
+        }
+
+        const after_health = store.accounts.get(key.slice());
+        if (after_health) |health| {
+            if (livenessIsAvailable(health.liveness)) {
+                summary.routes_available_after += 1;
+            } else if (accountLivenessBlocksRoute(health.liveness)) {
+                summary.routes_blocked_after += 1;
+            }
+        }
+
+        var probe_json = std.ArrayList(u8).init(allocator);
+        defer probe_json.deinit();
+        try writeProbeJson(probe_json.writer(), allocator, &store, &ctx, probe_error);
+
+        if (!first_result) try route_results.append(',');
+        first_result = false;
+        try writeCodexRevalidateRouteJson(
+            route_results.writer(),
+            route,
+            key.slice(),
+            previous_health,
+            after_health,
+            probe_json.items,
+            probe_error,
+            recorded_provider_evidence,
+            restored_previous,
+        );
+    }
+
+    store.persist();
+
+    var after = std.ArrayList(RouteEvaluation).init(allocator);
+    defer after.deinit();
+    try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &after);
+
+    const selected_index = try firstSelectableCodexBrokerRouteIndex(allocator, parsed.value, after.items);
+    const ok = summary.candidates > 0 and summary.probe_errors == 0;
+    const reason = if (summary.candidates == 0)
+        "no_exhausted_routes_to_revalidate"
+    else if (summary.probe_errors != 0)
+        "revalidation_probe_errors"
+    else if (summary.routes_available_after != 0)
+        "revalidation_found_available_route"
+    else
+        "provider_evidence_still_blocked";
+
+    if (args.json) {
+        try writeCodexRevalidateExhaustedJson(
+            writer,
+            allocator,
+            parsed.value,
+            before.items,
+            after.items,
+            before_selected_index,
+            selected_index,
+            args.profile,
+            capability,
+            summary,
+            ok,
+            reason,
+            route_results.items,
+        );
+    } else {
+        try writeCodexRevalidateExhaustedText(writer, before.items, after.items, before_selected_index, selected_index, capability, summary, ok, reason);
+    }
+}
+
+fn isCodexExhaustedRevalidationCandidate(
+    evaluation: RouteEvaluation,
+    capability: []const u8,
+    account_filter: ?[]const u8,
+) bool {
+    if (!std.mem.eql(u8, evaluation.route.provider, "codex")) return false;
+    if (!evaluation.runtime.isReady()) return false;
+    if (account_filter) |account| {
+        if (!std.mem.eql(u8, evaluation.route.account, account)) return false;
+    }
+    const route_capability = evaluation.route.capability orelse return false;
+    if (!std.mem.eql(u8, route_capability, capability)) return false;
+    return std.mem.eql(u8, evaluation.skip_reason, "quota_exhausted") or
+        std.mem.eql(u8, evaluation.skip_reason, "rate_limited");
+}
+
+fn repairPlanRouteHealthKey(route: RepairPlanRoute) health_mod.KeyBuf {
+    if (route.capability) |capability| {
+        return health_mod.capabilityKey(route.provider, route.account, capability);
+    }
+    return health_mod.accountKey(route.provider, route.account);
+}
+
+fn takeHealthEntry(store: *health_mod.HealthStore, key: []const u8) ?health_mod.AccountHealth {
+    if (store.accounts.fetchRemove(key)) |kv| {
+        defer store.allocator.free(kv.key);
+        return kv.value;
+    }
+    return null;
+}
+
+fn putHealthEntryCopy(store: *health_mod.HealthStore, key: []const u8, health: health_mod.AccountHealth) !void {
+    const result = try store.accounts.getOrPut(key);
+    if (!result.found_existing) {
+        result.key_ptr.* = try store.allocator.dupe(u8, key);
+    }
+    result.value_ptr.* = health;
+}
+
+fn writeCodexRevalidateRouteJson(
+    writer: anytype,
+    route: RepairPlanRoute,
+    health_key: []const u8,
+    before_health: ?health_mod.AccountHealth,
+    after_health: ?health_mod.AccountHealth,
+    probe_json: []const u8,
+    probe_error: ?types.PipelineError,
+    provider_evidence_recorded: bool,
+    restored_previous: bool,
+) !void {
+    try writer.writeByte('{');
+    try writer.writeAll("\"provider\":");
+    try std.json.stringify(route.provider, .{}, writer);
+    try writer.writeAll(",\"account\":");
+    try std.json.stringify(route.account, .{}, writer);
+    try writer.writeAll(",\"capability\":");
+    if (route.capability) |capability| try std.json.stringify(capability, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"health_key\":");
+    try std.json.stringify(health_key, .{}, writer);
+    try writer.writeAll(",\"before_liveness\":");
+    if (before_health) |health| try writeLivenessJson(writer, health.liveness) else try writer.writeAll("null");
+    try writer.writeAll(",\"after_liveness\":");
+    if (after_health) |health| try writeLivenessJson(writer, health.liveness) else try writer.writeAll("null");
+    try writer.writeAll(",\"after_probe\":");
+    if (after_health) |health| try writeProbeEvidenceJson(writer, health) else try writer.writeAll("null");
+    try writer.writeAll(",\"provider_evidence_recorded\":");
+    try writer.writeAll(if (provider_evidence_recorded) "true" else "false");
+    try writer.writeAll(",\"restored_previous_health\":");
+    try writer.writeAll(if (restored_previous) "true" else "false");
+    try writer.writeAll(",\"probe_error\":");
+    if (probe_error) |err| try std.json.stringify(@errorName(err), .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"probe\":");
+    const trimmed_probe_json = std.mem.trim(u8, probe_json, " \t\r\n");
+    if (trimmed_probe_json.len == 0) try writer.writeAll("null") else try writer.writeAll(trimmed_probe_json);
+    try writer.writeByte('}');
+}
+
+fn writeCodexRevalidateExhaustedJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    before: []const RouteEvaluation,
+    after: []const RouteEvaluation,
+    before_selected_index: ?usize,
+    selected_index: ?usize,
+    profile: ?[]const u8,
+    capability: []const u8,
+    summary: CodexRevalidateExhaustedSummary,
+    ok: bool,
+    reason: []const u8,
+    route_results: []const u8,
+) !void {
+    const session_summary = try summarizeCodexBrokerSessionPlan(allocator, cfg, after, selected_index);
+    try writer.writeAll("{\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"mode\":\"codex_exhausted_route_revalidation\",\"ok\":");
+    try writer.writeAll(if (ok) "true" else "false");
+    try writer.writeAll(",\"confirmed\":true,\"spends_provider_calls\":true,\"mutates_user_config\":false,\"mutates_route_health\":true");
+    try writer.writeAll(",\"reason\":");
+    try std.json.stringify(reason, .{}, writer);
+    try writer.writeAll(",\"claim\":{\"claim_version\":1,\"level\":\"route_health_revalidation\",\"proof_status\":\"spend_gated_exhausted_route_revalidation\",\"provider_originated_evidence\":");
+    try writer.writeAll(if (summary.provider_evidence_routes > 0) "true" else "false");
+    try writer.writeAll(",\"manual_health_reset_required\":false,\"next_turn_route_selection_refreshed\":");
+    try writer.writeAll(if (selected_index != null) "true" else "false");
+    try writer.writeAll(",\"next_turn_route_state_fallback\":false,\"same_turn_quota_recovery\":false,\"same_thread_quota_recovery\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
+    try writer.writeAll(",\"profile\":");
+    if (profile) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"capability\":");
+    try std.json.stringify(capability, .{}, writer);
+    try writer.writeAll(",\"previous_selected\":");
+    if (before_selected_index) |idx| try writeRouteSelectionJson(writer, before[idx].route) else try writer.writeAll("null");
+    try writer.writeAll(",\"selected\":");
+    if (selected_index) |idx| try writeRouteSelectionJson(writer, after[idx].route) else try writer.writeAll("null");
+    try writer.print(",\"summary\":{{\"routes_total\":{d},\"candidates\":{d},\"routes_probed\":{d},\"provider_evidence_routes\":{d},\"routes_available_after\":{d},\"routes_blocked_after\":{d},\"probe_errors\":{d},\"broker_ready_routes\":{d},\"selectable_broker_routes\":{d},\"selectable_fallback_routes\":{d},\"blocked_broker_routes\":{d}}}", .{
+        summary.routes_total,
+        summary.candidates,
+        summary.routes_probed,
+        summary.provider_evidence_routes,
+        summary.routes_available_after,
+        summary.routes_blocked_after,
+        summary.probe_errors,
+        session_summary.broker_ready_routes,
+        session_summary.selectable_broker_routes,
+        session_summary.selectable_fallback_routes,
+        session_summary.blocked_broker_routes,
+    });
+    try writer.writeAll(",\"revalidated_routes\":[");
+    try writer.writeAll(route_results);
+    try writer.writeAll("],\"redaction\":{\"tokens_printed\":false,\"account_id_printed\":false,\"raw_protocol_printed\":false}");
+    try writer.writeAll("}\n");
+}
+
+fn writeCodexRevalidateExhaustedText(
+    writer: anytype,
+    before: []const RouteEvaluation,
+    after: []const RouteEvaluation,
+    before_selected_index: ?usize,
+    selected_index: ?usize,
+    capability: []const u8,
+    summary: CodexRevalidateExhaustedSummary,
+    ok: bool,
+    reason: []const u8,
+) !void {
+    try writer.writeAll("oauth-mux Codex exhausted route revalidation\n\n");
+    try writer.print("  capability: {s}\n", .{capability});
+    try writer.print("  candidates: {d}\n", .{summary.candidates});
+    try writer.print("  probed: {d}\n", .{summary.routes_probed});
+    try writer.print("  provider evidence: {d}\n", .{summary.provider_evidence_routes});
+    try writer.print("  available after: {d}\n", .{summary.routes_available_after});
+    try writer.print("  blocked after: {d}\n", .{summary.routes_blocked_after});
+    try writer.print("  probe errors: {d}\n", .{summary.probe_errors});
+    try writer.writeAll("  previous selected: ");
+    if (before_selected_index) |idx| {
+        const route = before[idx].route;
+        try writer.print("{s}:{s}", .{ route.provider, route.account });
+        if (route.capability) |value| try writer.print("#{s}", .{value});
+        try writer.writeByte('\n');
+    } else {
+        try writer.writeAll("none\n");
+    }
+    try writer.writeAll("  selected after: ");
+    if (selected_index) |idx| {
+        const route = after[idx].route;
+        try writer.print("{s}:{s}", .{ route.provider, route.account });
+        if (route.capability) |value| try writer.print("#{s}", .{value});
+        try writer.writeByte('\n');
+    } else {
+        try writer.writeAll("none\n");
+    }
+    try writer.print("  ok: {s}\n", .{if (ok) "true" else "false"});
+    try writer.print("  reason: {s}\n", .{reason});
+    try writer.writeAll("  boundary: spend-gated provider revalidation; same-turn and same-thread quota recovery remain unproven\n");
 }
 
 const CodexBrokerTokenPlan = struct {


### PR DESCRIPTION
## Summary

Adds `oauth-mux codex revalidate-exhausted` as the spend-gated hygiene path for Codex routes that are already recorded as quota-exhausted or rate-limited. The command bypasses only those local route-health blocks, performs confirmed provider probes, persists the fresh evidence, and reports the current selected broker route without requiring a manual health reset.

The claim boundary is intentionally narrow: this proves provider revalidation and route-selection refresh after external billing, credit, or plan changes. It does not claim provider-originated in-session fallback, same-turn recovery, same-thread quota recovery, unmanaged TUI hot-swap, or per-request muxing.

## Why

The current four-account Codex dogfood setup exposed a real operator problem: dashboard credits may be available for one Codex tier while `codex-max` still returns provider quota exhaustion for a specific account-scoped route. Operators need a first-class way to refresh that capability evidence after billing or credit changes instead of hand-resetting route health keys.

## Validation

- `just check-local`
- `git diff --check`
- `./zig-out/bin/oauth-mux codex revalidate-exhausted --profile codex-max --capability codex-max --account max-3 --confirm-spend --json`
- `./zig-out/bin/oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json`

Live revalidation result: targeted `max-3#codex-max` revalidation completed with provider-originated evidence and `reason:"provider_evidence_still_blocked"`; `max-4` remained the selected `codex-max` route. Output stayed redacted and did not print tokens, account IDs, raw JWTs, credential paths, prompt text, assistant output, or raw app-server protocol.

Refs #131, #133.
