### PR TITLE
[codex] Capture soak agent gates

### DIFF
--- a/docs/spec/paid-cohort-soak-claim-policy-2026-05-03.md
+++ b/docs/spec/paid-cohort-soak-claim-policy-2026-05-03.md
@@ -48,6 +48,7 @@ mkdir -p "$out"
 ./zig-out/bin/oauth-mux providers list --json >"$out/providers.json"
 ./zig-out/bin/oauth-mux route explain --profile codex-max --capability codex-max --json >"$out/route-explain.json"
 ./zig-out/bin/oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json >"$out/broker-session-plan.json"
+./zig-out/bin/oauth-mux stay-afloat next --profile codex-max --capability codex-max --json >"$out/stay-afloat-next.json"
 ./zig-out/bin/oauth-mux stay-afloat --once --profile codex-max --capability codex-max --json >"$out/stay-afloat-once.json"
 ```
 
@@ -76,6 +77,12 @@ Do not run spend-gated commands from unattended loops. If a route has no spare
 fallback, record the `resilience_actions` and decide manually whether to
 revalidate, enroll another account, or wait for reset.
 
+The daily no-spend snapshot may also include confirmation-gate artifacts such
+as `revalidate-exhausted.confirmation.json` or
+`broker-run.confirmation.json`. Those files are expected to report
+`confirmation_required:true`; they prove the operator gate is still closed and
+are not evidence that provider calls ran.
+
 ## Artifact Rules
 
 Artifacts may be local under `dist/soak/<timestamp>/...` or hosted workflow
@@ -93,8 +100,12 @@ Minimum complete Codex soak snapshot:
 - `providers.json`;
 - `route-explain.json`;
 - `broker-session-plan.json`;
+- `stay-afloat-next.json`;
 - `stay-afloat-once.json`;
 - `stay-afloat-loop.json` when wrapper behavior is part of the claim;
+- `revalidate-exhausted.confirmation.json` and
+  `broker-run.confirmation.json` when the snapshot needs to prove spend gates
+  are closed;
 - `revalidate-exhausted.json` only when the operator intentionally spent a
   route revalidation call.
 

--- a/scripts/paid-cohort-soak-snapshot.sh
+++ b/scripts/paid-cohort-soak-snapshot.sh
@@ -80,6 +80,28 @@ run_artifact() {
   fi
 }
 
+run_confirmation_artifact() {
+  local label="$1"
+  local output_name="$2"
+  shift 2
+
+  local output_file="$out_dir/$output_name"
+  local log_file="$out_dir/${output_name}.stderr.log"
+
+  printf '\n=== %s ===\n' "$label" | tee -a "$summary"
+  set +e
+  "$@" >"$output_file" 2> >(redact >"$log_file")
+  local status="$?"
+  set -e
+
+  if grep -q '"confirmation_required":true' "$output_file"; then
+    printf 'wrote %s (confirmation gate, status %s)\n' "$output_name" "$status" | tee -a "$summary"
+  else
+    printf 'failed (%s): %s did not report confirmation_required\n' "$status" "$label" | tee -a "$summary" >&2
+    failures=$((failures + 1))
+  fi
+}
+
 run_text_artifact() {
   local label="$1"
   local output_name="$2"
@@ -106,17 +128,21 @@ run_artifact "route explain" "route-explain.json" "$bin" route explain --profile
 
 if [ "$provider" = "codex" ]; then
   run_artifact "codex broker-session-plan" "broker-session-plan.json" "$bin" codex broker-session-plan --profile "$profile" --capability "$capability" --json
+  run_confirmation_artifact "codex revalidate-exhausted spend gate" "revalidate-exhausted.confirmation.json" "$bin" codex revalidate-exhausted --profile "$profile" --capability "$capability" --json
+  run_confirmation_artifact "codex broker-run spend gate" "broker-run.confirmation.json" "$bin" codex broker-run --profile "$profile" --capability "$capability" --prompt "oauth-mux soak confirmation gate" --json
 else
   printf '\n=== broker-session-plan ===\n' | tee -a "$summary"
   printf 'skipped: broker-session-plan is Codex-specific\n' | tee "$out_dir/broker-session-plan.skipped.txt" | tee -a "$summary" >/dev/null
 fi
 
+run_artifact "stay-afloat next" "stay-afloat-next.json" "$bin" stay-afloat next --profile "$profile" --capability "$capability" --json
 run_artifact "stay-afloat once" "stay-afloat-once.json" "$bin" stay-afloat --once --profile "$profile" --capability "$capability" --json
 run_artifact "stay-afloat loop" "stay-afloat-loop.json" "$bin" stay-afloat --loop --iterations "$loop_iterations" --interval-ms "$loop_interval_ms" --profile "$profile" --capability "$capability" --json
 
 {
   printf '\nSpend-gated commands intentionally not run.\n'
-  printf 'Use codex revalidate-exhausted or live-provider QA only from an explicit operator-confirmed spend path.\n'
+  printf 'The confirmation artifacts prove the spend gates remain closed without --confirm-spend.\n'
+  printf 'Use codex revalidate-exhausted, broker-run, or live-provider QA only from an explicit operator-confirmed spend path.\n'
 } | tee -a "$summary"
 
 if [ "$failures" -ne 0 ]; then


### PR DESCRIPTION
## Summary

Extends `paid-cohort-soak-snapshot` so the daily no-spend artifact captures the agent-facing handoff and explicit spend gates.

- Adds `stay-afloat-next.json` to the snapshot output.
- Adds `revalidate-exhausted.confirmation.json` and `broker-run.confirmation.json` artifacts that must report `confirmation_required:true`.
- Updates the paid cohort soak claim policy so those files are treated as no-spend gate evidence, not provider-call proof.

## Why

The current stay-afloat truth depends on both route state and operator gates. A useful daily soak should show the selected/fallback route an agent would use and also prove that live revalidation or broker-run spend remains blocked unless the operator explicitly confirms it.

## Validation

- `bash -n scripts/paid-cohort-soak-snapshot.sh`
- `just paid-cohort-soak-snapshot`
- `just check-local`
- `git diff --check`

Fresh snapshot artifact:

- `dist/soak/20260503T044400Z/codex-max`
- `stay-afloat-next.json` reports prepared fallback with one spare route.
- Both confirmation artifacts report `confirmation_required:true`, `spends_provider_calls:true`, and `mutates_route_health:true`, with command status 1 and no provider calls run.

Refs #67, #131.