### PR TITLE
[codex] Clarify Codex four-route QA docs

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -85,9 +85,10 @@ oauth-mux stay-afloat --loop --iterations 2 --interval-ms 0 --profile codex-max 
 ```
 
 Those commands are installed CLI surface, not source-checkout-only helpers.
-Users can override the default three-account shape with
-`--accounts work,personal,team` and can point account stores somewhere explicit
-with `--store-root <path>`.
+The starter Codex shape is three accounts; after enrolling an extra route such
+as `max-4`, use `--accounts max-1,max-2,max-3,max-4` or
+`OMUX_CODEX_ACCOUNTS=max-1,max-2,max-3,max-4` for canary and live-QA helpers.
+Point account stores somewhere explicit with `--store-root <path>`.
 
 Live probes remain explicit because they can spend subscription calls:
 

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -111,7 +111,7 @@ To keep the formula installed after dogfood QA:
 OMUX_HOMEBREW_KEEP_INSTALLED=1 OMUX_HOMEBREW_KEEP_TAP=1 just homebrew-qa 0.1.6
 ```
 
-To include the three-account Codex canary from the installed Homebrew binary:
+To include the starter Codex canary from the installed Homebrew binary:
 
 ```bash
 OMUX_CONFIG=$PWD/examples/codex-max.config.json \

--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -25,7 +25,7 @@ Probe an account matrix:
 ```bash
 OMUX_LIVE_QA_CONFIRM=spend-real-calls \
 OMUX_LIVE_QA_PROVIDER=codex \
-OMUX_LIVE_QA_ACCOUNTS=max-1,max-2,max-3 \
+OMUX_LIVE_QA_ACCOUNTS=max-1,max-2,max-3,max-4 \
 OMUX_LIVE_QA_CAPABILITIES=codex-mini \
 just live-qa
 ```
@@ -35,13 +35,12 @@ Escalate to higher-cost routes only after the cheaper route is healthy:
 ```bash
 OMUX_LIVE_QA_CONFIRM=spend-real-calls \
 OMUX_LIVE_QA_PROVIDER=codex \
-OMUX_LIVE_QA_ACCOUNTS=max-1,max-2,max-3 \
+OMUX_LIVE_QA_ACCOUNTS=max-1,max-2,max-3,max-4 \
 OMUX_LIVE_QA_CAPABILITIES=codex-max \
 just live-qa
 ```
 
-For the Codex Max three-account path, prefer the canary before any spending
-run:
+For the Codex Max starter path, prefer the canary before any spending run:
 
 ```bash
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex canary
@@ -96,6 +95,19 @@ Operator-provided Codex state on 2026-04-28:
 - `max-3` is expected to remain active for API-backed usage.
 - These are not auth-dead accounts; the useful proof is preserving the
   distinction between weekly quota exhaustion and usable fallback routes.
+
+Current four-route Codex dogfood state on 2026-05-03:
+
+- The source example remains the three-route starter config. Add `max-4` to the
+  active operator config with `oauth-mux enroll codex --account max-4
+  --confirm-enroll --json` before using the four-route account matrix.
+- `max-1#codex-max` is selectable again after spend-gated exhausted-route
+  revalidation.
+- `max-4#codex-max` is the spare selectable fallback.
+- `max-2#codex-max` and `max-3#codex-max` still return provider quota
+  exhaustion from fresh probes.
+- Dashboard credit or Spark/mini availability is not generalized to
+  `codex-max`; trust provider execution evidence per route and capability.
 
 Hosted evidence from run `25029923810`:
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -411,7 +411,7 @@ definition declares `repair.owner = "oauth_mux_refresh"` and whose backend
 reports `automatic_refresh_admitted: true`. Codex remains upstream-CLI-owned.
 
 If `repair-plan --profile codex-max` reports a config validation error, the
-active config is not the three-account Codex Max shape. That usually means the
+active config is not the starter Codex Max shape. That usually means the
 machine still has an older generic config with only `codex:default`. Generate a
 safe sidecar candidate without modifying the active config:
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1215,7 +1215,7 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\  --help and -h are non-mutating for every Codex subcommand.
         \\
         \\Defaults:
-        \\  accounts:     max-1,max-2,max-3
+        \\  accounts:     max-1,max-2,max-3 (starter; pass --accounts for max-4)
         \\  capabilities: codex-mini,codex-max
         \\  store root:   $XDG_DATA_HOME/oauth-mux/codex or ~/.local/share/oauth-mux/codex
         \\


### PR DESCRIPTION
## Summary

Clarifies the active Codex operator docs after the four-route paid cohort cleanup.

- Updates live-provider QA examples to use `max-1,max-2,max-3,max-4` for the current four-route Codex dogfood matrix.
- Keeps the source example/starter shape honest as the three-route starter config, with `max-4` added through confirmed enrollment.
- Adds the current route truth: `max-1` selected after revalidation, `max-4` spare fallback, and `max-2`/`max-3` still provider quota-exhausted for `codex-max`.
- Clarifies CLI help/docs that the default account list is the starter default and enrolled routes should be passed explicitly.

## Tracking cleanup

Also closed stale PR #103 because its single-line README title replacement conflicts with the current product posture, and opened #149 / Linear TIN-925 for the separate omux.xoxd.ai site-copy/deploy source-owner lane.

## Validation

- `git diff --check`
- `just check-local`
