### PR TITLE
[codex] Add Codex managed resume diagnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,12 @@ selected store. `codex managed --profile ... --capability ... --` is the
 matching launch command; it uses the same route selection as `stay-afloat
 launch` and then execs native `codex`. Use `--resume-last
 --include-non-interactive` when resuming a session that was created under the
-same route-local store. This is managed process launch, not import or rescue of
-an unmanaged already-running Codex session.
+same route-local store. With explicit `--resume <id>`, the plan and launch path
+first check the selected route-local store for local evidence of that id
+(`session_index.jsonl`, rollout filenames, and Codex state-store bytes). If the
+id is not found, `codex managed` refuses before starting native Codex and does
+not print the id or store path. This is a diagnostic guard for route-local
+resume, not import or rescue of an unmanaged already-running Codex session.
 Codex app-server auth brokering is a separate proof track for mediated Codex
 sessions, not a current public claim for unmanaged Codex processes. Broker-owned
 Codex session surfaces use `claim.level:"broker_owned_app_server"`; reserve

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -129,8 +129,12 @@ oauth-mux. `oauth-mux codex managed --profile codex-max --capability codex-max
 --` is the matching entrypoint; it selects a route, injects the selected
 route-local `CODEX_HOME`, and execs native `codex`. Add `--resume-last
 --include-non-interactive` only for sessions created in that same selected
-route store. This is managed process launch/resume, not an unmanaged in-place
-handoff claim.
+route store. For explicit `--resume <id>`, oauth-mux checks the selected
+route-local Codex store for local evidence before launch and refuses without
+starting native Codex when the id appears to belong elsewhere or nowhere. The
+diagnostic checks index/filename/state-store bytes and does not print the
+resume id or store path. This is managed process launch/resume, not an
+unmanaged in-place handoff claim.
 
 `oauth-mux codex broker-plan --profile codex-max --capability codex-max --json`
 is the no-spend broker readiness check. It reads configured Codex auth stores

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -211,6 +211,10 @@ route-local resume, run
 --resume-last --include-non-interactive`. This resumes only within the selected
 route store; it does not import an unmanaged session from another account store
 or prove same-thread quota handoff.
+For a known session id, use `--resume <id>`. oauth-mux performs a no-spend
+selected-store diagnostic before launch and refuses if the route-local
+`CODEX_HOME` does not appear to own the id. Normal output reports status and
+evidence flags, not the resume id, credential paths, or store path.
 Use
 `oauth-mux codex broker-plan --profile codex-max --capability codex-max --json`
 to inspect whether enrolled Codex stores can supply the app-server

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -148,6 +148,11 @@ started with `oauth-mux codex managed`, not with an unmanaged `codex` process
 that oauth-mux tries to rescue later. Its claim level is `managed_codex_process`
 and its resume namespace is the selected route-local `CODEX_HOME`; it does not
 claim cross-route import, same-thread quota recovery, or unmanaged TUI hot-swap.
+Explicit `--resume <id>` now adds a route-local diagnostic: oauth-mux checks
+the selected store's session index, rollout filenames, and Codex state-store
+bytes before launch, refuses missing ids before child exec, and keeps ids and
+paths out of normal output. This improves wrong-route visibility without
+turning managed launch into seamless active-session handoff.
 
 The `TIN-913` / GitHub `#125` Codex app-server auth-broker artifact is
 `docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md`. It records the

--- a/docs/stay-afloat-wrappers.md
+++ b/docs/stay-afloat-wrappers.md
@@ -52,8 +52,10 @@ For native Codex, prefer `codex managed` over a bare `stay-afloat launch -- code
 when you want the invocation and resume semantics to be explicit. It uses the
 same selected route boundary, injects the selected route-local `CODEX_HOME`,
 and can forward `resume --last --include-non-interactive` for sessions created
-in that store. It still cannot import or rescue an unmanaged already-running
-Codex session.
+in that store. Explicit `--resume <id>` is preflighted against that selected
+store before native Codex starts; missing ids fail with a redacted diagnostic
+instead of launching the wrong account. It still cannot import or rescue an
+unmanaged already-running Codex session.
 
 Use `stay-afloat supervise --max-restarts <n> --restart-on-exit-code <code>
 -- <command>` when oauth-mux should own the child process boundary. The generic

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -793,6 +793,9 @@ cat >"$broker_auth_session_spare" <<EOF
 EOF
 cp "$broker_auth_session_fallback" "$broker_session_max2_home/auth.json"
 cp "$broker_auth_session_spare" "$broker_session_max3_home/auth.json"
+cat >"$broker_session_max2_home/session_index.jsonl" <<'EOF'
+{"id":"managed-good-session","thread_name":"managed-thread","updated_at":1}
+EOF
 cat >"$broker_session_config" <<EOF
 {
   "version": 1,
@@ -928,9 +931,26 @@ managed_resume_plan="$(PATH="$broker_session_bin:$PATH" OMUX_CONFIG="$broker_ses
 expect_contains "$managed_resume_plan" '"mode":"codex_managed_session_plan"' "managed --json returns a non-executing plan"
 expect_contains "$managed_resume_plan" '"requested":true' "managed --json reports resume request"
 expect_contains "$managed_resume_plan" '"resume_last":true' "managed --json reports resume-last"
+expect_contains "$managed_resume_plan" '"status":"resume_last_unchecked"' "managed --json leaves resume-last to native Codex"
 expect_contains "$managed_resume_plan" '"include_non_interactive":true' "managed --json reports include-non-interactive"
 expect_contains "$managed_resume_plan" '"passthrough_arg_count":2' "managed --json counts forwarded Codex args without printing them"
 expect_not_contains "$managed_resume_plan" 'gpt-5.5' "managed --json does not print forwarded model arg"
+
+managed_resume_found="$(PATH="$broker_session_bin:$PATH" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex managed --profile codex-max --capability codex-max --resume managed-good-session --json)"
+expect_contains "$managed_resume_found" '"ok":true' "managed explicit resume plan succeeds when id is in selected route store"
+expect_contains "$managed_resume_found" '"checked":true' "managed explicit resume plan checks selected route store"
+expect_contains "$managed_resume_found" '"found_in_selected_store":true' "managed explicit resume plan reports route-local match"
+expect_contains "$managed_resume_found" '"status":"found_in_selected_store"' "managed explicit resume plan reports found status"
+expect_contains "$managed_resume_found" '"session_index_match":true' "managed explicit resume plan uses session index evidence"
+expect_contains "$managed_resume_found" '"resume_id_printed":false' "managed explicit resume plan suppresses resume id"
+expect_not_contains "$managed_resume_found" 'managed-good-session' "managed explicit resume plan does not print resume id value"
+
+managed_resume_missing="$(PATH="$broker_session_bin:$PATH" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex managed --profile codex-max --capability codex-max --resume missing-session --json)"
+expect_contains "$managed_resume_missing" '"ok":false' "managed explicit resume plan fails when id is missing from selected route store"
+expect_contains "$managed_resume_missing" '"found_in_selected_store":false' "managed explicit resume plan reports missing route-local id"
+expect_contains "$managed_resume_missing" '"status":"not_found_in_selected_store"' "managed explicit resume plan reports missing status"
+expect_contains "$managed_resume_missing" '"unmanaged_cross_route_resume":false' "managed explicit resume plan refuses cross-route import claim"
+expect_not_contains "$managed_resume_missing" 'missing-session' "managed explicit resume plan does not print missing resume id value"
 
 printf 'e2e: codex managed launches native Codex with selected route-local CODEX_HOME\n'
 managed_launch_out="$tmp/managed-launch.out"
@@ -940,6 +960,25 @@ expect_contains "$managed_launch" 'account=max-2' "managed launch injects select
 expect_contains "$managed_launch" 'capability=codex-max' "managed launch injects selected capability"
 expect_contains "$managed_launch" "codex_home=$broker_session_max2_home" "managed launch injects selected route CODEX_HOME"
 expect_contains "$managed_launch" 'args=[--no-alt-screen]' "managed launch forwards Codex args after --"
+
+printf 'e2e: codex managed refuses wrong-route explicit resume before launching child\n'
+managed_resume_launch_out="$tmp/managed-resume-launch.out"
+PATH="$broker_session_bin:$PATH" OMUX_E2E_MANAGED_OUT="$managed_resume_launch_out" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex managed --profile codex-max --capability codex-max --resume managed-good-session -- --no-alt-screen
+managed_resume_launch="$(cat "$managed_resume_launch_out")"
+expect_contains "$managed_resume_launch" 'args=[resume][managed-good-session][--no-alt-screen]' "managed launch forwards route-local explicit resume after positive diagnostic"
+managed_refusal_out="$tmp/managed-refusal.out"
+managed_should_not_run="$tmp/managed-should-not-run.out"
+if PATH="$broker_session_bin:$PATH" OMUX_E2E_MANAGED_OUT="$managed_should_not_run" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex managed --profile codex-max --capability codex-max --resume missing-session >"$managed_refusal_out" 2>/dev/null; then
+  printf 'e2e assertion failed: managed explicit missing resume should refuse before launch\n' >&2
+  exit 1
+fi
+managed_refusal="$(cat "$managed_refusal_out")"
+expect_contains "$managed_refusal" 'status: not_found_in_selected_store' "managed missing explicit resume reports route-local diagnostic"
+expect_contains "$managed_refusal" 'resume_id_printed: false' "managed missing explicit resume suppresses id in text output"
+if [ -f "$managed_should_not_run" ]; then
+  printf 'e2e assertion failed: managed explicit missing resume launched child unexpectedly\n' >&2
+  exit 1
+fi
 
 printf 'e2e: codex revalidate-exhausted requires spend confirmation before mutating route health\n'
 broker_revalidate_prompt="$(OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex revalidate-exhausted --profile codex-max --capability codex-max --account max-1 --json 2>/dev/null || true)"

--- a/src/main.zig
+++ b/src/main.zig
@@ -8848,7 +8848,7 @@ fn runCodexManagedPlan(allocator: std.mem.Allocator, writer: anytype, args: cli.
     if (args.json) {
         try writeCodexManagedPlanJson(writer, allocator, parsed.value, evaluations.items, selected_index, args.profile, capability, args);
     } else {
-        try writeCodexManagedPlanText(writer, evaluations.items, selected_index, args.profile, capability, args);
+        try writeCodexManagedPlanText(writer, allocator, parsed.value, evaluations.items, selected_index, args.profile, capability, args);
     }
 }
 
@@ -8856,6 +8856,14 @@ fn runCodexManaged(allocator: std.mem.Allocator, writer: anytype, args: cli.Comm
     if (args.json) {
         try runCodexManagedPlan(allocator, writer, args);
         return;
+    }
+
+    if (args.resume_id != null) {
+        const resume_inspection = try inspectCodexManagedResumeForArgs(allocator, args);
+        if (!codexManagedResumeAllowsLaunch(resume_inspection)) {
+            try writeCodexManagedResumeRefusalText(writer, resume_inspection);
+            return error.ConfigValidationError;
+        }
     }
 
     const target_argv = try buildCodexManagedTargetArgv(allocator, args);
@@ -8899,6 +8907,241 @@ fn buildCodexManagedTargetArgv(allocator: std.mem.Allocator, args: cli.Command.C
     return try argv.toOwnedSlice();
 }
 
+const CodexManagedResumeInspection = struct {
+    requested: bool = false,
+    explicit_id: bool = false,
+    resume_last: bool = false,
+    include_non_interactive: bool = false,
+    checked: bool = false,
+    found: bool = false,
+    selected_route_available: bool = false,
+    store_available: bool = false,
+    session_index_checked: bool = false,
+    session_index_match: bool = false,
+    rollout_filenames_checked: bool = false,
+    rollout_filename_match: bool = false,
+    state_store_checked: bool = false,
+    state_store_match: bool = false,
+    path_printed: bool = false,
+    status: []const u8 = "not_requested",
+    diagnostic: []const u8 = "no resume id requested",
+};
+
+fn inspectCodexManagedResumeForArgs(allocator: std.mem.Allocator, args: cli.Command.CodexArgs) !CodexManagedResumeInspection {
+    const parsed = try config.load(allocator);
+    defer parsed.deinit();
+
+    var validation_messages = std.ArrayList(u8).init(allocator);
+    defer validation_messages.deinit();
+    try config.validate(parsed.value, validation_messages.writer());
+
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+
+    const capability = firstCommaValue(args.capabilities);
+    var routes = try collectRepairPlanRoutes(allocator, parsed.value, .{
+        .profile = args.profile,
+        .provider = if (args.profile == null) "codex" else null,
+        .account = args.account,
+        .capability = capability,
+    });
+    defer routes.deinit();
+
+    var evaluations = std.ArrayList(RouteEvaluation).init(allocator);
+    defer evaluations.deinit();
+    try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &evaluations);
+
+    const selected_index = firstSelectableRoute(evaluations.items);
+    const selected_route = if (selected_index) |idx| evaluations.items[idx].route else null;
+    return try inspectCodexManagedResume(allocator, parsed.value, selected_route, args);
+}
+
+fn inspectCodexManagedResume(
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    selected_route: ?RepairPlanRoute,
+    args: cli.Command.CodexArgs,
+) !CodexManagedResumeInspection {
+    var result = CodexManagedResumeInspection{
+        .requested = args.resume_id != null or args.resume_last,
+        .explicit_id = args.resume_id != null,
+        .resume_last = args.resume_last,
+        .include_non_interactive = args.include_non_interactive,
+    };
+
+    if (!result.requested) return result;
+    if (args.resume_last and args.resume_id == null) {
+        result.status = "resume_last_unchecked";
+        result.diagnostic = "resume --last is resolved by native Codex inside the selected route-local CODEX_HOME";
+        result.selected_route_available = selected_route != null;
+        return result;
+    }
+
+    const resume_id = args.resume_id orelse return result;
+    result.checked = true;
+
+    const route = selected_route orelse {
+        result.status = "selected_route_unavailable";
+        result.diagnostic = "no selectable route is available, so oauth-mux cannot check a route-local Codex resume id";
+        return result;
+    };
+    result.selected_route_available = true;
+
+    const store_dir = try codexManagedRouteConfigDir(allocator, cfg, route) orelse {
+        result.status = "selected_route_missing_store";
+        result.diagnostic = "selected Codex route does not define a CODEX_HOME store for resume lookup";
+        return result;
+    };
+    defer allocator.free(store_dir);
+    result.store_available = true;
+
+    const index_path = try std.fs.path.join(allocator, &.{ store_dir, "session_index.jsonl" });
+    defer allocator.free(index_path);
+    result.session_index_checked = true;
+    result.session_index_match = fileContainsNeedle(allocator, index_path, resume_id) catch false;
+
+    const sessions_dir = try std.fs.path.join(allocator, &.{ store_dir, "sessions" });
+    defer allocator.free(sessions_dir);
+    result.rollout_filenames_checked = true;
+    result.rollout_filename_match = directoryFileNameContainsNeedle(allocator, sessions_dir, resume_id) catch false;
+
+    result.state_store_checked = true;
+    result.state_store_match =
+        (try codexManagedStateFileContainsNeedle(allocator, store_dir, "state_5.sqlite", resume_id)) or
+        (try codexManagedStateFileContainsNeedle(allocator, store_dir, "state_5.sqlite-wal", resume_id));
+
+    result.found = result.session_index_match or result.rollout_filename_match or result.state_store_match;
+    if (result.found) {
+        result.status = "found_in_selected_store";
+        result.diagnostic = "resume id was found in the selected route-local Codex store";
+    } else {
+        result.status = "not_found_in_selected_store";
+        result.diagnostic = "resume id was not found in the selected route-local Codex store; choose the route that owns it or start a new managed session";
+    }
+    return result;
+}
+
+fn codexManagedRouteConfigDir(allocator: std.mem.Allocator, cfg: config.Config, route: RepairPlanRoute) !?[]const u8 {
+    const provider_cfg = cfg.providers.map.get(route.provider) orelse return null;
+    const account = provider_cfg.accounts.map.get(route.account) orelse return null;
+    const config_dir = account.config_dir orelse return null;
+    return try paths.expandTilde(allocator, config_dir);
+}
+
+fn codexManagedStateFileContainsNeedle(
+    allocator: std.mem.Allocator,
+    store_dir: []const u8,
+    filename: []const u8,
+    needle: []const u8,
+) !bool {
+    const path = try std.fs.path.join(allocator, &.{ store_dir, filename });
+    defer allocator.free(path);
+    return fileContainsNeedle(allocator, path, needle) catch false;
+}
+
+fn fileContainsNeedle(allocator: std.mem.Allocator, path: []const u8, needle: []const u8) !bool {
+    if (needle.len == 0) return false;
+    var file = std.fs.openFileAbsolute(path, .{}) catch |err| switch (err) {
+        error.FileNotFound, error.AccessDenied, error.NotDir => return false,
+        else => return err,
+    };
+    defer file.close();
+
+    var previous = std.ArrayList(u8).init(allocator);
+    defer previous.deinit();
+
+    var buf: [8192]u8 = undefined;
+    while (true) {
+        const n = try file.read(&buf);
+        if (n == 0) break;
+
+        var haystack = std.ArrayList(u8).init(allocator);
+        defer haystack.deinit();
+        try haystack.appendSlice(previous.items);
+        try haystack.appendSlice(buf[0..n]);
+        if (std.mem.indexOf(u8, haystack.items, needle) != null) return true;
+
+        previous.clearRetainingCapacity();
+        const keep = @min(needle.len - 1, haystack.items.len);
+        if (keep != 0) try previous.appendSlice(haystack.items[haystack.items.len - keep ..]);
+    }
+    return false;
+}
+
+fn directoryFileNameContainsNeedle(allocator: std.mem.Allocator, root: []const u8, needle: []const u8) !bool {
+    if (needle.len == 0) return false;
+    var dir = std.fs.openDirAbsolute(root, .{ .iterate = true }) catch |err| switch (err) {
+        error.FileNotFound, error.AccessDenied, error.NotDir => return false,
+        else => return err,
+    };
+    defer dir.close();
+
+    var walker = try dir.walk(allocator);
+    defer walker.deinit();
+
+    var inspected: usize = 0;
+    while (try walker.next()) |entry| {
+        if (entry.kind != .file) continue;
+        inspected += 1;
+        if (inspected > 20000) return false;
+        if (std.mem.indexOf(u8, entry.basename, needle) != null) return true;
+    }
+    return false;
+}
+
+fn codexManagedResumeAllowsLaunch(inspection: CodexManagedResumeInspection) bool {
+    if (!inspection.requested) return true;
+    if (!inspection.explicit_id) return true;
+    return inspection.found;
+}
+
+fn writeCodexManagedResumeJson(writer: anytype, inspection: CodexManagedResumeInspection) !void {
+    try writer.writeAll("{\"scope\":\"route_local_codex_home\",\"requested\":");
+    try writer.writeAll(if (inspection.requested) "true" else "false");
+    try writer.writeAll(",\"resume_last\":");
+    try writer.writeAll(if (inspection.resume_last) "true" else "false");
+    try writer.writeAll(",\"resume_id_provided\":");
+    try writer.writeAll(if (inspection.explicit_id) "true" else "false");
+    try writer.writeAll(",\"checked\":");
+    try writer.writeAll(if (inspection.checked) "true" else "false");
+    try writer.writeAll(",\"found_in_selected_store\":");
+    try writer.writeAll(if (inspection.found) "true" else "false");
+    try writer.writeAll(",\"selected_route_available\":");
+    try writer.writeAll(if (inspection.selected_route_available) "true" else "false");
+    try writer.writeAll(",\"store_available\":");
+    try writer.writeAll(if (inspection.store_available) "true" else "false");
+    try writer.writeAll(",\"status\":");
+    try std.json.stringify(inspection.status, .{}, writer);
+    try writer.writeAll(",\"include_non_interactive\":");
+    try writer.writeAll(if (inspection.include_non_interactive) "true" else "false");
+    try writer.writeAll(",\"resume_id_printed\":false,\"path_printed\":false,\"unmanaged_cross_route_resume\":false");
+    try writer.writeAll(",\"evidence\":{\"session_index_checked\":");
+    try writer.writeAll(if (inspection.session_index_checked) "true" else "false");
+    try writer.writeAll(",\"session_index_match\":");
+    try writer.writeAll(if (inspection.session_index_match) "true" else "false");
+    try writer.writeAll(",\"rollout_filenames_checked\":");
+    try writer.writeAll(if (inspection.rollout_filenames_checked) "true" else "false");
+    try writer.writeAll(",\"rollout_filename_match\":");
+    try writer.writeAll(if (inspection.rollout_filename_match) "true" else "false");
+    try writer.writeAll(",\"state_store_checked\":");
+    try writer.writeAll(if (inspection.state_store_checked) "true" else "false");
+    try writer.writeAll(",\"state_store_match\":");
+    try writer.writeAll(if (inspection.state_store_match) "true" else "false");
+    try writer.writeAll("},\"diagnostic\":");
+    try std.json.stringify(inspection.diagnostic, .{}, writer);
+    try writer.writeByte('}');
+}
+
+fn writeCodexManagedResumeRefusalText(writer: anytype, inspection: CodexManagedResumeInspection) !void {
+    try writer.writeAll("oauth-mux Codex managed resume diagnostic\n\n");
+    try writer.print("  ok: false\n  status: {s}\n", .{inspection.status});
+    try writer.print("  selected_route_available: {s}\n", .{if (inspection.selected_route_available) "true" else "false"});
+    try writer.writeAll("  resume_id_printed: false\n");
+    try writer.writeAll("  path_printed: false\n");
+    try writer.print("  diagnostic: {s}\n", .{inspection.diagnostic});
+    try writer.writeAll("  next: start a new managed session, or select the account whose route-local CODEX_HOME owns that session id\n");
+}
+
 fn writeCodexManagedPlanJson(
     writer: anytype,
     allocator: std.mem.Allocator,
@@ -8912,14 +9155,16 @@ fn writeCodexManagedPlanJson(
     const session_start_ready = selected_index != null;
     const fallback_count = selectableFallbackRouteCount(evaluations, selected_index);
     const prepared_fallback = session_start_ready and fallback_count > 0;
-    const resume_requested = args.resume_id != null or args.resume_last;
+    const selected_route = if (selected_index) |idx| evaluations[idx].route else null;
+    const resume_inspection = try inspectCodexManagedResume(allocator, cfg, selected_route, args);
+    const ok = session_start_ready and codexManagedResumeAllowsLaunch(resume_inspection);
 
     try writer.writeAll("{\"version\":");
     try std.json.stringify(cli.version, .{}, writer);
     try writer.writeAll(",\"mode\":\"codex_managed_session_plan\"");
     try writer.writeAll(",\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mutates_route_health\":false,\"executes_child\":false");
     try writer.writeAll(",\"ok\":");
-    try writer.writeAll(if (session_start_ready) "true" else "false");
+    try writer.writeAll(if (ok) "true" else "false");
     try writer.writeAll(",\"claim\":{\"claim_version\":1,\"level\":\"managed_codex_process\",\"proof_status\":\"managed_launch_planning_only\",\"managed_process_launch\":true,\"mediation_point\":\"stay-afloat launch\",\"route_local_resume\":true,\"resume_namespace\":\"selected_route_codex_home\",\"prepared_fallback\":");
     try writer.writeAll(if (prepared_fallback) "true" else "false");
     try writer.writeAll(",\"selectable_fallback_routes\":");
@@ -8930,15 +9175,8 @@ fn writeCodexManagedPlanJson(
     try writer.writeAll(",\"capability\":");
     if (capability) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"codex_home\":{\"env\":\"CODEX_HOME\",\"namespace\":\"selected_route_store\",\"path_printed\":false}");
-    try writer.writeAll(",\"resume\":{\"scope\":\"route_local_codex_home\",\"requested\":");
-    try writer.writeAll(if (resume_requested) "true" else "false");
-    try writer.writeAll(",\"resume_last\":");
-    try writer.writeAll(if (args.resume_last) "true" else "false");
-    try writer.writeAll(",\"resume_id_provided\":");
-    try writer.writeAll(if (args.resume_id != null) "true" else "false");
-    try writer.writeAll(",\"include_non_interactive\":");
-    try writer.writeAll(if (args.include_non_interactive) "true" else "false");
-    try writer.writeAll(",\"resume_id_printed\":false,\"unmanaged_cross_route_resume\":false,\"diagnostic\":\"resume ids are resolved by Codex inside the selected route-local CODEX_HOME\"}");
+    try writer.writeAll(",\"resume\":");
+    try writeCodexManagedResumeJson(writer, resume_inspection);
     try writer.writeAll(",\"target\":{\"program\":\"codex\",\"passthrough_arg_count\":");
     try writer.print("{d}", .{args.managed_argv.len});
     try writer.writeAll(",\"argv_printed\":false}");
@@ -8963,6 +9201,8 @@ fn writeCodexManagedPlanJson(
 
 fn writeCodexManagedPlanText(
     writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
     evaluations: []const RouteEvaluation,
     selected_index: ?usize,
     profile: ?[]const u8,
@@ -8970,6 +9210,8 @@ fn writeCodexManagedPlanText(
     args: cli.Command.CodexArgs,
 ) !void {
     const fallback_count = selectableFallbackRouteCount(evaluations, selected_index);
+    const selected_route = if (selected_index) |idx| evaluations[idx].route else null;
+    const resume_inspection = try inspectCodexManagedResume(allocator, cfg, selected_route, args);
     try writer.writeAll("oauth-mux Codex managed session plan\n\n");
     if (profile) |value| try writer.print("  profile: {s}\n", .{value});
     if (capability) |value| try writer.print("  capability: {s}\n", .{value});
@@ -8977,6 +9219,8 @@ fn writeCodexManagedPlanText(
     try writer.print("  session_start_ready: {s}\n", .{if (selected_index != null) "true" else "false"});
     try writer.print("  selectable_fallback_routes: {d}\n", .{fallback_count});
     try writer.print("  resume_requested: {s}\n", .{if (args.resume_id != null or args.resume_last) "true" else "false"});
+    try writer.print("  resume_status: {s}\n", .{resume_inspection.status});
+    try writer.print("  resume_found_in_selected_store: {s}\n", .{if (resume_inspection.found) "true" else "false"});
     if (selected_index) |idx| {
         const route = evaluations[idx].route;
         try writer.print("  selected: {s}:{s}", .{ route.provider, route.account });


### PR DESCRIPTION
## Summary

Adds a route-local resume diagnostic for `oauth-mux codex managed --resume <id>`. The plan and launch paths now inspect the selected route's `CODEX_HOME` for local evidence of the requested session id before native Codex starts.

Evidence sources are intentionally local and conservative: `session_index.jsonl`, rollout filenames under `sessions/`, and Codex state-store bytes. If the id is missing from the selected store, `codex managed` refuses before child exec and reports a redacted diagnostic.

## Why

TIN-934 / #160 exposed the remaining wrong-route resume gap: unmanaged or cross-route Codex session ids can fail in confusing ways after oauth-mux has already selected and launched a route. This makes that boundary visible before launch without claiming session import, same-thread quota recovery, or unmanaged active-session rescue.

## Redaction / Boundary

- No provider calls.
- No route health mutation.
- No resume id printed.
- No store path or credential path printed.
- `--resume-last` remains delegated to native Codex inside the selected route-local store.
- This is managed-process route-local resume hygiene, not seamless stay-afloat for an already-running unmanaged Codex process.

## Validation

- `zig build`
- `zig build test`
- `./scripts/e2e-local.sh`
- `just check-local`
- `git diff --check`

Refs #160.
