### PR TITLE
[codex] Record Codex native handoff gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ transcript content. Add `--continue-on-failure` to make a live quota/rate-limit
 failure start a fresh broker-owned session on the next selected route and replay
 the failed prompt plus remaining queued prompts. This is next-session
 continuation, not same-thread recovery.
+Negative live evidence matters here: a provider-owned Codex session that hit
+`You've hit your usage limit` on 2026-05-03 did not emit a native handoff or let
+oauth-mux switch accounts in place. After manual logout/login, `stay-afloat
+next` again reported a prepared next-process route with `max-1` selected and
+`max-4` as spare fallback. Treat native in-session handoff as unproven unless
+Codex exposes a supported hook.
 `codex revalidate-exhausted --confirm-spend --json` is the spend-gated
 post-billing-change check. It finds recorded exhausted Codex routes for the
 selected profile/capability, bypasses only those local health blocks, runs fresh

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -198,6 +198,12 @@ selected route after a live quota/rate-limit failure. The command replays the
 failed prompt plus remaining queued prompts and reports that this is
 next-session continuation, not same-thread recovery.
 
+Observed native Codex behavior reinforces that boundary: on 2026-05-03, a
+provider-owned Codex session reported `You've hit your usage limit` and did not
+offer an oauth-mux account handoff. Manual logout/login restored route readiness
+for future mediated launches, but it did not prove in-place or same-thread
+fallback.
+
 `oauth-mux codex revalidate-exhausted --profile codex-max --capability
 codex-max --confirm-spend --json` is the operator-safe post-billing-change
 refresh. It targets Codex routes already recorded as quota-exhausted or

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -22,6 +22,12 @@ exhaustion to `codex:max-2#codex-max`, but it also exposed that runtime
 permission/session ownership and automatic reauth are not solved by the current
 daemon.
 
+The 2026-05-03 usage-limit dogfood keeps the boundary in place as well. An
+already-running provider-owned Codex session hit `You've hit your usage limit`
+and no seamless daemon handoff occurred. Manual logout/login restored future
+`stay-afloat next` readiness, but the daemon did not harden that active session
+into a seamless fallback path.
+
 `oauth-mux doctor runtime`, `oauth-mux route explain`, `oauth-mux route
 select`, `oauth-mux repair-plan`, and `oauth-mux repair run` are the current
 bridge between dogfooding evidence and future daemon work. They read local

--- a/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
+++ b/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
@@ -344,6 +344,12 @@ For quota-driven account changes, use a different action name, such as
   that selected fallback and replay the failed prompt plus remaining queued
   prompts. It still does not prove same-thread recovery or unmanaged TUI
   hot-swap.
+- Native provider-owned Codex usage-limit behavior has negative evidence:
+  on 2026-05-03, an already-running Codex session returned `You've hit your
+  usage limit` and did not emit a provider-native handoff that oauth-mux could
+  answer. Manual logout/login restored future route readiness, but it did not
+  prove in-place fallback. Keep this distinct from broker-owned next-session
+  continuation.
 - Exhausted route revalidation is spend-gated. It exists for external billing,
   plan, or credit changes: bypass only recorded exhausted route-health blocks,
   re-probe the provider, and persist the fresh capability evidence. It removes

--- a/docs/spec/paid-cohort-soak-claim-policy-2026-05-03.md
+++ b/docs/spec/paid-cohort-soak-claim-policy-2026-05-03.md
@@ -177,6 +177,7 @@ Not allowed without new evidence:
   resource-token proof separately.
 - "Claude is proven" beyond the exact command/auth, subscription, and quota
   shapes with artifacts.
+- "A provider-owned Codex usage-limit screen proves native account handoff."
 
 ## Promotion Checklist
 

--- a/docs/spec/paid-multi-account-proof-cohort-2026-05-01.md
+++ b/docs/spec/paid-multi-account-proof-cohort-2026-05-01.md
@@ -81,6 +81,10 @@ Current dogfood truth as of 2026-05-03:
   exhaustion.
 - No logout or reauth was required when capacity changed; spend-gated
   `codex revalidate-exhausted` refreshed route health from provider evidence.
+- Separate from route-health revalidation, a provider-owned live Codex session
+  that hit `You've hit your usage limit` on 2026-05-03 did not perform a
+  native account handoff. Manual logout/login restored future mediated launch
+  readiness; it did not prove in-session fallback.
 - Dashboard credit/Spark availability must not be generalized to
   `codex-max`; route health remains capability-scoped.
 

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -128,6 +128,10 @@ proven reload, broker, restart, proxy, or in-agent mediation path.
 beta host for the same foreground tick engine. Status can report
 `stay_afloat_loop.hosted:true`, but production support remains false until
 soak and wrapper proof complete.
+The 2026-05-03 live usage-limit observation strengthens that caution: an
+already-running provider-owned Codex session hit a usage limit and no seamless
+daemon handoff occurred. Manual logout/login restored future mediated launch
+readiness, but did not prove active-session rescue.
 
 The `TIN-913` / GitHub `#125` Codex app-server auth-broker artifact is
 `docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md`. It records the
@@ -290,6 +294,8 @@ these precise provider-proof children.
 
 - Do not describe the public tap as Homebrew core.
 - Do not make daemon execution a first-run or release gate.
+- Do not describe the current daemon or beta loop as hardened seamless
+  stay-afloat for active provider-owned sessions.
 - Do not claim hot-swap inside an already-running harness without a proven
   reload, auth broker, supervised restart, proxy, or in-agent mediation path.
 - Track wrapper-owned supervised restart separately under

--- a/docs/stay-afloat-wrappers.md
+++ b/docs/stay-afloat-wrappers.md
@@ -108,6 +108,10 @@ is not yet the production background daemon claim tracked by GitHub #67.
 `claim.level:"prepared_fallback"` means the next mediated launch can select an
 account through `stay-afloat launch`; it does not claim current-process
 hot-swap, supervised restart, or per-request muxing.
+Observed usage-limit dogfood on 2026-05-03 confirmed that an unmanaged
+already-running Codex session does not seamlessly hand off through this daemon
+surface. The wrapper recipes should be treated as route-warming and launch
+mediation, not active-session rescue.
 
 ## Smoke And Soak
 


### PR DESCRIPTION
## Summary

Records the negative live Codex handoff evidence from the May 3 usage-limit dogfood.

- Documents that a provider-owned, already-running Codex session hit `You've hit your usage limit` and did not emit a native oauth-mux handoff.
- Clarifies that manual logout/login restored future mediated launch readiness, not in-place or same-thread fallback.
- Sharpens daemon language: the current daemon/beta loop can warm route state and surface handoffs, but is not hardened seamless stay-afloat for active provider-owned sessions.

## Current Truth

After manual reauth and an escalated no-spend refresh:

- `broker-session-plan` is ready with `max-1` selected and `max-4` as spare fallback.
- `max-2` and `max-3` remain quota-blocked for `codex-max`.
- `stay-afloat next` reports `ready_for_exec:true`, `prepared_fallback`, and `single_route_at_risk:false`.
- Spend-gated `revalidate-exhausted` and `broker-run` confirmation artifacts still stop at `confirmation_required:true`.

This means the next mediated process can be launched correctly, but the observed active Codex session did not seamlessly stay afloat.

## Validation

- `git diff --check`
- `just paid-cohort-soak-snapshot` outside the workspace sandbox so account-store readiness was real
- `just check-local`

Fresh no-spend artifact:

- `dist/soak/20260503T045753Z/codex-max`

Refs #131, #67, #123.