### PR TITLE
[codex] Truth stay-afloat cohort docs

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -85,10 +85,12 @@ oauth-mux stay-afloat --loop --iterations 2 --interval-ms 0 --profile codex-max 
 ```
 
 Those commands are installed CLI surface, not source-checkout-only helpers.
-The starter Codex shape is three accounts; after enrolling an extra route such
-as `max-4`, use `--accounts max-1,max-2,max-3,max-4` or
-`OMUX_CODEX_ACCOUNTS=max-1,max-2,max-3,max-4` for canary and live-QA helpers.
-Point account stores somewhere explicit with `--store-root <path>`.
+The source example remains a starter shape, but the current paid Codex dogfood
+cohort has four `codex-max` routes. Use
+`--accounts max-1,max-2,max-3,max-4` or
+`OMUX_CODEX_ACCOUNTS=max-1,max-2,max-3,max-4` for canary and live-QA helpers
+when validating that cohort. Point account stores somewhere explicit with
+`--store-root <path>`.
 
 Live probes remain explicit because they can spend subscription calls:
 

--- a/docs/spec/account-enrollment-agent-contract-2026-05-01.md
+++ b/docs/spec/account-enrollment-agent-contract-2026-05-01.md
@@ -6,7 +6,7 @@ Issue context: GitHub `Jesssullivan/oauth-mux#67` and `#68`; Linear `TIN-736`,
 
 ## Baseline
 
-Codex is product-proven for the current three-account path, but the first-run
+Codex is product-proven for the current paid cohort path, but the first-run
 surface is still more provider-specific than the final product should be.
 Claude and Figma have provider definitions and partial proof, but not a boring
 N-account enrollment contract.
@@ -17,9 +17,11 @@ storage quirks.
 
 The paid proof cohort in
 `docs/spec/paid-multi-account-proof-cohort-2026-05-01.md` is the first planned
-stress test for this contract: one lower-tier Codex account added to the
-existing Max cohort, three Claude Code account/billing shapes, and three Figma
-token/resource shapes.
+stress test for this contract: four `codex-max` routes plus lower-tier Codex
+contrast, three Claude Code account/billing shapes, and three Figma
+token/resource shapes. Current Codex route health remains capability-scoped:
+Spark/mini or dashboard-credit availability does not imply `codex-max`
+availability.
 
 ## Product Contract
 
@@ -84,7 +86,7 @@ plan/file metadata modes remain separate route shapes.
 ### Story A: user adds a fourth Codex account
 
 The user wants one more Codex subscription account without breaking the current
-three-account setup.
+paid-cohort setup.
 
 Expected flow:
 

--- a/docs/spec/codex-max-operator-plan-2026-04-25.md
+++ b/docs/spec/codex-max-operator-plan-2026-04-25.md
@@ -42,7 +42,7 @@ Redacted JSONL cassettes for these two `codex exec --json` outcomes live under:
 test/fixtures/cassettes/codex/
 ```
 
-Live three-account evidence captured on 2026-04-26:
+Historical starter evidence captured on 2026-04-26:
 
 ```text
 just codex-max-login-status-all
@@ -56,6 +56,11 @@ codex-mini: max-1, max-2, max-3 -> 200/use_this/live/available
 just codex-max-probe-all codex-max
 codex-max: max-1, max-2, max-3 -> 200/use_this/live/available
 ```
+
+Supersession note, 2026-05-03: current `codex-max` dogfood is tracked in
+`docs/spec/paid-multi-account-proof-cohort-2026-05-01.md`. The live cohort now
+has four broker-ready routes, with `max-1` selected, `max-4` spare fallback,
+and `max-2`/`max-3` quota-exhausted for `codex-max`.
 
 Only login status, auth store paths, and mux probe classifications were
 inspected. Token contents were not read or printed.

--- a/docs/spec/development-timeline-2026-04-27.md
+++ b/docs/spec/development-timeline-2026-04-27.md
@@ -4,21 +4,28 @@ Updated: 2026-04-28
 
 Issue context: Linear `TIN-491`, GitHub `tinyland-inc/lab#197`.
 
+Supersession note, 2026-05-03: this timeline records the original public
+release arc. Current Codex dogfood has moved from the initial starter path to a
+four-route paid `codex-max` cohort with broker-owned session planning, live
+broker-run, exhausted-route revalidation, controlled fallback drills, and a
+no-spend soak snapshot helper. Same-thread quota recovery and unmanaged TUI
+hot-swap remain unclaimed.
+
 ## Current Stage
 
 `oauth-mux` is now published as a controlled public tool for the first concrete
 use case. `v0.1.2` is the first usable public npm release, the Codex
-three-account path is live-proven through hosted secret-scoped QA, and the full
+starter Codex path is live-proven through hosted secret-scoped QA, and the full
 registry dry-run path has passed for the current release.
 
 The remaining product gap is no longer core selection or publication mechanics.
 The gap is adoption: first-run clarity, website narrative, provider-author
 contribution paths, community feedback, and precise provider-support language.
 
-The current Codex operator state is that all three configured Codex accounts are
-active and classify as `live.available` for both `codex-mini` and `codex-max`.
-Earlier quota-exhaustion permutations remain valuable fixture and QA scenarios:
-they should continue to classify as route-scoped availability, not generic
+The current operator truth has since moved into
+`docs/spec/paid-multi-account-proof-cohort-2026-05-01.md`. Earlier
+quota-exhaustion permutations remain valuable fixture and QA scenarios: they
+should continue to classify as route-scoped availability, not generic
 degradation or auth death.
 
 ## Completed Arc
@@ -115,7 +122,7 @@ degradation or auth death.
 Ready now:
 
 - internal operator experimentation;
-- local three-account Codex Max setup and explicit probe runs;
+- local Codex Max setup and explicit probe runs;
 - schema-only provider authoring against no-secret fixtures;
 - public npm install of `v0.1.2`;
 - hosted live QA for the Codex account matrix;

--- a/docs/spec/product-adoption-sprint-2026-04-28.md
+++ b/docs/spec/product-adoption-sprint-2026-04-28.md
@@ -17,9 +17,9 @@ tool for the first concrete use case:
 - GitHub Release, npm package layout, Homebrew formula audit, deb/rpm metadata,
   curl installer smoke, and rollback docs have all been exercised through the
   release proof or registry dry-run paths.
-- The Codex three-account path is live-proven through secret-scoped hosted QA.
-  All three current accounts classify as `live.available` across `codex-mini`
-  and `codex-max`.
+- The original Codex starter path is live-proven through secret-scoped hosted
+  QA. Current paid-cohort truth has since moved to
+  `docs/spec/paid-multi-account-proof-cohort-2026-05-01.md`.
 - Installed CLI commands now cover the core Codex flow:
   `oauth-mux codex onboard`, `oauth-mux codex canary`, and
   `oauth-mux codex probe-all`.
@@ -57,7 +57,7 @@ Primary claim:
 
 What to say now:
 
-- real three-account Codex muxing works;
+- real Codex route muxing works;
 - subscription quota exhaustion is a typed availability state, not generic
   failure;
 - the tool is zero external Zig dependencies and ships as static binaries;
@@ -114,7 +114,7 @@ Required sections:
      publication state precisely.
 
 5. First-run flows.
-   - Codex three-account happy path.
+   - Codex paid cohort path.
    - generic provider author path.
    - agent discovery path:
 

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -11,11 +11,19 @@ auth-broker proof `TIN-913` / GitHub `#125`.
 
 ## Baseline
 
-`oauth-mux` v0.1.6 is published and dogfooded for the Codex three-account
-route. The release has public GitHub assets, npm `latest`, `curl | sh`,
+`oauth-mux` v0.1.6 is published and dogfooded for the Codex route-selection
+path. The release has public GitHub assets, npm `latest`, `curl | sh`,
 deb/rpm assets, and a public Jess-owned Homebrew tap. The remaining adoption
 risks are no longer general release mechanics. They are specific product
 boundaries that need separate tracking.
+
+Supersession note, 2026-05-03: the Codex proof ladder now includes
+broker-owned session planning, no-spend local broker smokes, spend-gated
+broker-run live turns, bounded broker-run session loops, exhausted-route
+revalidation, and controlled fallback drills. The current paid `codex-max`
+cohort is four routes: `max-1` selected, `max-4` spare fallback, and
+`max-2`/`max-3` quota-exhausted for `codex-max`. Provider-originated
+in-session quota fallback remains tracked by GitHub `#131` / Linear `TIN-916`.
 
 ## Public Issue Map
 

--- a/docs/spec/production-publication-sprint-2026-04-28.md
+++ b/docs/spec/production-publication-sprint-2026-04-28.md
@@ -48,7 +48,7 @@ Evidence:
 
 ## Current Baseline
 
-- `origin/main` contains the merged core mux, typed liveness, Codex three-account
+- `origin/main` contains the merged core mux, typed liveness, Codex starter
   path, onboarding docs, live QA harness, registry dry-run scaffolding, and
   CI-only npm publish path.
 - Hosted CI has passed Zig tests, Nix validation, all six cross-compiles, and a
@@ -70,7 +70,7 @@ Evidence:
   cache-first validation.
 - Hosted live-provider QA has workflow support for secret-scoped config,
   Codex CLI bootstrap, and a minimal hosted credential-store bundle. Run
-  `25029923810` completed the Codex three-account matrix with
+  `25029923810` completed the original Codex starter matrix with
   `confirm=spend-real-calls`.
 
 ## Sprint Objective

--- a/src/main.zig
+++ b/src/main.zig
@@ -5325,9 +5325,9 @@ fn writeDoctorChecksJson(writer: anytype, stats: DoctorStats, validation_message
             stats.codex_max_configured,
             if (stats.codex_max_configured) "ok" else "warning",
             if (stats.codex_max_configured)
-                "three-account Codex Max mux shape configured"
+                "Codex Max mux shape configured"
             else
-                "Codex is configured but the three-account Codex Max mux shape is missing; run oauth-mux codex config-candidate",
+                "Codex is configured but the Codex Max mux shape is missing; run oauth-mux codex config-candidate",
         );
     }
     try writeDoctorCheckJson(writer, &first, "health_recorded", stats.health_entries > 0, if (stats.health_entries > 0) "ok" else "info", if (stats.health_entries > 0) "health state recorded" else "no health state recorded yet");


### PR DESCRIPTION
## Summary

Updates stale stay-afloat/Codex cohort language after the live proof ladder moved beyond the original starter account matrix.

- Replaces current-facing “three-account” Codex wording with paid cohort / Codex Max route wording.
- Adds supersession notes to dated specs that still carry historical starter-path claims.
- Updates doctor readiness text so it reports a Codex Max mux shape rather than a fixed three-account shape.

## Why

The current product truth is a four-route `codex-max` cohort with `max-1` selected, `max-4` spare fallback, and `max-2`/`max-3` quota-exhausted for `codex-max`. Spark/mini or dashboard-credit availability must stay capability-scoped and should not be generalized to Max availability.

This keeps operator docs aligned with the merged broker-owned session ladder, exhausted-route revalidation, controlled fallback drills, and no-spend soak snapshot helper, while continuing to leave provider-originated in-session quota fallback on TIN-916 / #131.

## Validation

- `just check-local`
- `git diff --check`
- targeted stale-string scan for old three-account/live-fallback overclaim wording
- no-spend paid cohort soak snapshot: `dist/soak/20260503T042544Z/codex-max`

The snapshot reports `max-1` selected, `max-4` spare fallback, `max-2`/`max-3` blocked for `codex-max`, and no resilience actions.

Refs #131, #67.