### PR TITLE
Continue broker-run after route failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,10 @@ as route-health evidence and reports the next selected route.
 For a bounded beta session loop, pipe line-delimited prompts to `codex
 broker-run --stdin --confirm-spend --json`; the command keeps one broker-owned
 app-server session open and reports prompt/turn counts without printing
-transcript content.
+transcript content. Add `--continue-on-failure` to make a live quota/rate-limit
+failure start a fresh broker-owned session on the next selected route and replay
+the failed prompt plus remaining queued prompts. This is next-session
+continuation, not same-thread recovery.
 `codex revalidate-exhausted --confirm-spend --json` is the spend-gated
 post-billing-change check. It finds recorded exhausted Codex routes for the
 selected profile/capability, bypasses only those local health blocks, runs fresh

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -174,7 +174,11 @@ quota/rate-limit failure is recorded as route-health evidence and the output
 reports the next selected route.
 For a bounded beta multi-turn session, pass `--stdin` instead of `--prompt` and
 pipe one prompt per line. The session stays broker-owned and redacted; the
-output reports prompt counts and completed turns, not transcript content.
+output reports prompt counts and completed turns, not transcript content. Add
+`--continue-on-failure` to start a fresh broker-owned session on the next
+selected route after a live quota/rate-limit failure. The command replays the
+failed prompt plus remaining queued prompts and reports that this is
+next-session continuation, not same-thread recovery.
 
 `oauth-mux codex revalidate-exhausted --profile codex-max --capability
 codex-max --confirm-spend --json` is the operator-safe post-billing-change

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -247,7 +247,11 @@ limiting, oauth-mux records route-health evidence and shows the next selected
 route.
 For a bounded beta broker-owned session loop, pipe line-delimited prompts and
 replace `--prompt ...` with `--stdin`. The same spend gate applies, and
-transcript content remains suppressed in normal output.
+transcript content remains suppressed in normal output. Add
+`--continue-on-failure` to let oauth-mux record the failed route, rerun
+planning, and start a fresh broker-owned session on the selected fallback. This
+replays the failed prompt plus remaining queued prompts, but it is still
+next-session continuation rather than same-thread recovery.
 Use
 `oauth-mux codex revalidate-exhausted --profile codex-max --capability
 codex-max --confirm-spend --json` after credits, plan, or billing changes. It

--- a/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
+++ b/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
@@ -290,15 +290,21 @@ For quota-driven account changes, use a different action name, such as
    live Codex provider for one turn and emits redacted protocol evidence.
    A bounded beta loop form accepts line-delimited prompts via `--stdin` and
    keeps one broker-owned app-server session open across those turns.
-13. Add a controlled fallback observation drill:
+13. Add explicit next-session continuation:
+   `oauth-mux codex broker-run ... --continue-on-failure` records a live
+   quota/rate-limit failure, reruns broker-session planning, starts a fresh
+   broker-owned app-server session on the selected fallback route, and replays
+   the failed prompt plus remaining queued prompts. This is the honest
+   next-session stay-afloat path; it is not same-thread recovery.
+14. Add a controlled fallback observation drill:
    `oauth-mux codex broker-fallback-drill --profile codex-max --capability
    codex-max --from-account max-3 --confirm-drill --json` records the named
    route as quota-exhausted in local route health and verifies the next
    broker-owned route selection picks a distinct fallback. This is no-spend
    route-state evidence, not provider-originated quota evidence.
-14. Only after topology A is green, attempt topology B with a remote TUI and
+15. Only after topology A is green, attempt topology B with a remote TUI and
    sidecar broker.
-15. Update website and README claim language only after live dogfood passes.
+16. Update website and README claim language only after live dogfood passes.
 
 ## Acceptance Criteria
 
@@ -321,10 +327,13 @@ For quota-driven account changes, use a different action name, such as
   still does not prove same-thread quota recovery or unmanaged TUI hot-swap.
 - The broker live run is spend-gated. Its `--prompt` form proves one live turn;
   its bounded `--stdin` beta can exercise multiple turns in one broker-owned
-   app-server session. It still does not prove fallback recovery or unmanaged
-   TUI hot-swap, and it reports counts without printing transcript content.
-   Live quota/rate-limit failures from the app-server protocol are now recorded
-   as route-health evidence so the output can report the next selected route.
+  app-server session. It reports counts without printing transcript content.
+  Live quota/rate-limit failures from the app-server protocol are recorded as
+  route-health evidence so the output can report the next selected route.
+- `broker-run --continue-on-failure` can start a fresh broker-owned session on
+  that selected fallback and replay the failed prompt plus remaining queued
+  prompts. It still does not prove same-thread recovery or unmanaged TUI
+  hot-swap.
 - Exhausted route revalidation is spend-gated. It exists for external billing,
   plan, or credit changes: bypass only recorded exhausted route-health blocks,
   re-probe the provider, and persist the fresh capability evidence. It removes

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -257,7 +257,10 @@ these precise provider-proof children.
    bounded `--stdin` beta keeps one broker-owned app-server session open across
    line-delimited live turns while still suppressing transcript content. Live
    quota/rate-limit failures are persisted as route-health evidence and the
-   output reports the next selected route.
+   output reports the next selected route. With `--continue-on-failure`, the
+   command starts a fresh broker-owned session on that selected fallback and
+   replays the failed prompt plus remaining queued prompts. This is the honest
+   next-session stay-afloat path; it does not imply same-thread recovery.
    `oauth-mux codex revalidate-exhausted --confirm-spend` is the spend-gated
    hygiene path after billing or credit changes: it re-probes only routes
    already blocked by recorded quota/rate evidence and persists the new provider

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -953,6 +953,79 @@ if [ "$broker_run_quota_turns" != "1" ]; then
   exit 1
 fi
 
+printf 'e2e: codex broker-run can continue on the next selected route after live quota failure\n'
+mock_codex_app_server_continue="$tmp/mock-codex-app-server-continue"
+cat >"$mock_codex_app_server_continue" <<'EOF'
+#!/bin/sh
+launch_count=1
+if [ -n "${OMUX_E2E_LAUNCH_COUNT:-}" ] && [ -f "$OMUX_E2E_LAUNCH_COUNT" ]; then
+  launch_count="$(cat "$OMUX_E2E_LAUNCH_COUNT")"
+  launch_count=$((launch_count + 1))
+fi
+if [ -n "${OMUX_E2E_LAUNCH_COUNT:-}" ]; then
+  printf '%s\n' "$launch_count" > "$OMUX_E2E_LAUNCH_COUNT"
+fi
+turn_count=0
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"id":1,"result":{}}'
+      ;;
+    *'"method":"account/login/start"'*)
+      printf '%s\n' '{"id":2,"result":{"type":"chatgptAuthTokens"}}'
+      printf '%s\n' '{"method":"account/login/completed","params":{"success":true}}'
+      printf '%s\n' '{"method":"account/updated","params":{"authMode":"chatgptAuthTokens","planType":"pro"}}'
+      ;;
+    *'"method":"thread/start"'*)
+      printf '%s\n' '{"id":3,"result":{"thread":{"id":"thread-continue"}}}'
+      ;;
+    *'"method":"turn/start"'*)
+      if [ -n "${OMUX_E2E_TURN_LOG:-}" ]; then
+        printf '%s\n' "$launch_count:$line" >> "$OMUX_E2E_TURN_LOG"
+      fi
+      if [ "$launch_count" = "1" ]; then
+        printf '%s\n' '{"id":4,"result":{}}'
+        printf '%s\n' '{"method":"turn/completed","params":{"turn":{"id":"turn-quota","status":"failed","error":{"type":"usage_limit_reached","message":"The usage limit has been reached","resets_in_seconds":7200}}}}'
+      else
+        turn_count=$((turn_count + 1))
+        printf '%s\n' '{"id":4,"result":{}}'
+        printf '{"method":"turn/completed","params":{"turn":{"id":"turn-ok-%s","status":"completed"}}}\n' "$turn_count"
+      fi
+      ;;
+  esac
+done
+EOF
+chmod +x "$mock_codex_app_server_continue"
+broker_run_continue_state="$tmp/broker-run-continue-state"
+broker_run_continue_turn_log="$tmp/broker-run-continue-turns.log"
+broker_run_continue_launch_count="$tmp/broker-run-continue-launch-count"
+mkdir -p "$broker_run_continue_state"
+cp "$broker_session_health_before_drill" "$broker_run_continue_state/health.json"
+broker_run_continue="$(printf 'one\ntwo\n' | PATH="$broker_session_bin:$PATH" OMUX_E2E_LAUNCH_COUNT="$broker_run_continue_launch_count" OMUX_E2E_TURN_LOG="$broker_run_continue_turn_log" OMUX_CODEX_APP_SERVER="$mock_codex_app_server_continue" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_run_continue_state" "$bin" codex broker-run --profile codex-max --capability codex-max --stdin --continue-on-failure --confirm-spend --json)"
+expect_contains "$broker_run_continue" '"mode":"codex_broker_owned_session_live_run"' "broker-run continuation reports live mode"
+expect_contains "$broker_run_continue" '"ok":true' "broker-run continuation reports overall success"
+expect_contains "$broker_run_continue" '"reason":"live_session_continued_after_route_failure"' "broker-run continuation reports continuation reason"
+expect_contains "$broker_run_continue" '"proof_status":"live_broker_owned_next_session_continuation"' "broker-run continuation reports proof status"
+expect_contains "$broker_run_continue" '"next_session_continuation":true' "broker-run continuation claim is explicit"
+expect_contains "$broker_run_continue" '"health_key":"codex:max-2#codex-max"' "broker-run continuation records failed selected route"
+expect_contains "$broker_run_continue" '"selected":{"provider":"codex","account":"max-3","capability":"codex-max"' "broker-run continuation chooses fallback route"
+expect_contains "$broker_run_continue" '"continuation":{"requested":true,"attempted":true' "broker-run continuation reports attempted continuation"
+expect_contains "$broker_run_continue" '"mode":"new_broker_owned_session"' "broker-run continuation reports new session mode"
+expect_contains "$broker_run_continue" '"prompt_start_index":0' "broker-run continuation replays failed prompt"
+expect_contains "$broker_run_continue" '"prompt_count":2' "broker-run continuation sends pending prompts"
+expect_contains "$broker_run_continue" '"replays_failed_prompt":true' "broker-run continuation replay is explicit"
+expect_contains "$broker_run_continue" '"turns_completed":2' "broker-run continuation completes fallback turns"
+expect_not_contains "$broker_run_continue" 'acct-session-fallback' "broker-run continuation does not expose selected account id value"
+expect_not_contains "$broker_run_continue" 'acct-session-spare' "broker-run continuation does not expose fallback account id value"
+expect_not_contains "$broker_run_continue" "$broker_jwt" "broker-run continuation does not expose token value"
+broker_run_continue_turns="$(wc -l < "$broker_run_continue_turn_log" | tr -d ' ')"
+if [ "$broker_run_continue_turns" != "3" ]; then
+  printf 'e2e assertion failed: broker-run continuation should send one failed turn plus two fallback turns\n' >&2
+  printf 'turn starts observed: %s\n' "$broker_run_continue_turns" >&2
+  printf 'output was:\n%s\n' "$broker_run_continue" >&2
+  exit 1
+fi
+
 printf 'e2e: codex broker-smoke verifies app-server stdio login without leaking tokens\n'
 mock_codex_app_server="$tmp/mock-codex-app-server"
 cat >"$mock_codex_app_server" <<'EOF'

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -212,6 +212,7 @@ pub const Command = union(enum) {
         model: ?[]const u8 = null,
         from_account: ?[]const u8 = null,
         stdin_prompts: bool = false,
+        continue_on_failure: bool = false,
         output: ?[]const u8 = null,
         candidate: ?[]const u8 = null,
         backup: ?[]const u8 = null,
@@ -964,6 +965,8 @@ fn parseCodexOptions(result: *Command.CodexArgs, args: []const []const u8, optio
             if (i < args.len) result.from_account = args[i];
         } else if (eql(args[i], "--stdin")) {
             result.stdin_prompts = true;
+        } else if (eql(args[i], "--continue-on-failure")) {
+            result.continue_on_failure = true;
         } else if (eql(args[i], "--device")) {
             result.device = true;
         } else if (eql(args[i], "--status-only")) {
@@ -1120,8 +1123,8 @@ pub fn printUsage(writer: anytype) !void {
         \\  codex broker-session-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\      Run a local multi-turn broker-owned Codex session smoke from the session plan.
         \\
-        \\  codex broker-run [--profile name] [--capability c] (--prompt text|--stdin) --confirm-spend [--model m] [--json]
-        \\      Run one or more live broker-owned Codex app-server turns from the session plan.
+        \\  codex broker-run [--profile name] [--capability c] (--prompt text|--stdin) --confirm-spend [--model m] [--continue-on-failure] [--json]
+        \\      Run live broker-owned Codex app-server turns from the session plan.
         \\
         \\  codex broker-fallback-drill [--profile name] [--capability c] --from-account name --confirm-drill [--json]
         \\      Mark one Codex route quota-exhausted locally and prove the next broker-owned route selection.
@@ -1180,7 +1183,7 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\  oauth-mux codex broker-plan [--profile name] [--capability c] [--json]
         \\  oauth-mux codex broker-session-plan [--profile name] [--capability c] [--json]
         \\  oauth-mux codex broker-session-smoke [--profile name] [--capability c] --confirm-broker [--json]
-        \\  oauth-mux codex broker-run [--profile name] [--capability c] (--prompt text|--stdin) --confirm-spend [--model m] [--json]
+        \\  oauth-mux codex broker-run [--profile name] [--capability c] (--prompt text|--stdin) --confirm-spend [--model m] [--continue-on-failure] [--json]
         \\  oauth-mux codex broker-fallback-drill [--profile name] [--capability c] --from-account name --confirm-drill [--json]
         \\  oauth-mux codex broker-smoke [--profile name] [--capability c] --confirm-broker [--json]
         \\  oauth-mux codex broker-refresh-smoke [--profile name] [--capability c] --confirm-broker [--json]
@@ -1202,7 +1205,9 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\  selected Codex route secret and send it only to a broker-owned
         \\  Codex app-server child process; they do not print token or
         \\  account-id values.
-        \\  broker-run may persist live quota/rate-limit evidence to route health.
+        \\  broker-run may persist live quota/rate-limit evidence to route health
+        \\  and, with --continue-on-failure, start a fresh broker-owned session on
+        \\  the next selected route.
         \\  broker-fallback-drill mutates only oauth-mux route health; it does
         \\  not spend provider calls or print secrets.
         \\  live-qa, revalidate-exhausted, and broker-run require --confirm-spend or
@@ -1471,7 +1476,7 @@ test "parse codex broker run" {
 }
 
 test "parse codex broker run stdin" {
-    const args = [_][]const u8{ "codex", "broker-run", "--profile", "codex-max", "--capability", "codex-max", "--stdin", "--confirm-spend", "--json" };
+    const args = [_][]const u8{ "codex", "broker-run", "--profile", "codex-max", "--capability", "codex-max", "--stdin", "--continue-on-failure", "--confirm-spend", "--json" };
     const cmd = parse(&args);
     switch (cmd) {
         .codex => |codex| {
@@ -1479,6 +1484,7 @@ test "parse codex broker run stdin" {
             try std.testing.expectEqualStrings("codex-max", codex.profile.?);
             try std.testing.expectEqualStrings("codex-max", codex.capabilities);
             try std.testing.expect(codex.stdin_prompts);
+            try std.testing.expect(codex.continue_on_failure);
             try std.testing.expect(codex.confirm_spend);
             try std.testing.expect(codex.json);
         },

--- a/src/main.zig
+++ b/src/main.zig
@@ -8079,6 +8079,13 @@ const CodexBrokerSmokeResult = struct {
     route_health_recorded: bool = false,
 };
 
+const CodexBrokerRunContinuation = struct {
+    route: RepairPlanRoute,
+    prompt_start_index: usize = 0,
+    prompt_count: usize = 0,
+    result: CodexBrokerSmokeResult = .{},
+};
+
 const CodexBroker401HttpObservation = struct {
     request_count: usize = 0,
     responses_request_count: usize = 0,
@@ -9158,10 +9165,51 @@ fn runCodexBrokerRun(
         after_failure_summary = try summarizeCodexBrokerSessionPlan(allocator, parsed.value, after_failure_evaluations.items, after_failure_selected_index);
     }
 
+    var continuation: ?CodexBrokerRunContinuation = null;
+    if (args.continue_on_failure and result.route_health_recorded) {
+        if (after_failure_selected_index) |idx| {
+            const continuation_route = after_failure_evaluations.items[idx].route;
+            if (!sameRepairPlanRouteIdentity(selected.?.route, continuation_route)) {
+                const prompt_start_index = codexBrokerRunContinuationPromptStart(result, prompts.items.len);
+                if (prompt_start_index < prompts.items.len) {
+                    var continuation_credentials = CodexBrokerRouteCredentials{
+                        .route = continuation_route,
+                        .credentials = try loadCodexBrokerCredentialsForRoute(allocator, parsed.value, continuation_route),
+                    };
+                    defer continuation_credentials.deinit(allocator);
+
+                    const continuation_dir = try std.fmt.allocPrint(allocator, "{s}/codex-broker-run-{d}-continue", .{ state_dir, std.time.milliTimestamp() });
+                    defer allocator.free(continuation_dir);
+                    try std.fs.cwd().makePath(continuation_dir);
+                    try writeCodexBrokerLiveAppServerFiles(allocator, continuation_dir, model);
+
+                    var continuation_result = try runCodexAppServerLiveBrokerRun(
+                        allocator,
+                        continuation_credentials.credentials,
+                        continuation_dir,
+                        model,
+                        prompts.items[prompt_start_index..],
+                    );
+                    if (continuation_result.live_provider_failure) |classification| {
+                        recordCodexBrokerRunRouteHealth(&store, continuation_route, classification);
+                        continuation_result.route_health_recorded = true;
+                        store.persist();
+                    }
+                    continuation = .{
+                        .route = continuation_route,
+                        .prompt_start_index = prompt_start_index,
+                        .prompt_count = prompts.items.len - prompt_start_index,
+                        .result = continuation_result,
+                    };
+                }
+            }
+        }
+    }
+
     if (args.json) {
-        try writeCodexBrokerRunJson(writer, selected.?.route, capability, model, if (args.stdin_prompts) "stdin" else "prompt", prompts.items, summary, result, after_failure_evaluations.items, after_failure_selected_index, after_failure_summary);
+        try writeCodexBrokerRunJson(writer, selected.?.route, capability, model, if (args.stdin_prompts) "stdin" else "prompt", prompts.items, summary, result, after_failure_evaluations.items, after_failure_selected_index, after_failure_summary, args.continue_on_failure, continuation);
     } else {
-        try writeCodexBrokerRunText(writer, selected.?.route, capability, model, if (args.stdin_prompts) "stdin" else "prompt", prompts.items, summary, result, after_failure_evaluations.items, after_failure_selected_index);
+        try writeCodexBrokerRunText(writer, selected.?.route, capability, model, if (args.stdin_prompts) "stdin" else "prompt", prompts.items, summary, result, after_failure_evaluations.items, after_failure_selected_index, args.continue_on_failure, continuation);
     }
 }
 
@@ -9202,6 +9250,23 @@ fn codexBrokerRunOk(result: CodexBrokerSmokeResult, expected_turns: usize) bool 
         !result.protocol.experimental_api_required_error;
 }
 
+fn codexBrokerRunContinuationPromptStart(result: CodexBrokerSmokeResult, prompt_count: usize) usize {
+    if (prompt_count == 0) return 0;
+    const completed = @min(result.protocol.turn_completed_count, prompt_count);
+    if (result.live_provider_failure != null and completed > 0) return completed - 1;
+    return completed;
+}
+
+fn codexBrokerRunOverallOk(
+    result: CodexBrokerSmokeResult,
+    expected_turns: usize,
+    continuation: ?CodexBrokerRunContinuation,
+) bool {
+    if (codexBrokerRunOk(result, expected_turns)) return true;
+    if (continuation) |value| return codexBrokerRunOk(value.result, value.prompt_count);
+    return false;
+}
+
 fn codexBrokerRunProviderFailureReason(classification: types.HttpClassification) []const u8 {
     return switch (classification) {
         .quota_exhausted => "live_quota_exhausted",
@@ -9219,6 +9284,18 @@ fn codexBrokerRunReason(result: CodexBrokerSmokeResult, expected_turns: usize) [
         return if (expected_turns == 1) "live_turn_completed" else "live_session_turns_completed";
     }
     return result.reason;
+}
+
+fn codexBrokerRunOverallReason(
+    result: CodexBrokerSmokeResult,
+    expected_turns: usize,
+    continuation: ?CodexBrokerRunContinuation,
+) []const u8 {
+    if (codexBrokerRunOk(result, expected_turns)) return codexBrokerRunReason(result, expected_turns);
+    if (continuation) |value| {
+        if (codexBrokerRunOk(value.result, value.prompt_count)) return "live_session_continued_after_route_failure";
+    }
+    return codexBrokerRunReason(result, expected_turns);
 }
 
 fn codexBrokerPromptsTotalChars(prompts: []const []const u8) usize {
@@ -9239,23 +9316,27 @@ fn writeCodexBrokerRunJson(
     after_failure_evaluations: []const RouteEvaluation,
     after_failure_selected_index: ?usize,
     after_failure_summary: ?CodexBrokerSessionSummary,
+    continue_on_failure: bool,
+    continuation: ?CodexBrokerRunContinuation,
 ) !void {
     const prepared_fallback = summary.selectable_fallback_routes > 0;
     const prompt_chars_total = codexBrokerPromptsTotalChars(prompts);
     try writer.writeAll("{\"version\":");
     try std.json.stringify(cli.version, .{}, writer);
     try writer.writeAll(",\"mode\":\"codex_broker_owned_session_live_run\",\"ok\":");
-    try writer.writeAll(if (codexBrokerRunOk(result, prompts.len)) "true" else "false");
+    try writer.writeAll(if (codexBrokerRunOverallOk(result, prompts.len, continuation)) "true" else "false");
     try writer.writeAll(",\"confirmed\":true,\"spends_provider_calls\":true,\"mutates_user_config\":false,\"mutates_route_health\":");
     try writer.writeAll(if (result.route_health_recorded) "true" else "false");
     try writer.writeAll(",\"reason\":");
-    try std.json.stringify(codexBrokerRunReason(result, prompts.len), .{}, writer);
+    try std.json.stringify(codexBrokerRunOverallReason(result, prompts.len, continuation), .{}, writer);
     try writer.writeAll(",\"claim\":{\"claim_version\":1,\"level\":\"current_process_auth_broker\",\"proof_status\":");
-    try std.json.stringify(if (prompts.len == 1) "live_broker_owned_session_one_turn" else "live_broker_owned_session_loop", .{}, writer);
+    try std.json.stringify(if (continuation != null) "live_broker_owned_next_session_continuation" else if (prompts.len == 1) "live_broker_owned_session_one_turn" else "live_broker_owned_session_loop", .{}, writer);
     try writer.writeAll(",\"broker_owned_session\":true,\"route_selection_source\":\"broker_session_plan\",\"session_start_ready\":true,\"live_provider_turn\":true,\"session_loop\":");
     try writer.writeAll(if (prompts.len > 1) "true" else "false");
     try writer.writeAll(",\"prepared_fallback\":");
     try writer.writeAll(if (prepared_fallback) "true" else "false");
+    try writer.writeAll(",\"next_session_continuation\":");
+    try writer.writeAll(if (continuation != null) "true" else "false");
     try writer.writeAll(",\"next_thread_quota_fallback\":false,\"same_turn_quota_recovery\":false,\"same_thread_quota_recovery\":false,\"supervised_restart\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
     try writer.writeAll(",\"selected\":");
     try writeRouteSelectionJson(writer, route);
@@ -9319,10 +9400,44 @@ fn writeCodexBrokerRunJson(
     } else {
         try writer.writeAll("{\"recorded\":false}");
     }
+    try writer.writeAll(",\"continuation\":");
+    try writeCodexBrokerRunContinuationJson(writer, continue_on_failure, continuation);
     try writer.writeAll(",\"protocol\":");
     try writeCodexBrokerProtocolJson(writer, result);
     try writer.writeAll(",\"redaction\":{\"tokens_printed\":false,\"account_id_printed\":false,\"raw_protocol_printed\":false,\"prompt_printed\":false,\"assistant_output_printed\":false}");
     try writer.writeAll("}\n");
+}
+
+fn writeCodexBrokerRunContinuationJson(
+    writer: anytype,
+    continue_on_failure: bool,
+    continuation: ?CodexBrokerRunContinuation,
+) !void {
+    if (continuation) |value| {
+        try writer.writeByte('{');
+        try writer.writeAll("\"requested\":true,\"attempted\":true,\"mode\":\"new_broker_owned_session\",\"same_thread\":false,\"same_turn\":false,\"selected\":");
+        try writeRouteSelectionJson(writer, value.route);
+        try writer.print(",\"prompt_start_index\":{d},\"prompt_count\":{d},\"replays_failed_prompt\":true", .{ value.prompt_start_index, value.prompt_count });
+        try writer.writeAll(",\"ok\":");
+        try writer.writeAll(if (codexBrokerRunOk(value.result, value.prompt_count)) "true" else "false");
+        try writer.writeAll(",\"reason\":");
+        try std.json.stringify(codexBrokerRunReason(value.result, value.prompt_count), .{}, writer);
+        try writer.writeAll(",\"turns_completed\":");
+        try writer.print("{d}", .{value.result.protocol.turn_completed_count});
+        try writer.writeAll(",\"live_failure\":");
+        if (value.result.live_provider_failure) |classification| {
+            try writeCodexBrokerRunFailureJson(writer, classification, value.result.live_provider_failure_source, value.result.route_health_recorded);
+        } else {
+            try writer.writeAll("null");
+        }
+        try writer.writeAll(",\"protocol\":");
+        try writeCodexBrokerProtocolJson(writer, value.result);
+        try writer.writeByte('}');
+    } else {
+        try writer.writeAll("{\"requested\":");
+        try writer.writeAll(if (continue_on_failure) "true" else "false");
+        try writer.writeAll(",\"attempted\":false}");
+    }
 }
 
 fn writeCodexBrokerRunFailureJson(
@@ -9356,6 +9471,8 @@ fn writeCodexBrokerRunText(
     result: CodexBrokerSmokeResult,
     after_failure_evaluations: []const RouteEvaluation,
     after_failure_selected_index: ?usize,
+    continue_on_failure: bool,
+    continuation: ?CodexBrokerRunContinuation,
 ) !void {
     const prompt_chars_total = codexBrokerPromptsTotalChars(prompts);
     try writer.writeAll("oauth-mux Codex broker-owned live run\n\n");
@@ -9367,8 +9484,9 @@ fn writeCodexBrokerRunText(
     try writer.print("  prompt count: {d}\n", .{prompts.len});
     try writer.print("  prompt chars total: {d}\n", .{prompt_chars_total});
     try writer.print("  prepared fallback: {s}\n", .{if (summary.selectable_fallback_routes > 0) "true" else "false"});
-    try writer.print("  ok: {s}\n", .{if (codexBrokerRunOk(result, prompts.len)) "true" else "false"});
-    try writer.print("  reason: {s}\n", .{codexBrokerRunReason(result, prompts.len)});
+    try writer.print("  continue on failure: {s}\n", .{if (continue_on_failure) "true" else "false"});
+    try writer.print("  ok: {s}\n", .{if (codexBrokerRunOverallOk(result, prompts.len, continuation)) "true" else "false"});
+    try writer.print("  reason: {s}\n", .{codexBrokerRunOverallReason(result, prompts.len, continuation)});
     if (result.live_provider_failure) |classification| {
         try writer.print("  live failure: {s}", .{codexBrokerRunProviderFailureReason(classification)});
         if (health_mod.retryAfterFromClassification(classification)) |retry_after| try writer.print(" retry_after_s={d}", .{retry_after});
@@ -9382,6 +9500,17 @@ fn writeCodexBrokerRunText(
         } else {
             try writer.writeAll("none\n");
         }
+    }
+    if (continuation) |value| {
+        try writer.writeAll("  continuation: new broker-owned session ");
+        try writer.print("{s}:{s}", .{ value.route.provider, value.route.account });
+        if (value.route.capability) |cap| try writer.print("#{s}", .{cap});
+        try writer.print(" prompt_start_index={d} prompt_count={d} ok={s} reason={s}\n", .{
+            value.prompt_start_index,
+            value.prompt_count,
+            if (codexBrokerRunOk(value.result, value.prompt_count)) "true" else "false",
+            codexBrokerRunReason(value.result, value.prompt_count),
+        });
     }
     try writer.print("  turn_completed: {s}\n", .{if (result.protocol.turn_completed) "true" else "false"});
     try writer.writeAll("  redaction: tokens/account ids/raw protocol/prompt/assistant output not printed\n");


### PR DESCRIPTION
## Summary

Adds `oauth-mux codex broker-run --continue-on-failure` as the explicit next-session stay-afloat path for broker-owned Codex sessions.

When a live broker-owned run observes a quota/rate-limit failure, oauth-mux already records route health and reruns the broker session planner. This PR lets the operator opt into the next step: start a fresh broker-owned app-server session on the newly selected fallback route and replay the failed prompt plus any remaining queued stdin prompts.

The claim remains deliberately narrow: this is next-session continuation, not same-turn recovery, same-thread quota recovery, unmanaged TUI hot-swap, or per-request muxing.

## Changes

- Adds `--continue-on-failure` parsing and help for `codex broker-run`.
- Starts a second broker-owned app-server session only after a live provider failure is classified, route health is recorded, and a distinct fallback route is selected.
- Replays from the failed prompt index so the failed prompt and remaining queued prompts are attempted on the fallback route.
- Adds redacted JSON/text evidence under `continuation` with selected route, prompt counts, replay status, turn counts, and protocol summary.
- Extends e2e coverage with a no-spend mock: first app-server launch fails with usage-limit, second launch succeeds on the fallback session.
- Updates operator docs to state the next-session boundary.

## Validation

- `zig build`
- `zig build test`
- `./scripts/e2e-local.sh`
- `just check-local`
- `git diff --check`

No live provider spend was used for this PR. The continuation path is covered by the local mocked app-server fixture.

Refs #131
Refs #133
