### PR TITLE
[codex] Ignore paid cohort soak artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ dist/build/
 dist/out/
 dist/live-qa/
 dist/codex-canary/
+dist/soak/
 *.tar.gz
 *.deb
 *.rpm


### PR DESCRIPTION
## Summary

Ignores local paid cohort soak artifacts under `dist/soak/`.

## Why

PR #151 introduced the TIN-895 soak policy and recommends local redacted snapshots under `dist/soak/<timestamp>/...`. Those artifacts are useful operator evidence, but they should not be accidentally staged in normal repo work.

## Validation

- `git diff --check`
- `just check-local`

I also collected the first no-spend local snapshot under `dist/soak/20260503T033125Z/codex-max`; it remains ignored.
