### PR TITLE
Expose stay-afloat spare fallback risk

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ secret mutation. It also returns a `claim` object so agents can distinguish the
 current product level: today `prepared_fallback` means a new process can be
 launched through `claim.launch_argv`, while `current_process_hotswap`,
 `supervised_restart`, and `per_request_muxing` remain false.
+`resilience.spare_fallback_ready` and `claim.single_route_at_risk` distinguish
+"a selected route exists" from "another selectable route is already available
+behind it"; an afloat profile with no spare route is still usable, but the next
+quota/rate-limit failure may need revalidation or waiting.
 Codex app-server auth brokering is a separate proof track for mediated Codex
 sessions, not a current public claim.
 `codex broker-plan --json` is the no-spend first slice of that track: it reads
@@ -278,9 +282,11 @@ uses the earliest summary wake-up hint between ticks, bounded by
 latest `daemon status --json` snapshot also include `claim.level`. A
 `prepared_fallback` claim means the next mediated `stay-afloat launch` can pick
 a route; it does not claim current-process hot-swap, supervised restart, or
-per-request muxing. A provider-specific auth-broker path, starting with Codex
-app-server external auth, must be proven before `current_process_hotswap` can
-be true. `daemon status --json` also reports
+per-request muxing. Use `resilience.spare_fallback_ready` and
+`claim.single_route_at_risk` to tell whether that selected route has another
+ready fallback behind it. A provider-specific auth-broker path, starting with
+Codex app-server external auth, must be proven before
+`current_process_hotswap` can be true. `daemon status --json` also reports
 `stay_afloat_snapshot` metadata with presence, parseability, `last_tick_at`,
 `age_seconds`, active-loop correlation, a 300 second staleness threshold, and a
 fresh/stale reason so wrappers can reject old prepared-fallback claims. When

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -109,10 +109,12 @@ an exact `exec_argv` when already afloat, otherwise it returns the typed repair
 or user-handoff action to mediate before retrying. It also returns `claim`:
 `prepared_fallback` means use `claim.launch_argv` for a fresh harness process,
 while current-process hot swap, supervised restart, and per-request muxing are
-explicitly false until those product levels are implemented and proven. Codex
-app-server auth brokering is now tracked as the first plausible
-current-process proof path for mediated Codex sessions, but it is not a claim
-for unmanaged Codex TUI/CLI processes.
+explicitly false until those product levels are implemented and proven.
+`resilience.spare_fallback_ready:false` / `claim.single_route_at_risk:true`
+means the selected route can launch but no other selectable route is currently
+ready behind it. Codex app-server auth brokering is now tracked as the first
+plausible current-process proof path for mediated Codex sessions, but it is not
+a claim for unmanaged Codex TUI/CLI processes.
 
 `oauth-mux codex broker-plan --profile codex-max --capability codex-max --json`
 is the no-spend broker readiness check. It reads configured Codex auth stores

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -146,7 +146,10 @@ proxy, or in-agent adapter proves those stronger levels.
 - `claim.level:"prepared_fallback"` in `stay-afloat` / `daemon tick` JSON and
   in the latest `daemon status --json` snapshot when a route is selectable.
   Wrappers should pair that with the emitted `claim.launch_argv` and should not
-  infer current-process hot-swap or per-request muxing.
+  infer current-process hot-swap or per-request muxing. They should also read
+  `resilience.spare_fallback_ready` / `claim.single_route_at_risk`: a selected
+  route without a spare fallback is afloat for the next launch, but not
+  resilient to another immediate quota/rate-limit failure.
 - `oauth-mux daemon run --stay-afloat --profile <profile> --capability
   <capability>` as the first opt-in beta host for the same tick engine. It
   reports `stay_afloat_loop.hosted:true` plus the hosted selector, cadence, and

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -190,6 +190,10 @@ repair owner, and any user-facing command to run. The same response includes a
 `claim` object. `claim.level:"prepared_fallback"` means oauth-mux can start the
 next harness process through `claim.launch_argv`; it is not a current-process
 hot swap, supervised restart, or per-request muxing claim.
+Check `resilience.spare_fallback_ready` and `claim.single_route_at_risk` before
+calling a profile comfortably afloat: if only one route is selectable, the next
+quota/rate-limit failure may still need revalidation, waiting, or another
+account.
 Codex app-server auth brokering is tracked separately as a possible
 current-process proof for mediated Codex sessions; unmanaged Codex launches
 should still be treated as prepared fallback only.

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -364,7 +364,9 @@ stay_next="$(omux stay-afloat next --profile expensive --capability expensive --
 expect_contains "$stay_next" '"action":"next"' "stay-afloat next reports action"
 expect_contains "$stay_next" '"ready_for_exec":true' "stay-afloat next reports executable route"
 expect_contains "$stay_next" '"selected":{"provider":"toy","account":"a2"' "stay-afloat next selects fallback account a2"
+expect_contains "$stay_next" '"resilience":{"selected_route_ready":true,"selectable_fallback_routes":0,"spare_fallback_ready":false,"single_route_at_risk":true' "stay-afloat next reports no spare fallback"
 expect_contains "$stay_next" '"claim":{"claim_version":1,"level":"prepared_fallback"' "stay-afloat next reports prepared fallback claim"
+expect_contains "$stay_next" '"single_route_at_risk":true' "stay-afloat next claim reports single-route risk"
 expect_contains "$stay_next" '"current_process_hotswap":false' "stay-afloat next refuses current-process hot swap claim"
 expect_contains "$stay_next" '"launch_argv":["oauth-mux","stay-afloat","launch","--profile","expensive","--capability","expensive","--","<command>"]' "stay-afloat next returns launch argv claim"
 expect_contains "$stay_next" '"next_action":{"kind":"exec"' "stay-afloat next returns exec mediation"
@@ -398,6 +400,7 @@ expect_contains "$daemon_tick" '"mode":"once"' "daemon tick reports one-shot mod
 expect_contains "$daemon_tick" '"executed":false' "daemon tick does not execute probes or repair"
 expect_contains "$daemon_tick" '"afloat":true' "daemon tick reports profile afloat"
 expect_contains "$daemon_tick" '"selected":{"provider":"toy","account":"a2"' "daemon tick selects fallback account a2"
+expect_contains "$daemon_tick" '"resilience":{"selected_route_ready":true,"selectable_fallback_routes":0,"spare_fallback_ready":false,"single_route_at_risk":true' "daemon tick reports no spare fallback"
 expect_contains "$daemon_tick" '"claim":{"claim_version":1,"level":"prepared_fallback"' "daemon tick reports prepared fallback claim"
 expect_contains "$daemon_tick" '"max_supported_level":"prepared_fallback"' "daemon tick reports maximum supported claim level"
 expect_contains "$daemon_tick" '"current_process_hotswap":false' "daemon tick refuses current-process hot-swap claim"
@@ -415,6 +418,7 @@ expect_contains "$stay_afloat" '"mode":"once"' "stay-afloat reports one-shot mod
 expect_contains "$stay_afloat" '"executed":false' "stay-afloat remains planning-only by default"
 expect_contains "$stay_afloat" '"afloat":true' "stay-afloat reports profile afloat"
 expect_contains "$stay_afloat" '"selected":{"provider":"toy","account":"a2"' "stay-afloat selects fallback account a2"
+expect_contains "$stay_afloat" '"single_route_at_risk":true' "stay-afloat reports selected route has no spare fallback"
 expect_contains "$stay_afloat" '"next_tick_reason":"wait_until"' "stay-afloat exposes scheduler summary"
 
 printf 'e2e: daemon status exposes latest stay-afloat snapshot without promoting socket daemon\n'

--- a/src/main.zig
+++ b/src/main.zig
@@ -3858,8 +3858,10 @@ fn writeDaemonTickSnapshot(
     } else {
         try writer.writeAll("null");
     }
+    try writer.writeAll(",\"resilience\":");
+    try writeRouteResilienceJson(writer, evaluations, selected_index);
     try writer.writeAll(",\"claim\":");
-    try writeStayAfloatClaimJson(writer, selectorFromDaemonTickArgs(args), selectedRoute(evaluations, selected_index));
+    try writeStayAfloatClaimJson(writer, selectorFromDaemonTickArgs(args), selectedRoute(evaluations, selected_index), selectableFallbackRouteCount(evaluations, selected_index));
     try writer.writeAll(",\"summary\":");
     try writeDaemonTickStatsJson(writer, stats);
     try writer.writeByte('}');
@@ -3872,6 +3874,38 @@ fn selectedRoute(evaluations: []const RouteEvaluation, selected_index: ?usize) ?
         if (idx < evaluations.len) return evaluations[idx].route;
     }
     return null;
+}
+
+fn selectableFallbackRouteCount(evaluations: []const RouteEvaluation, selected_index: ?usize) usize {
+    var count: usize = 0;
+    for (evaluations, 0..) |evaluation, idx| {
+        if (!evaluation.selectable) continue;
+        if (selected_index) |selected| {
+            if (idx == selected) continue;
+        }
+        count += 1;
+    }
+    return count;
+}
+
+fn writeRouteResilienceJson(
+    writer: anytype,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+) !void {
+    const fallback_count = selectableFallbackRouteCount(evaluations, selected_index);
+    const selected = selected_index != null;
+    try writer.writeByte('{');
+    try writer.writeAll("\"selected_route_ready\":");
+    try writer.writeAll(if (selected) "true" else "false");
+    try writer.print(",\"selectable_fallback_routes\":{d}", .{fallback_count});
+    try writer.writeAll(",\"spare_fallback_ready\":");
+    try writer.writeAll(if (selected and fallback_count > 0) "true" else "false");
+    try writer.writeAll(",\"single_route_at_risk\":");
+    try writer.writeAll(if (selected and fallback_count == 0) "true" else "false");
+    try writer.writeAll(",\"state\":");
+    try std.json.stringify(if (!selected) "not_afloat" else if (fallback_count > 0) "afloat_with_spare_fallback" else "afloat_without_spare_fallback", .{}, writer);
+    try writer.writeByte('}');
 }
 
 const StayAfloatSelector = struct {
@@ -3903,6 +3937,7 @@ fn writeStayAfloatClaimJson(
     writer: anytype,
     selector: StayAfloatSelector,
     route: ?RepairPlanRoute,
+    selectable_fallback_routes: usize,
 ) !void {
     const prepared = route != null;
     try writer.writeAll("{\"claim_version\":1");
@@ -3911,6 +3946,11 @@ fn writeStayAfloatClaimJson(
     try writer.writeAll(",\"max_supported_level\":\"prepared_fallback\"");
     try writer.writeAll(",\"prepared_fallback\":");
     try writer.writeAll(if (prepared) "true" else "false");
+    try writer.print(",\"selectable_fallback_routes\":{d}", .{selectable_fallback_routes});
+    try writer.writeAll(",\"spare_fallback_ready\":");
+    try writer.writeAll(if (prepared and selectable_fallback_routes > 0) "true" else "false");
+    try writer.writeAll(",\"single_route_at_risk\":");
+    try writer.writeAll(if (prepared and selectable_fallback_routes == 0) "true" else "false");
     try writer.writeAll(",\"requires_mediation\":true");
     try writer.writeAll(",\"mediation_point\":\"stay-afloat launch\"");
     try writer.writeAll(",\"target_boundary\":\"process_start\"");
@@ -4469,6 +4509,8 @@ fn writeRouteJson(
     } else {
         try writer.writeAll("null");
     }
+    try writer.writeAll(",\"resilience\":");
+    try writeRouteResilienceJson(writer, evaluations, selected_index);
     try writer.writeAll(",\"routes\":[");
     for (evaluations, 0..) |evaluation, idx| {
         if (idx > 0) try writer.writeByte(',');
@@ -4510,8 +4552,10 @@ fn writeStayAfloatNextJson(
     } else {
         try writer.writeAll("null");
     }
+    try writer.writeAll(",\"resilience\":");
+    try writeRouteResilienceJson(writer, evaluations, selected_index);
     try writer.writeAll(",\"claim\":");
-    try writeStayAfloatClaimJson(writer, selectorFromRouteArgs(args), selectedRoute(evaluations, selected_index));
+    try writeStayAfloatClaimJson(writer, selectorFromRouteArgs(args), selectedRoute(evaluations, selected_index), selectableFallbackRouteCount(evaluations, selected_index));
     try writer.writeAll(",\"next_action\":");
     try writeStayAfloatNextActionJson(writer, allocator, evaluations, selected_index, candidate_index);
     try writer.writeAll(",\"routes\":[");
@@ -4811,8 +4855,10 @@ fn writeDaemonTickJsonObject(
     } else {
         try writer.writeAll("null");
     }
+    try writer.writeAll(",\"resilience\":");
+    try writeRouteResilienceJson(writer, evaluations, selected_index);
     try writer.writeAll(",\"claim\":");
-    try writeStayAfloatClaimJson(writer, selectorFromDaemonTickArgs(args), selectedRoute(evaluations, selected_index));
+    try writeStayAfloatClaimJson(writer, selectorFromDaemonTickArgs(args), selectedRoute(evaluations, selected_index), selectableFallbackRouteCount(evaluations, selected_index));
     try writer.writeAll(",\"summary\":");
     try writeDaemonTickStatsJson(writer, stats);
     try writer.writeAll(",\"executions\":");
@@ -13912,6 +13958,7 @@ test "route select picks first ready live route and explains skipped quota route
 
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"ok\":true") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"selected\":{\"provider\":\"toy\",\"account\":\"a2\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"resilience\":{\"selected_route_ready\":true,\"selectable_fallback_routes\":0,\"spare_fallback_ready\":false,\"single_route_at_risk\":true") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"skip_reason\":\"quota_exhausted\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"skip_reason\":\"available\"") != null);
 }
@@ -13966,7 +14013,9 @@ test "stay-afloat next emits exact exec argv for selected fallback" {
 
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"action\":\"next\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"ready_for_exec\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"resilience\":{\"selected_route_ready\":true,\"selectable_fallback_routes\":0,\"spare_fallback_ready\":false,\"single_route_at_risk\":true") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"claim\":{\"claim_version\":1,\"level\":\"prepared_fallback\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"spare_fallback_ready\":false") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"current_process_hotswap\":false") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"launch_argv\":[\"oauth-mux\",\"stay-afloat\",\"launch\",\"--profile\",\"work\",\"--capability\",\"chat\",\"--\",\"<command>\"]") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"next_action\":{\"kind\":\"exec\"") != null);
@@ -14019,6 +14068,7 @@ test "stay-afloat next emits mediated repair action when no route is selectable"
     });
 
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"ready_for_exec\":false") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"resilience\":{\"selected_route_ready\":false,\"selectable_fallback_routes\":0,\"spare_fallback_ready\":false,\"single_route_at_risk\":false,\"state\":\"not_afloat\"}") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"claim\":{\"claim_version\":1,\"level\":\"mediation_required\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"prepared_fallback\":false") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"launch_argv\":[\"oauth-mux\",\"stay-afloat\",\"launch\",\"--profile\",\"needs-reauth\",\"--capability\",\"codex-max\",\"--\",\"<command>\"]") != null);


### PR DESCRIPTION
## Summary

Adds an explicit stay-afloat resilience signal so `afloat:true` does not overstate the current route state when only one route is selectable.

The new `resilience` object appears on route/stay-afloat JSON surfaces and the claim now includes spare-route fields:

- `resilience.selected_route_ready`
- `resilience.selectable_fallback_routes`
- `resilience.spare_fallback_ready`
- `resilience.single_route_at_risk`
- `resilience.state`
- `claim.selectable_fallback_routes`
- `claim.spare_fallback_ready`
- `claim.single_route_at_risk`

This makes the current four-account Codex state explicit: `max-4` can launch `codex-max`, but there is no selectable `codex-max` fallback behind it until another route revalidates or resets.

## Validation

- `zig build`
- `zig build test`
- `./scripts/e2e-local.sh`
- `just check-local`
- `git diff --check`
- No-spend Codex truthing: `stay-afloat --once`, `stay-afloat next`, and `route explain` report `max-4` selected with `spare_fallback_ready:false`, `single_route_at_risk:true`, and `state:"afloat_without_spare_fallback"`.

Refs #131
Refs #133
