### PR TITLE
[codex] Truth stay-afloat docs against live cohort

### DIFF
--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -28,6 +28,13 @@ and no seamless daemon handoff occurred. Manual logout/login restored future
 `stay-afloat next` readiness, but the daemon did not harden that active session
 into a seamless fallback path.
 
+The current paid Codex Max route matrix is also newer than the original
+2026-04-30 example: `max-1#codex-max` is selected after spend-gated
+revalidation, `max-4#codex-max` is the spare fallback, and `max-2#codex-max`
+plus `max-3#codex-max` remain provider quota-exhausted for `codex-max`.
+Dashboard credit or mini/Spark availability must not be treated as Max route
+availability; use provider execution evidence per route and capability.
+
 `oauth-mux doctor runtime`, `oauth-mux route explain`, `oauth-mux route
 select`, `oauth-mux repair-plan`, and `oauth-mux repair run` are the current
 bridge between dogfooding evidence and future daemon work. They read local

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -1,6 +1,6 @@
 # Install Beta Matrix
 
-Updated: 2026-05-01
+Updated: 2026-05-03
 
 This matrix tracks clean-install proof for the public adoption surfaces. It is
 operator evidence, not a credential runbook: do not paste OAuth stores, `.env`
@@ -17,7 +17,7 @@ files, SOPS plaintext, or token-shaped values here.
 | Homebrew formula | 0.1.6 | macOS arm64 + hosted Ubuntu dry-run | public `jesssullivan/omux` tap | Pass | Clean local uninstall/untap followed by `just homebrew-qa 0.1.6` installed from `Jesssullivan/homebrew-omux`; hosted registry dry-run `25199131583` checked out the public tap and passed the Homebrew lane. |
 | deb package | 0.1.6 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25195456319` installed package and ran `/usr/bin/oauth-mux version`. |
 | rpm package | 0.1.6 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25195456319` installed package and ran `/usr/bin/oauth-mux version`. |
-| Codex route dogfood | 0.1.6 | macOS arm64 | public npm one-shot | Pass with degraded route | Published npm binary selected `max-2#codex-max` while recorded liveness kept `max-1#codex-max` quota exhausted. |
+| Codex route dogfood | 0.1.6 | macOS arm64 | public npm one-shot | Pass with degraded route | Historical 2026-05-01 snapshot: published npm binary selected `max-2#codex-max` while recorded liveness kept `max-1#codex-max` quota exhausted. Current paid-cohort truth is `max-1` selected, `max-4` spare fallback, and `max-2`/`max-3` quota-exhausted for `codex-max`. |
 | lab dogfood | 0.1.6 | macOS arm64 | public npm one-shot | Pass | Installed `oauth-mux doctor --json` reports `ok: true` against local config/state. |
 | first-run source e2e | main | macOS arm64 | source checkout | Pass | `just first-run-e2e` runs with temporary HOME/XDG roots and proves no-config `init --codex-max`, JSON diagnostics, runtime diagnostics, redacted report, no-spend route explanation/select refusal, and non-mutating Codex help. |
 
@@ -152,7 +152,7 @@ brew test tinyland/tools/oauth-mux: pass
 Production tap PR `tinyland-inc/homebrew-tools#4` merged at `f3016e3`.
 ```
 
-Latest public npm dogfood proof:
+Latest public npm dogfood proof, historical 2026-05-01 snapshot:
 
 ```text
 npm publish workflow run 25195609579: pass
@@ -163,6 +163,12 @@ npx -y oauth-mux@0.1.6 route select --profile codex-max --capability codex-max -
   selected: codex:max-2#codex-max
   max-1#codex-max: quota_exhausted reset@1777987200
 ```
+
+Current paid-cohort truth is tracked in
+`docs/spec/paid-multi-account-proof-cohort-2026-05-01.md`: `max-1#codex-max`
+is selected after revalidation, `max-4#codex-max` is the spare fallback, and
+`max-2#codex-max` plus `max-3#codex-max` remain provider quota-exhausted for
+`codex-max`.
 
 System package install QA after GitHub Release publication:
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -458,6 +458,9 @@ thin aliases for installed commands. `just codex-max-setup` is a thin alias for
 installed live QA command. `just codex-max-probe-all` is likewise a thin alias
 for `oauth-mux codex probe-all`. These source helpers intentionally share the
 default oauth-mux state directory so dogfood probes feed later route selection.
+Their default account list matches the three-route starter config; set
+`OMUX_CODEX_ACCOUNTS=max-1,max-2,max-3,max-4` when running them against the
+paid four-route cohort.
 Set `OMUX_STATE_DIR=/tmp/<dir>` explicitly when a run should be isolated for CI
 or artifact collection. Route selection and explanation should be run through
 the installed CLI directly:

--- a/docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md
+++ b/docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md
@@ -19,10 +19,21 @@ oauth-mux stay-afloat --once --profile <profile> --capability <capability> --jso
 oauth-mux stay-afloat --loop --iterations <n> --interval-ms <ms> --profile <profile> --capability <capability> --json
 ```
 
-The current Codex dogfood state proves that route-scoped fallback works:
-`codex:max-1#codex-max` is parked as quota exhausted until its reset window,
-`codex:max-2#codex-max` is selected, and `codex:max-3#codex-max` remains a
-selectable fallback. That is real product evidence.
+The current Codex dogfood state proves that route-scoped fallback works, but
+the live matrix has moved since the first daemon contract was written. As of
+2026-05-03, the paid `codex-max` cohort has four broker-ready routes:
+`codex:max-1#codex-max` is selected after spend-gated revalidation,
+`codex:max-4#codex-max` is the spare selectable fallback, and
+`codex:max-2#codex-max` plus `codex:max-3#codex-max` have fresh
+provider-originated quota-exhausted evidence for `codex-max`. Mini/Spark
+availability or dashboard credit text must not be generalized to Max-capable
+route availability; trust provider execution evidence per route and
+capability.
+
+Negative evidence is now part of the baseline: a provider-owned Codex session
+that hit the native usage-limit screen on 2026-05-03 did not hand off through
+oauth-mux. Manual logout/login restored future mediated launch readiness, not
+active-session rescue.
 
 The stronger product goal is not proven yet:
 

--- a/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
+++ b/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
@@ -5,12 +5,22 @@ Issue context: `TIN-736` (Expand oauth-mux provider proof beyond Codex),
 `TIN-812` (Dogfood install surfaces), `TIN-814` (non-mutating Codex help),
 `TIN-734` (website launch truth), and `tinyland-inc/lab#197`.
 
+Supersession note, 2026-05-03: this is a historical adoption and install proof
+plan. Current Codex dogfood truth has moved to
+`docs/spec/paid-multi-account-proof-cohort-2026-05-01.md` and
+`docs/spec/paid-cohort-soak-claim-policy-2026-05-03.md`. The live `codex-max`
+cohort is now four routes: `max-1` selected, `max-4` spare fallback, and
+`max-2`/`max-3` provider quota-exhausted for `codex-max`. Broker-owned session
+surfaces and supervised restart surfaces exist, but true provider-owned
+active-session seamless handoff remains unproven.
+
 ## Current State
 
 `oauth-mux` is no longer speculative for the first target lane. The repo has a
 public canonical source, a public npm package, release assets, installed
 diagnostic commands, typed liveness, route-scoped health, and a live-proven
-three-account Codex path.
+historical three-account Codex path. Treat route matrices in this document as
+dated snapshots unless they are repeated in the current paid-cohort docs.
 
 The next risk is not compiler correctness. The next risk is adoption truth:
 whether a user can arrive from an advertised install command, configure expected
@@ -79,11 +89,13 @@ These are the adoption blockers that should stay visible:
    a product surface until `TIN-738` defines provider ownership, budgets, and
    anti-surprise rules.
 
-7. Stay-afloat automation is not yet built.
-   The mux can fall through from a quota-exhausted Codex route to an available
-   account, but it does not yet automatically repair stale credentials, persist
-   refreshed tokens, or drive browser/device reauth. See
-   `docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md`.
+7. Historical stay-afloat automation gap.
+   This was true for the first adoption plan. Since then, prepared fallback,
+   bounded foreground loops, broker-owned Codex sessions, supervised restart
+   wrappers, exhausted-route revalidation, and controlled fallback drills have
+   landed. The remaining hard gap is narrower and more important: native
+   provider-owned active-session handoff, same-thread quota recovery, and
+   unmanaged TUI hot-swap remain unproven.
 
 ## User Story Gates
 
@@ -134,7 +146,7 @@ roots, and no inherited `OMUX_*` overrides. It also verifies the Codex Max
 starter config uses the same resolved store root as Codex setup, so users with
 `XDG_DATA_HOME` or `OMUX_CODEX_STORE_ROOT` do not get split-brain account paths.
 
-### Story B: Codex Subscription User With Three Accounts
+### Story B: Historical Codex Subscription User With Three Accounts
 
 Goal: prove the flagship multi-account subscription use case.
 

--- a/docs/spec/product-adoption-sprint-2026-04-28.md
+++ b/docs/spec/product-adoption-sprint-2026-04-28.md
@@ -8,6 +8,12 @@ Repository context: the canonical public source repo is
 `Jesssullivan/oauth-mux`; Tinyland remains the release-infrastructure and launch
 partner.
 
+Supersession note, 2026-05-03: this sprint plan is historical. It records the
+first public adoption push, not the current stay-afloat truth. Current docs must
+use the five-level claim ladder, the four-route paid Codex cohort, and the
+negative evidence that provider-owned active-session handoff did not occur at
+the native Codex usage-limit screen.
+
 ## Baseline
 
 `oauth-mux` has crossed the line from architecture experiment to usable public

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -29,7 +29,7 @@ in-session quota fallback remains tracked by GitHub `#131` / Linear `TIN-916`.
 
 | Facet | Public GitHub issue | Linear tracking | Current posture |
 | --- | --- | --- | --- |
-| Homebrew distribution | `#66` | `TIN-858`, related to `TIN-737` | Public Jess-owned tap exists and clean local install QA passes; Tinyland tap remains private/staged. Live website copy still needs to stop advertising the private tap. |
+| Homebrew distribution | `#66` | `TIN-858`, related to `TIN-737` | Public Jess-owned tap exists and clean local install QA passes; Tinyland tap remains private/staged. Live website copy was rechecked on 2026-05-03 and now uses the public `jesssullivan/omux` tap. |
 | Stay-afloat daemon | `#67` | `TIN-738`, `TIN-859`, `TIN-860`, `TIN-866`, `TIN-867`, `TIN-897`, `TIN-898` | Foreground/agent-safe stay-afloat is shipped; production background daemon is not. Socket daemon is explicitly non-product plumbing for this release line. `TIN-897` defines the mediation boundary for seamless handoff claims; `TIN-898` adds the first opt-in beta supervised loop without changing default policy or production claims. |
 | Provider expansion | `#68` | `TIN-736`, `TIN-861`, `TIN-862`, `TIN-863`, `TIN-876`, `TIN-877`, `TIN-878`, `TIN-879` | Codex is live-proven; non-Codex proof is capability-level or still needs operator proof. |
 | Paid multi-account proof | `#67`, `#68` | `TIN-892`, `TIN-893`, `TIN-894`, `TIN-895`, `TIN-896` | A one-month paid cohort is now tracked for Codex lower-tier contrast, Claude subscription/billing shapes, Figma token/seat/plan shapes, and a foreground stay-afloat soak gate. |
@@ -47,13 +47,15 @@ Current truth:
 - This is not Homebrew core. It is a public Homebrew tap.
 - Formula updates must continue to come from public GitHub Release
   `oauth-mux.rb` and `SHA256SUMS`, not local `dist/out` output.
-- A live check of `https://omux.xoxd.ai/` on 2026-05-01 still found
-  `brew install tinyland-inc/tools/oauth-mux`; `#66` / `TIN-858` stay open
-  until website and release copy use the public `jesssullivan/omux` tap.
+- A historical live check of `https://omux.xoxd.ai/` on 2026-05-01 still
+  found `brew install tinyland-inc/tools/oauth-mux`. A 2026-05-03 recheck of
+  the live site shows the public `jesssullivan/omux` tap instead. Keep any
+  remaining `#66` / `TIN-858` work scoped to release-copy or artifact cleanup,
+  not the live website tap string.
 
 The decision record is
-`docs/spec/homebrew-public-lane-decision-2026-05-01.md`. The website can now
-use public tap wording once it matches this repo truth.
+`docs/spec/homebrew-public-lane-decision-2026-05-01.md`. The live website now
+uses the public tap wording that matches this repo truth.
 
 ## Stay-Afloat Daemon Boundary
 
@@ -77,14 +79,20 @@ Current truth:
   as non-product plumbing for this release line.
 - The default daemon policy refuses provider-spend probes, silent interactive
   auth, and silent mutation.
-- Codex fallback is proven from quota-exhausted `max-1#codex-max` to available
-  `max-2#codex-max`; automatic reauth and background repair are not proven.
-- A 2026-05-01 recheck split the runtime truth cleanly: inside the current
-  Codex sandbox, all three configured Codex account stores report
-  `unwritable_store`; outside that sandbox, all three stores are runtime-ready
-  and `stay-afloat --once --profile codex-max --capability codex-max --json`
-  selects `codex:max-2#codex-max` with `max-3` still selectable. This is a
-  sandbox/runtime-boundary product concern, not OAuth death or quota failure.
+- Codex fallback is proven across several scopes: historical 2026-05-01
+  route-state evidence moved from exhausted `max-1#codex-max` to available
+  `max-2#codex-max`; the current 2026-05-03 four-route cohort selects
+  `max-1#codex-max`, keeps `max-4#codex-max` as spare fallback, and records
+  `max-2#codex-max` plus `max-3#codex-max` as provider quota-exhausted for
+  `codex-max`.
+- The 2026-05-01 sandbox recheck remains useful historical evidence: inside
+  the Codex sandbox, all configured Codex account stores reported
+  `unwritable_store`; outside that sandbox, the stores were runtime-ready and
+  route selection worked. This is a sandbox/runtime-boundary product concern,
+  not OAuth death or quota failure.
+- Automatic reauth, background repair, provider-originated active-session
+  quota fallback, same-thread quota recovery, and unmanaged TUI hot-swap remain
+  unproven.
 
 Remaining daemon split:
 

--- a/docs/spec/stay-afloat-permission-broker-contract-2026-05-01.md
+++ b/docs/spec/stay-afloat-permission-broker-contract-2026-05-01.md
@@ -7,14 +7,22 @@ Issue context: Linear `TIN-891`, child of `TIN-738`; GitHub
 ## Baseline
 
 `oauth-mux` can keep a Codex Max profile afloat when it runs in the same
-process boundary that owns the configured Codex account stores. The 2026-05-01
-dogfood check proved the split:
+process boundary that owns the configured Codex account stores. The original
+2026-05-01 dogfood check proved the runtime split:
 
 - inside the current Codex sandbox, all configured Codex stores report
   `unwritable_store`;
 - outside that sandbox, all three stores are runtime-ready;
 - foreground `stay-afloat --once` selects `codex:max-2#codex-max`, keeps
   `max-3` selectable, and parks quota-exhausted `max-1` until its reset.
+
+That bullet list is historical. As of the 2026-05-03 paid-cohort pass, the
+operator matrix has four Codex Max routes: `max-1` is selected after
+spend-gated revalidation, `max-4` is the spare fallback, and `max-2`/`max-3`
+have fresh provider-originated quota-exhausted evidence for `codex-max`.
+Provider-owned active-session handoff was also observed to fail at the native
+usage-limit screen; the broker can prepare the next mediated launch, but this
+contract still must not imply unmanaged in-session hot-swap.
 
 That means the remaining product gap is not provider liveness. It is how a
 wrapper, shell, agent, or user-mediated permission broker should run local

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -5,6 +5,16 @@ Issue context: follow-up to `TIN-736`, `TIN-815`, and daemon-boundary work
 from `TIN-738`. Linear writes were unavailable during this checkpoint because
 the connected account had exhausted Codex usage until 2026-05-05 13:20.
 
+Supersession note, 2026-05-03: this is a historical runtime-gap plan. Current
+stay-afloat truth is covered by
+`docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md`,
+`docs/spec/paid-multi-account-proof-cohort-2026-05-01.md`, and
+`docs/spec/paid-cohort-soak-claim-policy-2026-05-03.md`. The active Codex Max
+cohort is four routes: `max-1` selected, `max-4` spare fallback, and
+`max-2`/`max-3` provider quota-exhausted for `codex-max`. Prepared fallback,
+broker-owned sessions, and supervised restart wrappers have landed; true
+provider-owned active-session handoff remains unproven.
+
 ## Correction
 
 The project has proven installability, first-run diagnostics, typed liveness,
@@ -395,13 +405,13 @@ obvious and copy-pastable for humans and agents.
 
 ## Product Gates
 
-### M1: Stay-Afloat One-Shot
+### M1: Historical Stay-Afloat One-Shot
 
 - Add `route select` and `route explain`.
 - Add runtime permission classification.
 - Add a dogfood script that runs real `oauth-mux probe` outside restricted
   sandboxes and stores redacted evidence.
-- Prove current Codex state:
+- Prove the then-current Codex state:
   - `max-1#codex-mini` available;
   - `max-1#codex-max` quota exhausted;
   - `max-2#codex-max` selected as fallback.

--- a/scripts/codex-max-canary.sh
+++ b/scripts/codex-max-canary.sh
@@ -5,7 +5,8 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
 config_path="${OMUX_CONFIG:-$repo_root/examples/codex-max.config.json}"
-accounts_csv="${OMUX_CODEX_ACCOUNTS:-max-1,max-2,max-3}"
+default_accounts_csv="max-1,max-2,max-3"
+accounts_csv="${OMUX_CODEX_ACCOUNTS:-$default_accounts_csv}"
 capabilities_csv="${OMUX_CODEX_CANARY_CAPABILITIES:-codex-mini,codex-max}"
 store_root="${OMUX_CODEX_STORE_ROOT:-${XDG_DATA_HOME:-$HOME/.local/share}/oauth-mux/codex}"
 state_dir="${OMUX_STATE_DIR:-}"
@@ -52,6 +53,9 @@ summary="$out_dir/summary.txt"
   printf 'accounts:     %s\n' "$accounts_csv"
   printf 'capabilities: %s\n' "$capabilities_csv"
   printf 'artifacts:    %s\n' "$out_dir"
+  if [ "$accounts_csv" = "$default_accounts_csv" ]; then
+    printf 'note:         default accounts match the three-route starter config; set OMUX_CODEX_ACCOUNTS=max-1,max-2,max-3,max-4 for the paid cohort\n'
+  fi
 } | tee "$summary"
 
 printf '\n=== config validate ===\n' | tee -a "$summary"

--- a/scripts/onboard-codex-max.sh
+++ b/scripts/onboard-codex-max.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-accounts_csv="${OMUX_CODEX_ACCOUNTS:-max-1,max-2,max-3}"
+default_accounts_csv="max-1,max-2,max-3"
+accounts_csv="${OMUX_CODEX_ACCOUNTS:-$default_accounts_csv}"
 login_mode="${OMUX_CODEX_LOGIN_MODE:-browser}"
 config_path="${OMUX_CONFIG:-$repo_root/examples/codex-max.config.json}"
 bin="${OMUX_BIN:-$repo_root/zig-out/bin/oauth-mux}"
@@ -27,6 +28,9 @@ IFS=',' read -r -a accounts <<<"$accounts_csv"
 
 printf 'oauth-mux Codex Max onboarding\n\n'
 printf 'config: %s\n' "$config_path"
+if [ "$accounts_csv" = "$default_accounts_csv" ]; then
+  printf 'note:   default accounts match the three-route starter config; set OMUX_CODEX_ACCOUNTS=max-1,max-2,max-3,max-4 for the paid cohort\n'
+fi
 printf 'mode:   %s\n\n' "$login_mode"
 
 export OMUX_CONFIG="$config_path"


### PR DESCRIPTION
## Summary

Truths stale stay-afloat and adoption docs against the current May 3 evidence:

- current `codex-max` paid cohort is `max-1` selected, `max-4` spare fallback, and `max-2`/`max-3` provider quota-exhausted for Max
- provider-owned Codex usage-limit did not hand off through oauth-mux; future mediated launch readiness is distinct from active-session rescue
- older route matrices are now labeled as historical snapshots instead of current truth
- live website Homebrew wording was rechecked and now uses the public `jesssullivan/omux` tap
- source checkout Codex helper scripts now print the three-route starter vs four-route paid cohort distinction

## Validation

- `bash -n scripts/codex-max-canary.sh`
- `bash -n scripts/onboard-codex-max.sh`
- `git diff --check`
- `just check-local`

Refs #165.
