### PR TITLE
[codex] Add Codex managed entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux stay-afloat launch --p
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux repair-plan --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux accounts list --provider codex --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux doctor runtime --profile codex-max --capability codex-max --json
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex managed-plan --profile codex-max --capability codex-max --json
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex managed --profile codex-max --capability codex-max -- --no-alt-screen
+OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex managed --profile codex-max --capability codex-max --resume-last --include-non-interactive
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-plan --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json
 OMUX_CONFIG=$PWD/examples/codex-max.config.json oauth-mux codex broker-session-smoke --profile codex-max --capability codex-max --confirm-broker --json
@@ -143,6 +146,16 @@ launched through `claim.launch_argv`, while `current_process_hotswap`,
 "a selected route exists" from "another selectable route is already available
 behind it"; an afloat profile with no spare route is still usable, but the next
 quota/rate-limit failure may need revalidation or waiting.
+`codex managed-plan --json` is the no-spend planning surface for native Codex
+sessions started under oauth-mux from the beginning. It reports the route that
+would launch, the selected route-local `CODEX_HOME` namespace, immediate
+fallback readiness, and the fact that resume IDs are resolved inside that
+selected store. `codex managed --profile ... --capability ... --` is the
+matching launch command; it uses the same route selection as `stay-afloat
+launch` and then execs native `codex`. Use `--resume-last
+--include-non-interactive` when resuming a session that was created under the
+same route-local store. This is managed process launch, not import or rescue of
+an unmanaged already-running Codex session.
 Codex app-server auth brokering is a separate proof track for mediated Codex
 sessions, not a current public claim for unmanaged Codex processes. Broker-owned
 Codex session surfaces use `claim.level:"broker_owned_app_server"`; reserve

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -123,6 +123,15 @@ ready behind it. Codex app-server auth brokering is now tracked as the first
 plausible current-process proof path for mediated Codex sessions, but it is not
 a claim for unmanaged Codex TUI/CLI processes.
 
+`oauth-mux codex managed-plan --profile codex-max --capability codex-max
+--json` is the no-spend plan for native Codex sessions launched under
+oauth-mux. `oauth-mux codex managed --profile codex-max --capability codex-max
+--` is the matching entrypoint; it selects a route, injects the selected
+route-local `CODEX_HOME`, and execs native `codex`. Add `--resume-last
+--include-non-interactive` only for sessions created in that same selected
+route store. This is managed process launch/resume, not an unmanaged in-place
+handoff claim.
+
 `oauth-mux codex broker-plan --profile codex-max --capability codex-max --json`
 is the no-spend broker readiness check. It reads configured Codex auth stores
 locally and reports whether each route can supply `accessToken`,

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -214,6 +214,7 @@ proxy, or in-agent adapter proves those stronger levels.
 | Command surface | Claim level | Boundary | Spend | Route health mutation | Provider-originated evidence | Same-thread support | Unmanaged TUI support |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `stay-afloat next`, `stay-afloat launch`, `daemon tick` | `prepared_fallback` | next mediated process start | no | no by default | no | no | no |
+| `codex managed-plan`, `codex managed` | `managed_codex_process` | native Codex started under selected route-local `CODEX_HOME` | child-dependent for launch | no by default | child-dependent | no | managed launch only |
 | `codex broker-session-plan` | `broker_owned_app_server` | planning for oauth-mux-owned Codex app-server | no | no | no | no | no |
 | `codex broker-session-smoke` | `broker_owned_app_server` | local mocked broker-owned app-server | no | no | simulated only | new thread only | no |
 | `codex broker-run` | `broker_owned_app_server` | live broker-owned app-server | yes, after confirmation | on classified live failure | yes when provider failure occurs | no | no |

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -198,6 +198,20 @@ Codex app-server auth brokering is tracked separately as a possible
 current-process proof for mediated Codex sessions; unmanaged Codex launches
 should still be treated as prepared fallback only.
 Use
+`oauth-mux codex managed-plan --profile codex-max --capability codex-max
+--json` to inspect the native Codex managed-launch boundary without starting
+Codex. It reports the selected route, the route-local `CODEX_HOME` resume
+namespace, and fallback readiness while keeping credential paths and forwarded
+native argv out of output.
+Use
+`oauth-mux codex managed --profile codex-max --capability codex-max --` to
+start native Codex under oauth-mux route selection from the beginning. For
+route-local resume, run
+`oauth-mux codex managed --profile codex-max --capability codex-max
+--resume-last --include-non-interactive`. This resumes only within the selected
+route store; it does not import an unmanaged session from another account store
+or prove same-thread quota handoff.
+Use
 `oauth-mux codex broker-plan --profile codex-max --capability codex-max --json`
 to inspect whether enrolled Codex stores can supply the app-server
 external-auth tuple for that future broker path. It is local, redacted,

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -142,6 +142,13 @@ already-running provider-owned Codex session hit a usage limit and no seamless
 daemon handoff occurred. Manual logout/login restored future mediated launch
 readiness, but did not prove active-session rescue.
 
+The `TIN-934` / GitHub `#160` managed-entrypoint slice addresses the practical
+startup gap: native Codex sessions that need route-local resume should be
+started with `oauth-mux codex managed`, not with an unmanaged `codex` process
+that oauth-mux tries to rescue later. Its claim level is `managed_codex_process`
+and its resume namespace is the selected route-local `CODEX_HOME`; it does not
+claim cross-route import, same-thread quota recovery, or unmanaged TUI hot-swap.
+
 The `TIN-913` / GitHub `#125` Codex app-server auth-broker artifact is
 `docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md`. It records the
 source-backed opportunity discovered after the supervised-restart contract:

--- a/docs/stay-afloat-wrappers.md
+++ b/docs/stay-afloat-wrappers.md
@@ -26,6 +26,9 @@ The supported contract is still the portable tick engine:
 ```bash
 oauth-mux stay-afloat next --profile codex-max --capability codex-max --json
 oauth-mux stay-afloat launch --profile codex-max --capability codex-max -- codex
+oauth-mux codex managed-plan --profile codex-max --capability codex-max --json
+oauth-mux codex managed --profile codex-max --capability codex-max -- --no-alt-screen
+oauth-mux codex managed --profile codex-max --capability codex-max --resume-last --include-non-interactive
 oauth-mux stay-afloat supervise --profile codex-max --capability codex-max --max-restarts 1 --restart-on-exit-code 42 -- codex
 oauth-mux stay-afloat --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
 oauth-mux daemon tick --loop --iterations 2 --interval-ms 0 --profile codex-max --capability codex-max --json
@@ -44,6 +47,13 @@ state before startup, launch can refresh route evidence and try the next
 selectable account when a route that looked selectable at preflight is
 reclassified before the target starts. If no selectable account remains, it
 prints the refreshed mediation text and exits nonzero.
+
+For native Codex, prefer `codex managed` over a bare `stay-afloat launch -- codex`
+when you want the invocation and resume semantics to be explicit. It uses the
+same selected route boundary, injects the selected route-local `CODEX_HOME`,
+and can forward `resume --last --include-non-interactive` for sessions created
+in that store. It still cannot import or rescue an unmanaged already-running
+Codex session.
 
 Use `stay-afloat supervise --max-restarts <n> --restart-on-exit-code <code>
 -- <command>` when oauth-mux should own the child process boundary. The generic

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -753,6 +753,18 @@ broker_session_bin="$tmp/broker-session-bin"
 mkdir -p "$broker_session_state" "$broker_session_max1_home" "$broker_session_max2_home" "$broker_session_max3_home" "$broker_session_bin"
 cat >"$broker_session_bin/codex" <<'EOF'
 #!/bin/sh
+if [ -n "${OMUX_E2E_MANAGED_OUT:-}" ]; then
+  {
+    printf 'account=%s\n' "${OMUX_ACTIVE_ACCOUNT:-}"
+    printf 'capability=%s\n' "${OMUX_ACTIVE_CAPABILITY:-}"
+    printf 'codex_home=%s\n' "${CODEX_HOME:-}"
+    printf 'args='
+    for arg in "$@"; do
+      printf '[%s]' "$arg"
+    done
+    printf '\n'
+  } >"$OMUX_E2E_MANAGED_OUT"
+fi
 exit 0
 EOF
 chmod +x "$broker_session_bin/codex"
@@ -892,6 +904,42 @@ expect_not_contains "$broker_session_plan" 'acct-session-spare' "broker-session-
 expect_not_contains "$broker_session_plan" "$broker_jwt" "broker-session-plan does not expose token value"
 expect_not_contains "$broker_session_plan" 'broker-session-refresh-token' "broker-session-plan does not expose refresh token value"
 expect_not_contains "$broker_session_plan" 'broker-session-spare-token' "broker-session-plan does not expose spare refresh token value"
+
+printf 'e2e: codex managed-plan reports route-local native launch boundary\n'
+managed_plan="$(PATH="$broker_session_bin:$PATH" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex managed-plan --profile codex-max --capability codex-max --json)"
+expect_contains "$managed_plan" '"mode":"codex_managed_session_plan"' "managed-plan reports managed session mode"
+expect_contains "$managed_plan" '"spends_provider_calls":false' "managed-plan reports no provider spend"
+expect_contains "$managed_plan" '"mutates_route_health":false' "managed-plan reports no route-health mutation"
+expect_contains "$managed_plan" '"executes_child":false' "managed-plan does not launch child in plan mode"
+expect_contains "$managed_plan" '"level":"managed_codex_process"' "managed-plan reports managed process claim level"
+expect_contains "$managed_plan" '"proof_status":"managed_launch_planning_only"' "managed-plan scopes proof to planning"
+expect_contains "$managed_plan" '"route_local_resume":true' "managed-plan reports route-local resume namespace"
+expect_contains "$managed_plan" '"resume_namespace":"selected_route_codex_home"' "managed-plan names selected CODEX_HOME namespace"
+expect_contains "$managed_plan" '"selected":{"provider":"codex","account":"max-2","capability":"codex-max"' "managed-plan selects first live route"
+expect_contains "$managed_plan" '"prepared_fallback":true' "managed-plan reports prepared fallback"
+expect_contains "$managed_plan" '"path_printed":false' "managed-plan does not print CODEX_HOME path"
+expect_contains "$managed_plan" '"argv_printed":false' "managed-plan does not print native Codex argv"
+expect_contains "$managed_plan" '"unmanaged_cross_route_resume":false' "managed-plan refuses unmanaged cross-route resume claim"
+expect_contains "$managed_plan" '"unmanaged_tui_hotswap":false' "managed-plan keeps unmanaged TUI boundary explicit"
+expect_not_contains "$managed_plan" "$broker_session_max2_home" "managed-plan does not expose selected CODEX_HOME path"
+expect_not_contains "$managed_plan" 'acct-session-fallback' "managed-plan does not expose selected account id value"
+
+managed_resume_plan="$(PATH="$broker_session_bin:$PATH" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex managed --profile codex-max --capability codex-max --resume-last --include-non-interactive --json -- --model gpt-5.5)"
+expect_contains "$managed_resume_plan" '"mode":"codex_managed_session_plan"' "managed --json returns a non-executing plan"
+expect_contains "$managed_resume_plan" '"requested":true' "managed --json reports resume request"
+expect_contains "$managed_resume_plan" '"resume_last":true' "managed --json reports resume-last"
+expect_contains "$managed_resume_plan" '"include_non_interactive":true' "managed --json reports include-non-interactive"
+expect_contains "$managed_resume_plan" '"passthrough_arg_count":2' "managed --json counts forwarded Codex args without printing them"
+expect_not_contains "$managed_resume_plan" 'gpt-5.5' "managed --json does not print forwarded model arg"
+
+printf 'e2e: codex managed launches native Codex with selected route-local CODEX_HOME\n'
+managed_launch_out="$tmp/managed-launch.out"
+PATH="$broker_session_bin:$PATH" OMUX_E2E_MANAGED_OUT="$managed_launch_out" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex managed --profile codex-max --capability codex-max -- --no-alt-screen
+managed_launch="$(cat "$managed_launch_out")"
+expect_contains "$managed_launch" 'account=max-2' "managed launch injects selected account"
+expect_contains "$managed_launch" 'capability=codex-max' "managed launch injects selected capability"
+expect_contains "$managed_launch" "codex_home=$broker_session_max2_home" "managed launch injects selected route CODEX_HOME"
+expect_contains "$managed_launch" 'args=[--no-alt-screen]' "managed launch forwards Codex args after --"
 
 printf 'e2e: codex revalidate-exhausted requires spend confirmation before mutating route health\n'
 broker_revalidate_prompt="$(OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex revalidate-exhausted --profile codex-max --capability codex-max --account max-1 --json 2>/dev/null || true)"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -196,6 +196,8 @@ pub const Command = union(enum) {
         probe_all,
         config_candidate,
         config_merge,
+        managed_plan,
+        managed,
         broker_plan,
         broker_session_plan,
         broker_session_smoke,
@@ -224,6 +226,10 @@ pub const Command = union(enum) {
         prompt: ?[]const u8 = null,
         model: ?[]const u8 = null,
         from_account: ?[]const u8 = null,
+        resume_id: ?[]const u8 = null,
+        resume_last: bool = false,
+        include_non_interactive: bool = false,
+        managed_argv: []const []const u8 = &.{},
         stdin_prompts: bool = false,
         continue_on_failure: bool = false,
         output: ?[]const u8 = null,
@@ -948,6 +954,10 @@ fn parseCodex(args: []const []const u8) Command {
             result.action = .config_candidate;
         } else if (eql(args[0], "config-merge")) {
             result.action = .config_merge;
+        } else if (eql(args[0], "managed-plan")) {
+            result.action = .managed_plan;
+        } else if (eql(args[0], "managed")) {
+            result.action = .managed;
         } else if (eql(args[0], "broker-plan")) {
             result.action = .broker_plan;
         } else if (eql(args[0], "broker-session-plan")) {
@@ -981,7 +991,10 @@ fn parseCodex(args: []const []const u8) Command {
 fn parseCodexOptions(result: *Command.CodexArgs, args: []const []const u8, option_start: usize) void {
     var i = option_start;
     while (i < args.len) : (i += 1) {
-        if (eql(args[i], "--profile") or eql(args[i], "-p")) {
+        if (eql(args[i], "--")) {
+            result.managed_argv = args[i + 1 ..];
+            break;
+        } else if (eql(args[i], "--profile") or eql(args[i], "-p")) {
             i += 1;
             if (i < args.len) result.profile = args[i];
         } else if (eql(args[i], "--account")) {
@@ -1014,6 +1027,13 @@ fn parseCodexOptions(result: *Command.CodexArgs, args: []const []const u8, optio
         } else if (eql(args[i], "--from-account")) {
             i += 1;
             if (i < args.len) result.from_account = args[i];
+        } else if (eql(args[i], "--resume")) {
+            i += 1;
+            if (i < args.len) result.resume_id = args[i];
+        } else if (eql(args[i], "--resume-last")) {
+            result.resume_last = true;
+        } else if (eql(args[i], "--include-non-interactive")) {
+            result.include_non_interactive = true;
         } else if (eql(args[i], "--stdin")) {
             result.stdin_prompts = true;
         } else if (eql(args[i], "--continue-on-failure")) {
@@ -1167,6 +1187,12 @@ pub fn printUsage(writer: anytype) !void {
         \\  codex probe-all [--accounts a,b,c] [--capabilities c1,c2] [--json]
         \\      Probe every selected Codex account/capability route.
         \\
+        \\  codex managed-plan [--profile name] [--capability c] [--json]
+        \\      Plan a managed native Codex launch with route-local resume semantics.
+        \\
+        \\  codex managed [--profile name] [--capability c] [--resume id|--resume-last] [--include-non-interactive] [-- codex-args...]
+        \\      Launch native Codex through stay-afloat route selection and selected CODEX_HOME.
+        \\
         \\  codex broker-plan [--profile name] [--capability c] [--json]
         \\      Inspect local app-server auth material only; use broker-session-plan for route-aware selection.
         \\
@@ -1233,6 +1259,8 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\  oauth-mux codex live-qa [--accounts a,b,c] [--capabilities c1,c2] [--confirm-spend] [--json]
         \\  oauth-mux codex revalidate-exhausted [--profile name] [--capability c] [--account a] --confirm-spend [--json]
         \\  oauth-mux codex probe-all [--accounts a,b,c] [--capability c] [--json]
+        \\  oauth-mux codex managed-plan [--profile name] [--capability c] [--json]
+        \\  oauth-mux codex managed [--profile name] [--capability c] [--resume id|--resume-last] [--include-non-interactive] [-- codex-args...]
         \\  oauth-mux codex broker-plan [--profile name] [--capability c] [--json]
         \\  oauth-mux codex broker-session-plan [--profile name] [--capability c] [--json]
         \\  oauth-mux codex broker-session-smoke [--profile name] [--capability c] --confirm-broker [--json]
@@ -1253,6 +1281,9 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\Safety:
         \\  canary is no-spend unless --live is provided.
         \\  live-qa, revalidate-exhausted, probe-all, and canary --live run real provider probes.
+        \\  managed-plan is no-spend. managed launches native Codex under the
+        \\  selected route-local CODEX_HOME, so provider calls depend on the
+        \\  Codex child process and are not made during planning.
         \\  broker-smoke, broker-refresh-smoke, broker-401-smoke,
         \\  broker-quota-smoke, broker-session-smoke, and broker-run read a
         \\  selected Codex route secret and send it only to a broker-owned
@@ -1491,6 +1522,39 @@ test "parse codex broker session plan" {
             try std.testing.expectEqualStrings("codex-max", codex.profile.?);
             try std.testing.expectEqualStrings("codex-max", codex.capabilities);
             try std.testing.expect(codex.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse codex managed plan" {
+    const args = [_][]const u8{ "codex", "managed-plan", "--profile", "codex-max", "--capability", "codex-max", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex => |codex| {
+            try std.testing.expect(codex.action == .managed_plan);
+            try std.testing.expectEqualStrings("codex-max", codex.profile.?);
+            try std.testing.expectEqualStrings("codex-max", codex.capabilities);
+            try std.testing.expect(codex.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse codex managed resume last passthrough" {
+    const args = [_][]const u8{ "codex", "managed", "--profile", "codex-max", "--capability", "codex-max", "--resume-last", "--include-non-interactive", "--", "--model", "gpt-5.5", "--no-alt-screen" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex => |codex| {
+            try std.testing.expect(codex.action == .managed);
+            try std.testing.expectEqualStrings("codex-max", codex.profile.?);
+            try std.testing.expectEqualStrings("codex-max", codex.capabilities);
+            try std.testing.expect(codex.resume_last);
+            try std.testing.expect(codex.include_non_interactive);
+            try std.testing.expectEqual(@as(usize, 3), codex.managed_argv.len);
+            try std.testing.expectEqualStrings("--model", codex.managed_argv[0]);
+            try std.testing.expectEqualStrings("gpt-5.5", codex.managed_argv[1]);
+            try std.testing.expectEqualStrings("--no-alt-screen", codex.managed_argv[2]);
         },
         else => return error.Unexpected,
     }
@@ -2130,7 +2194,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary live-qa revalidate-exhausted probe-all broker-plan broker-session-plan broker-session-smoke broker-run broker-fallback-drill broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary live-qa revalidate-exhausted probe-all managed-plan managed broker-plan broker-session-plan broker-session-smoke broker-run broker-fallback-drill broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run supervise start stop status events handoffs tick' -d 'Daemon subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l stay-afloat -d 'Host beta supervised stay-afloat loop'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l json -d 'JSON output'

--- a/src/main.zig
+++ b/src/main.zig
@@ -8019,6 +8019,8 @@ fn runCodex(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Cod
         .probe_all => try runCodexProbeAll(allocator, writer, args),
         .config_candidate => try runCodexConfigCandidate(allocator, writer, args, root),
         .config_merge => try runCodexConfigMerge(allocator, writer, args),
+        .managed_plan => try runCodexManagedPlan(allocator, writer, args),
+        .managed => try runCodexManaged(allocator, writer, args),
         .broker_plan => try runCodexBrokerPlan(allocator, writer, args),
         .broker_session_plan => try runCodexBrokerSessionPlan(allocator, writer, args),
         .broker_session_smoke => try runCodexBrokerSessionSmoke(allocator, writer, args),
@@ -8814,6 +8816,177 @@ fn runCodexBrokerSessionPlan(allocator: std.mem.Allocator, writer: anytype, args
     } else {
         try writeCodexBrokerSessionPlanText(writer, allocator, parsed.value, evaluations.items, selected_index, args.profile, capability);
     }
+}
+
+fn runCodexManagedPlan(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs) !void {
+    const parsed = try config.load(allocator);
+    defer parsed.deinit();
+
+    var validation_messages = std.ArrayList(u8).init(allocator);
+    defer validation_messages.deinit();
+    try config.validate(parsed.value, validation_messages.writer());
+
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+
+    const capability = firstCommaValue(args.capabilities);
+    var routes = try collectRepairPlanRoutes(allocator, parsed.value, .{
+        .profile = args.profile,
+        .provider = if (args.profile == null) "codex" else null,
+        .account = args.account,
+        .capability = capability,
+        .json = args.json,
+    });
+    defer routes.deinit();
+
+    var evaluations = std.ArrayList(RouteEvaluation).init(allocator);
+    defer evaluations.deinit();
+    try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &evaluations);
+
+    const selected_index = firstSelectableRoute(evaluations.items);
+
+    if (args.json) {
+        try writeCodexManagedPlanJson(writer, allocator, parsed.value, evaluations.items, selected_index, args.profile, capability, args);
+    } else {
+        try writeCodexManagedPlanText(writer, evaluations.items, selected_index, args.profile, capability, args);
+    }
+}
+
+fn runCodexManaged(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs) !void {
+    if (args.json) {
+        try runCodexManagedPlan(allocator, writer, args);
+        return;
+    }
+
+    const target_argv = try buildCodexManagedTargetArgv(allocator, args);
+    defer allocator.free(target_argv);
+
+    const capability = firstCommaValue(args.capabilities);
+    try runStayAfloatLaunch(allocator, writer, .{
+        .profile = args.profile,
+        .provider = if (args.profile == null) "codex" else null,
+        .account = args.account,
+        .capability = capability,
+        .target_argv = target_argv,
+    });
+}
+
+fn buildCodexManagedTargetArgv(allocator: std.mem.Allocator, args: cli.Command.CodexArgs) ![]const []const u8 {
+    if (args.resume_id != null and args.resume_last) {
+        log.err("codex managed: use either --resume <id> or --resume-last, not both", .{});
+        return error.ConfigValidationError;
+    }
+    if (args.include_non_interactive and args.resume_id == null and !args.resume_last) {
+        log.err("codex managed: --include-non-interactive only applies to --resume or --resume-last", .{});
+        return error.ConfigValidationError;
+    }
+
+    var argv = std.ArrayList([]const u8).init(allocator);
+    errdefer argv.deinit();
+    try argv.append("codex");
+
+    if (args.resume_id != null or args.resume_last) {
+        try argv.append("resume");
+        if (args.resume_last) {
+            try argv.append("--last");
+        } else if (args.resume_id) |resume_id| {
+            try argv.append(resume_id);
+        }
+        if (args.include_non_interactive) try argv.append("--include-non-interactive");
+    }
+
+    for (args.managed_argv) |arg| try argv.append(arg);
+    return try argv.toOwnedSlice();
+}
+
+fn writeCodexManagedPlanJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+    profile: ?[]const u8,
+    capability: ?[]const u8,
+    args: cli.Command.CodexArgs,
+) !void {
+    const session_start_ready = selected_index != null;
+    const fallback_count = selectableFallbackRouteCount(evaluations, selected_index);
+    const prepared_fallback = session_start_ready and fallback_count > 0;
+    const resume_requested = args.resume_id != null or args.resume_last;
+
+    try writer.writeAll("{\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"mode\":\"codex_managed_session_plan\"");
+    try writer.writeAll(",\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mutates_route_health\":false,\"executes_child\":false");
+    try writer.writeAll(",\"ok\":");
+    try writer.writeAll(if (session_start_ready) "true" else "false");
+    try writer.writeAll(",\"claim\":{\"claim_version\":1,\"level\":\"managed_codex_process\",\"proof_status\":\"managed_launch_planning_only\",\"managed_process_launch\":true,\"mediation_point\":\"stay-afloat launch\",\"route_local_resume\":true,\"resume_namespace\":\"selected_route_codex_home\",\"prepared_fallback\":");
+    try writer.writeAll(if (prepared_fallback) "true" else "false");
+    try writer.writeAll(",\"selectable_fallback_routes\":");
+    try writer.print("{d}", .{fallback_count});
+    try writer.writeAll(",\"same_turn_quota_recovery\":false,\"same_thread_quota_recovery\":false,\"current_process_auth_broker\":false,\"broker_owned_app_server\":false,\"supervised_restart\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
+    try writer.writeAll(",\"profile\":");
+    if (profile) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"capability\":");
+    if (capability) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"codex_home\":{\"env\":\"CODEX_HOME\",\"namespace\":\"selected_route_store\",\"path_printed\":false}");
+    try writer.writeAll(",\"resume\":{\"scope\":\"route_local_codex_home\",\"requested\":");
+    try writer.writeAll(if (resume_requested) "true" else "false");
+    try writer.writeAll(",\"resume_last\":");
+    try writer.writeAll(if (args.resume_last) "true" else "false");
+    try writer.writeAll(",\"resume_id_provided\":");
+    try writer.writeAll(if (args.resume_id != null) "true" else "false");
+    try writer.writeAll(",\"include_non_interactive\":");
+    try writer.writeAll(if (args.include_non_interactive) "true" else "false");
+    try writer.writeAll(",\"resume_id_printed\":false,\"unmanaged_cross_route_resume\":false,\"diagnostic\":\"resume ids are resolved by Codex inside the selected route-local CODEX_HOME\"}");
+    try writer.writeAll(",\"target\":{\"program\":\"codex\",\"passthrough_arg_count\":");
+    try writer.print("{d}", .{args.managed_argv.len});
+    try writer.writeAll(",\"argv_printed\":false}");
+    try writer.writeAll(",\"selected\":");
+    if (selected_index) |idx| {
+        try writeRouteSelectionJson(writer, evaluations[idx].route);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"resilience\":");
+    try writeCodexBrokerSessionResilienceJson(writer, session_start_ready, fallback_count);
+    try writer.writeAll(",\"resilience_actions\":");
+    try writeCodexBrokerSessionRiskActionsJson(writer, allocator, profile, capability, session_start_ready, fallback_count);
+    try writer.writeAll(",\"routes\":[");
+    for (evaluations, 0..) |evaluation, idx| {
+        if (idx > 0) try writer.writeByte(',');
+        const selected = if (selected_index) |selected_idx| idx == selected_idx else false;
+        try writeRouteEvaluationJson(writer, allocator, cfg, evaluation, selected);
+    }
+    try writer.writeAll("]}\n");
+}
+
+fn writeCodexManagedPlanText(
+    writer: anytype,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+    profile: ?[]const u8,
+    capability: ?[]const u8,
+    args: cli.Command.CodexArgs,
+) !void {
+    const fallback_count = selectableFallbackRouteCount(evaluations, selected_index);
+    try writer.writeAll("oauth-mux Codex managed session plan\n\n");
+    if (profile) |value| try writer.print("  profile: {s}\n", .{value});
+    if (capability) |value| try writer.print("  capability: {s}\n", .{value});
+    try writer.writeAll("  claim: planning-only managed_codex_process launch with route-local CODEX_HOME resume namespace\n");
+    try writer.print("  session_start_ready: {s}\n", .{if (selected_index != null) "true" else "false"});
+    try writer.print("  selectable_fallback_routes: {d}\n", .{fallback_count});
+    try writer.print("  resume_requested: {s}\n", .{if (args.resume_id != null or args.resume_last) "true" else "false"});
+    if (selected_index) |idx| {
+        const route = evaluations[idx].route;
+        try writer.print("  selected: {s}:{s}", .{ route.provider, route.account });
+        if (route.capability) |value| try writer.print("#{s}", .{value});
+        try writer.writeByte('\n');
+    } else {
+        try writer.writeAll("  selected: none\n");
+    }
+    try writer.writeAll("  codex_home: selected route store; path not printed\n");
+    try writer.writeAll("  boundary: this plans/launches native Codex under oauth-mux mediation; it does not import unmanaged sessions or prove same-thread quota handoff\n");
 }
 
 const CodexBrokerSessionSummary = struct {


### PR DESCRIPTION
## Summary

Adds a native Codex managed entrypoint for route-local sessions:

- `oauth-mux codex managed-plan --profile ... --capability ... --json` reports a no-spend launch plan with the selected route, fallback readiness, and route-local `CODEX_HOME` resume namespace.
- `oauth-mux codex managed --profile ... --capability ... --` launches native `codex` through the existing `stay-afloat launch` route selection path.
- `--resume <id>`, `--resume-last`, and `--include-non-interactive` are forwarded as native `codex resume` args for sessions created inside the selected route store.

The claim boundary is intentionally narrow: this is `managed_codex_process`, not unmanaged TUI hot-swap, cross-route session import, same-thread quota recovery, app-server brokering, or per-request muxing.

## Validation

- `codex resume --help` confirmed the local Codex CLI supports `--last` and `--include-non-interactive`.
- `zig build`
- `zig build test`
- `./scripts/e2e-local.sh`
- `just check-local`
- `git diff --check`

The e2e uses a temp fake `codex` binary to prove `codex managed` injects the selected route's `CODEX_HOME`, active account, and capability, while `managed-plan` and `managed --json` do not execute a child or print forwarded native argv.

Refs #160.