### PR TITLE
Truth stay-afloat docs after managed resume

### DIFF
--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -214,10 +214,11 @@ proxy, or in-agent adapter proves those stronger levels.
 | Command surface | Claim level | Boundary | Spend | Route health mutation | Provider-originated evidence | Same-thread support | Unmanaged TUI support |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `stay-afloat next`, `stay-afloat launch`, `daemon tick` | `prepared_fallback` | next mediated process start | no | no by default | no | no | no |
-| `codex managed-plan`, `codex managed` | `managed_codex_process` | native Codex started under selected route-local `CODEX_HOME` | child-dependent for launch | no by default | child-dependent | no | managed launch only |
+| `codex managed-plan`, `codex managed` | `managed_codex_process` | native Codex started under selected route-local `CODEX_HOME`; explicit resume ids are preflighted against that store | child-dependent for launch | no by default | child-dependent | no | managed launch only |
 | `codex broker-session-plan` | `broker_owned_app_server` | planning for oauth-mux-owned Codex app-server | no | no | no | no | no |
 | `codex broker-session-smoke` | `broker_owned_app_server` | local mocked broker-owned app-server | no | no | simulated only | new thread only | no |
 | `codex broker-run` | `broker_owned_app_server` | live broker-owned app-server | yes, after confirmation | on classified live failure | yes when provider failure occurs | no | no |
+| `codex revalidate-exhausted` | `prepared_fallback` route-health refresh | spend-gated recheck of routes already recorded exhausted/rate-limited | yes, after confirmation | yes, from fresh probe | yes | no | no |
 | `codex broker-fallback-drill` | `controlled_route_health_drill` | local route-health mutation | no | yes | no | no | no |
 | `stay-afloat supervise` | `supervised_process` or `supervised_restart` after restart | wrapper-owned child process | child-dependent | on classified child failure | yes when child emits it | no | wrapper-launched child only |
 | future native hook | `current_process_auth_broker` | already-running provider process with supported auth-update hook | hook-dependent | hook-dependent | hook-dependent | unproven | unproven |

--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -88,13 +88,15 @@ exit with typed non-dead `liveness` is still accepted unless
 `OMUX_LIVE_QA_REQUIRE_AVAILABLE=1`; missing or unreadable credentials classify
 as `dead` and fail the run by default.
 
-Operator-provided Codex state on 2026-04-28:
+Historical operator-provided Codex state on 2026-04-28:
 
 - `max-1#codex-max` and `max-2#codex-max` are expected to classify as
   `live/quota_exhausted` until weekly limits refresh.
 - `max-3` is expected to remain active for API-backed usage.
 - These are not auth-dead accounts; the useful proof is preserving the
   distinction between weekly quota exhaustion and usable fallback routes.
+This three-route snapshot is retained only to explain earlier artifacts. Use
+the current four-route section below for operator decisions and website copy.
 
 Current four-route Codex dogfood state on 2026-05-03:
 

--- a/docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md
+++ b/docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md
@@ -237,7 +237,12 @@ Supported near-term product shape:
   commands with the selected account;
 - a Codex-specific wrapper can relaunch a child Codex process when the selected
   route changes;
-- app-server auth brokering is a beta proof target, not a public claim yet;
+- broker-owned app-server sessions are proven for scoped Codex commands
+  (`broker-session-plan`, `broker-session-smoke`, and spend-gated
+  `broker-run`) under `claim.level:"broker_owned_app_server"`;
+- `codex managed` is the native managed-entrypoint path for route-local
+  `CODEX_HOME` launch/resume hygiene, including explicit resume-id diagnostics
+  before child exec;
 - direct hot-swap inside an unmanaged already-running Codex session is not
   promised.
 
@@ -355,8 +360,10 @@ mutating admission.
 ### D4: mediation adapters
 
 - Promote `oauth-mux exec` and shell wrappers as Level 1 mediation.
-- Add a Codex wrapper story for selected-account launch and supervised restart.
-- Add a Codex app-server auth-broker proof for Level 3 broker-owned mediation.
+- Keep the Codex wrapper story scoped to selected-account launch and
+  supervised restart until interactive PTY dogfood is green.
+- Extend the shipped Codex app-server auth-broker proof for Level 3
+  broker-owned mediation; do not rename it current-process auth brokering.
 - Add MCP/in-agent tools for route visibility and handoff surfacing.
 - Consider request-level proxying only where the harness protocol can support
   Level 5 per-request muxing.

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -30,9 +30,9 @@ in-session quota fallback remains tracked by GitHub `#131` / Linear `TIN-916`.
 | Facet | Public GitHub issue | Linear tracking | Current posture |
 | --- | --- | --- | --- |
 | Homebrew distribution | `#66` | `TIN-858`, related to `TIN-737` | Public Jess-owned tap exists and clean local install QA passes; Tinyland tap remains private/staged. Live website copy was rechecked on 2026-05-03 and now uses the public `jesssullivan/omux` tap. |
-| Stay-afloat daemon | `#67` | `TIN-738`, `TIN-859`, `TIN-860`, `TIN-866`, `TIN-867`, `TIN-897`, `TIN-898` | Foreground/agent-safe stay-afloat is shipped; production background daemon is not. Socket daemon is explicitly non-product plumbing for this release line. `TIN-897` defines the mediation boundary for seamless handoff claims; `TIN-898` adds the first opt-in beta supervised loop without changing default policy or production claims. |
-| Provider expansion | `#68` | `TIN-736`, `TIN-861`, `TIN-862`, `TIN-863`, `TIN-876`, `TIN-877`, `TIN-878`, `TIN-879` | Codex is live-proven; non-Codex proof is capability-level or still needs operator proof. |
-| Paid multi-account proof | `#67`, `#68` | `TIN-892`, `TIN-893`, `TIN-894`, `TIN-895`, `TIN-896` | A one-month paid cohort is now tracked for Codex lower-tier contrast, Claude subscription/billing shapes, Figma token/seat/plan shapes, and a foreground stay-afloat soak gate. |
+| Stay-afloat daemon | `#67` | `TIN-738`, `TIN-859`, `TIN-860`, `TIN-866`, `TIN-867`, `TIN-897`, `TIN-898`, `TIN-940` | Foreground/agent-safe stay-afloat is shipped; production background daemon is not. Socket daemon is explicitly non-product plumbing. The active claim matrix lives in `docs/daemon-boundary.md`; managed Codex launch/resume, broker-owned app-server sessions, and supervised restart beta are separate claim levels. |
+| Provider expansion | `#68` | `TIN-736`, `TIN-861`, `TIN-862`, `TIN-863`, `TIN-876`, `TIN-877`, `TIN-878`, `TIN-879` | Codex route selection and broker-owned sessions are live-proven for scoped commands; true seamless active-session handoff is not. Non-Codex proof is capability-level or still needs operator proof. |
+| Paid multi-account proof | `#67`, `#68` | `TIN-892`, `TIN-893`, `TIN-894`, `TIN-895`, `TIN-896` | Codex has a current four-route paid cohort: `max-1` selected, `max-4` spare fallback, and `max-2`/`max-3` quota-exhausted for `codex-max`. Claude, Figma, and long-window soak evidence remain separate gates. |
 
 ## Homebrew Boundary
 
@@ -49,9 +49,10 @@ Current truth:
   `oauth-mux.rb` and `SHA256SUMS`, not local `dist/out` output.
 - A historical live check of `https://omux.xoxd.ai/` on 2026-05-01 still
   found `brew install tinyland-inc/tools/oauth-mux`. A 2026-05-03 recheck of
-  the live site shows the public `jesssullivan/omux` tap instead. Keep any
-  remaining `#66` / `TIN-858` work scoped to release-copy or artifact cleanup,
-  not the live website tap string.
+  the live site shows the public `jesssullivan/omux` tap, the current
+  four-route Codex Max state, and an explicit provider-originated fallback
+  proof lane. Keep any remaining `#66` / `TIN-858` work scoped to release-copy
+  or artifact cleanup, not the live website tap string.
 
 The decision record is
 `docs/spec/homebrew-public-lane-decision-2026-05-01.md`. The live website now
@@ -253,28 +254,32 @@ these precise provider-proof children.
 
 ## Immediate Execution Order
 
-1. Keep provider-neutral account inventory and enrollment planning aligned with
-   the account-enrollment contract, so agents can inspect N configured accounts
-   and explain setup before route, repair, handoff, or live-proof decisions.
-2. Use the Codex, Claude, and Figma confirmed enrollment paths as the
-   consent/mutation reference before adding MCP mutation tools.
-3. Update website/release copy to use the public `jesssullivan/omux` Homebrew
-   tap and close `#66` / `TIN-858` after those surfaces are aligned.
-4. Finish `TIN-862` by adding Linear OAuth bearer proof. GitHub identity and
-   Linear API-key identity are locally proven; Linear OAuth `identity` remains
-   `needs_operator_proof`.
-5. Continue `TIN-861` and `TIN-863` on their remaining hard shapes: Claude
+1. Keep `TIN-940` open until active docs and site-copy evidence agree with the
+   May 3 dogfood truth: foreground prepared fallback, scoped broker-owned
+   sessions, managed Codex launch/resume, and no unmanaged active-session
+   handoff claim.
+2. Continue `TIN-937` for interactive supervised restart with PTY capture; the
+   restart classifier exists, but polished interactive dogfood is not done.
+3. Continue `TIN-936` for Codex session-store portability and explicit import
+   policy; `codex managed --resume <id>` now diagnoses route-local ownership
+   but does not copy or import sessions.
+4. Continue `TIN-938` only if the managed local entrypoint is insufficient and
+   a remote app-server sidecar can preserve oauth-mux mediation.
+5. Draft `TIN-939` upstream usage-limit handoff proposal after the local
+   session-store and wrapper semantics are clean.
+6. Continue `TIN-861` and `TIN-863` on their remaining hard shapes: Claude
    quota/repair semantics and MCP resource-bound bearer-token proof.
-6. Start `TIN-892` paid proof once billing choices are confirmed. Use
+7. Continue `TIN-892` paid proof as billing choices are confirmed. Use
    `docs/spec/paid-multi-account-proof-cohort-2026-05-01.md` as the cohort
    matrix and keep provider-level promotion conservative.
-7. Work provider proof in narrow slices: `TIN-876` Vercel, `TIN-877` Figma,
+8. Work provider proof in narrow slices: `TIN-876` Vercel, `TIN-877` Figma,
    `TIN-878` FlakeHub/Determinate, and `TIN-879` Gemini.
-8. Work `TIN-897` as the daemon promotion contract: define daemon snapshot
+9. Work `TIN-897` as the daemon promotion contract: define daemon snapshot
    status, supervised tick loop, wrapper recipes, and mediation adapters before
    making seamless handoff claims.
-9. Work `TIN-913` / GitHub `#125` as the Codex app-server auth-broker proof
-   track before assuming restart is the only viable Codex current-process path.
+10. Keep `TIN-913` / GitHub `#125` as the Codex app-server auth-broker proof
+   record; broker-owned app-server paths are viable, but still separate from
+   unmanaged current-process auth brokering.
    `oauth-mux codex broker-plan` proves local credential tuple readiness only;
    it does not read route liveness or claim prepared fallback. Use
    `oauth-mux codex broker-session-plan` for route-aware selection.

--- a/docs/spec/supervised-harness-restart-contract-2026-05-02.md
+++ b/docs/spec/supervised-harness-restart-contract-2026-05-02.md
@@ -5,6 +5,14 @@ Issue context: Linear `TIN-911`, GitHub `#123`, parent `TIN-738` / GitHub
 `#67`. Parallel higher-upside proof: Linear `TIN-913`, GitHub `#125`,
 `docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md`.
 
+Update, 2026-05-03: this contract is still the right wrapper-owned restart
+boundary, but the route examples below are historical. Current Codex Max
+dogfood has four routes: `max-1#codex-max` selected after spend-gated
+revalidation, `max-4#codex-max` spare fallback, and `max-2#codex-max` /
+`max-3#codex-max` provider quota-exhausted. The usage-limit classifier and
+restart engine exist for wrapper-owned children; interactive PTY capture and
+real usage-limit restart dogfood remain tracked by TIN-937 / GitHub #162.
+
 ## State
 
 `oauth-mux` can now keep route evidence warm, expose fresh daemon snapshots,


### PR DESCRIPTION
## Summary

Follow-up TIN-940 docs truthing after PR #169. This keeps the active docs aligned with the May 3 Codex dogfood state and the managed-resume/broker-owned/supervised-restart claim ladder.

## What changed

- Updates the daemon command claim matrix for `codex managed` explicit resume diagnostics and `codex revalidate-exhausted`.
- Marks the older three-route live QA snapshot as historical and points operators to the current four-route matrix.
- Reconciles the background daemon contract with shipped broker-owned app-server surfaces and the managed Codex entrypoint.
- Adds a 2026-05-03 update banner to the supervised restart contract so old `max-3` route examples are not read as current truth.
- Refreshes the product gap execution order around TIN-940, TIN-937, TIN-936, TIN-938, and TIN-939.

## Site Truthing

Fetched `https://omux.xoxd.ai/` on 2026-05-03. The live page already states the current four-route Codex Max posture (`max-1` selected, `max-4` spare fallback, `max-2`/`max-3` quota-exhausted for `codex-max`) and keeps provider-originated in-session fallback as an open proof lane. No repo site source was present to edit in this checkout.

## Validation

- `./scripts/stay-afloat-wrapper-doc-smoke.sh`
- `just check-local`
- `git diff --check`

Refs #165.
