### PR TITLE
[codex] Add stay-afloat supervised restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,13 @@ selectable account. If no route remains selectable, launch prints the refreshed
 mediation text and exits nonzero without running the target. If no route is
 selectable at preflight, launch also prints the mediated repair/handoff text
 and exits nonzero without running the target.
+`stay-afloat supervise --max-restarts <n> --restart-on-exit-code <code> -- <command>`
+is the first wrapper-owned restart surface. It spawns a child instead of
+`execve` replacement, injects the selected route, and restarts on the next
+selectable route only when the child exits with the operator-classified code.
+The JSON claim can set `supervised_restart:true` for that wrapper-owned child
+path; it still does not claim current-process hot-swap, unmanaged TUI handoff,
+or per-request muxing.
 
 `doctor runtime --json` is also no-spend. It checks local runtime prerequisites
 such as upstream binaries, configured account store directories, write access,

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -229,6 +229,12 @@ selected route, launch re-runs selection and tries the next selectable account.
 If no route remains selectable, launch prints refreshed mediation text and exits
 nonzero without starting the target. If no route is selectable at preflight, it
 also prints mediation text and exits nonzero without starting the target.
+`oauth-mux stay-afloat supervise --max-restarts <n>
+--restart-on-exit-code <code> -- <command>` is the wrapper-owned restart beta.
+It keeps oauth-mux as the parent process, injects the selected route into a
+child, and restarts on a distinct selectable route only for the configured exit
+code. This is useful for harnesses or test wrappers that can make failures
+typed; it is not unmanaged in-process token replacement.
 
 `oauth-mux accounts list --json` is the provider-neutral account inventory
 surface. It reports configured accounts, runtime readiness, capability proof,

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -151,6 +151,12 @@ proxy, or in-agent adapter proves those stronger levels.
 - `oauth-mux daemon tick --loop --iterations <n> --interval-ms <ms> --json`
   as the lower-level wrapper-author spelling for the same bounded foreground
   loop.
+- `oauth-mux stay-afloat supervise --max-restarts <n>
+  --restart-on-exit-code <code> -- <command>` as the beta wrapper-owned restart
+  path. It can claim `supervised_restart:true` only after oauth-mux spawned the
+  child, observed the configured exit code, and restarted on another selectable
+  route. It does not promote the socket daemon or claim current-process
+  hot-swap.
 - `claim.level:"prepared_fallback"` in `stay-afloat` / `daemon tick` JSON and
   in the latest `daemon status --json` snapshot when a route is selectable.
   Wrappers should pair that with the emitted `claim.launch_argv` and should not

--- a/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
+++ b/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
@@ -350,6 +350,15 @@ For quota-driven account changes, use a different action name, such as
   answer. Manual logout/login restored future route readiness, but it did not
   prove in-place fallback. Keep this distinct from broker-owned next-session
   continuation.
+- The upstream Codex OSS shape matches that boundary. In `openai/codex`,
+  `UsageLimitReached` is a distinct, non-retryable core error mapped to
+  `CodexErrorInfo::UsageLimitExceeded`; the app-server
+  `account/chatgptAuthTokens/refresh` path is tested for 401 unauthorized
+  refresh, not quota handoff. Relevant source surfaces:
+  <https://github.com/openai/codex/blob/main/codex-rs/protocol/src/error.rs>,
+  <https://github.com/openai/codex/blob/main/codex-rs/core/src/session/turn.rs>,
+  and
+  <https://github.com/openai/codex/blob/main/codex-rs/app-server/tests/suite/v2/account.rs>.
 - Exhausted route revalidation is spend-gated. It exists for external billing,
   plan, or credit changes: bypass only recorded exhausted route-health blocks,
   re-probe the provider, and persist the fresh capability evidence. It removes

--- a/docs/spec/supervised-harness-restart-contract-2026-05-02.md
+++ b/docs/spec/supervised-harness-restart-contract-2026-05-02.md
@@ -57,15 +57,16 @@ the selected route is reclassified during the final `oauth-mux exec` preflight.
 
 ### Level 2: supervised_restart
 
-Not implemented yet.
+First implementation slice exists.
 
-This requires a distinct parent-wrapper command. Tentative spelling:
+The parent-wrapper command is:
 
 ```bash
 oauth-mux stay-afloat supervise \
   --profile <profile> \
   --capability <capability> \
   --max-restarts <n> \
+  --restart-on-exit-code <code> \
   -- <command>
 ```
 
@@ -81,8 +82,12 @@ must:
 7. relaunch with a different selectable route only when policy admits restart;
 8. stop after a bounded restart count.
 
-This is the first path that can honestly set `claim.supervised_restart:true`,
-and only for the wrapper-owned process.
+The first implementation classifies only an operator-declared exit code. It does
+not parse arbitrary provider output and does not persist route-health evidence
+from generic child failure. This is deliberate: the wrapper can prove
+`claim.supervised_restart:true` for the child it owns after an actual restart,
+while still avoiding claims about in-process token replacement, unmanaged TUI
+handoff, or per-request muxing.
 
 ### Level 3: current_process_hotswap
 
@@ -109,7 +114,7 @@ Generic nonzero exit is not enough to poison a credential. A failing command may
 exit because of user code, network conditions, interrupted terminal state, bad
 flags, or provider auth.
 
-Initial admission should require one of:
+Initial admission requires one of:
 
 - provider-specific classifier evidence from captured stderr/stdout;
 - an explicit wrapper policy such as `--restart-on-exit-code <code>` for test
@@ -118,9 +123,10 @@ Initial admission should require one of:
 - a follow-up `stay-afloat refresh --execute` tick that marks the current route
   degraded, dead, quota-exhausted, or temporarily unavailable.
 
-The first implementation should not parse unlimited output into memory. Use a
-bounded stderr/stdout capture or inherit output by default and require an
-explicit `--classify-output` mode before buffering provider text.
+The current implementation uses the explicit `--restart-on-exit-code` path. It
+inherits child output in text mode and suppresses it in JSON mode, so JSON
+evidence remains redacted. A future provider-specific classifier can add bounded
+stderr/stdout capture, but that must remain opt-in.
 
 ## JSON Shape
 
@@ -201,11 +207,13 @@ When the extra paid Codex account is ready:
 
 1. Keep PR #122's freshness and active-loop correlation as the proof gate.
 2. Add this contract and public docs language before implementing a new command.
-3. Add a toy-provider E2E fixture for wrapper-owned child restart.
-4. Add the `stay-afloat supervise` CLI parser and help text.
+3. Add a toy-provider E2E fixture for wrapper-owned child restart. Done.
+4. Add the `stay-afloat supervise` CLI parser and help text. Done.
 5. Refactor exec environment preparation so `launch` can keep using `execve`
-   while `supervise` can spawn with the same selected env.
-6. Add bounded restart JSON and event logging.
+   while `supervise` can spawn with the same selected env. First spawn path
+   added.
+6. Add bounded restart JSON and event logging. JSON evidence added; event
+   logging remains open.
 7. Run Codex dogfood with one exhausted account and one credited fallback
    account.
 8. Only then consider promoting `claim.supervised_restart:true` for the exact

--- a/docs/stay-afloat-wrappers.md
+++ b/docs/stay-afloat-wrappers.md
@@ -1,6 +1,7 @@
 # Stay-Afloat Wrapper Recipes
 
-Status: beta operator recipes for the supervised stay-afloat loop.
+Status: beta operator recipes for the supervised stay-afloat loop and
+wrapper-owned child restart.
 
 These recipes make the current daemon beta dogfoodable without changing the
 public product claim. The loop can keep route-state evidence warm and queue
@@ -8,9 +9,10 @@ user-mediated repair handoffs, but it does not hot-swap credentials inside an
 unmanaged already-running upstream harness process.
 
 The next stronger claim is wrapper-mediated supervised restart, tracked in
-`docs/spec/supervised-harness-restart-contract-2026-05-02.md`. That path needs a
-separate parent-wrapper command because `stay-afloat launch` intentionally uses
-`execve` and cannot observe the target process after startup.
+`docs/spec/supervised-harness-restart-contract-2026-05-02.md`. The first slice
+is now `stay-afloat supervise`: a parent-wrapper command that spawns a child
+instead of using `execve`, observes the child exit, and can restart on another
+selected route when the operator gives a typed exit-code classifier.
 
 Codex now also has a separate app-server auth-broker proof track:
 `docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md`. That path may become
@@ -24,6 +26,7 @@ The supported contract is still the portable tick engine:
 ```bash
 oauth-mux stay-afloat next --profile codex-max --capability codex-max --json
 oauth-mux stay-afloat launch --profile codex-max --capability codex-max -- codex
+oauth-mux stay-afloat supervise --profile codex-max --capability codex-max --max-restarts 1 --restart-on-exit-code 42 -- codex
 oauth-mux stay-afloat --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
 oauth-mux daemon tick --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
 ```
@@ -41,6 +44,15 @@ state before startup, launch can refresh route evidence and try the next
 selectable account when a route that looked selectable at preflight is
 reclassified before the target starts. If no selectable account remains, it
 prints the refreshed mediation text and exits nonzero.
+
+Use `stay-afloat supervise --max-restarts <n> --restart-on-exit-code <code>
+-- <command>` when oauth-mux should own the child process boundary. The first
+implementation is intentionally conservative: it does not parse arbitrary
+provider output and it does not persist route-health evidence from a generic
+child failure. It restarts only when the child exits with the configured code,
+skips the already-attempted route for that supervise run, and emits redacted
+JSON/text evidence with `claim.supervised_restart:true` only after an actual
+wrapper-owned restart occurred.
 
 The beta supervised daemon host wraps that same engine:
 

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -398,6 +398,32 @@ OMUX_E2E_EXEC_OUT="$stale_launch_out" omux stay-afloat launch --profile expensiv
 stale_launch_result="$(cat "$stale_launch_out")"
 expect_contains "$stale_launch_result" 'a2:omux-e2e-a2' "stay-afloat launch falls through to a2 after a1 reclassification"
 
+printf 'e2e: stay-afloat supervise restarts wrapper-owned child on classified exit code\n'
+printf '%s\n' 'expensive:a1:ok' >"$probe_mode_file"
+omux health --reset toy:a1#expensive >/dev/null
+omux health --reset toy:a2#expensive >/dev/null
+supervise_a1_probe="$(omux probe --provider toy --account a1 --capability expensive --json)"
+expect_contains "$supervise_a1_probe" '"account":"a1"' "supervise setup records a1 as available"
+supervise_a2_probe="$(omux probe --provider toy --account a2 --capability expensive --json)"
+expect_contains "$supervise_a2_probe" '"account":"a2"' "supervise setup records a2 as available"
+supervise_out="$tmp/stay-supervise.out"
+supervise_json="$(OMUX_E2E_SUPERVISE_OUT="$supervise_out" omux stay-afloat supervise --profile expensive --capability expensive --max-restarts 1 --restart-on-exit-code 42 --json -- sh -c 'if [ "$OMUX_ACTIVE_ACCOUNT" = a1 ]; then exit 42; fi; printf "%s:%s" "$OMUX_ACTIVE_ACCOUNT" "$TOY_TOKEN" > "$OMUX_E2E_SUPERVISE_OUT"')"
+supervise_result="$(cat "$supervise_out")"
+expect_contains "$supervise_result" 'a2:omux-e2e-a2' "stay-afloat supervise restarts child on selected fallback"
+expect_contains "$supervise_json" '"mode":"stay_afloat_supervise"' "stay-afloat supervise reports mode"
+expect_contains "$supervise_json" '"ok":true' "stay-afloat supervise reports success after restart"
+expect_contains "$supervise_json" '"level":"supervised_restart"' "stay-afloat supervise claims wrapper restart only after restart"
+expect_contains "$supervise_json" '"supervised_restart":true' "stay-afloat supervise sets supervised restart claim"
+expect_contains "$supervise_json" '"current_process_hotswap":false' "stay-afloat supervise refuses current-process hot swap"
+expect_contains "$supervise_json" '"restart_count":1' "stay-afloat supervise reports restart count"
+expect_contains "$supervise_json" '"restart_admitted":true' "stay-afloat supervise reports admitted restart attempt"
+expect_contains "$supervise_json" '"selected":{"provider":"toy","account":"a2"' "stay-afloat supervise records fallback attempt"
+expect_not_contains "$supervise_json" "omux-e2e-a1" "stay-afloat supervise JSON does not expose first token"
+expect_not_contains "$supervise_json" "omux-e2e-a2" "stay-afloat supervise JSON does not expose fallback token"
+rm -f "$probe_mode_file"
+post_supervise_probe="$(omux probe --profile expensive --capability expensive --json)"
+expect_contains "$post_supervise_probe" '"account":"a2"' "post-supervise setup restores a2 as selected fallback"
+
 printf 'e2e: daemon tick plans stay-afloat without executing work\n'
 daemon_tick="$(omux daemon tick --once --profile expensive --capability expensive --json)"
 expect_contains "$daemon_tick" '"mode":"once"' "daemon tick reports one-shot mode"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -20,6 +20,7 @@ pub const Command = union(enum) {
     route: RouteArgs,
     stay_afloat_next: RouteArgs,
     stay_afloat_launch: ExecArgs,
+    stay_afloat_supervise: SuperviseArgs,
     stay_afloat: DaemonTickArgs,
     stay_afloat_handoff: HandoffArgs,
     config_validate,
@@ -45,6 +46,17 @@ pub const Command = union(enum) {
         capability: ?[]const u8 = null,
         strategy: ?[]const u8 = null,
         target_argv: []const []const u8 = &.{},
+    };
+
+    pub const SuperviseArgs = struct {
+        profile: ?[]const u8 = null,
+        provider: ?[]const u8 = null,
+        account: ?[]const u8 = null,
+        capability: ?[]const u8 = null,
+        target_argv: []const []const u8 = &.{},
+        max_restarts: u32 = 1,
+        restart_on_exit_code: ?u8 = null,
+        json: bool = false,
     };
 
     pub const EnvArgs = struct {
@@ -725,6 +737,7 @@ fn parseDaemonTick(args: []const []const u8) Command {
 
 fn parseStayAfloat(args: []const []const u8) Command {
     if (args.len > 0 and eql(args[0], "launch")) return .{ .stay_afloat_launch = parseExecArgs(args[1..]) };
+    if (args.len > 0 and eql(args[0], "supervise")) return parseStayAfloatSupervise(args[1..]);
     if (args.len > 0 and eql(args[0], "next")) return parseStayAfloatNext(args[1..]);
     if (args.len > 0 and eql(args[0], "handoffs")) return parseDaemonHandoffs(args[1..]);
     if (args.len > 0 and eql(args[0], "handoff")) return parseStayAfloatHandoff(args[1..]);
@@ -736,6 +749,41 @@ fn parseStayAfloat(args: []const []const u8) Command {
         return .{ .stay_afloat = tick };
     }
     return .{ .stay_afloat = parseDaemonTickArgs(args) };
+}
+
+fn parseStayAfloatSupervise(args: []const []const u8) Command {
+    var result = Command.SuperviseArgs{};
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        if (eql(args[i], "--")) {
+            if (i + 1 < args.len) {
+                result.target_argv = args[i + 1 ..];
+            }
+            break;
+        }
+        if (eql(args[i], "--profile") or eql(args[i], "-p")) {
+            i += 1;
+            if (i < args.len) result.profile = args[i];
+        } else if (eql(args[i], "--provider")) {
+            i += 1;
+            if (i < args.len) result.provider = args[i];
+        } else if (eql(args[i], "--account")) {
+            i += 1;
+            if (i < args.len) result.account = args[i];
+        } else if (eql(args[i], "--capability")) {
+            i += 1;
+            if (i < args.len) result.capability = args[i];
+        } else if (eql(args[i], "--max-restarts")) {
+            i += 1;
+            if (i < args.len) result.max_restarts = std.fmt.parseInt(u32, args[i], 10) catch result.max_restarts;
+        } else if (eql(args[i], "--restart-on-exit-code")) {
+            i += 1;
+            if (i < args.len) result.restart_on_exit_code = std.fmt.parseInt(u8, args[i], 10) catch result.restart_on_exit_code;
+        } else if (eql(args[i], "--json")) {
+            result.json = true;
+        }
+    }
+    return .{ .stay_afloat_supervise = result };
 }
 
 fn parseStayAfloatNext(args: []const []const u8) Command {
@@ -1065,6 +1113,8 @@ pub fn printUsage(writer: anytype) !void {
         \\      Show the next mediated action: exec argv when afloat, otherwise typed repair/handoff.
         \\  stay-afloat launch [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] -- <cmd> [args...]
         \\      Launch a target only when route evidence selects an exact account; otherwise print mediation and exit nonzero.
+        \\  stay-afloat supervise [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--max-restarts <n>] [--restart-on-exit-code <code>] [--json] -- <cmd> [args...]
+        \\      Spawn a wrapper-owned child and restart on an operator-classified exit code.
         \\  stay-afloat refresh [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
         \\      Run one execute tick to refresh route evidence after user-mediated auth.
         \\  stay-afloat handoffs [--json] [--limit <n>] [--all]
@@ -1879,6 +1929,26 @@ test "parse stay-afloat launch selector and target" {
     }
 }
 
+test "parse stay-afloat supervise selector restart policy and target" {
+    const args = [_][]const u8{ "stay-afloat", "supervise", "--profile", "codex-max", "--provider", "codex", "--account", "max-2", "--capability", "codex-max", "--max-restarts", "2", "--restart-on-exit-code", "42", "--json", "--", "codex", "--ask-for-approval=never" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .stay_afloat_supervise => |supervise| {
+            try std.testing.expectEqualStrings("codex-max", supervise.profile.?);
+            try std.testing.expectEqualStrings("codex", supervise.provider.?);
+            try std.testing.expectEqualStrings("max-2", supervise.account.?);
+            try std.testing.expectEqualStrings("codex-max", supervise.capability.?);
+            try std.testing.expectEqual(@as(u32, 2), supervise.max_restarts);
+            try std.testing.expectEqual(@as(u8, 42), supervise.restart_on_exit_code.?);
+            try std.testing.expect(supervise.json);
+            try std.testing.expectEqual(@as(usize, 2), supervise.target_argv.len);
+            try std.testing.expectEqualStrings("codex", supervise.target_argv[0]);
+            try std.testing.expectEqualStrings("--ask-for-approval=never", supervise.target_argv[1]);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 test "parse daemon run stay-afloat supervisor" {
     const args = [_][]const u8{ "daemon", "run", "--stay-afloat", "--profile", "codex-max", "--capability", "codex-max", "--iterations", "2", "--interval-ms", "0" };
     const cmd = parse(&args);
@@ -2041,7 +2111,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from route' -a 'select explain' -d 'Route subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from route' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l json -d 'JSON output'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -a 'next launch handoffs handoff refresh' -d 'Stay-afloat subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -a 'next launch supervise handoffs handoff refresh' -d 'Stay-afloat subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from handoff' -a 'ack clear' -d 'Handoff action'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l once -d 'Run one stay-afloat tick'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l loop -d 'Run bounded foreground stay-afloat ticks'
@@ -2050,6 +2120,8 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l interval-ms -d 'Milliseconds between ticks' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l limit -d 'Limit handoff count' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l all -d 'Include historical handoff events'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l max-restarts -d 'Maximum supervised child restarts' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l restart-on-exit-code -d 'Exit code that admits supervised restart' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'

--- a/src/main.zig
+++ b/src/main.zig
@@ -157,6 +157,13 @@ pub fn main() !void {
             };
         },
 
+        .stay_afloat_supervise => |supervise_args| {
+            runStayAfloatSupervise(allocator, stdout, supervise_args) catch |e| {
+                log.err("stay-afloat supervise: {s}", .{@errorName(e)});
+                std.process.exit(exitCodeFromPipelineError(e));
+            };
+        },
+
         .stay_afloat => |tick_args| {
             runDaemonTick(allocator, stdout, tick_args, "oauth-mux stay-afloat") catch |e| {
                 log.err("stay-afloat: {s}", .{@errorName(e)});
@@ -3649,6 +3656,248 @@ fn runStayAfloatLaunch(allocator: std.mem.Allocator, writer: anytype, args: cli.
     );
     if (last_exec_error) |err| return err;
     return error.AllAccountsExhausted;
+}
+
+const SuperviseAttempt = struct {
+    route: RepairPlanRoute,
+    term: std.process.Child.Term,
+    restart_admitted: bool,
+};
+
+fn runStayAfloatSupervise(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    args: cli.Command.SuperviseArgs,
+) !void {
+    if (args.target_argv.len == 0) {
+        log.err("stay-afloat supervise: no target command specified (use -- before the command)", .{});
+        return error.ConfigValidationError;
+    }
+
+    const parsed = try config.load(allocator);
+    defer parsed.deinit();
+
+    var validation_messages = std.ArrayList(u8).init(allocator);
+    defer validation_messages.deinit();
+    try config.validate(parsed.value, validation_messages.writer());
+
+    const selector = cli.Command.RouteArgs{
+        .action = .explain,
+        .profile = args.profile,
+        .provider = args.provider,
+        .account = args.account,
+        .capability = args.capability,
+    };
+    var routes = try collectRepairPlanRoutes(allocator, parsed.value, .{
+        .profile = selector.profile,
+        .provider = selector.provider,
+        .account = selector.account,
+        .capability = selector.capability,
+    });
+    defer routes.deinit();
+
+    var attempted_routes = std.ArrayList(RepairPlanRoute).init(allocator);
+    defer attempted_routes.deinit();
+    var attempts = std.ArrayList(SuperviseAttempt).init(allocator);
+    defer attempts.deinit();
+
+    var restart_count: u32 = 0;
+    var reason: []const u8 = "no_attempt";
+
+    while (true) {
+        var store = health_mod.HealthStore.load(allocator, .{});
+        defer store.deinit();
+
+        var evaluations = std.ArrayList(RouteEvaluation).init(allocator);
+        defer evaluations.deinit();
+        try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &evaluations);
+
+        const selected_index = firstSelectableRouteNotAttempted(evaluations.items, attempted_routes.items);
+        if (selected_index == null) {
+            reason = if (attempts.items.len == 0) "no_selectable_route" else "no_fallback_route";
+            break;
+        }
+
+        const selected = evaluations.items[selected_index.?].route;
+        try attempted_routes.append(selected);
+
+        var env_map = buildPinnedExecEnvMap(allocator, parsed.value, &store, selected, args) catch {
+            reason = "preflight_reclassified_route";
+            continue;
+        };
+        defer env_map.deinit();
+
+        var child = std.process.Child.init(args.target_argv, allocator);
+        child.stdin_behavior = .Inherit;
+        child.stdout_behavior = if (args.json) .Ignore else .Inherit;
+        child.stderr_behavior = if (args.json) .Ignore else .Inherit;
+        child.env_map = &env_map;
+
+        const term = child.spawnAndWait() catch return error.ExecFailed;
+        const restart_admitted = superviseRestartAdmitted(args, term, restart_count);
+        try attempts.append(.{
+            .route = selected,
+            .term = term,
+            .restart_admitted = restart_admitted,
+        });
+
+        if (restart_admitted) {
+            restart_count += 1;
+            reason = "restart_admitted";
+            continue;
+        }
+
+        reason = if (superviseTermSucceeded(term)) "target_completed" else "target_failed";
+        break;
+    }
+
+    if (args.json) {
+        try writeStayAfloatSuperviseJson(writer, args, attempts.items, restart_count, reason);
+    } else {
+        try writeStayAfloatSuperviseText(writer, args, attempts.items, restart_count, reason);
+    }
+}
+
+fn buildPinnedExecEnvMap(
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    store: *health_mod.HealthStore,
+    route: RepairPlanRoute,
+    args: cli.Command.SuperviseArgs,
+) !std.process.EnvMap {
+    var ctx = pipeline.Context.init(allocator, cfg, store);
+    defer ctx.deinit();
+
+    ctx.provider_name = route.provider;
+    ctx.account_name = route.account;
+    ctx.capability_name = route.capability orelse args.capability;
+    ctx.target_argv = args.target_argv;
+
+    pipeline.runExec(&ctx) catch |e| {
+        store.persist();
+        return e;
+    };
+
+    var env_map = try std.process.getEnvMap(allocator);
+    errdefer env_map.deinit();
+    for (ctx.env_pairs.items) |pair| {
+        try env_map.put(pair[0], pair[1]);
+    }
+    try env_map.put("OMUX_VERSION", cli.version);
+    store.persist();
+    return env_map;
+}
+
+fn superviseRestartAdmitted(
+    args: cli.Command.SuperviseArgs,
+    term: std.process.Child.Term,
+    restart_count: u32,
+) bool {
+    const expected = args.restart_on_exit_code orelse return false;
+    if (restart_count >= args.max_restarts) return false;
+    return switch (term) {
+        .Exited => |code| code == expected,
+        else => false,
+    };
+}
+
+fn superviseTermSucceeded(term: std.process.Child.Term) bool {
+    return switch (term) {
+        .Exited => |code| code == 0,
+        else => false,
+    };
+}
+
+fn superviseTermKind(term: std.process.Child.Term) []const u8 {
+    return switch (term) {
+        .Exited => "exited",
+        .Signal => "signal",
+        .Stopped => "stopped",
+        .Unknown => "unknown",
+    };
+}
+
+fn superviseTermCode(term: std.process.Child.Term) u32 {
+    return switch (term) {
+        .Exited => |code| code,
+        .Signal => |signal| signal,
+        .Stopped => |signal| signal,
+        .Unknown => |code| code,
+    };
+}
+
+fn writeStayAfloatSuperviseJson(
+    writer: anytype,
+    args: cli.Command.SuperviseArgs,
+    attempts: []const SuperviseAttempt,
+    restart_count: u32,
+    reason: []const u8,
+) !void {
+    const ok = attempts.len > 0 and superviseTermSucceeded(attempts[attempts.len - 1].term);
+    const prepared_fallback = attempts.len > 0;
+    try writer.writeAll("{\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"mode\":\"stay_afloat_supervise\",\"ok\":");
+    try writer.writeAll(if (ok) "true" else "false");
+    try writer.writeAll(",\"reason\":");
+    try std.json.stringify(reason, .{}, writer);
+    try writer.writeAll(",\"claim\":{\"claim_version\":1,\"level\":");
+    try std.json.stringify(if (restart_count > 0) "supervised_restart" else "supervised_process", .{}, writer);
+    try writer.writeAll(",\"prepared_fallback\":");
+    try writer.writeAll(if (prepared_fallback) "true" else "false");
+    try writer.writeAll(",\"supervised_restart\":");
+    try writer.writeAll(if (restart_count > 0) "true" else "false");
+    try writer.writeAll(",\"wrapper_owned_process\":true,\"restart_classification_source\":");
+    try std.json.stringify(if (args.restart_on_exit_code != null) "operator_exit_code" else "none", .{}, writer);
+    try writer.writeAll(",\"route_health_recorded\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
+    try writer.writeAll(",\"max_restarts\":");
+    try writer.print("{d}", .{args.max_restarts});
+    try writer.writeAll(",\"restart_on_exit_code\":");
+    if (args.restart_on_exit_code) |code| try writer.print("{d}", .{code}) else try writer.writeAll("null");
+    try writer.writeAll(",\"restart_count\":");
+    try writer.print("{d}", .{restart_count});
+    try writer.writeAll(",\"attempts\":[");
+    for (attempts, 0..) |attempt, idx| {
+        if (idx != 0) try writer.writeByte(',');
+        try writer.writeByte('{');
+        try writer.writeAll("\"selected\":");
+        try writeRouteSelectionJson(writer, attempt.route);
+        try writer.writeAll(",\"term\":{\"kind\":");
+        try std.json.stringify(superviseTermKind(attempt.term), .{}, writer);
+        try writer.writeAll(",\"code\":");
+        try writer.print("{d}", .{superviseTermCode(attempt.term)});
+        try writer.writeAll("},\"restart_admitted\":");
+        try writer.writeAll(if (attempt.restart_admitted) "true" else "false");
+        try writer.writeByte('}');
+    }
+    try writer.writeAll("],\"redaction\":{\"tokens_printed\":false,\"captured_output_printed\":false,\"raw_protocol_printed\":false}}\n");
+}
+
+fn writeStayAfloatSuperviseText(
+    writer: anytype,
+    args: cli.Command.SuperviseArgs,
+    attempts: []const SuperviseAttempt,
+    restart_count: u32,
+    reason: []const u8,
+) !void {
+    const ok = attempts.len > 0 and superviseTermSucceeded(attempts[attempts.len - 1].term);
+    try writer.writeAll("oauth-mux stay-afloat supervise\n\n");
+    try writer.print("  ok: {s}\n", .{if (ok) "true" else "false"});
+    try writer.print("  reason: {s}\n", .{reason});
+    try writer.print("  max restarts: {d}\n", .{args.max_restarts});
+    try writer.writeAll("  restart on exit code: ");
+    if (args.restart_on_exit_code) |code| try writer.print("{d}\n", .{code}) else try writer.writeAll("not configured\n");
+    try writer.print("  restart count: {d}\n", .{restart_count});
+    for (attempts, 0..) |attempt, idx| {
+        try writer.print("  attempt {d}: {s}:{s}", .{ idx + 1, attempt.route.provider, attempt.route.account });
+        if (attempt.route.capability) |cap| try writer.print("#{s}", .{cap});
+        try writer.print(" {s}:{d} restart_admitted={s}\n", .{
+            superviseTermKind(attempt.term),
+            superviseTermCode(attempt.term),
+            if (attempt.restart_admitted) "true" else "false",
+        });
+    }
+    try writer.writeAll("  boundary: wrapper-owned child restart only; no current-process hot-swap or per-request muxing\n");
 }
 
 fn firstSelectableRouteNotAttempted(


### PR DESCRIPTION
## Summary

Adds the first wrapper-owned supervised restart surface:

- `oauth-mux stay-afloat supervise --max-restarts <n> --restart-on-exit-code <code> -- <command>`
- Spawns the target as an oauth-mux-owned child instead of `execve` replacement.
- Injects the selected route into each child attempt using the existing pipeline.
- Restarts on the next selectable route only when the child exits with the operator-classified code.
- Emits redacted JSON/text evidence and sets `claim.supervised_restart:true` only after an actual wrapper-owned restart.

This intentionally does not parse arbitrary provider output, persist route-health evidence from generic child failure, claim unmanaged TUI hot-swap, or claim per-request muxing.

## Why

The 2026-05-03 Codex usage-limit dogfood showed no native handoff inside a provider-owned Codex process. That does not invalidate the shared OAuth daemon model, but it means the next honest product boundary is an oauth-mux-owned mediation point: broker-owned sessions or wrapper-owned restart.

The upstream `openai/codex` sources also support the boundary: usage-limit is a distinct non-retryable error mapped to `UsageLimitExceeded`, while the app-server ChatGPT auth refresh hook is tested for 401 unauthorized refresh, not quota handoff.

## Validation

- `zig build`
- `zig build test`
- `./scripts/e2e-local.sh`
- `just check-local`

The new e2e forces `toy:a1#expensive` to exit with code 42, verifies `stay-afloat supervise` restarts on `toy:a2#expensive`, reports `restart_count:1` and `supervised_restart:true`, and does not print token values.

Refs #123, #67.
