### PR TITLE
[codex] Add broker MCP core

### DIFF
--- a/justfile
+++ b/justfile
@@ -173,7 +173,7 @@ check:
     nix develop --command just check-local
 
 check-local:
-    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh && ./scripts/stay-afloat-wrapper-doc-smoke.sh'
+    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh && ./scripts/stay-afloat-wrapper-doc-smoke.sh && ./scripts/smoke-broker.sh'
     @echo "all checks passed"
 
 e2e:
@@ -192,6 +192,15 @@ first-run-e2e-local:
 
 live-qa:
     nix develop --command ./scripts/live-provider-qa.sh
+
+# ── Broker MCP smoke (provider-neutral regression catch-net) ──
+
+smoke-broker:
+    nix develop --command just smoke-broker-local
+
+smoke-broker-local:
+    zig build
+    ./scripts/smoke-broker.sh
 
 # ── Config ──
 

--- a/scripts/smoke-broker.sh
+++ b/scripts/smoke-broker.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Automated end-to-end smoke for oauth-mux mcp (broker MCP server).
+#
+# Anchor: docs/spec/broker-mcp-contract-2026-05-03.md.
+# Replaces the prior manual `echo '{...}' | oauth-mux mcp` pipe
+# documented in commit 3152898's body. This is the regression
+# catch-net for the broker JSON-RPC dispatch path; it MUST stay
+# green or Phase 2 acceptance is invalidated.
+#
+# Coverage (in order of issue):
+#   1. surface/info        — basic dispatch + response writer round-trip
+#   2. surface/handshake   — session minting + storage
+#   3. account/list        — pool population + JSON shape
+#   4. account/select      — election + opaque credential_handle
+#   5. credential/materialize — chatgpt_auth_tokens shape, plan_type
+#                              extraction from id_token JWT
+#   6. quota/observe       — kind=quota_exhausted, resets_at, now_selectable
+#   7. account/select again — proves prior account was actually marked
+#                             non-selectable in the pool
+#   8. account/swap        — full swap chain with claim.level promotion
+#   9. quota/status        — pool snapshot reflects all prior mutations
+#
+# Exit 0 = all assertions pass. Exit non-zero = which step failed.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$ROOT/zig-out/bin/oauth-mux"
+
+if [[ ! -x "$BIN" ]]; then
+    echo "smoke-broker: oauth-mux binary not built at $BIN" >&2
+    echo "  run: just build" >&2
+    exit 64
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "smoke-broker: jq required" >&2
+    exit 64
+fi
+
+# Tempdir + cleanup
+TMP="$(mktemp -d -t omux-smoke-broker.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# A minimal codex auth.json shape so credential/materialize can resolve
+# fixture token strings. id_token payload encodes plan_type=pro and
+# chatgpt_account_is_fedramp=true so the JWT decoder is exercised.
+cat >"$TMP/auth.json" <<'EOF'
+{
+  "OPENAI_API_KEY": null,
+  "tokens": {
+    "id_token": "h.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9wbGFuX3R5cGUiOiJwcm8iLCJjaGF0Z3B0X2FjY291bnRfaXNfZmVkcmFtcCI6dHJ1ZX19.s",
+    "access_token": "AT-smoke-1",
+    "refresh_token": "RT-smoke",
+    "account_id": "acc-smoke-1"
+  },
+  "auth_mode": "Chatgpt"
+}
+EOF
+
+cat >"$TMP/config.json" <<EOF
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "kind": "codex",
+      "accounts": {
+        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "$TMP/auth.json" } },
+        "max-2": { "priority": 20, "secret": { "backend": "file", "path": "$TMP/auth.json" } },
+        "max-3": { "priority": 10, "secret": { "backend": "file", "path": "$TMP/auth.json" } }
+      }
+    }
+  },
+  "profiles": {
+    "codex-max": { "providers": ["codex:max-1#codex-max", "codex:max-2#codex-max", "codex:max-3#codex-max"] }
+  }
+}
+EOF
+
+# Build the JSON-RPC request sequence.
+REQUESTS=$(cat <<'REQ'
+{"jsonrpc":"2.0","id":1,"method":"surface/info"}
+{"jsonrpc":"2.0","id":2,"method":"surface/handshake","params":{"adapter":"smoke","adapter_version":"0","harness_target":"codex","session_pid":1}}
+{"jsonrpc":"2.0","id":3,"method":"account/list","params":{"session_id":"x"}}
+{"jsonrpc":"2.0","id":4,"method":"account/select","params":{"session_id":"x"}}
+{"jsonrpc":"2.0","id":5,"method":"credential/materialize","params":{"session_id":"x","credential_handle":"ch:codex:max-1:0","shape":"chatgpt_auth_tokens"}}
+{"jsonrpc":"2.0","id":6,"method":"quota/observe","params":{"session_id":"x","account":"codex:max-1","kind":"quota_exhausted","http_status":429,"body_class":"usage_limit_reached","resets_at":1788000000}}
+{"jsonrpc":"2.0","id":7,"method":"account/select","params":{"session_id":"x"}}
+{"jsonrpc":"2.0","id":8,"method":"account/swap","params":{"session_id":"x","current_account":"codex:max-2","reason":"quota_exhausted","evidence":{"http_status":429,"resets_at":1788000000}}}
+{"jsonrpc":"2.0","id":9,"method":"quota/status","params":{"session_id":"x"}}
+REQ
+)
+
+# Pipe + capture every response on its own line.
+RESPONSES="$(printf '%s\n' "$REQUESTS" | OMUX_CONFIG="$TMP/config.json" "$BIN" mcp --profile codex-max 2>"$TMP/stderr.log")"
+
+# Helper: pluck the response with the matching id.
+resp_for() {
+    local id=$1
+    printf '%s\n' "$RESPONSES" | jq -c "select(.id==$id)"
+}
+
+assert_eq() {
+    local label=$1 expected=$2 actual=$3
+    if [[ "$expected" != "$actual" ]]; then
+        echo "smoke-broker: FAIL [$label] expected=$expected actual=$actual" >&2
+        exit 1
+    fi
+    echo "  ✓ $label"
+}
+
+# 1. surface/info
+r=$(resp_for 1)
+assert_eq "surface/info.surface_version" "1" "$(echo "$r" | jq -r .result.surface_version)"
+assert_eq "surface/info.transports[0]"   "stdio" "$(echo "$r" | jq -r .result.transports[0])"
+
+# 2. surface/handshake
+r=$(resp_for 2)
+sid_present=$(echo "$r" | jq -r '.result.session_id | length > 0')
+assert_eq "surface/handshake.session_id present" "true" "$sid_present"
+assert_eq "surface/handshake.claim_floor" "broker_owned" "$(echo "$r" | jq -r .result.claim_floor)"
+
+# 3. account/list
+r=$(resp_for 3)
+assert_eq "account/list count" "3" "$(echo "$r" | jq -r '.result.accounts | length')"
+assert_eq "account/list[0].id" "codex:max-1" "$(echo "$r" | jq -r .result.accounts[0].id)"
+
+# 4. account/select picks max-1
+r=$(resp_for 4)
+assert_eq "account/select.account" "codex:max-1" "$(echo "$r" | jq -r .result.account)"
+assert_eq "account/select.claim.level" "broker_owned" "$(echo "$r" | jq -r .result.claim.level)"
+
+# 5. credential/materialize returns the JWT-decoded plan + fedramp
+r=$(resp_for 5)
+assert_eq "credential/materialize.shape" "chatgpt_auth_tokens" "$(echo "$r" | jq -r .result.shape)"
+assert_eq "credential/materialize.access_token" "AT-smoke-1" "$(echo "$r" | jq -r .result.access_token)"
+assert_eq "credential/materialize.account_id" "acc-smoke-1" "$(echo "$r" | jq -r .result.account_id)"
+assert_eq "credential/materialize.plan_type" "pro" "$(echo "$r" | jq -r .result.plan_type)"
+assert_eq "credential/materialize.fedramp" "true" "$(echo "$r" | jq -r .result.fedramp)"
+
+# 6. quota/observe records exhaustion
+r=$(resp_for 6)
+assert_eq "quota/observe.recorded" "true" "$(echo "$r" | jq -r .result.recorded)"
+assert_eq "quota/observe.now_selectable" "false" "$(echo "$r" | jq -r .result.now_selectable)"
+assert_eq "quota/observe.next_eligible_at" "1788000000" "$(echo "$r" | jq -r .result.next_eligible_at)"
+
+# 7. account/select after observe -> picks max-2 (max-1 is exhausted)
+r=$(resp_for 7)
+assert_eq "account/select-post-observe" "codex:max-2" "$(echo "$r" | jq -r .result.account)"
+
+# 8. account/swap on max-2 returns max-3 with next_turn_seamless
+r=$(resp_for 8)
+assert_eq "account/swap.account" "codex:max-3" "$(echo "$r" | jq -r .result.account)"
+assert_eq "account/swap.claim.level" "next_turn_seamless" "$(echo "$r" | jq -r .result.claim.level)"
+assert_eq "account/swap.previous_marked.as" "quota_exhausted" "$(echo "$r" | jq -r .result.previous_marked.as)"
+
+# 9. quota/status reflects two exhausted + one selectable
+r=$(resp_for 9)
+assert_eq "quota/status.selectable_count" "1" "$(echo "$r" | jq -r .result.selectable_count)"
+assert_eq "quota/status.max-1.availability" "quota_exhausted" "$(echo "$r" | jq -r '.result.accounts[] | select(.id=="codex:max-1") | .availability')"
+assert_eq "quota/status.max-3.availability" "available" "$(echo "$r" | jq -r '.result.accounts[] | select(.id=="codex:max-3") | .availability')"
+
+echo
+echo "smoke-broker: all 22 assertions passed."

--- a/src/broker/account_pool.zig
+++ b/src/broker/account_pool.zig
@@ -1,0 +1,309 @@
+//! Account pool. Read-side store of `provider:account` identities.
+//!
+//! Phase 1 scope: in-memory list with selectability and (eventual)
+//! availability. Population from the active oauth-mux Config lives in
+//! `src/broker_loader.zig` so this module stays config-agnostic; the
+//! broker's contract should not depend on Config's struct shape.
+//!
+//! No token bytes EVER cross this boundary in either direction.
+
+const std = @import("std");
+const types = @import("types.zig");
+
+pub const Liveness = enum { live, degraded, dead, unknown };
+pub const Availability = enum { available, rate_limited, quota_exhausted, cooldown, unknown };
+
+pub const AccountSummary = struct {
+    id: []const u8, // owned by pool
+    selectable: bool,
+    liveness: Liveness,
+    availability: Availability,
+    next_eligible_at: ?i64 = null,
+};
+
+/// The pool. Phase 1 implementation uses an in-memory list seeded from
+/// the existing config; later tasks wire health/quota state from
+/// src/health.zig and src/repair_state.zig.
+pub const AccountPool = struct {
+    allocator: std.mem.Allocator,
+    accounts: std.ArrayListUnmanaged(AccountSummary) = .{},
+
+    pub fn init(allocator: std.mem.Allocator) AccountPool {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(self: *AccountPool) void {
+        for (self.accounts.items) |a| self.allocator.free(a.id);
+        self.accounts.deinit(self.allocator);
+    }
+
+    pub fn add(self: *AccountPool, summary: AccountSummary) !void {
+        const owned_id = try self.allocator.dupe(u8, summary.id);
+        errdefer self.allocator.free(owned_id);
+        var owned = summary;
+        owned.id = owned_id;
+        try self.accounts.append(self.allocator, owned);
+    }
+
+    /// Limit visible accounts to a set of allowed `provider:account`
+    /// ids. Accounts not in the allowed set are marked non-selectable
+    /// in place (the entry stays so callers can see why it's hidden).
+    pub fn restrictToAllowList(self: *AccountPool, allow: []const []const u8) void {
+        for (self.accounts.items) |*a| {
+            var found = false;
+            for (allow) |allowed| {
+                if (std.mem.eql(u8, allowed, a.id)) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) a.selectable = false;
+        }
+    }
+
+    /// Mark an account as quota-exhausted with an absolute reset
+    /// timestamp. The account becomes non-selectable until the
+    /// timestamp passes (callers consult `now` against
+    /// `next_eligible_at` at elect-time).
+    /// Anchor: docs/spec/broker-mcp-contract-2026-05-03.md §2.2 account/swap
+    /// + §2.4 quota/observe.
+    pub fn markQuotaExhausted(
+        self: *AccountPool,
+        account_id: []const u8,
+        resets_at: i64,
+    ) types.BrokerError!void {
+        for (self.accounts.items) |*a| {
+            if (std.mem.eql(u8, a.id, account_id)) {
+                a.availability = .quota_exhausted;
+                a.next_eligible_at = resets_at;
+                a.selectable = false;
+                return;
+            }
+        }
+        return types.BrokerError.AccountNotFound;
+    }
+
+    /// Mark an account as rate-limited with a Retry-After hint. Sets
+    /// availability = .rate_limited and next_eligible_at, but does
+    /// not flip `selectable` because rate-limit windows are short
+    /// enough that we may want this account back within the same
+    /// turn boundary.
+    pub fn markRateLimited(
+        self: *AccountPool,
+        account_id: []const u8,
+        retry_after_at: i64,
+    ) types.BrokerError!void {
+        for (self.accounts.items) |*a| {
+            if (std.mem.eql(u8, a.id, account_id)) {
+                a.availability = .rate_limited;
+                a.next_eligible_at = retry_after_at;
+                return;
+            }
+        }
+        return types.BrokerError.AccountNotFound;
+    }
+
+    /// Mark an account as authorization-failed (401). Becomes
+    /// non-selectable; recovery requires either credential refresh
+    /// (Phase 3) or operator re-enrollment.
+    pub fn markUnauthorized(
+        self: *AccountPool,
+        account_id: []const u8,
+    ) types.BrokerError!void {
+        for (self.accounts.items) |*a| {
+            if (std.mem.eql(u8, a.id, account_id)) {
+                a.liveness = .dead;
+                a.selectable = false;
+                return;
+            }
+        }
+        return types.BrokerError.AccountNotFound;
+    }
+
+    /// Walk the pool, restoring any accounts whose `next_eligible_at`
+    /// is in the past. Called opportunistically before elect.
+    pub fn refreshTimeBased(self: *AccountPool, now_unix: i64) void {
+        for (self.accounts.items) |*a| {
+            if (a.next_eligible_at) |t| {
+                if (t <= now_unix) {
+                    // Reset to available; selectability flag follows.
+                    a.availability = .available;
+                    a.next_eligible_at = null;
+                    if (a.liveness != .dead) a.selectable = true;
+                }
+            }
+        }
+    }
+
+    /// List accounts visible to a session, optionally filtered by profile
+    /// and capability. Phase 1: returns all configured accounts; profile/
+    /// capability filtering wired in task #17.
+    pub fn list(
+        self: *const AccountPool,
+        out: *std.ArrayListUnmanaged(AccountSummary),
+        out_alloc: std.mem.Allocator,
+        profile: ?[]const u8,
+        capability: ?[]const u8,
+    ) !void {
+        _ = profile;
+        _ = capability;
+        try out.ensureTotalCapacity(out_alloc, self.accounts.items.len);
+        for (self.accounts.items) |a| out.appendAssumeCapacity(a);
+    }
+
+    /// Pick a selectable account, optionally excluding some. Returns
+    /// BrokerError.NoAccountSelectable when no candidate qualifies.
+    pub fn elect(
+        self: *const AccountPool,
+        profile: ?[]const u8,
+        capability: ?[]const u8,
+        exclude: []const []const u8,
+    ) types.BrokerError!AccountSummary {
+        _ = profile;
+        _ = capability;
+        outer: for (self.accounts.items) |a| {
+            if (!a.selectable) continue;
+            if (a.availability != .available) continue;
+            for (exclude) |ex| {
+                if (std.mem.eql(u8, ex, a.id)) continue :outer;
+            }
+            return a;
+        }
+        return types.BrokerError.NoAccountSelectable;
+    }
+};
+
+test "AccountPool markQuotaExhausted blocks selection until reset" {
+    var pool = AccountPool.init(std.testing.allocator);
+    defer pool.deinit();
+    try pool.add(.{ .id = "codex:max-1", .selectable = true, .liveness = .live, .availability = .available });
+    try pool.add(.{ .id = "codex:max-2", .selectable = true, .liveness = .live, .availability = .available });
+
+    try pool.markQuotaExhausted("codex:max-1", 1_800_000_000);
+    const a = try pool.elect(null, null, &.{});
+    try std.testing.expectEqualStrings("codex:max-2", a.id);
+
+    // After reset clock passes, refreshTimeBased restores selectability.
+    pool.refreshTimeBased(1_800_000_001);
+    var found_max1_available = false;
+    for (pool.accounts.items) |entry| {
+        if (std.mem.eql(u8, entry.id, "codex:max-1")) {
+            try std.testing.expect(entry.selectable);
+            try std.testing.expectEqual(Availability.available, entry.availability);
+            found_max1_available = true;
+        }
+    }
+    try std.testing.expect(found_max1_available);
+}
+
+test "AccountPool markUnauthorized stays dead through refresh" {
+    var pool = AccountPool.init(std.testing.allocator);
+    defer pool.deinit();
+    try pool.add(.{ .id = "codex:max-1", .selectable = true, .liveness = .live, .availability = .available });
+
+    try pool.markUnauthorized("codex:max-1");
+    try std.testing.expectError(
+        types.BrokerError.NoAccountSelectable,
+        pool.elect(null, null, &.{}),
+    );
+    pool.refreshTimeBased(std.math.maxInt(i64));
+    // Dead is sticky — refresh does not resurrect it.
+    try std.testing.expectError(
+        types.BrokerError.NoAccountSelectable,
+        pool.elect(null, null, &.{}),
+    );
+}
+
+test "AccountPool restrictToAllowList narrows selectability" {
+    var pool = AccountPool.init(std.testing.allocator);
+    defer pool.deinit();
+    try pool.add(.{ .id = "codex:max-1", .selectable = true, .liveness = .live, .availability = .available });
+    try pool.add(.{ .id = "codex:max-2", .selectable = true, .liveness = .live, .availability = .available });
+    try pool.add(.{ .id = "claude:personal", .selectable = true, .liveness = .live, .availability = .available });
+
+    pool.restrictToAllowList(&.{ "codex:max-1", "codex:max-2" });
+    try std.testing.expectEqual(@as(usize, 3), pool.accounts.items.len);
+
+    const elected = try pool.elect(null, null, &.{});
+    try std.testing.expect(std.mem.eql(u8, elected.id, "codex:max-1"));
+
+    // claude:personal is non-selectable now
+    var found = false;
+    for (pool.accounts.items) |a| {
+        if (std.mem.eql(u8, a.id, "claude:personal")) {
+            found = true;
+            try std.testing.expect(!a.selectable);
+        }
+    }
+    try std.testing.expect(found);
+}
+
+test "AccountPool.elect property: never returns excluded id (random)" {
+    // PBT: 100 random pool configurations; assert elect never returns
+    // an id that's in the exclude slice. Catches off-by-one in the
+    // continue:outer loop.
+    var prng = std.Random.DefaultPrng.init(0xDEADBEEF);
+    const r = prng.random();
+    var i: usize = 0;
+    while (i < 100) : (i += 1) {
+        var pool = AccountPool.init(std.testing.allocator);
+        defer pool.deinit();
+
+        const n = 1 + r.intRangeAtMost(usize, 0, 7); // 1..8 accounts
+        var ids_buf: [8][]const u8 = undefined;
+        const id_strs = [_][]const u8{
+            "codex:a", "codex:b", "codex:c", "codex:d",
+            "codex:e", "codex:f", "codex:g", "codex:h",
+        };
+        var j: usize = 0;
+        while (j < n) : (j += 1) {
+            try pool.add(.{
+                .id = id_strs[j],
+                .selectable = true,
+                .liveness = .live,
+                .availability = .available,
+            });
+            ids_buf[j] = id_strs[j];
+        }
+
+        // Random exclude: each id is in/out independently with p=0.5.
+        var exc_buf: [8][]const u8 = undefined;
+        var exc_count: usize = 0;
+        for (ids_buf[0..n]) |id| {
+            if (r.boolean()) {
+                exc_buf[exc_count] = id;
+                exc_count += 1;
+            }
+        }
+
+        const elected = pool.elect(null, null, exc_buf[0..exc_count]) catch {
+            // No selectable account is acceptable (all-excluded).
+            // Verify that all ids are in fact excluded.
+            try std.testing.expectEqual(n, exc_count);
+            continue;
+        };
+        // Elected id MUST NOT appear in the exclude slice.
+        for (exc_buf[0..exc_count]) |ex| {
+            try std.testing.expect(!std.mem.eql(u8, ex, elected.id));
+        }
+    }
+}
+
+test "AccountPool elect honors exclude" {
+    var pool = AccountPool.init(std.testing.allocator);
+    defer pool.deinit();
+
+    try pool.add(.{ .id = "codex:max-1", .selectable = true, .liveness = .live, .availability = .available });
+    try pool.add(.{ .id = "codex:max-2", .selectable = true, .liveness = .live, .availability = .available });
+
+    const a = try pool.elect(null, null, &.{});
+    try std.testing.expectEqualStrings("codex:max-1", a.id);
+
+    const b = try pool.elect(null, null, &.{"codex:max-1"});
+    try std.testing.expectEqualStrings("codex:max-2", b.id);
+
+    try std.testing.expectError(
+        types.BrokerError.NoAccountSelectable,
+        pool.elect(null, null, &.{ "codex:max-1", "codex:max-2" }),
+    );
+}

--- a/src/broker/methods.zig
+++ b/src/broker/methods.zig
@@ -1,0 +1,685 @@
+//! Method dispatch + handlers for the broker MCP surface.
+//! Anchor: docs/spec/broker-mcp-contract-2026-05-03.md §2.
+//!
+//! TIN-941 scope: surface lifecycle, account list/select/swap,
+//! credential/materialize, quota observe/status, and policy/get are live.
+//! Refresh, event subscriptions, and admission control remain explicit typed
+//! not_implemented responses for later slices.
+
+const std = @import("std");
+const types = @import("types.zig");
+const session_mod = @import("session.zig");
+const account_pool_mod = @import("account_pool.zig");
+
+// Avoid an import cycle: the Context is defined in server.zig and
+// passed in by reference.
+const Context = @import("server.zig").Context;
+
+pub const DispatchOutcome = union(enum) {
+    ok: std.json.Value,
+    err: BrokerErrWithMessage,
+};
+
+pub const BrokerErrWithMessage = struct {
+    err: types.BrokerError,
+    message: []const u8,
+};
+
+/// Top-level dispatch by method string.
+pub fn dispatch(
+    ctx: *Context,
+    method: []const u8,
+    params: ?std.json.Value,
+) DispatchOutcome {
+    if (std.mem.eql(u8, method, "surface/info")) return surfaceInfo(ctx);
+    if (std.mem.eql(u8, method, "surface/handshake")) return surfaceHandshake(ctx, params);
+    if (std.mem.eql(u8, method, "surface/teardown")) return surfaceTeardown(ctx, params);
+
+    if (std.mem.eql(u8, method, "account/list")) return accountList(ctx, params);
+    if (std.mem.eql(u8, method, "account/select")) return accountSelect(ctx, params);
+    if (std.mem.eql(u8, method, "account/swap")) return accountSwap(ctx, params);
+
+    if (std.mem.eql(u8, method, "credential/materialize")) return credentialMaterialize(ctx, params);
+    if (std.mem.eql(u8, method, "credential/refresh")) return notImpl("credential/refresh is Phase 3 (task #27)");
+
+    if (std.mem.eql(u8, method, "quota/observe")) return quotaObserve(ctx, params);
+    if (std.mem.eql(u8, method, "quota/status")) return quotaStatus(ctx, params);
+
+    if (std.mem.eql(u8, method, "events/append")) return notImpl("events/append is Phase 1 follow-up");
+    if (std.mem.eql(u8, method, "events/subscribe")) return notImpl("events/subscribe is Phase 2");
+
+    if (std.mem.eql(u8, method, "policy/get")) return policyGet(ctx, params);
+    if (std.mem.eql(u8, method, "policy/request_admission")) return notImpl("policy/request_admission is Phase 3");
+
+    return .{ .err = .{ .err = error.NotImplemented, .message = "unknown method" } };
+}
+
+fn notImpl(msg: []const u8) DispatchOutcome {
+    return .{ .err = .{ .err = error.NotImplemented, .message = msg } };
+}
+
+// ── surface/* ──────────────────────────────────────────────────────────
+
+fn surfaceInfo(ctx: *Context) DispatchOutcome {
+    var obj = std.json.ObjectMap.init(ctx.allocator);
+    obj.put("surface_version", .{ .integer = 1 }) catch return oom();
+    obj.put("build", .{ .string = @import("mod.zig").BUILD_TAG }) catch return oom();
+
+    var transports = std.json.Array.init(ctx.allocator);
+    transports.append(.{ .string = "stdio" }) catch return oom();
+    transports.append(.{ .string = "unix" }) catch return oom();
+    obj.put("transports", .{ .array = transports }) catch return oom();
+
+    var caps = std.json.Array.init(ctx.allocator);
+    inline for (.{ "accounts", "quota", "refresh", "events", "policy" }) |c| {
+        caps.append(.{ .string = c }) catch return oom();
+    }
+    obj.put("capabilities", .{ .array = caps }) catch return oom();
+
+    return .{ .ok = .{ .object = obj } };
+}
+
+fn surfaceHandshake(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
+    const p = params orelse return invalidParams("missing params");
+    if (p != .object) return invalidParams("params must be object");
+    const obj = p.object;
+
+    const adapter = strField(obj, "adapter") orelse return invalidParams("missing adapter");
+    const adapter_version = strField(obj, "adapter_version") orelse "0.0.0";
+    const harness_target = strField(obj, "harness_target") orelse "";
+    const session_pid: u32 = blk: {
+        const v = obj.get("session_pid") orelse break :blk 0;
+        break :blk if (v == .integer) @intCast(v.integer) else 0;
+    };
+
+    const sid = ctx.sessions.newId() catch return oom();
+    defer ctx.allocator.free(sid);
+
+    ctx.sessions.create(.{
+        .id = sid,
+        .adapter = adapter,
+        .adapter_version = adapter_version,
+        .harness_target = harness_target,
+        .session_pid = session_pid,
+        .claim_floor = .broker_owned,
+        .started_at_ms = std.time.milliTimestamp(),
+    }) catch return oom();
+
+    var out = std.json.ObjectMap.init(ctx.allocator);
+    out.put("session_id", .{ .string = ctx.allocator.dupe(u8, sid) catch return oom() }) catch return oom();
+
+    var policy_obj = std.json.ObjectMap.init(ctx.allocator);
+    policy_obj.put("allow_interactive", .{ .bool = false }) catch return oom();
+    policy_obj.put("allow_mutating", .{ .bool = false }) catch return oom();
+    policy_obj.put("spend_admitted_for_session", .{ .bool = false }) catch return oom();
+    out.put("policy", .{ .object = policy_obj }) catch return oom();
+
+    out.put("claim_floor", .{ .string = "broker_owned" }) catch return oom();
+
+    return .{ .ok = .{ .object = out } };
+}
+
+fn surfaceTeardown(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
+    const p = params orelse return invalidParams("missing params");
+    if (p != .object) return invalidParams("params must be object");
+    const sid = strField(p.object, "session_id") orelse return invalidParams("missing session_id");
+    _ = ctx.sessions.drop(sid);
+
+    var out = std.json.ObjectMap.init(ctx.allocator);
+    out.put("ok", .{ .bool = true }) catch return oom();
+    return .{ .ok = .{ .object = out } };
+}
+
+// ── account/* ─────────────────────────────────────────────────────────
+
+fn accountList(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
+    const p = params orelse return invalidParams("missing params");
+    if (p != .object) return invalidParams("params must be object");
+    if (strField(p.object, "session_id") == null) return invalidParams("missing session_id");
+
+    // Phase 1 scope: profile/capability params are accepted but per-call
+    // filtering is not applied here. The pool was already populated for
+    // the session's profile in `oauth-mux mcp` startup
+    // (broker_loader.populatePool). Accounts not in the loaded profile
+    // are present in the list with `selectable:false`.
+    const profile = strField(p.object, "profile");
+    const capability = strField(p.object, "capability");
+
+    var list_buf = std.ArrayListUnmanaged(account_pool_mod.AccountSummary){};
+    defer list_buf.deinit(ctx.allocator);
+    ctx.pool.list(&list_buf, ctx.allocator, profile, capability) catch return oom();
+
+    var arr = std.json.Array.init(ctx.allocator);
+    for (list_buf.items) |a| {
+        var entry = std.json.ObjectMap.init(ctx.allocator);
+        entry.put("id", .{ .string = a.id }) catch return oom();
+        entry.put("selectable", .{ .bool = a.selectable }) catch return oom();
+        entry.put("liveness", .{ .string = @tagName(a.liveness) }) catch return oom();
+        entry.put("availability", .{ .string = @tagName(a.availability) }) catch return oom();
+        entry.put(
+            "next_eligible_at",
+            if (a.next_eligible_at) |t| std.json.Value{ .integer = t } else std.json.Value{ .null = {} },
+        ) catch return oom();
+        arr.append(.{ .object = entry }) catch return oom();
+    }
+
+    var out = std.json.ObjectMap.init(ctx.allocator);
+    out.put("accounts", .{ .array = arr }) catch return oom();
+    return .{ .ok = .{ .object = out } };
+}
+
+fn accountSelect(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
+    const p = params orelse return invalidParams("missing params");
+    if (p != .object) return invalidParams("params must be object");
+    if (strField(p.object, "session_id") == null) return invalidParams("missing session_id");
+
+    const profile = strField(p.object, "profile");
+    const capability = strField(p.object, "capability");
+
+    // exclude is optional []string
+    var excl_buf = std.ArrayListUnmanaged([]const u8){};
+    defer excl_buf.deinit(ctx.allocator);
+    if (p.object.get("exclude")) |ex_v| {
+        if (ex_v == .array) {
+            for (ex_v.array.items) |item| {
+                if (item == .string) excl_buf.append(ctx.allocator, item.string) catch return oom();
+            }
+        }
+    }
+
+    const elected = ctx.pool.elect(profile, capability, excl_buf.items) catch |e| return .{
+        .err = .{ .err = e, .message = "no selectable account" },
+    };
+
+    var out = std.json.ObjectMap.init(ctx.allocator);
+    out.put("account", .{ .string = elected.id }) catch return oom();
+
+    // Phase 1 returns a placeholder credential_handle. Real materialization
+    // happens in task #18 (credential/materialize).
+    const handle = std.fmt.allocPrint(
+        ctx.allocator,
+        "ch:{s}:{x}",
+        .{ elected.id, std.time.milliTimestamp() },
+    ) catch return oom();
+    out.put("credential_handle", .{ .string = handle }) catch return oom();
+
+    var claim_obj = std.json.ObjectMap.init(ctx.allocator);
+    claim_obj.put("level", .{ .string = "broker_owned" }) catch return oom();
+    claim_obj.put("spare_fallback_ready", .{ .bool = false }) catch return oom();
+    out.put("claim", .{ .object = claim_obj }) catch return oom();
+
+    return .{ .ok = .{ .object = out } };
+}
+
+/// Parse a `reason` string into a SwapReason, defaulting to
+/// quota_exhausted (the most common Phase 2 case) for unknown values.
+fn parseSwapReason(s: []const u8) types.SwapReason {
+    if (std.mem.eql(u8, s, "quota_exhausted")) return .quota_exhausted;
+    if (std.mem.eql(u8, s, "rate_limited_long")) return .rate_limited_long;
+    if (std.mem.eql(u8, s, "auth_unauthorized")) return .auth_unauthorized;
+    if (std.mem.eql(u8, s, "operator_requested")) return .operator_requested;
+    return .quota_exhausted;
+}
+
+fn parseQuotaKind(s: []const u8) ?types.QuotaKind {
+    if (std.mem.eql(u8, s, "ok")) return .ok;
+    if (std.mem.eql(u8, s, "rate_limited")) return .rate_limited;
+    if (std.mem.eql(u8, s, "quota_exhausted")) return .quota_exhausted;
+    if (std.mem.eql(u8, s, "auth_unauthorized")) return .auth_unauthorized;
+    if (std.mem.eql(u8, s, "tier_insufficient")) return .tier_insufficient;
+    if (std.mem.eql(u8, s, "provider_5xx")) return .provider_5xx;
+    return null;
+}
+
+fn intField(obj: std.json.ObjectMap, key: []const u8) ?i64 {
+    const v = obj.get(key) orelse return null;
+    return if (v == .integer) v.integer else null;
+}
+
+/// account/swap: mark `current_account` as failed for the given typed
+/// reason, then elect a fresh account.
+fn accountSwap(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
+    const p = params orelse return invalidParams("missing params");
+    if (p != .object) return invalidParams("params must be object");
+    if (strField(p.object, "session_id") == null) return invalidParams("missing session_id");
+
+    const current = strField(p.object, "current_account") orelse
+        return invalidParams("missing current_account");
+    const reason_str = strField(p.object, "reason") orelse "quota_exhausted";
+    const reason = parseSwapReason(reason_str);
+
+    // Pull resets_at / retry_after from the evidence object if present.
+    var resets_at: ?i64 = null;
+    if (p.object.get("evidence")) |ev| {
+        if (ev == .object) {
+            resets_at = intField(ev.object, "resets_at") orelse intField(ev.object, "retry_after_at");
+        }
+    }
+
+    // Apply the typed mark to the pool. Default reset window = 7 days
+    // (weekly quota) when not provided; rate_limited gets a 60s default.
+    const now_unix = std.time.timestamp();
+    const default_quota_until = now_unix + 7 * 24 * 60 * 60;
+    const default_rate_until = now_unix + 60;
+
+    switch (reason) {
+        .quota_exhausted => {
+            ctx.pool.markQuotaExhausted(current, resets_at orelse default_quota_until) catch |e|
+                return .{ .err = .{ .err = e, .message = "current_account not in pool" } };
+        },
+        .rate_limited_long => {
+            ctx.pool.markRateLimited(current, resets_at orelse default_rate_until) catch |e|
+                return .{ .err = .{ .err = e, .message = "current_account not in pool" } };
+        },
+        .auth_unauthorized => {
+            ctx.pool.markUnauthorized(current) catch |e|
+                return .{ .err = .{ .err = e, .message = "current_account not in pool" } };
+        },
+        .operator_requested => {
+            // Operator-requested swaps don't permanently mark the
+            // current account; we just exclude it from this elect.
+        },
+    }
+
+    // Elect a replacement, excluding the current account.
+    const exclude = [_][]const u8{current};
+    const elected = ctx.pool.elect(null, null, exclude[0..]) catch |e| return .{
+        .err = .{ .err = e, .message = "no replacement account selectable" },
+    };
+
+    // Build response.
+    var out = std.json.ObjectMap.init(ctx.allocator);
+    out.put("account", .{ .string = elected.id }) catch return oom();
+    const handle = std.fmt.allocPrint(
+        ctx.allocator,
+        "ch:{s}:{x}",
+        .{ elected.id, std.time.milliTimestamp() },
+    ) catch return oom();
+    out.put("credential_handle", .{ .string = handle }) catch return oom();
+
+    var claim_obj = std.json.ObjectMap.init(ctx.allocator);
+    claim_obj.put("level", .{ .string = "next_turn_seamless" }) catch return oom();
+    claim_obj.put("spare_fallback_ready", .{ .bool = anotherSelectableExists(ctx.pool, elected.id) }) catch return oom();
+    out.put("claim", .{ .object = claim_obj }) catch return oom();
+
+    var prev_obj = std.json.ObjectMap.init(ctx.allocator);
+    prev_obj.put("as", .{ .string = @tagName(reason) }) catch return oom();
+    if (resets_at) |t| {
+        prev_obj.put("until", .{ .integer = t }) catch return oom();
+    } else {
+        prev_obj.put("until", .{ .null = {} }) catch return oom();
+    }
+    out.put("previous_marked", .{ .object = prev_obj }) catch return oom();
+
+    return .{ .ok = .{ .object = out } };
+}
+
+fn anotherSelectableExists(pool: anytype, except_id: []const u8) bool {
+    var count: usize = 0;
+    for (pool.accounts.items) |a| {
+        if (a.selectable and !std.mem.eql(u8, a.id, except_id)) {
+            count += 1;
+            if (count >= 1) return true;
+        }
+    }
+    return false;
+}
+
+/// quota/observe: record an observation on the current account
+/// without forcing a swap. Used by the wire proxy on EVERY response,
+/// so the broker has up-to-date quota state for the next elect.
+fn quotaObserve(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
+    const p = params orelse return invalidParams("missing params");
+    if (p != .object) return invalidParams("params must be object");
+    if (strField(p.object, "session_id") == null) return invalidParams("missing session_id");
+
+    const account = strField(p.object, "account") orelse
+        return invalidParams("missing account");
+    const kind_str = strField(p.object, "kind") orelse
+        return invalidParams("missing kind");
+    const kind = parseQuotaKind(kind_str) orelse
+        return invalidParams("unknown quota kind");
+    const resets_at = intField(p.object, "resets_at");
+
+    var now_selectable = true;
+    var next_eligible_at: ?i64 = null;
+
+    const now_unix = std.time.timestamp();
+    switch (kind) {
+        .ok => {
+            // Healthy turn — opportunity to clear stale rate-limit
+            // marks. Phase 2 keeps this lean: only restore time-based
+            // entries that are already past their reset.
+            ctx.pool.refreshTimeBased(now_unix);
+        },
+        .rate_limited => {
+            const until = resets_at orelse (now_unix + 60);
+            ctx.pool.markRateLimited(account, until) catch |e|
+                return .{ .err = .{ .err = e, .message = "account not in pool" } };
+            next_eligible_at = until;
+            // rate_limited keeps selectable=true (short window); see
+            // AccountPool.markRateLimited.
+        },
+        .quota_exhausted => {
+            const until = resets_at orelse (now_unix + 7 * 24 * 60 * 60);
+            ctx.pool.markQuotaExhausted(account, until) catch |e|
+                return .{ .err = .{ .err = e, .message = "account not in pool" } };
+            now_selectable = false;
+            next_eligible_at = until;
+        },
+        .auth_unauthorized => {
+            ctx.pool.markUnauthorized(account) catch |e|
+                return .{ .err = .{ .err = e, .message = "account not in pool" } };
+            now_selectable = false;
+        },
+        .tier_insufficient, .provider_5xx => {
+            // Recorded for telemetry; no pool mutation in Phase 2.
+        },
+    }
+
+    var out = std.json.ObjectMap.init(ctx.allocator);
+    out.put("recorded", .{ .bool = true }) catch return oom();
+    out.put("now_selectable", .{ .bool = now_selectable }) catch return oom();
+    if (next_eligible_at) |t| {
+        out.put("next_eligible_at", .{ .integer = t }) catch return oom();
+    } else {
+        out.put("next_eligible_at", .{ .null = {} }) catch return oom();
+    }
+    return .{ .ok = .{ .object = out } };
+}
+
+/// quota/status: snapshot of pool availability for the calling
+/// session's profile. Used by the proxy on session start to know
+/// the spare-fallback count without driving extra account/list calls.
+fn quotaStatus(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
+    const p = params orelse return invalidParams("missing params");
+    if (p != .object) return invalidParams("params must be object");
+    if (strField(p.object, "session_id") == null) return invalidParams("missing session_id");
+
+    var arr = std.json.Array.init(ctx.allocator);
+    var selectable_count: usize = 0;
+    for (ctx.pool.accounts.items) |a| {
+        var entry = std.json.ObjectMap.init(ctx.allocator);
+        entry.put("id", .{ .string = a.id }) catch return oom();
+        entry.put("availability", .{ .string = @tagName(a.availability) }) catch return oom();
+        if (a.next_eligible_at) |t| {
+            entry.put("next_eligible_at", .{ .integer = t }) catch return oom();
+        } else {
+            entry.put("next_eligible_at", .{ .null = {} }) catch return oom();
+        }
+        arr.append(.{ .object = entry }) catch return oom();
+        if (a.selectable) selectable_count += 1;
+    }
+
+    var out = std.json.ObjectMap.init(ctx.allocator);
+    out.put("accounts", .{ .array = arr }) catch return oom();
+    out.put("selectable_count", .{ .integer = @intCast(selectable_count) }) catch return oom();
+    return .{ .ok = .{ .object = out } };
+}
+
+// ── credential/* ──────────────────────────────────────────────────────
+
+/// Parse the `ch:<provider>:<account>:<ts>` shape minted by accountSelect.
+/// Returns the `<provider>:<account>` head, or null if the handle format
+/// is unrecognized.
+fn accountIdFromHandle(handle: []const u8) ?[]const u8 {
+    if (!std.mem.startsWith(u8, handle, "ch:")) return null;
+    const after = handle[3..];
+    // Find the LAST ':' to strip the timestamp suffix.
+    const last_colon = std.mem.lastIndexOfScalar(u8, after, ':') orelse return null;
+    return after[0..last_colon];
+}
+
+fn credentialMaterialize(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
+    const p = params orelse return invalidParams("missing params");
+    if (p != .object) return invalidParams("params must be object");
+    if (strField(p.object, "session_id") == null) return invalidParams("missing session_id");
+
+    const handle = strField(p.object, "credential_handle") orelse
+        return invalidParams("missing credential_handle");
+    const shape = strField(p.object, "shape") orelse "chatgpt_auth_tokens";
+
+    if (!std.mem.eql(u8, shape, "chatgpt_auth_tokens")) {
+        return .{ .err = .{
+            .err = error.UnsupportedShape,
+            .message = "only chatgpt_auth_tokens supported in Phase 1",
+        } };
+    }
+
+    const account_id = accountIdFromHandle(handle) orelse
+        return invalidParams("malformed credential_handle");
+
+    const mat = ctx.materializer orelse return .{ .err = .{
+        .err = error.NotImplemented,
+        .message = "no credential materializer wired (broker started without one)",
+    } };
+
+    const tokens = mat.materialize_chatgpt(mat.ctx, ctx.allocator, account_id) catch |e| return .{
+        .err = .{ .err = e, .message = "materialize failed" },
+    };
+
+    var out = std.json.ObjectMap.init(ctx.allocator);
+    out.put("shape", .{ .string = "chatgpt_auth_tokens" }) catch return oom();
+    out.put("access_token", .{ .string = tokens.access_token }) catch return oom();
+    out.put("account_id", .{ .string = tokens.account_id }) catch return oom();
+    if (tokens.plan_type) |pt| {
+        out.put("plan_type", .{ .string = pt }) catch return oom();
+    } else {
+        out.put("plan_type", .{ .null = {} }) catch return oom();
+    }
+    out.put("fedramp", .{ .bool = tokens.fedramp }) catch return oom();
+    return .{ .ok = .{ .object = out } };
+}
+
+// ── policy/* ──────────────────────────────────────────────────────────
+
+fn policyGet(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
+    _ = params;
+    var out = std.json.ObjectMap.init(ctx.allocator);
+    var budgets = std.json.Array.init(ctx.allocator);
+    budgets.append(.{ .string = "free_local" }) catch return oom();
+    budgets.append(.{ .string = "free_command" }) catch return oom();
+    out.put("allowed_budgets", .{ .array = budgets }) catch return oom();
+    out.put("allow_interactive", .{ .bool = false }) catch return oom();
+    out.put("allow_mutating", .{ .bool = false }) catch return oom();
+    out.put("spend_admitted_for_session", .{ .bool = false }) catch return oom();
+    return .{ .ok = .{ .object = out } };
+}
+
+// ── helpers ───────────────────────────────────────────────────────────
+
+fn strField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const v = obj.get(key) orelse return null;
+    return if (v == .string) v.string else null;
+}
+
+fn invalidParams(msg: []const u8) DispatchOutcome {
+    return .{ .err = .{ .err = error.InvalidParams, .message = msg } };
+}
+
+fn oom() DispatchOutcome {
+    return .{ .err = .{ .err = error.OutOfMemory, .message = "out of memory" } };
+}
+
+test "dispatch surface/info returns object with surface_version=1" {
+    // Use an arena so leak-checking doesn't trip on the response's
+    // intentionally-borrowed-by-server allocations. In the real server,
+    // the buffered stdout writer flushes the JSON and the arena is
+    // dropped per-request.
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var sessions = session_mod.SessionTable.init(arena.allocator());
+    var pool = account_pool_mod.AccountPool.init(arena.allocator());
+
+    var stderr_buf: [0]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(stderr_buf[0..]);
+    var ctx = Context{
+        .allocator = arena.allocator(),
+        .sessions = &sessions,
+        .pool = &pool,
+        .materializer = null,
+        .log_writer = fbs.writer().any(),
+    };
+
+    const out = dispatch(&ctx, "surface/info", null);
+    switch (out) {
+        .ok => |v| {
+            try std.testing.expect(v == .object);
+            const sv = v.object.get("surface_version") orelse return error.TestFailed;
+            try std.testing.expect(sv == .integer);
+            try std.testing.expectEqual(@as(i64, 1), sv.integer);
+        },
+        .err => return error.TestFailed,
+    }
+}
+
+test "surface/handshake mints session and stores it; teardown drops it" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var sessions = session_mod.SessionTable.init(arena.allocator());
+    var pool = account_pool_mod.AccountPool.init(arena.allocator());
+    var stderr_buf: [0]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(stderr_buf[0..]);
+    var ctx = Context{
+        .allocator = arena.allocator(),
+        .sessions = &sessions,
+        .pool = &pool,
+        .materializer = null,
+        .log_writer = fbs.writer().any(),
+    };
+
+    // handshake — params.adapter required
+    var hs_obj = std.json.ObjectMap.init(arena.allocator());
+    try hs_obj.put("adapter", .{ .string = "smoke" });
+    try hs_obj.put("adapter_version", .{ .string = "0.0" });
+    try hs_obj.put("harness_target", .{ .string = "codex" });
+    try hs_obj.put("session_pid", .{ .integer = 12345 });
+    const out = dispatch(&ctx, "surface/handshake", .{ .object = hs_obj });
+    const sid_v = switch (out) {
+        .ok => |v| v.object.get("session_id") orelse return error.TestFailed,
+        .err => return error.TestFailed,
+    };
+    try std.testing.expect(sid_v == .string);
+    try std.testing.expect(sid_v.string.len > 0);
+
+    // session must now be retrievable from the long-lived table
+    try std.testing.expect(sessions.get(sid_v.string) != null);
+
+    // teardown drops it
+    var td_obj = std.json.ObjectMap.init(arena.allocator());
+    try td_obj.put("session_id", .{ .string = sid_v.string });
+    const td_out = dispatch(&ctx, "surface/teardown", .{ .object = td_obj });
+    try std.testing.expect(td_out == .ok);
+    try std.testing.expect(sessions.get(sid_v.string) == null);
+}
+
+test "surface/handshake without adapter returns InvalidParams" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var sessions = session_mod.SessionTable.init(arena.allocator());
+    var pool = account_pool_mod.AccountPool.init(arena.allocator());
+    var stderr_buf: [0]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(stderr_buf[0..]);
+    var ctx = Context{
+        .allocator = arena.allocator(),
+        .sessions = &sessions,
+        .pool = &pool,
+        .materializer = null,
+        .log_writer = fbs.writer().any(),
+    };
+
+    var bad_obj = std.json.ObjectMap.init(arena.allocator());
+    try bad_obj.put("foo", .{ .string = "bar" });
+    const out = dispatch(&ctx, "surface/handshake", .{ .object = bad_obj });
+    switch (out) {
+        .err => |e| try std.testing.expectEqual(error.InvalidParams, e.err),
+        else => return error.TestFailed,
+    }
+}
+
+test "accountIdFromHandle property: round-trip with 200 random ids" {
+    // PBT: for any provider:account-shaped string, mint a handle of
+    // the documented format `ch:<id>:<ts>`, then assert
+    // accountIdFromHandle recovers exactly the original id. Catches
+    // off-by-one in the last-colon lookup and edge cases like
+    // multi-segment account names (e.g. codex:max-1, codex:org/team).
+    var prng = std.Random.DefaultPrng.init(0xCAFEF00D);
+    const r = prng.random();
+    const providers = [_][]const u8{ "codex", "claude", "anthropic", "cursor", "p" };
+    const accounts = [_][]const u8{ "a", "max-1", "max-99", "personal-2026", "team/work" };
+
+    var i: usize = 0;
+    while (i < 200) : (i += 1) {
+        const provider = providers[r.uintLessThan(usize, providers.len)];
+        const account = accounts[r.uintLessThan(usize, accounts.len)];
+        const ts = r.int(u32);
+
+        const id_only = try std.fmt.allocPrint(std.testing.allocator, "{s}:{s}", .{ provider, account });
+        defer std.testing.allocator.free(id_only);
+        const handle = try std.fmt.allocPrint(std.testing.allocator, "ch:{s}:{x}", .{ id_only, ts });
+        defer std.testing.allocator.free(handle);
+
+        const recovered = accountIdFromHandle(handle) orelse {
+            std.debug.print("failed to parse handle: {s}\n", .{handle});
+            return error.ParseFailed;
+        };
+        try std.testing.expectEqualStrings(id_only, recovered);
+    }
+}
+
+test "accountIdFromHandle parses ch:provider:account:ts shape" {
+    try std.testing.expectEqualStrings("codex:max-1", accountIdFromHandle("ch:codex:max-1:19def8fe019").?);
+    try std.testing.expect(accountIdFromHandle("nope") == null);
+    try std.testing.expect(accountIdFromHandle("ch:no-second-colon") == null);
+    try std.testing.expect(accountIdFromHandle("") == null);
+}
+
+test "ErrorCode.fromBrokerError covers all variants" {
+    // Smoke each BrokerError variant against the mapping. If a future
+    // variant is added without a switch arm in fromBrokerError, the
+    // underlying switch becomes non-exhaustive and the build fails;
+    // this test just confirms the runtime mapping is sane for known
+    // variants.
+    const server_mod = @import("server.zig");
+    const variants = [_]types.BrokerError{
+        error.NotImplemented,    error.NoAccountSelectable,
+        error.AccountNotFound,   error.SessionNotFound,
+        error.PolicyDenied,      error.InvalidParams,
+        error.InvalidShape,      error.ParseError,
+        error.RefreshFailed,     error.UnsupportedShape,
+        error.SecretUnavailable, error.OutOfMemory,
+    };
+    for (variants) |v| {
+        const code = server_mod.ErrorCode.fromBrokerError(v);
+        _ = @intFromEnum(code);
+    }
+    // OutOfMemory specifically maps to internal_error, not invalid_params.
+    try std.testing.expectEqual(
+        server_mod.ErrorCode.internal_error,
+        server_mod.ErrorCode.fromBrokerError(error.OutOfMemory),
+    );
+}
+
+test "dispatch unknown method returns NotImplemented" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var sessions = session_mod.SessionTable.init(arena.allocator());
+    var pool = account_pool_mod.AccountPool.init(arena.allocator());
+    var stderr_buf: [0]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(stderr_buf[0..]);
+    var ctx = Context{
+        .allocator = arena.allocator(),
+        .sessions = &sessions,
+        .pool = &pool,
+        .materializer = null,
+        .log_writer = fbs.writer().any(),
+    };
+
+    const out = dispatch(&ctx, "no/such/method", null);
+    switch (out) {
+        .ok => return error.TestFailed,
+        .err => |e| try std.testing.expectEqual(error.NotImplemented, e.err),
+    }
+}

--- a/src/broker/mod.zig
+++ b/src/broker/mod.zig
@@ -1,0 +1,38 @@
+//! oauth-mux broker module — public entry.
+//!
+//! The broker is the product anchor (see
+//! docs/spec/broker-mcp-contract-2026-05-03.md). It exposes an MCP-shaped
+//! JSON-RPC 2.0 surface over stdio that adapters (oauth-mux codex,
+//! oauth-mux claude, …) consume to drive seamless in-place account swap
+//! against their respective harnesses.
+//!
+//! This module is the namespace; concrete machinery lives in:
+//!   types.zig         — broker-public types (SessionId, AccountId, …)
+//!   server.zig        — JSON-RPC stdio server + dispatch
+//!   methods.zig       — method handlers (surface/*, account/*, …)
+//!   session.zig       — session table
+//!   account_pool.zig  — read-side account access over the existing config
+//!
+//! Surface version is `1` (see broker spec §2). Method shapes are stable
+//! within a major; adding optional fields is allowed.
+
+const std = @import("std");
+
+pub const types = @import("types.zig");
+pub const server = @import("server.zig");
+pub const methods = @import("methods.zig");
+pub const session_mod = @import("session.zig");
+pub const account_pool_mod = @import("account_pool.zig");
+
+pub const SURFACE_VERSION: u32 = 1;
+pub const BUILD_TAG: []const u8 = "oauth-mux 0.2.0+broker";
+
+pub const Server = server.Server;
+pub const Session = session_mod.Session;
+pub const AccountPool = account_pool_mod.AccountPool;
+pub const ClaimLevel = types.ClaimLevel;
+pub const BrokerError = types.BrokerError;
+
+test {
+    std.testing.refAllDeclsRecursive(@This());
+}

--- a/src/broker/server.zig
+++ b/src/broker/server.zig
@@ -1,0 +1,224 @@
+//! MCP-shaped JSON-RPC 2.0 stdio server.
+//!
+//! Wire framing: line-delimited JSON-RPC 2.0 (one object per line). MCP's
+//! stdio transport reserves stdout for valid MCP messages; logs go to
+//! stderr. See:
+//!   https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
+//!   https://www.jsonrpc.org/specification
+//!
+//! Phase 1 scope: framing, parse, dispatch, write. Method handlers in
+//! methods.zig.
+
+const std = @import("std");
+const types = @import("types.zig");
+const session_mod = @import("session.zig");
+const account_pool_mod = @import("account_pool.zig");
+const methods = @import("methods.zig");
+
+/// JSON-RPC standard error codes.
+pub const ErrorCode = enum(i32) {
+    parse_error = -32700,
+    invalid_request = -32600,
+    method_not_found = -32601,
+    invalid_params = -32602,
+    internal_error = -32603,
+
+    // -32000 .. -32099 are reserved for the server. We reuse a chunk for
+    // broker-semantic errors so adapters can branch on them.
+    no_account_selectable = -32010,
+    account_not_found = -32011,
+    session_not_found = -32012,
+    policy_denied = -32013,
+    refresh_failed = -32014,
+    invalid_shape = -32015,
+    not_implemented = -32099,
+
+    pub fn fromBrokerError(err: types.BrokerError) ErrorCode {
+        return switch (err) {
+            error.NotImplemented => .not_implemented,
+            error.NoAccountSelectable => .no_account_selectable,
+            error.AccountNotFound => .account_not_found,
+            error.SessionNotFound => .session_not_found,
+            error.PolicyDenied => .policy_denied,
+            error.InvalidParams => .invalid_params,
+            error.InvalidShape => .invalid_shape,
+            error.ParseError => .parse_error,
+            error.RefreshFailed => .refresh_failed,
+            error.UnsupportedShape => .invalid_shape,
+            error.SecretUnavailable => .internal_error,
+            error.OutOfMemory => .internal_error,
+        };
+    }
+};
+
+/// Server context handed to every method handler.
+pub const Context = struct {
+    allocator: std.mem.Allocator,
+    sessions: *session_mod.SessionTable,
+    pool: *account_pool_mod.AccountPool,
+    /// Optional credential resolver. main.zig wires the Config-aware
+    /// implementation; method handlers call it via
+    /// credential/materialize. Absent in pure unit tests.
+    materializer: ?types.CredentialMaterializer,
+    /// stderr writer for diagnostic logs (never on stdout).
+    log_writer: std.io.AnyWriter,
+};
+
+/// Parsed inbound request.
+pub const Request = struct {
+    jsonrpc: []const u8,
+    id: ?std.json.Value, // notifications have no id
+    method: []const u8,
+    params: ?std.json.Value,
+};
+
+pub const Server = struct {
+    allocator: std.mem.Allocator,
+    sessions: session_mod.SessionTable,
+    pool: account_pool_mod.AccountPool,
+    materializer: ?types.CredentialMaterializer = null,
+
+    pub fn init(allocator: std.mem.Allocator) Server {
+        return .{
+            .allocator = allocator,
+            .sessions = session_mod.SessionTable.init(allocator),
+            .pool = account_pool_mod.AccountPool.init(allocator),
+        };
+    }
+
+    pub fn setMaterializer(self: *Server, m: types.CredentialMaterializer) void {
+        self.materializer = m;
+    }
+
+    pub fn deinit(self: *Server) void {
+        self.sessions.deinit();
+        self.pool.deinit();
+    }
+
+    /// Run the server loop on stdin/stdout. Returns when stdin closes or
+    /// an unrecoverable error occurs (logged to stderr, exit non-zero).
+    pub fn runStdio(self: *Server) !void {
+        const stdin = std.io.getStdIn();
+        const stdout = std.io.getStdOut();
+        const stderr = std.io.getStdErr();
+
+        var buf_reader = std.io.bufferedReader(stdin.reader());
+        const reader = buf_reader.reader();
+
+        var buf_writer = std.io.bufferedWriter(stdout.writer());
+        const writer = buf_writer.writer();
+
+        var line_buf = std.ArrayListUnmanaged(u8){};
+        defer line_buf.deinit(self.allocator);
+
+        while (true) {
+            line_buf.clearRetainingCapacity();
+            reader.streamUntilDelimiter(line_buf.writer(self.allocator), '\n', null) catch |err| switch (err) {
+                error.EndOfStream => return,
+                else => return err,
+            };
+            if (line_buf.items.len == 0) continue;
+
+            // Per-request arena: every method handler allocates against
+            // this; we drop it after writing the response so long-lived
+            // servers don't accumulate per-call response objects.
+            var arena = std.heap.ArenaAllocator.init(self.allocator);
+            defer arena.deinit();
+
+            var ctx: Context = .{
+                .allocator = arena.allocator(),
+                .sessions = &self.sessions,
+                .pool = &self.pool,
+                .materializer = self.materializer,
+                .log_writer = stderr.writer().any(),
+            };
+
+            self.handleLine(&ctx, line_buf.items, writer) catch |err| {
+                stderr.writer().print("broker: handleLine error: {s}\n", .{@errorName(err)}) catch {};
+            };
+            buf_writer.flush() catch {};
+        }
+    }
+
+    fn handleLine(
+        self: *Server,
+        ctx: *Context,
+        line: []const u8,
+        writer: anytype,
+    ) !void {
+        _ = self;
+        var parsed = std.json.parseFromSlice(std.json.Value, ctx.allocator, line, .{}) catch {
+            try writeError(writer, null, .parse_error, "parse error");
+            return;
+        };
+        defer parsed.deinit();
+
+        const root = parsed.value;
+        if (root != .object) {
+            try writeError(writer, null, .invalid_request, "request must be an object");
+            return;
+        }
+
+        const obj = root.object;
+        const method_v = obj.get("method") orelse {
+            try writeError(writer, obj.get("id"), .invalid_request, "missing method");
+            return;
+        };
+        if (method_v != .string) {
+            try writeError(writer, obj.get("id"), .invalid_request, "method must be a string");
+            return;
+        }
+
+        const req_id = obj.get("id"); // null/missing for notifications
+        const params = obj.get("params");
+
+        const result_or_err = methods.dispatch(ctx, method_v.string, params);
+        if (req_id == null) return; // notification: no response
+
+        switch (result_or_err) {
+            .ok => |result_json| {
+                try writeOk(writer, req_id.?, result_json);
+            },
+            .err => |berr| {
+                const code = ErrorCode.fromBrokerError(berr.err);
+                try writeError(writer, req_id, code, berr.message);
+            },
+        }
+    }
+};
+
+fn writeOk(writer: anytype, id: std.json.Value, result: std.json.Value) !void {
+    var sw = std.json.writeStream(writer, .{});
+    try sw.beginObject();
+    try sw.objectField("jsonrpc");
+    try sw.write("2.0");
+    try sw.objectField("id");
+    try sw.write(id);
+    try sw.objectField("result");
+    try sw.write(result);
+    try sw.endObject();
+    try writer.writeByte('\n');
+}
+
+fn writeError(writer: anytype, id: ?std.json.Value, code: ErrorCode, msg: []const u8) !void {
+    var sw = std.json.writeStream(writer, .{});
+    try sw.beginObject();
+    try sw.objectField("jsonrpc");
+    try sw.write("2.0");
+    try sw.objectField("id");
+    if (id) |v| try sw.write(v) else try sw.write(null);
+    try sw.objectField("error");
+    try sw.beginObject();
+    try sw.objectField("code");
+    try sw.write(@intFromEnum(code));
+    try sw.objectField("message");
+    try sw.write(msg);
+    try sw.endObject();
+    try sw.endObject();
+    try writer.writeByte('\n');
+}
+
+test "ErrorCode round-trip from BrokerError" {
+    try std.testing.expectEqual(ErrorCode.no_account_selectable, ErrorCode.fromBrokerError(error.NoAccountSelectable));
+    try std.testing.expectEqual(ErrorCode.session_not_found, ErrorCode.fromBrokerError(error.SessionNotFound));
+}

--- a/src/broker/session.zig
+++ b/src/broker/session.zig
@@ -1,0 +1,138 @@
+//! Session table. Sessions are scoped to one adapter handshake and live
+//! for the duration of that adapter's MCP connection.
+
+const std = @import("std");
+const types = @import("types.zig");
+
+pub const Session = struct {
+    id: []const u8,
+    adapter: []const u8, // e.g. "codex"
+    adapter_version: []const u8,
+    harness_target: []const u8,
+    session_pid: u32,
+    claim_floor: types.ClaimLevel,
+    started_at_ms: i64,
+    /// Adapter's currently-elected account, if any. Updated on
+    /// `account/select` and `account/swap`.
+    current_account: ?[]const u8 = null,
+    policy: types.Policy = .{},
+};
+
+pub const SessionTable = struct {
+    allocator: std.mem.Allocator,
+    /// Maps session id -> Session. Owns string memory for ids and adapter
+    /// fields.
+    map: std.StringHashMap(Session),
+    /// Monotonic counter for id generation.
+    next_id: u64 = 1,
+    rand: std.Random.DefaultPrng,
+
+    pub fn init(allocator: std.mem.Allocator) SessionTable {
+        const seed: u64 = @intCast(std.time.nanoTimestamp() & std.math.maxInt(u64));
+        return .{
+            .allocator = allocator,
+            .map = std.StringHashMap(Session).init(allocator),
+            .rand = std.Random.DefaultPrng.init(seed),
+        };
+    }
+
+    pub fn deinit(self: *SessionTable) void {
+        var it = self.map.iterator();
+        while (it.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+            self.allocator.free(entry.value_ptr.adapter);
+            self.allocator.free(entry.value_ptr.adapter_version);
+            self.allocator.free(entry.value_ptr.harness_target);
+            if (entry.value_ptr.current_account) |a| self.allocator.free(a);
+        }
+        self.map.deinit();
+    }
+
+    /// Generate a fresh opaque session id. Format: `oms-<base36-counter>-<rand-hex>`.
+    pub fn newId(self: *SessionTable) ![]const u8 {
+        const counter = self.next_id;
+        self.next_id += 1;
+        const r = self.rand.random().int(u32);
+        return std.fmt.allocPrint(self.allocator, "oms-{x}-{x}", .{ counter, r });
+    }
+
+    pub fn create(self: *SessionTable, s: Session) !void {
+        const owned_id = try self.allocator.dupe(u8, s.id);
+        errdefer self.allocator.free(owned_id);
+        var owned = s;
+        owned.id = owned_id;
+        owned.adapter = try self.allocator.dupe(u8, s.adapter);
+        owned.adapter_version = try self.allocator.dupe(u8, s.adapter_version);
+        owned.harness_target = try self.allocator.dupe(u8, s.harness_target);
+        try self.map.put(owned_id, owned);
+    }
+
+    pub fn get(self: *SessionTable, id: []const u8) ?Session {
+        return self.map.get(id);
+    }
+
+    pub fn drop(self: *SessionTable, id: []const u8) bool {
+        const entry = self.map.fetchRemove(id) orelse return false;
+        self.allocator.free(entry.key);
+        self.allocator.free(entry.value.adapter);
+        self.allocator.free(entry.value.adapter_version);
+        self.allocator.free(entry.value.harness_target);
+        if (entry.value.current_account) |a| self.allocator.free(a);
+        return true;
+    }
+};
+
+test "SessionTable.newId property: 1000 ids never collide" {
+    // PBT (broker-spec §2.1 surface/handshake): minted session ids
+    // must be globally unique within a SessionTable lifetime so the
+    // adapter's session_id can't accidentally alias an old session.
+    var t = SessionTable.init(std.testing.allocator);
+    defer t.deinit();
+
+    var seen = std.StringHashMap(void).init(std.testing.allocator);
+    defer {
+        var it = seen.iterator();
+        while (it.next()) |e| std.testing.allocator.free(e.key_ptr.*);
+        seen.deinit();
+    }
+
+    var i: usize = 0;
+    while (i < 1000) : (i += 1) {
+        const id = try t.newId();
+        // Property: id is never empty.
+        try std.testing.expect(id.len > 0);
+        // Property: id starts with our prefix.
+        try std.testing.expect(std.mem.startsWith(u8, id, "oms-"));
+        // Property: never collides with any prior id.
+        const gop = try seen.getOrPut(id);
+        if (gop.found_existing) {
+            std.testing.allocator.free(id);
+            return error.IdCollision;
+        }
+        // hand the id over to the seen-set; it owns the memory.
+    }
+}
+
+test "SessionTable create/get/drop" {
+    var t = SessionTable.init(std.testing.allocator);
+    defer t.deinit();
+
+    const id = try t.newId();
+    defer std.testing.allocator.free(id);
+
+    try t.create(.{
+        .id = id,
+        .adapter = "codex",
+        .adapter_version = "0.1.0",
+        .harness_target = "codex 0.128.0",
+        .session_pid = 1234,
+        .claim_floor = .broker_owned,
+        .started_at_ms = std.time.milliTimestamp(),
+    });
+
+    const got = t.get(id) orelse return error.TestFailed;
+    try std.testing.expectEqualStrings("codex", got.adapter);
+
+    try std.testing.expect(t.drop(id));
+    try std.testing.expect(t.get(id) == null);
+}

--- a/src/broker/types.zig
+++ b/src/broker/types.zig
@@ -1,0 +1,144 @@
+//! Broker public types. Stable within `surface_version` major.
+//! Anchor: docs/spec/broker-mcp-contract-2026-05-03.md §2.
+
+const std = @import("std");
+
+/// The claim ladder. Lower = weaker; the product target is `next_turn_seamless`.
+/// `mid_turn_seamless` is a stretch; `cross_session_thread_continuity` is
+/// honestly labelled as may-not-exist.
+pub const ClaimLevel = enum {
+    unmuxed,
+    prepared_fallback,
+    broker_owned,
+    next_turn_seamless,
+    mid_turn_seamless,
+    cross_session_thread_continuity,
+
+    pub fn toString(self: ClaimLevel) []const u8 {
+        return switch (self) {
+            .unmuxed => "unmuxed",
+            .prepared_fallback => "prepared_fallback",
+            .broker_owned => "broker_owned",
+            .next_turn_seamless => "next_turn_seamless",
+            .mid_turn_seamless => "mid_turn_seamless",
+            .cross_session_thread_continuity => "cross_session_thread_continuity",
+        };
+    }
+};
+
+/// `provider:account` opaque identity. Owned by the broker config.
+pub const AccountId = struct {
+    text: []const u8, // e.g. "codex:max-1"
+};
+
+/// Opaque per-broker session id given out at handshake.
+pub const SessionId = struct {
+    text: []const u8,
+};
+
+/// Opaque credential handle returned by `account/select`. Resolves to
+/// concrete token bytes only via `credential/materialize` (kept local
+/// when possible; never crosses the wire).
+pub const CredentialHandle = struct {
+    text: []const u8,
+};
+
+/// Quota observation kinds. Matches broker spec §2.4 `quota/observe`.
+pub const QuotaKind = enum {
+    ok,
+    rate_limited,
+    quota_exhausted,
+    auth_unauthorized,
+    tier_insufficient,
+    provider_5xx,
+};
+
+/// Refresh trigger reasons. Matches broker spec §2.3 `credential/refresh`.
+pub const RefreshTrigger = enum {
+    proactive_exp,
+    unauthorized_401,
+    external_event,
+};
+
+/// Typed reasons for `account/swap` and the underlying state machine.
+pub const SwapReason = enum {
+    quota_exhausted,
+    rate_limited_long,
+    auth_unauthorized,
+    operator_requested,
+};
+
+/// Refresh failure classification from the provider's token endpoint.
+/// Mirrors codex `classify_refresh_token_failure` (manager.rs L850–871).
+pub const RefreshFailure = enum {
+    refresh_token_expired,
+    refresh_token_reused,
+    refresh_token_invalidated,
+    provider_5xx,
+    policy_denied,
+    other,
+};
+
+/// Session-wide policy (from `policy/get`).
+pub const Policy = struct {
+    allowed_budgets: []const []const u8 = &.{ "free_local", "free_command" },
+    allow_interactive: bool = false,
+    allow_mutating: bool = false,
+    spend_admitted_for_session: bool = false,
+};
+
+/// All errors the broker surfaces to its callers. Out-of-band protocol
+/// errors are JSON-RPC errors; these are semantic ones.
+pub const BrokerError = error{
+    NotImplemented,
+    NoAccountSelectable,
+    AccountNotFound,
+    SessionNotFound,
+    PolicyDenied,
+    InvalidParams,
+    InvalidShape,
+    ParseError,
+    RefreshFailed,
+    /// Adapter requested a credential shape this account/backend cannot
+    /// produce (e.g. chatgpt_auth_tokens for a non-codex account).
+    UnsupportedShape,
+    /// Secret backend or file unavailable when materializing.
+    SecretUnavailable,
+    OutOfMemory,
+};
+
+/// Codex-shaped token tuple per Codex app-server's `chatgptAuthTokens`
+/// login mode (see codex-rs/login/src/auth/storage.rs auth.json).
+/// All fields are owned by the caller's allocator.
+pub const ChatgptAuthTokens = struct {
+    access_token: []const u8,
+    account_id: []const u8,
+    plan_type: ?[]const u8 = null,
+    fedramp: bool = false,
+
+    pub fn deinit(self: ChatgptAuthTokens, allocator: std.mem.Allocator) void {
+        allocator.free(self.access_token);
+        allocator.free(self.account_id);
+        if (self.plan_type) |s| allocator.free(s);
+    }
+};
+
+/// Plumb-through resolver. The broker is config-agnostic; the wiring
+/// code (main.zig) provides this implementation against the loaded
+/// Config + secret backends.
+pub const CredentialMaterializer = struct {
+    ctx: *anyopaque,
+    /// Materialize a chatgpt_auth_tokens tuple for the given
+    /// `provider:account`. The returned struct owns memory in the
+    /// caller's allocator; caller must call `.deinit(allocator)`.
+    materialize_chatgpt: *const fn (
+        ctx: *anyopaque,
+        allocator: std.mem.Allocator,
+        account_id: []const u8,
+    ) BrokerError!ChatgptAuthTokens,
+};
+
+test "ClaimLevel.toString round-trip subset" {
+    try std.testing.expectEqualStrings("broker_owned", ClaimLevel.broker_owned.toString());
+    try std.testing.expectEqualStrings("next_turn_seamless", ClaimLevel.next_turn_seamless.toString());
+}

--- a/src/broker_loader.zig
+++ b/src/broker_loader.zig
@@ -1,0 +1,363 @@
+//! Bridge between the existing oauth-mux Config and the broker
+//! AccountPool + CredentialMaterializer. Lives at the same level as
+//! main.zig so it can import both `config.zig` and `broker/mod.zig`
+//! without leaking either side across module boundaries.
+//!
+//! Anchor: docs/spec/broker-mcp-contract-2026-05-03.md §2.2 / §2.3.
+//! Adapter consumer: src/broker/account_pool.zig + Server.materializer.
+
+const std = @import("std");
+const config_mod = @import("config.zig");
+const broker = @import("broker/mod.zig");
+const broker_types = @import("broker/types.zig");
+
+/// Populate `pool` with one entry per `<provider>:<account>` defined in
+/// the active Config. Liveness is `.unknown` and availability is
+/// `.available`; Phase 2 wires real health correlation.
+///
+/// `profile_name` (optional) restricts visible accounts to those listed
+/// in the named profile. Profile entries may be `provider:account` or
+/// `provider:account#capability`; we match the `provider:account`
+/// prefix. Out-of-profile accounts stay in the pool but are marked
+/// non-selectable so callers can introspect why they're hidden.
+pub fn populatePool(
+    pool: *broker.AccountPool,
+    cfg: config_mod.Config,
+    profile_name: ?[]const u8,
+) !void {
+    var prov_it = cfg.providers.map.iterator();
+    while (prov_it.next()) |prov_entry| {
+        const provider_name = prov_entry.key_ptr.*;
+        const provider_cfg = prov_entry.value_ptr.*;
+        var acc_it = provider_cfg.accounts.map.iterator();
+        while (acc_it.next()) |acc_entry| {
+            const account_name = acc_entry.key_ptr.*;
+            const id_buf = try std.fmt.allocPrint(
+                pool.allocator,
+                "{s}:{s}",
+                .{ provider_name, account_name },
+            );
+            defer pool.allocator.free(id_buf);
+            try pool.add(.{
+                .id = id_buf,
+                .selectable = true,
+                .liveness = .unknown,
+                .availability = .available,
+            });
+        }
+    }
+
+    if (profile_name) |pname| {
+        if (cfg.profiles.map.get(pname)) |profile| {
+            // Build a slice-of-slices into the original profile entries,
+            // each trimmed to the `provider:account` prefix. No
+            // allocation; restrictToAllowList only reads.
+            var allow_buf = std.ArrayListUnmanaged([]const u8){};
+            defer allow_buf.deinit(pool.allocator);
+            for (profile.providers) |entry| {
+                const head = if (std.mem.indexOfScalar(u8, entry, '#')) |idx| entry[0..idx] else entry;
+                try allow_buf.append(pool.allocator, head);
+            }
+            pool.restrictToAllowList(allow_buf.items);
+        }
+    }
+}
+
+// ── credential materializer ──────────────────────────────────────────
+
+/// Holds a borrowed reference to a loaded Config so the broker's
+/// CredentialMaterializer vtable can find an account's configured
+/// secret store. Lifetime: must outlive the broker server.
+pub const ChatgptMaterializerCtx = struct {
+    cfg: *const config_mod.Config,
+
+    /// Cast to/from the broker's opaque ctx pointer.
+    pub fn vtable(self: *ChatgptMaterializerCtx) broker_types.CredentialMaterializer {
+        return .{
+            .ctx = @as(*anyopaque, @ptrCast(self)),
+            .materialize_chatgpt = chatgptThunk,
+        };
+    }
+};
+
+fn chatgptThunk(
+    raw: *anyopaque,
+    allocator: std.mem.Allocator,
+    account_id: []const u8,
+) broker_types.BrokerError!broker_types.ChatgptAuthTokens {
+    const self: *ChatgptMaterializerCtx = @ptrCast(@alignCast(raw));
+    return materializeChatgpt(self.cfg.*, allocator, account_id);
+}
+
+/// Resolve a `provider:account` to a chatgpt_auth_tokens tuple by
+/// reading the account's configured secret store. Phase 1 supports the
+/// `backend: "file"` shape, which is what oauth-mux uses for managed
+/// codex accounts under ~/.config/oauth-mux/codex/<account>/auth.json.
+pub fn materializeChatgpt(
+    cfg: config_mod.Config,
+    allocator: std.mem.Allocator,
+    account_id: []const u8,
+) broker_types.BrokerError!broker_types.ChatgptAuthTokens {
+    const colon = std.mem.indexOfScalar(u8, account_id, ':') orelse
+        return broker_types.BrokerError.InvalidParams;
+    const provider = account_id[0..colon];
+    const account = account_id[colon + 1 ..];
+
+    const provider_cfg = cfg.providers.map.get(provider) orelse
+        return broker_types.BrokerError.AccountNotFound;
+    const acct_cfg = provider_cfg.accounts.map.get(account) orelse
+        return broker_types.BrokerError.AccountNotFound;
+
+    if (!std.mem.eql(u8, acct_cfg.secret.backend, "file")) {
+        // Phase 1: only file-backend is wired. Other backends
+        // (keychain, sops/age, command, env, stdin) need their own
+        // secret/*.zig invocations, follow-up.
+        return broker_types.BrokerError.SecretUnavailable;
+    }
+    const path_raw = acct_cfg.secret.path orelse
+        return broker_types.BrokerError.SecretUnavailable;
+
+    // Tilde-expand a leading ~ for ergonomics; otherwise use the path
+    // as-is.
+    const path = if (std.mem.startsWith(u8, path_raw, "~/")) blk: {
+        const home = std.process.getEnvVarOwned(allocator, "HOME") catch
+            return broker_types.BrokerError.SecretUnavailable;
+        defer allocator.free(home);
+        break :blk std.fmt.allocPrint(allocator, "{s}{s}", .{ home, path_raw[1..] }) catch
+            return broker_types.BrokerError.OutOfMemory;
+    } else allocator.dupe(u8, path_raw) catch
+        return broker_types.BrokerError.OutOfMemory;
+    defer allocator.free(path);
+
+    const file = (if (std.fs.path.isAbsolute(path))
+        std.fs.openFileAbsolute(path, .{})
+    else
+        std.fs.cwd().openFile(path, .{})) catch
+        return broker_types.BrokerError.SecretUnavailable;
+    defer file.close();
+
+    const max_bytes = 1 << 20; // 1 MiB cap on auth.json
+    const bytes = file.readToEndAlloc(allocator, max_bytes) catch
+        return broker_types.BrokerError.SecretUnavailable;
+    defer allocator.free(bytes);
+
+    return parseAuthJson(allocator, bytes);
+}
+
+/// Parse a codex-shaped auth.json into ChatgptAuthTokens. Schema
+/// reference: codex-rs/login/src/auth/storage.rs (AuthDotJson).
+fn parseAuthJson(
+    allocator: std.mem.Allocator,
+    bytes: []const u8,
+) broker_types.BrokerError!broker_types.ChatgptAuthTokens {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, bytes, .{}) catch
+        return broker_types.BrokerError.ParseError;
+    defer parsed.deinit();
+
+    if (parsed.value != .object) return broker_types.BrokerError.InvalidShape;
+    const tokens_v = parsed.value.object.get("tokens") orelse return broker_types.BrokerError.InvalidShape;
+    if (tokens_v != .object) return broker_types.BrokerError.InvalidShape;
+
+    const access_v = tokens_v.object.get("access_token") orelse return broker_types.BrokerError.InvalidShape;
+    if (access_v != .string) return broker_types.BrokerError.InvalidShape;
+    const account_v = tokens_v.object.get("account_id") orelse return broker_types.BrokerError.InvalidShape;
+    if (account_v != .string) return broker_types.BrokerError.InvalidShape;
+
+    const access_token = allocator.dupe(u8, access_v.string) catch return broker_types.BrokerError.OutOfMemory;
+    errdefer allocator.free(access_token);
+    const acct_id = allocator.dupe(u8, account_v.string) catch return broker_types.BrokerError.OutOfMemory;
+    errdefer allocator.free(acct_id);
+
+    // Best-effort: extract chatgpt_plan_type and chatgpt_account_is_fedramp
+    // from the id_token JWT's "https://api.openai.com/auth" claim. JWT
+    // body is the second base64url-encoded segment; we decode it and
+    // look up the nested field. Failure is non-fatal: plan_type stays
+    // null, fedramp stays false.
+    var plan_type: ?[]const u8 = null;
+    var fedramp = false;
+    if (tokens_v.object.get("id_token")) |id_v| {
+        if (id_v == .string) {
+            extractIdTokenClaims(allocator, id_v.string, &plan_type, &fedramp) catch {};
+        }
+    }
+
+    return broker_types.ChatgptAuthTokens{
+        .access_token = access_token,
+        .account_id = acct_id,
+        .plan_type = plan_type,
+        .fedramp = fedramp,
+    };
+}
+
+fn extractIdTokenClaims(
+    allocator: std.mem.Allocator,
+    jwt: []const u8,
+    out_plan_type: *?[]const u8,
+    out_fedramp: *bool,
+) !void {
+    // JWT shape: header.payload.signature, all base64url-no-padding.
+    const dot1 = std.mem.indexOfScalar(u8, jwt, '.') orelse return error.BadJwt;
+    const after_header = jwt[dot1 + 1 ..];
+    const dot2 = std.mem.indexOfScalar(u8, after_header, '.') orelse return error.BadJwt;
+    const payload_b64 = after_header[0..dot2];
+
+    const decoder = std.base64.url_safe_no_pad.Decoder;
+    const payload_len = try decoder.calcSizeForSlice(payload_b64);
+    const payload_buf = try allocator.alloc(u8, payload_len);
+    defer allocator.free(payload_buf);
+    try decoder.decode(payload_buf, payload_b64);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, payload_buf, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return;
+
+    const auth_claim = parsed.value.object.get("https://api.openai.com/auth") orelse return;
+    if (auth_claim != .object) return;
+
+    if (auth_claim.object.get("chatgpt_plan_type")) |pt| {
+        if (pt == .string) {
+            out_plan_type.* = try allocator.dupe(u8, pt.string);
+        }
+    }
+    if (auth_claim.object.get("chatgpt_account_is_fedramp")) |f| {
+        if (f == .bool) out_fedramp.* = f.bool;
+    }
+}
+
+test "parseAuthJson minimal shape" {
+    const bytes =
+        \\{
+        \\  "OPENAI_API_KEY": null,
+        \\  "tokens": {
+        \\    "id_token": "ignored.eyJ9.x",
+        \\    "access_token": "AT-1234",
+        \\    "refresh_token": "RT-5678",
+        \\    "account_id": "acc-abc"
+        \\  },
+        \\  "last_refresh": "now",
+        \\  "auth_mode": "Chatgpt"
+        \\}
+    ;
+    var tokens = try parseAuthJson(std.testing.allocator, bytes);
+    defer tokens.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("AT-1234", tokens.access_token);
+    try std.testing.expectEqualStrings("acc-abc", tokens.account_id);
+    try std.testing.expect(tokens.plan_type == null);
+    try std.testing.expect(!tokens.fedramp);
+}
+
+test "parseAuthJson rejects missing tokens key" {
+    const bytes = "{\"OPENAI_API_KEY\":null,\"auth_mode\":\"Chatgpt\"}";
+    const result = parseAuthJson(std.testing.allocator, bytes);
+    try std.testing.expectError(broker_types.BrokerError.InvalidShape, result);
+}
+
+test "parseAuthJson tolerates malformed id_token (silent fallback)" {
+    // Single dot instead of two — JWT extractor returns BadJwt, but we
+    // swallow it and keep plan_type/fedramp at defaults.
+    const bytes =
+        \\{"tokens":{"access_token":"AT","account_id":"AID","id_token":"only-one-dot"}}
+    ;
+    var tokens = try parseAuthJson(std.testing.allocator, bytes);
+    defer tokens.deinit(std.testing.allocator);
+    try std.testing.expect(tokens.plan_type == null);
+    try std.testing.expect(!tokens.fedramp);
+    try std.testing.expectEqualStrings("AT", tokens.access_token);
+}
+
+test "parseAuthJson with plan_type from id_token" {
+    // id_token payload: {"https://api.openai.com/auth":{"chatgpt_plan_type":"pro","chatgpt_account_is_fedramp":true}}
+    // base64url-no-pad encoded:
+    const id_token = "h.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9wbGFuX3R5cGUiOiJwcm8iLCJjaGF0Z3B0X2FjY291bnRfaXNfZmVkcmFtcCI6dHJ1ZX19.s";
+    const bytes = try std.fmt.allocPrint(std.testing.allocator,
+        \\{{"tokens":{{"access_token":"a","account_id":"b","id_token":"{s}"}}}}
+    , .{id_token});
+    defer std.testing.allocator.free(bytes);
+
+    var tokens = try parseAuthJson(std.testing.allocator, bytes);
+    defer tokens.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("pro", tokens.plan_type.?);
+    try std.testing.expect(tokens.fedramp);
+}
+
+// ── pool population (above) ──────────────────────────────────────────
+
+test "populatePool from JSON config" {
+    const cfg_json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "/tmp/a" } },
+        \\        "max-2": { "priority": 20, "secret": { "backend": "file", "path": "/tmp/b" } }
+        \\      }
+        \\    },
+        \\    "claude": {
+        \\      "kind": "claude-command",
+        \\      "accounts": {
+        \\        "personal": { "priority": 10, "secret": { "backend": "command", "command": ["true"] } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "codex-max": { "providers": ["codex:max-1#codex-max", "codex:max-2#codex-max"] }
+        \\  }
+        \\}
+    ;
+    var parsed = try config_mod.loadFromBytes(std.testing.allocator, cfg_json);
+    defer parsed.deinit();
+
+    var pool = broker.AccountPool.init(std.testing.allocator);
+    defer pool.deinit();
+    try populatePool(&pool, parsed.value, null);
+
+    try std.testing.expectEqual(@as(usize, 3), pool.accounts.items.len);
+}
+
+test "populatePool with profile filter narrows selectable" {
+    const cfg_json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "/tmp/a" } },
+        \\        "max-2": { "priority": 20, "secret": { "backend": "file", "path": "/tmp/b" } }
+        \\      }
+        \\    },
+        \\    "claude": {
+        \\      "kind": "claude-command",
+        \\      "accounts": {
+        \\        "personal": { "priority": 10, "secret": { "backend": "command", "command": ["true"] } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "codex-max": { "providers": ["codex:max-1#codex-max", "codex:max-2#codex-max"] }
+        \\  }
+        \\}
+    ;
+    var parsed = try config_mod.loadFromBytes(std.testing.allocator, cfg_json);
+    defer parsed.deinit();
+
+    var pool = broker.AccountPool.init(std.testing.allocator);
+    defer pool.deinit();
+    try populatePool(&pool, parsed.value, "codex-max");
+
+    try std.testing.expectEqual(@as(usize, 3), pool.accounts.items.len);
+
+    const elected = try pool.elect(null, null, &.{});
+    try std.testing.expect(std.mem.eql(u8, elected.id, "codex:max-1") or std.mem.eql(u8, elected.id, "codex:max-2"));
+
+    var claude_present_and_blocked = false;
+    for (pool.accounts.items) |a| {
+        if (std.mem.eql(u8, a.id, "claude:personal")) {
+            try std.testing.expect(!a.selectable);
+            claude_present_and_blocked = true;
+        }
+    }
+    try std.testing.expect(claude_present_and_blocked);
+}

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -29,6 +29,7 @@ pub const Command = union(enum) {
     codex: CodexArgs,
     completions: CompletionsArgs,
     daemon_run: DaemonRunArgs,
+    mcp: McpArgs,
     daemon_start,
     daemon_stop,
     daemon_status: DaemonStatusArgs,
@@ -38,6 +39,11 @@ pub const Command = union(enum) {
     version_cmd,
     help,
     codex_help,
+
+    pub const McpArgs = struct {
+        profile: ?[]const u8 = null,
+        capability: ?[]const u8 = null,
+    };
 
     pub const ExecArgs = struct {
         profile: ?[]const u8 = null,
@@ -314,6 +320,7 @@ pub fn parse(args: []const []const u8) Command {
     if (eql(cmd, "init")) return parseInit(rest);
     if (eql(cmd, "setup")) return parseSetup(rest);
     if (eql(cmd, "codex")) return parseCodex(rest);
+    if (eql(cmd, "mcp")) return parseMcp(rest);
     if (eql(cmd, "version") or eql(cmd, "--version") or eql(cmd, "-v")) return .version_cmd;
     if (eql(cmd, "daemon")) {
         if (rest.len > 0) {
@@ -340,6 +347,21 @@ pub fn parse(args: []const []const u8) Command {
 
 fn parseExec(args: []const []const u8) Command {
     return .{ .exec = parseExecArgs(args) };
+}
+
+fn parseMcp(args: []const []const u8) Command {
+    var result = Command.McpArgs{};
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        if (eql(args[i], "--profile") and i + 1 < args.len) {
+            i += 1;
+            result.profile = args[i];
+        } else if (eql(args[i], "--capability") and i + 1 < args.len) {
+            i += 1;
+            result.capability = args[i];
+        }
+    }
+    return .{ .mcp = result };
 }
 
 fn parseExecArgs(args: []const []const u8) Command.ExecArgs {
@@ -1168,6 +1190,9 @@ pub fn printUsage(writer: anytype) !void {
         \\
         \\  daemon tick [--once|--loop] [--execute] [--iterations <n>] [--interval-ms <ms>] [--profile <name>] [--provider <name>] [--account <name>] [--capability <name>] [--json]
         \\      Plan daemon ticks; --execute runs at most one admitted non-interactive action per tick.
+        \\
+        \\  mcp [--profile <name>] [--capability <name>]
+        \\      Run the broker MCP/JSON-RPC server on stdio for harness adapters.
         \\
         \\  init [--interactive] [--codex-max]
         \\      Generate a starter config file.
@@ -2126,6 +2151,18 @@ test "parse daemon tick bounded loop" {
     }
 }
 
+test "parse mcp broker server profile" {
+    const args = [_][]const u8{ "mcp", "--profile", "codex-max", "--capability", "codex-max" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .mcp => |mcp| {
+            try std.testing.expectEqualStrings("codex-max", mcp.profile.?);
+            try std.testing.expectEqualStrings("codex-max", mcp.capability.?);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
     if (eql(shell_name, "fish")) {
         try writer.writeAll(
@@ -2150,6 +2187,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n __fish_use_subcommand -a setup -d 'First-run setup'
             \\complete -c oauth-mux -n __fish_use_subcommand -a codex -d 'Codex account onboarding'
             \\complete -c oauth-mux -n __fish_use_subcommand -a daemon -d 'Daemon operations'
+            \\complete -c oauth-mux -n __fish_use_subcommand -a mcp -d 'Run broker MCP server'
             \\complete -c oauth-mux -n __fish_use_subcommand -a version -d 'Print version'
             \\complete -c oauth-mux -n __fish_use_subcommand -a completions -d 'Generate completions'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route stay-afloat' -l profile -s p -d 'Profile name' -r
@@ -2226,6 +2264,8 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l provider -d 'Provider name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l account -d 'Account name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l capability -d 'Route capability' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from mcp' -l profile -s p -d 'Profile name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from mcp' -l capability -d 'Route capability' -r
             \\
         );
     } else if (eql(shell_name, "zsh")) {
@@ -2254,6 +2294,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\    'setup:First-run setup'
             \\    'codex:Codex account onboarding'
             \\    'daemon:Daemon operations'
+            \\    'mcp:Run broker MCP server'
             \\    'version:Print version'
             \\    'completions:Generate completions'
             \\  )
@@ -2266,7 +2307,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
         try writer.writeAll(
             \\_oauth_mux_completions() {
             \\  local cur="${COMP_WORDS[COMP_CWORD]}"
-            \\  COMPREPLY=($(compgen -W "exec env probe doctor report providers accounts enroll status health discover repair-plan repair route stay-afloat config init setup codex daemon version completions" -- "$cur"))
+            \\  COMPREPLY=($(compgen -W "exec env probe doctor report providers accounts enroll status health discover repair-plan repair route stay-afloat config init setup codex daemon mcp version completions" -- "$cur"))
             \\}
             \\complete -F _oauth_mux_completions oauth-mux
             \\

--- a/src/main.zig
+++ b/src/main.zig
@@ -14,6 +14,14 @@ const daemon = @import("daemon.zig");
 const repair_state = @import("repair_state.zig");
 const runtime_mod = @import("runtime.zig");
 const secret_mod = @import("secret.zig");
+const broker = @import("broker/mod.zig");
+const broker_loader = @import("broker_loader.zig");
+
+comptime {
+    // Pull broker + loader modules into the test build.
+    _ = broker;
+    _ = broker_loader;
+}
 
 pub fn main() !void {
     log.init();
@@ -34,6 +42,44 @@ pub fn main() !void {
         .version_cmd => try stdout.print("oauth-mux {s}\n", .{cli.version}),
         .help => try cli.printUsage(stdout),
         .codex_help => try cli.printCodexUsage(stdout),
+
+        .mcp => |mcp_args| {
+            // Broker MCP server on stdio. Anchor:
+            // docs/spec/broker-mcp-contract-2026-05-03.md.
+            const parsed = config.load(allocator) catch |e| switch (e) {
+                error.FileNotFound => {
+                    log.err("mcp: no oauth-mux config found; run `oauth-mux init` first", .{});
+                    std.process.exit(types.ExitCode.config_error.int());
+                },
+                else => {
+                    log.err("mcp: config load: {s}", .{@errorName(e)});
+                    std.process.exit(types.ExitCode.config_error.int());
+                },
+            };
+            defer parsed.deinit();
+
+            var server = broker.Server.init(allocator);
+            defer server.deinit();
+
+            broker_loader.populatePool(&server.pool, parsed.value, mcp_args.profile) catch |e| {
+                log.err("mcp: pool populate: {s}", .{@errorName(e)});
+                std.process.exit(types.ExitCode.general_error.int());
+            };
+
+            var mat_ctx = broker_loader.ChatgptMaterializerCtx{ .cfg = &parsed.value };
+            server.setMaterializer(mat_ctx.vtable());
+
+            log.info("mcp: broker surface_version={d} accounts={d} profile={s}", .{
+                broker.SURFACE_VERSION,
+                server.pool.accounts.items.len,
+                mcp_args.profile orelse "(none)",
+            });
+
+            server.runStdio() catch |e| {
+                log.err("mcp: server: {s}", .{@errorName(e)});
+                std.process.exit(types.ExitCode.general_error.int());
+            };
+        },
 
         .config_path => {
             const path = try paths.configFilePath(allocator);


### PR DESCRIPTION
## Summary

Adds the provider-neutral broker MCP core for TIN-941 / #172:

- top-level `oauth-mux mcp` stdio JSON-RPC server
- broker modules for surface lifecycle, session tracking, account pool election/swap, credential materialization, quota observe/status, and policy/get
- config loader that populates broker accounts from existing oauth-mux profiles
- `scripts/smoke-broker.sh`, wired into `check-local`, with 22 synthetic assertions

## Why

This lands the adapter contract before Codex-specific proxy work. The goal is a stable broker surface that `oauth-mux codex`, `oauth-mux claude`, and later harness adapters can consume without baking Codex behavior into the core.

## Boundary

This is synthetic and provider-neutral. It uses fake fixture token strings in a temp config. It does not add the Codex adapter/proxy/cassette/live acceptance work, does not call providers, and does not claim seamless Codex quota fallback yet.

## Validation

- `just smoke-broker`
- `just check`
- `git diff --check`

Refs #172. Related #174, #175, #176, #177.
