### PR TITLE
Expose route resilience actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,10 @@ boundary without starting Codex or probing providers. Read
 `resilience.spare_fallback_ready` and `resilience.single_route_at_risk` to
 distinguish a ready session with another route behind it from a ready session
 that will need revalidation, waiting, or a new account after its next failure.
-When the session is single-route-at-risk, `resilience_actions` lists the
-operator-safe todo list: spend-gated exhausted-route revalidation, enrolling
-another Codex account, or waiting for quota reset.
+When the selected Codex route is single-route-at-risk, the broker-session,
+`route explain`, and `stay-afloat` JSON surfaces expose `resilience_actions`:
+spend-gated exhausted-route revalidation, enrolling another Codex account, or
+waiting for quota reset.
 `codex broker-session-smoke --confirm-broker --json` takes the next no-spend UX
 step: it uses the session plan's selected and fallback routes, starts a local
 broker-owned app-server session against mocked Responses/ChatGPT endpoints, and
@@ -293,7 +294,9 @@ latest `daemon status --json` snapshot also include `claim.level`. A
 a route; it does not claim current-process hot-swap, supervised restart, or
 per-request muxing. Use `resilience.spare_fallback_ready` and
 `claim.single_route_at_risk` to tell whether that selected route has another
-ready fallback behind it. A provider-specific auth-broker path, starting with
+ready fallback behind it. For Codex routes, `resilience_actions` carries the
+same revalidate/enroll/wait operator choices surfaced by broker-session
+planning. A provider-specific auth-broker path, starting with
 Codex app-server external auth, must be proven before
 `current_process_hotswap` can be true. `daemon status --json` also reports
 `stay_afloat_snapshot` metadata with presence, parseability, `last_tick_at`,

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -163,9 +163,10 @@ reports the selected route, immediate selectable fallbacks, quota-blocked broker
 routes, and the same explicit no-hot-swap/no-same-thread quota boundary. Its
 `resilience` object is the operator shortcut: `spare_fallback_ready:false` with
 `single_route_at_risk:true` means the selected broker session can start, but no
-second route is currently ready behind it. In that state, `resilience_actions`
-is the todo list: revalidate exhausted routes behind an explicit spend gate,
-enroll another Codex account, or wait for quota reset.
+second route is currently ready behind it. For Codex routes, the broker-session,
+`route explain`, and `stay-afloat` JSON surfaces expose `resilience_actions` as
+the todo list: revalidate exhausted routes behind an explicit spend gate, enroll
+another Codex account, or wait for quota reset.
 
 `oauth-mux codex broker-session-smoke --profile codex-max --capability codex-max
 --confirm-broker --json` is the matching no-spend multi-turn UX smoke. It uses

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -149,10 +149,10 @@ proxy, or in-agent adapter proves those stronger levels.
   infer current-process hot-swap or per-request muxing. They should also read
   `resilience.spare_fallback_ready` / `claim.single_route_at_risk`: a selected
   route without a spare fallback is afloat for the next launch, but not
-  resilient to another immediate quota/rate-limit failure. Broker-owned Codex
-  session surfaces also expose `resilience_actions` so wrappers can display the
-  explicit choices: revalidate exhausted routes, enroll another account, or
-  wait for reset.
+  resilient to another immediate quota/rate-limit failure. For Codex routes,
+  broker-owned session, `route explain`, and `stay-afloat` JSON surfaces expose
+  `resilience_actions` so wrappers can display the explicit choices: revalidate
+  exhausted routes, enroll another account, or wait for reset.
 - `oauth-mux daemon run --stay-afloat --profile <profile> --capability
   <capability>` as the first opt-in beta host for the same tick engine. It
   reports `stay_afloat_loop.hosted:true` plus the hosted selector, cadence, and

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -238,9 +238,10 @@ Codex or spending provider calls. It joins route liveness with broker token
 readiness and reports which route would start the session plus which broker-ready
 routes are immediate fallbacks. Check `resilience.spare_fallback_ready` and
 `resilience.single_route_at_risk` before treating the session as comfortably
-afloat. When the session is single-route-at-risk, use `resilience_actions` as
-the operator todo list: revalidate exhausted routes, enroll another account, or
-wait for quota reset.
+afloat. When the selected Codex route is single-route-at-risk, use
+`resilience_actions` from broker-session, `route explain`, or `stay-afloat` JSON
+as the operator todo list: revalidate exhausted routes, enroll another account,
+or wait for quota reset.
 Use
 `oauth-mux codex broker-session-smoke --profile codex-max --capability codex-max
 --confirm-broker --json` to exercise that plan as a local multi-turn

--- a/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
+++ b/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
@@ -281,9 +281,10 @@ For quota-driven account changes, use a different action name, such as
    and reports selected, fallback, quota-blocked, and auth-unready routes for
    the future broker-owned session UX. Its `resilience` object explicitly marks
    whether the selected broker session has a spare fallback route or is a
-   single-route-at-risk state. `resilience_actions` turns that state into an
-   operator todo list: revalidate exhausted routes, enroll another account, or
-   wait for quota reset.
+   single-route-at-risk state. For Codex routes, broker-session, `route
+   explain`, and `stay-afloat` JSON surfaces expose `resilience_actions` to turn
+   that state into an operator todo list: revalidate exhausted routes, enroll
+   another account, or wait for quota reset.
 11. Add a no-spend broker-owned session smoke:
    `oauth-mux codex broker-session-smoke --profile codex-max --capability
    codex-max --confirm-broker --json` uses the session plan's selected and

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -349,6 +349,7 @@ route_explain="$(omux route explain --profile expensive --capability expensive -
 expect_contains "$route_explain" '"action":"explain"' "route explain reports action"
 expect_contains "$route_explain" '"ok":true' "route explain reports available selection"
 expect_contains "$route_explain" '"selected":{"provider":"toy","account":"a2"' "route explain selects fallback account a2"
+expect_contains "$route_explain" '"resilience_actions":[]' "route explain does not emit Codex-specific actions for toy provider"
 expect_contains "$route_explain" '"skip_reason":"quota_exhausted"' "route explain keeps exhausted reason"
 expect_contains "$route_explain" '"skip_reason":"available"' "route explain marks available selected route"
 expect_contains "$route_explain" '"writeback":{"capability":"readonly","automatic_refresh_admitted":false,"reason":"provider_repair_is_manual_only"}' "route explain reports readonly writeback boundary"
@@ -365,6 +366,7 @@ expect_contains "$stay_next" '"action":"next"' "stay-afloat next reports action"
 expect_contains "$stay_next" '"ready_for_exec":true' "stay-afloat next reports executable route"
 expect_contains "$stay_next" '"selected":{"provider":"toy","account":"a2"' "stay-afloat next selects fallback account a2"
 expect_contains "$stay_next" '"resilience":{"selected_route_ready":true,"selectable_fallback_routes":0,"spare_fallback_ready":false,"single_route_at_risk":true' "stay-afloat next reports no spare fallback"
+expect_contains "$stay_next" '"resilience_actions":[]' "stay-afloat next does not emit Codex-specific actions for toy provider"
 expect_contains "$stay_next" '"claim":{"claim_version":1,"level":"prepared_fallback"' "stay-afloat next reports prepared fallback claim"
 expect_contains "$stay_next" '"single_route_at_risk":true' "stay-afloat next claim reports single-route risk"
 expect_contains "$stay_next" '"current_process_hotswap":false' "stay-afloat next refuses current-process hot swap claim"
@@ -401,6 +403,7 @@ expect_contains "$daemon_tick" '"executed":false' "daemon tick does not execute 
 expect_contains "$daemon_tick" '"afloat":true' "daemon tick reports profile afloat"
 expect_contains "$daemon_tick" '"selected":{"provider":"toy","account":"a2"' "daemon tick selects fallback account a2"
 expect_contains "$daemon_tick" '"resilience":{"selected_route_ready":true,"selectable_fallback_routes":0,"spare_fallback_ready":false,"single_route_at_risk":true' "daemon tick reports no spare fallback"
+expect_contains "$daemon_tick" '"resilience_actions":[]' "daemon tick does not emit Codex-specific actions for toy provider"
 expect_contains "$daemon_tick" '"claim":{"claim_version":1,"level":"prepared_fallback"' "daemon tick reports prepared fallback claim"
 expect_contains "$daemon_tick" '"max_supported_level":"prepared_fallback"' "daemon tick reports maximum supported claim level"
 expect_contains "$daemon_tick" '"current_process_hotswap":false' "daemon tick refuses current-process hot-swap claim"
@@ -419,6 +422,7 @@ expect_contains "$stay_afloat" '"executed":false' "stay-afloat remains planning-
 expect_contains "$stay_afloat" '"afloat":true' "stay-afloat reports profile afloat"
 expect_contains "$stay_afloat" '"selected":{"provider":"toy","account":"a2"' "stay-afloat selects fallback account a2"
 expect_contains "$stay_afloat" '"single_route_at_risk":true' "stay-afloat reports selected route has no spare fallback"
+expect_contains "$stay_afloat" '"resilience_actions":[]' "stay-afloat alias does not emit Codex-specific actions for toy provider"
 expect_contains "$stay_afloat" '"next_tick_reason":"wait_until"' "stay-afloat exposes scheduler summary"
 
 printf 'e2e: daemon status exposes latest stay-afloat snapshot without promoting socket daemon\n'
@@ -896,6 +900,18 @@ expect_contains "$broker_session_plan_after_drill" '"resilience_actions":[{"kind
 expect_contains "$broker_session_plan_after_drill" '"command":"oauth-mux codex revalidate-exhausted --profile codex-max --capability codex-max --confirm-spend --json"' "broker-session-plan after drill includes spend-gated revalidation command"
 expect_contains "$broker_session_plan_after_drill" '"kind":"enroll_codex_account"' "broker-session-plan after drill recommends account enrollment option"
 expect_contains "$broker_session_plan_after_drill" '"kind":"wait_for_quota_reset"' "broker-session-plan after drill includes wait option"
+
+broker_route_explain_after_drill="$(PATH="$broker_session_bin:$PATH" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" route explain --profile codex-max --capability codex-max --json)"
+expect_contains "$broker_route_explain_after_drill" '"resilience":{"selected_route_ready":true,"selectable_fallback_routes":0,"spare_fallback_ready":false,"single_route_at_risk":true,"state":"afloat_without_spare_fallback"}' "route explain after drill exposes no-spare Codex state"
+expect_contains "$broker_route_explain_after_drill" '"resilience_actions":[{"kind":"revalidate_exhausted_routes"' "route explain after drill recommends exhausted-route revalidation"
+expect_contains "$broker_route_explain_after_drill" '"kind":"enroll_codex_account"' "route explain after drill recommends account enrollment"
+expect_contains "$broker_route_explain_after_drill" '"kind":"wait_for_quota_reset"' "route explain after drill includes wait option"
+
+broker_stay_afloat_after_drill="$(PATH="$broker_session_bin:$PATH" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" stay-afloat --once --profile codex-max --capability codex-max --json)"
+expect_contains "$broker_stay_afloat_after_drill" '"resilience":{"selected_route_ready":true,"selectable_fallback_routes":0,"spare_fallback_ready":false,"single_route_at_risk":true,"state":"afloat_without_spare_fallback"}' "stay-afloat after drill exposes no-spare Codex state"
+expect_contains "$broker_stay_afloat_after_drill" '"resilience_actions":[{"kind":"revalidate_exhausted_routes"' "stay-afloat after drill recommends exhausted-route revalidation"
+expect_contains "$broker_stay_afloat_after_drill" '"kind":"enroll_codex_account"' "stay-afloat after drill recommends account enrollment"
+expect_contains "$broker_stay_afloat_after_drill" '"kind":"wait_for_quota_reset"' "stay-afloat after drill includes wait option"
 
 printf 'e2e: codex broker-session-smoke requires explicit confirmation before starting app-server\n'
 broker_session_smoke_prompt="$(OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex broker-session-smoke --profile codex-max --capability codex-max --json)"

--- a/src/main.zig
+++ b/src/main.zig
@@ -3908,6 +3908,28 @@ fn writeRouteResilienceJson(
     try writer.writeByte('}');
 }
 
+fn writeRouteResilienceActionsJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+    profile: ?[]const u8,
+    capability: ?[]const u8,
+) !void {
+    const selected = selected_index orelse {
+        try writer.writeAll("[]");
+        return;
+    };
+    if (selected >= evaluations.len or !std.mem.eql(u8, evaluations[selected].route.provider, "codex")) {
+        try writer.writeAll("[]");
+        return;
+    }
+
+    const fallback_count = selectableFallbackRouteCount(evaluations, selected_index);
+    const action_capability = capability orelse evaluations[selected].route.capability;
+    try writeCodexBrokerSessionRiskActionsJson(writer, allocator, profile, action_capability, true, fallback_count);
+}
+
 const StayAfloatSelector = struct {
     profile: ?[]const u8 = null,
     provider: ?[]const u8 = null,
@@ -4511,6 +4533,8 @@ fn writeRouteJson(
     }
     try writer.writeAll(",\"resilience\":");
     try writeRouteResilienceJson(writer, evaluations, selected_index);
+    try writer.writeAll(",\"resilience_actions\":");
+    try writeRouteResilienceActionsJson(writer, allocator, evaluations, selected_index, args.profile, args.capability);
     try writer.writeAll(",\"routes\":[");
     for (evaluations, 0..) |evaluation, idx| {
         if (idx > 0) try writer.writeByte(',');
@@ -4554,6 +4578,8 @@ fn writeStayAfloatNextJson(
     }
     try writer.writeAll(",\"resilience\":");
     try writeRouteResilienceJson(writer, evaluations, selected_index);
+    try writer.writeAll(",\"resilience_actions\":");
+    try writeRouteResilienceActionsJson(writer, allocator, evaluations, selected_index, args.profile, args.capability);
     try writer.writeAll(",\"claim\":");
     try writeStayAfloatClaimJson(writer, selectorFromRouteArgs(args), selectedRoute(evaluations, selected_index), selectableFallbackRouteCount(evaluations, selected_index));
     try writer.writeAll(",\"next_action\":");
@@ -4857,6 +4883,8 @@ fn writeDaemonTickJsonObject(
     }
     try writer.writeAll(",\"resilience\":");
     try writeRouteResilienceJson(writer, evaluations, selected_index);
+    try writer.writeAll(",\"resilience_actions\":");
+    try writeRouteResilienceActionsJson(writer, allocator, evaluations, selected_index, args.profile, args.capability);
     try writer.writeAll(",\"claim\":");
     try writeStayAfloatClaimJson(writer, selectorFromDaemonTickArgs(args), selectedRoute(evaluations, selected_index), selectableFallbackRouteCount(evaluations, selected_index));
     try writer.writeAll(",\"summary\":");
@@ -14168,6 +14196,7 @@ test "route select picks first ready live route and explains skipped quota route
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"ok\":true") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"selected\":{\"provider\":\"toy\",\"account\":\"a2\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"resilience\":{\"selected_route_ready\":true,\"selectable_fallback_routes\":0,\"spare_fallback_ready\":false,\"single_route_at_risk\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"resilience_actions\":[]") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"skip_reason\":\"quota_exhausted\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"skip_reason\":\"available\"") != null);
 }
@@ -14223,6 +14252,7 @@ test "stay-afloat next emits exact exec argv for selected fallback" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"action\":\"next\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"ready_for_exec\":true") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"resilience\":{\"selected_route_ready\":true,\"selectable_fallback_routes\":0,\"spare_fallback_ready\":false,\"single_route_at_risk\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"resilience_actions\":[]") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"claim\":{\"claim_version\":1,\"level\":\"prepared_fallback\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"spare_fallback_ready\":false") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"current_process_hotswap\":false") != null);


### PR DESCRIPTION
## Summary

Adds `resilience_actions` to the route-level stay-afloat surfaces when the selected at-risk route is Codex:

- `route explain --json`
- `stay-afloat next --json`
- `stay-afloat --once` / daemon tick JSON

The actions match the broker-session plan surface: spend-gated exhausted-route revalidation, confirmed Codex account enrollment, or waiting for quota reset. Non-Codex route surfaces emit an empty action list, so provider-specific commands are not suggested for generic providers.

## Why

After the four-account dogfood landed in a max-4-only state, `broker-session-plan` correctly explained the single-route risk, but broader operator surfaces only exposed the boolean resilience state. This makes wrappers and operators see the same todo list wherever they inspect stay-afloat readiness.

## Validation

- `just test`
- `./scripts/e2e-local.sh`
- `just check-local`
- `git diff --check`
- No-spend live surface check on current `codex-max` route state:
  - `route explain` reports `max-4`, `ready_without_spare_fallback` / `afloat_without_spare_fallback`, and the three `resilience_actions`.
  - `stay-afloat --once` reports the same actions.

## Live Route Truth

A spend-gated `codex revalidate-exhausted --profile codex-max --capability codex-max --confirm-spend --json` was run before this PR. Provider-originated probes still classify `max-1`, `max-2`, and `max-3` as quota-exhausted for `codex-max`; `max-4` remains the only selectable route. This PR does not claim provider-originated live fallback, same-thread recovery, unmanaged TUI hot-swap, or per-request muxing.

Refs #133
Refs #131
