### PR TITLE
Show Codex risk actions in text output

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,10 @@ boundary without starting Codex or probing providers. Read
 distinguish a ready session with another route behind it from a ready session
 that will need revalidation, waiting, or a new account after its next failure.
 When the selected Codex route is single-route-at-risk, the broker-session,
-`route explain`, and `stay-afloat` JSON surfaces expose `resilience_actions`:
+`route explain`, and `stay-afloat` surfaces expose the same next actions:
 spend-gated exhausted-route revalidation, enrolling another Codex account, or
-waiting for quota reset.
+waiting for quota reset. JSON clients read those actions from
+`resilience_actions`; text output prints the same concise `next:` hint.
 `codex broker-session-smoke --confirm-broker --json` takes the next no-spend UX
 step: it uses the session plan's selected and fallback routes, starts a local
 broker-owned app-server session against mocked Responses/ChatGPT endpoints, and

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -164,9 +164,10 @@ routes, and the same explicit no-hot-swap/no-same-thread quota boundary. Its
 `resilience` object is the operator shortcut: `spare_fallback_ready:false` with
 `single_route_at_risk:true` means the selected broker session can start, but no
 second route is currently ready behind it. For Codex routes, the broker-session,
-`route explain`, and `stay-afloat` JSON surfaces expose `resilience_actions` as
-the todo list: revalidate exhausted routes behind an explicit spend gate, enroll
-another Codex account, or wait for quota reset.
+`route explain`, and `stay-afloat` surfaces expose the same todo list:
+revalidate exhausted routes behind an explicit spend gate, enroll another Codex
+account, or wait for quota reset. JSON clients read `resilience_actions`; text
+output prints the matching `next:` hint.
 
 `oauth-mux codex broker-session-smoke --profile codex-max --capability codex-max
 --confirm-broker --json` is the matching no-spend multi-turn UX smoke. It uses

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -150,9 +150,10 @@ proxy, or in-agent adapter proves those stronger levels.
   `resilience.spare_fallback_ready` / `claim.single_route_at_risk`: a selected
   route without a spare fallback is afloat for the next launch, but not
   resilient to another immediate quota/rate-limit failure. For Codex routes,
-  broker-owned session, `route explain`, and `stay-afloat` JSON surfaces expose
-  `resilience_actions` so wrappers can display the explicit choices: revalidate
-  exhausted routes, enroll another account, or wait for reset.
+  broker-owned session, `route explain`, and `stay-afloat` surfaces expose the
+  same explicit choices: revalidate exhausted routes, enroll another account, or
+  wait for reset. JSON clients read `resilience_actions`; text output prints the
+  matching `next:` hint.
 - `oauth-mux daemon run --stay-afloat --profile <profile> --capability
   <capability>` as the first opt-in beta host for the same tick engine. It
   reports `stay_afloat_loop.hosted:true` plus the hosted selector, cadence, and

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -238,10 +238,11 @@ Codex or spending provider calls. It joins route liveness with broker token
 readiness and reports which route would start the session plus which broker-ready
 routes are immediate fallbacks. Check `resilience.spare_fallback_ready` and
 `resilience.single_route_at_risk` before treating the session as comfortably
-afloat. When the selected Codex route is single-route-at-risk, use
-`resilience_actions` from broker-session, `route explain`, or `stay-afloat` JSON
-as the operator todo list: revalidate exhausted routes, enroll another account,
-or wait for quota reset.
+afloat. When the selected Codex route is single-route-at-risk, use the
+broker-session, `route explain`, or `stay-afloat` next-action output as the
+operator todo list: revalidate exhausted routes, enroll another account, or wait
+for quota reset. JSON clients read `resilience_actions`; text output prints the
+matching `next:` hint.
 Use
 `oauth-mux codex broker-session-smoke --profile codex-max --capability codex-max
 --confirm-broker --json` to exercise that plan as a local multi-turn

--- a/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
+++ b/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
@@ -282,9 +282,10 @@ For quota-driven account changes, use a different action name, such as
    the future broker-owned session UX. Its `resilience` object explicitly marks
    whether the selected broker session has a spare fallback route or is a
    single-route-at-risk state. For Codex routes, broker-session, `route
-   explain`, and `stay-afloat` JSON surfaces expose `resilience_actions` to turn
-   that state into an operator todo list: revalidate exhausted routes, enroll
-   another account, or wait for quota reset.
+   explain`, and `stay-afloat` surfaces expose the same operator todo list:
+   revalidate exhausted routes, enroll another account, or wait for quota reset.
+   JSON clients read `resilience_actions`; text output prints the matching
+   `next:` hint.
 11. Add a no-spend broker-owned session smoke:
    `oauth-mux codex broker-session-smoke --profile codex-max --capability
    codex-max --confirm-broker --json` uses the session plan's selected and

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -353,6 +353,8 @@ expect_contains "$route_explain" '"resilience_actions":[]' "route explain does n
 expect_contains "$route_explain" '"skip_reason":"quota_exhausted"' "route explain keeps exhausted reason"
 expect_contains "$route_explain" '"skip_reason":"available"' "route explain marks available selected route"
 expect_contains "$route_explain" '"writeback":{"capability":"readonly","automatic_refresh_admitted":false,"reason":"provider_repair_is_manual_only"}' "route explain reports readonly writeback boundary"
+route_explain_text="$(omux route explain --profile expensive --capability expensive)"
+expect_not_contains "$route_explain_text" 'next: revalidate exhausted routes' "route explain text does not emit Codex-specific actions for toy provider"
 
 printf 'e2e: route select chooses selected fallback without probing\n'
 route_select="$(omux route select --profile expensive --capability expensive --json)"
@@ -912,6 +914,10 @@ expect_contains "$broker_stay_afloat_after_drill" '"resilience":{"selected_route
 expect_contains "$broker_stay_afloat_after_drill" '"resilience_actions":[{"kind":"revalidate_exhausted_routes"' "stay-afloat after drill recommends exhausted-route revalidation"
 expect_contains "$broker_stay_afloat_after_drill" '"kind":"enroll_codex_account"' "stay-afloat after drill recommends account enrollment"
 expect_contains "$broker_stay_afloat_after_drill" '"kind":"wait_for_quota_reset"' "stay-afloat after drill includes wait option"
+broker_route_explain_text_after_drill="$(PATH="$broker_session_bin:$PATH" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" route explain --profile codex-max --capability codex-max)"
+expect_contains "$broker_route_explain_text_after_drill" 'next: revalidate exhausted routes, enroll another Codex account, or wait for quota reset' "route explain text after drill includes Codex risk actions"
+broker_stay_afloat_text_after_drill="$(PATH="$broker_session_bin:$PATH" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" stay-afloat --once --profile codex-max --capability codex-max)"
+expect_contains "$broker_stay_afloat_text_after_drill" 'next: revalidate exhausted routes, enroll another Codex account, or wait for quota reset' "stay-afloat text after drill includes Codex risk actions"
 
 printf 'e2e: codex broker-session-smoke requires explicit confirmation before starting app-server\n'
 broker_session_smoke_prompt="$(OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex broker-session-smoke --profile codex-max --capability codex-max --json)"

--- a/src/main.zig
+++ b/src/main.zig
@@ -3930,6 +3930,20 @@ fn writeRouteResilienceActionsJson(
     try writeCodexBrokerSessionRiskActionsJson(writer, allocator, profile, action_capability, true, fallback_count);
 }
 
+fn writeRouteResilienceActionsText(
+    writer: anytype,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+) !void {
+    const selected = selected_index orelse return;
+    if (selected >= evaluations.len) return;
+    const route = evaluations[selected].route;
+    if (!std.mem.eql(u8, route.provider, "codex")) return;
+    if (!codexBrokerSessionSingleRouteAtRisk(true, selectableFallbackRouteCount(evaluations, selected_index))) return;
+
+    try writer.writeAll("  next: revalidate exhausted routes, enroll another Codex account, or wait for quota reset\n");
+}
+
 const StayAfloatSelector = struct {
     profile: ?[]const u8 = null,
     provider: ?[]const u8 = null,
@@ -4411,6 +4425,7 @@ fn writeRouteText(
         try writer.print("  selected: {s}:{s}", .{ selected.provider, selected.account });
         if (selected.capability) |capability| try writer.print("#{s}", .{capability});
         try writer.writeByte('\n');
+        try writeRouteResilienceActionsText(writer, evaluations, selected_index);
     } else {
         try writer.writeAll("  selected: none\n");
     }
@@ -4482,7 +4497,9 @@ fn writeStayAfloatMediationText(
         try writer.writeAll("  ready_for_exec: true\n");
         try writer.print("  selected: {s}:{s}", .{ selected.provider, selected.account });
         if (selected.capability) |capability| try writer.print("#{s}", .{capability});
-        try writer.writeAll("\n  exec: ");
+        try writer.writeByte('\n');
+        try writeRouteResilienceActionsText(writer, evaluations, selected_index);
+        try writer.writeAll("  exec: ");
         try writeStayAfloatExecCommandText(writer, selected);
         try writer.writeByte('\n');
         return;
@@ -4775,6 +4792,7 @@ fn writeDaemonTickText(
         try writer.print("  selected: {s}:{s}", .{ selected.provider, selected.account });
         if (selected.capability) |capability| try writer.print("#{s}", .{capability});
         try writer.writeByte('\n');
+        try writeRouteResilienceActionsText(writer, evaluations, selected_index);
     } else {
         try writer.writeAll("  selected: none\n");
     }


### PR DESCRIPTION
## Summary

Adds text-output parity for the Codex single-route-at-risk state. `route explain`, `stay-afloat next`, and `stay-afloat --once` now print the same concise next-action hint already available in JSON and broker-session surfaces:

```
next: revalidate exhausted routes, enroll another Codex account, or wait for quota reset
```

The hint is scoped to Codex selected routes with no spare fallback. Generic providers stay quiet.

## Why

After PR #146, JSON clients had the right action list everywhere, but humans using the plain text output still saw only the selected route. In the current live state, `max-4` is the only selectable `codex-max` route, so the text output should say exactly what the operator can do next.

## Validation

- `just build`
- `./scripts/e2e-local.sh`
- `just check-local`
- `git diff --check`
- Live no-spend text check on current `codex-max` state:
  - `route explain` prints `max-4` plus the `next:` hint.
  - `stay-afloat --once` prints `max-4` plus the `next:` hint.

Refs #133
Refs #131
