### PR TITLE
Truth paid Codex cohort docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ just release
 runs Zig tests, builds the binary, validates every example config, and runs the
 synthetic local E2E harness.
 
+When validating behavior from a source checkout on `main`, prefer the freshly
+built repo binary (`just run -- ...` or `./zig-out/bin/oauth-mux` after
+`just build`). Installed packages may trail unreleased command surfaces and
+operator text.
+
 ## Quick Checks
 
 Discover the redacted, agent-safe inventory:

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -56,6 +56,10 @@ Source checkouts prove this path without touching real operator state:
 just first-run-e2e
 ```
 
+When checking unreleased behavior from source, use `just run -- ...` or
+`./zig-out/bin/oauth-mux` after `just build` so local observations match repo
+`main` rather than an older installed package.
+
 For Codex subscription users working from a source checkout today:
 
 ```bash

--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -224,8 +224,9 @@ paid cohort, not a default CI lane.
 
 Target shapes:
 
-- Codex: existing three Max-capable accounts plus one lower-tier OAuth account
-  to prove tier and usage contrast.
+- Codex: the current dogfood lane has four Max-capable routes. Keep lower-tier
+  OAuth as a separate contrast target; do not infer Max availability from
+  dashboard or Spark/mini credit text.
 - Claude Code: three isolated account/billing shapes across Pro, Max, and a
   team/API-billed route where available.
 - Figma: three token/resource shapes across PAT, OAuth bearer, and

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -46,7 +46,7 @@ oauth-mux enroll figma --account <name> --mode pat --confirm-enroll --json
 oauth-mux discover
 ```
 
-Codex Max three-account starter:
+Codex Max starter plus fourth-account enrollment:
 
 ```bash
 oauth-mux init --codex-max

--- a/docs/spec/paid-multi-account-proof-cohort-2026-05-01.md
+++ b/docs/spec/paid-multi-account-proof-cohort-2026-05-01.md
@@ -69,16 +69,29 @@ Primary sources:
 
 ### Codex: `TIN-893`
 
-Use the existing three Max-capable accounts as the high-usage cohort. Add one
-lower-tier OAuth account to prove tier and usage contrast.
+Use the current four Max-capable account-scoped routes as the high-usage
+cohort. Keep one lower-tier OAuth account as a separate proof target for tier
+and usage contrast.
+
+Current dogfood truth as of 2026-05-03:
+
+- `max-1#codex-max` revalidated from provider evidence and is selectable.
+- `max-4#codex-max` is selectable fallback.
+- `max-2#codex-max` and `max-3#codex-max` still return provider quota
+  exhaustion.
+- No logout or reauth was required when capacity changed; spend-gated
+  `codex revalidate-exhausted` refreshed route health from provider evidence.
+- Dashboard credit/Spark availability must not be generalized to
+  `codex-max`; route health remains capability-scoped.
 
 Suggested labels:
 
 | Label | Intended shape | Proof value |
 | --- | --- | --- |
-| `codex-max-1` | Existing Max-capable account | Quota exhaustion, weekly reset, and fallback history. |
-| `codex-max-2` | Existing Max-capable account | Independent Max-capable route with the same capability names. |
-| `codex-max-3` | Existing active/API-backed route | Available fallback when other Max routes are exhausted. |
+| `codex-max-1` | Max-capable account | Revalidated selected route after capacity change. |
+| `codex-max-2` | Max-capable account | Fresh quota-exhausted provider evidence. |
+| `codex-max-3` | Max-capable account with mini/Spark availability | Capability-scoped contrast: mini/Spark can pass while Max remains exhausted. |
+| `codex-max-4` | Max-capable account | Selectable fallback route behind `max-1`. |
 | `codex-plus-1` | New lower-tier ChatGPT OAuth account | Tier/usage contrast against Max; proves lower-tier accounts do not poison Max route health. |
 
 Do not model the lower-tier account as a broken Max account. Expected outcomes
@@ -103,7 +116,7 @@ Spendful proof remains behind explicit confirmation:
 ```bash
 OMUX_LIVE_QA_CONFIRM=spend-real-calls \
 OMUX_LIVE_QA_PROVIDER=codex \
-OMUX_LIVE_QA_ACCOUNTS=max-1,max-2,max-3,codex-plus-1 \
+OMUX_LIVE_QA_ACCOUNTS=max-1,max-2,max-3,max-4,codex-plus-1 \
 OMUX_LIVE_QA_CAPABILITIES=codex-mini,codex-max \
   just live-qa
 ```


### PR DESCRIPTION
## Summary

Truths the paid Codex cohort docs after the latest spend-gated route revalidation.

- updates the Codex cohort from the old three-Max-account wording to the current four-route Max shape
- records the current provider-evidence state: max-1 selected, max-4 fallback, max-2/max-3 quota-exhausted for codex-max
- keeps lower-tier OAuth contrast as a separate remaining proof target
- adds a source-checkout note to use the repo-built binary for unreleased main behavior instead of an older installed package

## Tracker cleanup

Also moved Linear TIN-917 / GitHub #133 to Done/closed because the broker-owned session UX surface is implemented. Remaining provider-originated live quota proof stays under TIN-916 / GitHub #131.

## Validation

- `git diff --check`
- `just check-local`
