### PR TITLE
[codex] Add Codex adapter synthetic smoke

### DIFF
--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -20,6 +20,22 @@ Source references (codex repo, ref `main` @ `67849d9` 2026-05-03):
 - `codex-rs/exec/src/lib.rs` L1580–1588 — exec rejects external refresh.
 - `codex-rs/tui/src/app/app_server_requests.rs` L136 — TUI silently drops it.
 
+## 0.0 Current Implementation Checkpoint
+
+TIN-948 is a bounded skeleton slice, not the full adapter described by
+the rest of this contract. It adds `oauth-mux codex run`, an
+oauth-mux-owned localhost wire proxy, and a synthetic smoke where a stub
+Codex child keeps the same PID while the proxy observes quota exhaustion,
+marks the selected route unavailable, and sends the next request with a
+different account's fixture credentials.
+
+That smoke is structural evidence only. It uses local stubs and fake
+fixture tokens, makes no provider calls, and keeps the adapter output at
+`claim_level:"broker_owned"` while reporting
+`synthetic_swap_observed:true`. It does **not** claim live
+`next_turn_seamless`, provider-originated quota handling, same-thread
+recovery, or unmanaged Codex TUI hot-swap.
+
 ## 0. Scope
 
 This adapter exists to deliver the `oauth-mux codex` user entrypoint and

--- a/justfile
+++ b/justfile
@@ -173,7 +173,7 @@ check:
     nix develop --command just check-local
 
 check-local:
-    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh && ./scripts/stay-afloat-wrapper-doc-smoke.sh && ./scripts/smoke-broker.sh'
+    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh && ./scripts/stay-afloat-wrapper-doc-smoke.sh && ./scripts/smoke-broker.sh && ./scripts/smoke-codex-acceptance.sh'
     @echo "all checks passed"
 
 e2e:
@@ -201,6 +201,15 @@ smoke-broker:
 smoke-broker-local:
     zig build
     ./scripts/smoke-broker.sh
+
+# ── Codex adapter synthetic smoke (no provider traffic) ──
+
+smoke-codex-acceptance:
+    nix develop --command just smoke-codex-acceptance-local
+
+smoke-codex-acceptance-local:
+    zig build
+    ./scripts/smoke-codex-acceptance.sh
 
 # ── Config ──
 

--- a/scripts/smoke-codex-acceptance.sh
+++ b/scripts/smoke-codex-acceptance.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Synthetic in-session smoke for `oauth-mux codex run` covering the
+# adapter/proxy swap structure WITHOUT any real Codex traffic.
+#
+# Anchor: docs/spec/codex-acceptance-procedure-2026-05-03.md.
+#
+# Stands up:
+#   - scripts/test-stub-upstream.py  : emulates chatgpt.com, returns
+#                                      200 then 429 per ChatGPT-Account-ID
+#   - scripts/test-stub-codex.py     : emulates the codex CLI; reads
+#                                      CODEX_HOME/config.toml, sends N
+#                                      POSTs through the proxy, records
+#                                      its own PID for stability check
+#
+# Drives: oauth-mux codex run --profile codex-max --json-status with:
+#   OMUX_UPSTREAM_HOST=127.0.0.1:<stub-port>
+#   OMUX_UPSTREAM_SCHEME=http
+#   OMUX_CODEX_BIN=path/to/test-stub-codex.py
+#
+# Asserts the full NDJSON sequence on stderr:
+#   session_started        (account A elected)
+#   proxy_turn 200 ok      (account A, multiple times)
+#   proxy_turn 429 quota_exhausted (account A)
+#   proxy_post_swap_turn   (A -> B, dropped x-codex-turn-state)
+#   proxy_turn 200 ok      (account B, claim_level broker_owned)
+#   session_ended          (final_claim_level broker_owned, synthetic_swap_observed true,
+#                           exit_code 0)
+#
+# Plus: stub-codex.report.pid_stable == true, proving this smoke did
+# not rely on child restart/relaunch behavior.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$ROOT/zig-out/bin/oauth-mux"
+
+if [[ ! -x "$BIN" ]]; then
+    echo "smoke-codex-acceptance: oauth-mux binary not built at $BIN" >&2
+    echo "  run: just build" >&2
+    exit 64
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "smoke-codex-acceptance: jq required" >&2
+    exit 64
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "smoke-codex-acceptance: python3 required" >&2
+    exit 64
+fi
+
+TMP="$(mktemp -d -t omux-acceptance.XXXXXX)"
+PORTFILE="$TMP/upstream.port"
+UPLOG="$TMP/upstream.log"
+NDJSON="$TMP/adapter.ndjson"
+STUB_PIDFILE="$TMP/stub-codex.pid"
+STUB_REPORT="$TMP/stub-codex.report"
+
+cleanup() {
+    if [[ -n "${UPSTREAM_PID:-}" ]] && kill -0 "$UPSTREAM_PID" 2>/dev/null; then
+        kill "$UPSTREAM_PID" 2>/dev/null || true
+        wait "$UPSTREAM_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+# 1. Synthetic accounts. id_token JWT payload encodes plan_type=pro
+# and chatgpt_account_is_fedramp=true so credential/materialize
+# exercises the JWT decode path on each account.
+mkdir -p "$TMP/account-A" "$TMP/account-B"
+ID_TOKEN="h.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9wbGFuX3R5cGUiOiJwcm8iLCJjaGF0Z3B0X2FjY291bnRfaXNfZmVkcmFtcCI6dHJ1ZX19.s"
+
+cat >"$TMP/account-A/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"AT-acceptance-A","refresh_token":"RT-A","account_id":"acc-A-id"},"auth_mode":"Chatgpt"}
+EOF
+cat >"$TMP/account-B/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"AT-acceptance-B","refresh_token":"RT-B","account_id":"acc-B-id"},"auth_mode":"Chatgpt"}
+EOF
+
+cat >"$TMP/oauth-mux.config.json" <<EOF
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "kind": "codex",
+      "accounts": {
+        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "$TMP/account-A/auth.json" } },
+        "max-2": { "priority": 20, "secret": { "backend": "file", "path": "$TMP/account-B/auth.json" } }
+      }
+    }
+  },
+  "profiles": {
+    "codex-max": { "providers": ["codex:max-1#codex-max", "codex:max-2#codex-max"] }
+  }
+}
+EOF
+
+# 2. Start stub upstream
+OMUX_STUB_PORT=0 \
+  OMUX_STUB_PORTFILE="$PORTFILE" \
+  OMUX_STUB_OK_BEFORE_429=2 \
+  OMUX_STUB_LOGFILE="$UPLOG" \
+  python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$TMP/upstream.stderr" &
+UPSTREAM_PID=$!
+
+for i in {1..40}; do
+    [[ -s "$PORTFILE" ]] && break
+    sleep 0.05
+done
+if [[ ! -s "$PORTFILE" ]]; then
+    echo "smoke-codex-acceptance: stub upstream did not write port" >&2
+    cat "$TMP/upstream.stderr" >&2
+    exit 1
+fi
+UPSTREAM_PORT="$(cat "$PORTFILE" | tr -d '[:space:]')"
+echo "smoke-codex-acceptance: stub upstream pid=$UPSTREAM_PID port=$UPSTREAM_PORT"
+
+# 3. Run oauth-mux codex run
+echo "smoke-codex-acceptance: running adapter..."
+OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+  OMUX_UPSTREAM_HOST="127.0.0.1:$UPSTREAM_PORT" \
+  OMUX_UPSTREAM_SCHEME="http" \
+  OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+  OMUX_STUB_CODEX_TURNS=5 \
+  OMUX_STUB_CODEX_PIDFILE="$STUB_PIDFILE" \
+  OMUX_STUB_CODEX_REPORT="$STUB_REPORT" \
+  "$BIN" codex run --profile codex-max --json-status 2>"$NDJSON" || {
+    echo "smoke-codex-acceptance: adapter exited nonzero" >&2
+    echo "---NDJSON---" >&2
+    cat "$NDJSON" >&2
+    echo "---upstream log---" >&2
+    cat "$UPLOG" >&2 || true
+    exit 1
+}
+
+# 4. Assertions
+assert_grep() {
+    local label=$1 pattern=$2 file=$3
+    if grep -q -E "$pattern" "$file"; then
+        echo "  ✓ $label"
+    else
+        echo "  ✗ $label" >&2
+        echo "    pattern: $pattern" >&2
+        echo "    file: $file" >&2
+        return 1
+    fi
+}
+
+echo "smoke-codex-acceptance: assertions"
+
+assert_grep "session_started"           '"kind":"session_started"'           "$NDJSON"
+assert_grep "session_started has proxy_port" '"proxy_port":[0-9]+'           "$NDJSON"
+assert_grep "session_started redacts CODEX_HOME path" '"codex_home_path_printed":false' "$NDJSON"
+assert_grep "proxy_turn 200 ok"         '"kind":"proxy_turn".*"status":200.*"classification":"ok"' "$NDJSON"
+assert_grep "proxy_turn 429 quota_exhausted" '"kind":"proxy_turn".*"status":429.*"classification":"quota_exhausted"' "$NDJSON"
+assert_grep "proxy_post_swap_turn fired" '"kind":"proxy_post_swap_turn"'     "$NDJSON"
+assert_grep "post-swap dropped x-codex-turn-state" '"dropped":"x-codex-turn-state"' "$NDJSON"
+assert_grep "claim_level remains broker_owned" '"claim_level":"broker_owned"' "$NDJSON"
+assert_grep "session_ended final_claim_level broker_owned" '"kind":"session_ended".*"final_claim_level":"broker_owned"' "$NDJSON"
+assert_grep "session_ended records synthetic swap" '"kind":"session_ended".*"synthetic_swap_observed":true' "$NDJSON"
+
+ACCOUNT_HITS=$(grep -oE '"account":"codex:max-[12]"' "$NDJSON" | sort -u | wc -l | tr -d ' ')
+if [[ "$ACCOUNT_HITS" -ge 2 ]]; then
+    echo "  ✓ both accounts max-1 and max-2 elected"
+else
+    echo "  ✗ expected both accounts elected; saw distinct=$ACCOUNT_HITS" >&2
+    exit 1
+fi
+
+if [[ ! -s "$STUB_REPORT" ]]; then
+    echo "  ✗ stub-codex report missing" >&2
+    exit 1
+fi
+PID_STABLE=$(jq -r .pid_stable "$STUB_REPORT")
+START_PID=$(jq -r .start_pid "$STUB_REPORT")
+END_PID=$(jq -r .end_pid "$STUB_REPORT")
+if [[ "$PID_STABLE" == "true" ]]; then
+    echo "  ✓ stub-codex PID stable across swap (start=$START_PID end=$END_PID)"
+else
+    echo "  ✗ stub-codex PID changed: start=$START_PID end=$END_PID" >&2
+    exit 1
+fi
+
+UPSTREAM_ACCT_COUNT=$(jq -r .account_id "$UPLOG" 2>/dev/null | sort -u | wc -l | tr -d ' ' || echo 0)
+if [[ "$UPSTREAM_ACCT_COUNT" -ge 2 ]]; then
+    echo "  ✓ stub upstream saw 2+ distinct ChatGPT-Account-IDs (proxy substituted both)"
+else
+    echo "  ✗ upstream saw only $UPSTREAM_ACCT_COUNT distinct account-ids" >&2
+    cat "$UPLOG" >&2
+    exit 1
+fi
+
+echo
+echo "smoke-codex-acceptance: all 13 assertions passed."
+echo "  full ndjson: $NDJSON"
+echo "  stub upstream log: $UPLOG"
+echo "  stub codex report: $STUB_REPORT"

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Stub `codex` binary for in-session acceptance smoke.
+
+Stands in for the real `codex` CLI when the `oauth-mux codex run`
+adapter spawns it. Reads its `CODEX_HOME/config.toml` to find the
+proxy port, then sends a fixed sequence of POSTs to the proxy
+emulating codex's real-turn traffic shape.
+
+Records its own PID at start and at end so the harness can assert
+PID stability across the swap (the no-restart proof).
+
+Env (set by the adapter):
+  CODEX_HOME  — directory containing config.toml + auth.json
+  OMUX_ACTIVE_PROVIDER / OMUX_ACTIVE_ACCOUNT / OMUX_ACTIVE_PROFILE
+              — informational breadcrumbs
+
+Env (set by the smoke harness):
+  OMUX_STUB_CODEX_TURNS  — number of POST turns to send (default 5)
+  OMUX_STUB_CODEX_PIDFILE — file to write our PID into (default
+                            /tmp/omux-stub-codex.pid)
+  OMUX_STUB_CODEX_REPORT  — JSON summary path (default
+                            /tmp/omux-stub-codex.report)
+"""
+
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+
+def _read_proxy_url(codex_home: Path) -> str:
+    cfg = (codex_home / "config.toml").read_text()
+    m = re.search(r'base_url\s*=\s*"([^"]+)"', cfg)
+    if not m:
+        print("stub-codex: config.toml missing base_url", file=sys.stderr)
+        sys.exit(2)
+    return m.group(1)
+
+
+def _post(proxy_url: str, body: bytes) -> tuple[int, str]:
+    # base_url is like http://127.0.0.1:NNNN/backend-api/codex
+    # We want to POST to that prefix + /responses.
+    m = re.match(r"http://([^/]+)(/.*)$", proxy_url)
+    if not m:
+        print(f"stub-codex: cannot parse base_url={proxy_url}", file=sys.stderr)
+        sys.exit(2)
+    netloc, prefix = m.group(1), m.group(2)
+    conn = http.client.HTTPConnection(netloc, timeout=15)
+    try:
+        conn.request(
+            "POST",
+            prefix + "/responses",
+            body=body,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "stub-codex/0",
+                "x-codex-turn-state": "stub-turn-state-v1",
+                "x-codex-installation-id": "stub-install-1",
+                "OpenAI-Beta": "responses_websockets=2026-02-06",
+            },
+        )
+        resp = conn.getresponse()
+        return resp.status, resp.read().decode("utf-8", errors="replace")
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    pid = os.getpid()
+    pidfile = Path(os.environ.get("OMUX_STUB_CODEX_PIDFILE", "/tmp/omux-stub-codex.pid"))
+    pidfile.write_text(f"{pid}\n")
+
+    report_path = Path(os.environ.get("OMUX_STUB_CODEX_REPORT", "/tmp/omux-stub-codex.report"))
+    turns = int(os.environ.get("OMUX_STUB_CODEX_TURNS", "5"))
+
+    codex_home = Path(os.environ["CODEX_HOME"])
+    proxy_url = _read_proxy_url(codex_home)
+
+    started_at = time.time()
+    print(
+        f"stub-codex: pid={pid} CODEX_HOME=<redacted> proxy={proxy_url} turns={turns} "
+        f"OMUX_ACTIVE_ACCOUNT={os.environ.get('OMUX_ACTIVE_ACCOUNT')}",
+        file=sys.stderr, flush=True,
+    )
+
+    turn_results: list[dict] = []
+    for i in range(turns):
+        status, body = _post(
+            proxy_url,
+            json.dumps({"input": f"stub turn {i}"}).encode("utf-8"),
+        )
+        turn_results.append({"turn": i, "status": status, "body_head": body[:120]})
+        print(f"stub-codex: turn {i} -> {status}", file=sys.stderr, flush=True)
+        time.sleep(0.05)
+
+    end_pid = os.getpid()
+    report = {
+        "start_pid": pid,
+        "end_pid": end_pid,
+        "pid_stable": pid == end_pid,
+        "duration_s": round(time.time() - started_at, 3),
+        "turns": turn_results,
+        "codex_home_path_printed": False,
+        "active_account_at_start": os.environ.get("OMUX_ACTIVE_ACCOUNT"),
+    }
+    report_path.write_text(json.dumps(report, indent=2))
+    print(f"stub-codex: pid_stable={report['pid_stable']} turns={turns}", file=sys.stderr, flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-stub-upstream.py
+++ b/scripts/test-stub-upstream.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Stub upstream HTTP server for in-session Codex acceptance smoke.
+
+Emulates the surface of `chatgpt.com/backend-api/codex/responses`
+just enough to drive the wire proxy's classification matrix
+through a full quota-exhaust → swap → recover sequence WITHOUT
+any real Codex traffic.
+
+Behavior (configurable via env):
+  OMUX_STUB_PORT      — bind port (default 0 = ephemeral; written to
+                        OMUX_STUB_PORTFILE so the harness can read it)
+  OMUX_STUB_PORTFILE  — path to write the chosen port (default
+                        /tmp/omux-stub-upstream.port)
+  OMUX_STUB_OK_BEFORE_429 — number of 200 responses before 429 fires
+                            for ANY GIVEN account-id (default 2)
+  OMUX_STUB_LOGFILE   — path to append per-request JSON log lines
+                        (default /tmp/omux-stub-upstream.log)
+
+Per request:
+  - Logs a JSON line with: ts, path, method, account_id (from
+    ChatGPT-Account-ID header), auth_prefix (first 6 chars of the
+    Bearer token + sha256 hash[:10] for redacted correlation),
+    status_returned, response_classification.
+  - If the request count for THIS ChatGPT-Account-ID has not yet
+    crossed OMUX_STUB_OK_BEFORE_429, return 200 with a tiny SSE-shaped
+    body.
+  - Else, return 429 + JSON body
+    {"error":{"type":"usage_limit_reached","plan_type":"pro","resets_at":<unix+86400>}}
+    once (per account). After one 429 for an account, that account
+    stays 429 until process restart.
+
+This is enough for the proxy to:
+  1. classify 200 as ok for the elected account
+  2. classify 429+usage_limit_reached as quota_exhausted
+  3. mark that account in the pool
+  4. on next request, elect a different account (the broker's
+     account/swap semantics)
+  5. proxy_post_swap_turn fires (proxy notices account change,
+     drops x-codex-turn-state)
+  6. that next request lands on the new account at the stub
+  7. stub sees the new account_id, returns 200 (per-account counter)
+
+The harness asserts the NDJSON status frames on stderr from
+`oauth-mux codex run` for the right shape + ordering.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import http.server
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+PORT = int(os.environ.get("OMUX_STUB_PORT", "0"))
+PORTFILE = Path(os.environ.get("OMUX_STUB_PORTFILE", "/tmp/omux-stub-upstream.port"))
+OK_BEFORE_429 = int(os.environ.get("OMUX_STUB_OK_BEFORE_429", "2"))
+LOGFILE = Path(os.environ.get("OMUX_STUB_LOGFILE", "/tmp/omux-stub-upstream.log"))
+
+# OMUX_STUB_429_TYPE chooses what the stub returns once an account
+# crosses OK_BEFORE_429:
+#   "usage_limit_reached" (default) — the swap-eligible quota path
+#   "usage_not_included"           — the plan-tier path; MUST NOT swap
+#   "rate_limited"                 — bare 429 with no error.type body
+ERROR_TYPE = os.environ.get("OMUX_STUB_429_TYPE", "usage_limit_reached")
+
+# OMUX_STUB_ALWAYS_STATUS forces the stub to return this HTTP status
+# on every request, regardless of OK_BEFORE_429 / 429_TYPE. Used by
+# negative-path smokes that need a steady-state 401 / 5xx / etc to
+# verify proxy classification + behavior end-to-end.
+ALWAYS_STATUS = os.environ.get("OMUX_STUB_ALWAYS_STATUS", "")
+
+
+# Per-account request counter. Reset only on process restart.
+ACCOUNT_REQ_COUNT: dict[str, int] = {}
+
+
+def _hash10(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()[:10]
+
+
+def _log(record: dict) -> None:
+    record["ts"] = time.time()
+    with LOGFILE.open("a") as f:
+        f.write(json.dumps(record) + "\n")
+
+
+class StubHandler(http.server.BaseHTTPRequestHandler):
+    # Silence default access logging — we do our own structured logs.
+    def log_message(self, format, *args):  # noqa: A002
+        return
+
+    def _read_body(self) -> bytes:
+        cl = self.headers.get("Content-Length")
+        if cl:
+            return self.rfile.read(int(cl))
+        # Chunked is unlikely from the proxy (proxy decodes to
+        # Content-Length on its way out). Best-effort.
+        te = (self.headers.get("Transfer-Encoding") or "").lower()
+        if "chunked" in te:
+            buf = bytearray()
+            while True:
+                size_line = self.rfile.readline().strip()
+                if not size_line:
+                    break
+                size = int(size_line, 16)
+                if size == 0:
+                    self.rfile.readline()  # final CRLF
+                    break
+                buf += self.rfile.read(size)
+                self.rfile.readline()  # CRLF
+            return bytes(buf)
+        return b""
+
+    def _account_id(self) -> str:
+        return self.headers.get("ChatGPT-Account-ID", "<missing>")
+
+    def _auth_prefix(self) -> str:
+        a = self.headers.get("Authorization", "")
+        parts = a.split(" ", 1)
+        if len(parts) == 2 and parts[0].lower() == "bearer":
+            return parts[1][:6] + ":" + _hash10(parts[1])
+        return _hash10(a) if a else "<missing>"
+
+    def _classify_for_account(self) -> tuple[int, dict]:
+        # OMUX_STUB_ALWAYS_STATUS short-circuits everything: return
+        # this exact status with a minimal JSON body. Counters still
+        # advance so per-account log records remain unique.
+        if ALWAYS_STATUS:
+            try:
+                code = int(ALWAYS_STATUS)
+            except ValueError:
+                code = 500
+            ACCOUNT_REQ_COUNT[self._account_id()] = ACCOUNT_REQ_COUNT.get(self._account_id(), 0) + 1
+            return code, {"detail": f"forced status {code}"}
+
+        acct = self._account_id()
+        n = ACCOUNT_REQ_COUNT.get(acct, 0)
+        ACCOUNT_REQ_COUNT[acct] = n + 1
+        if n < OK_BEFORE_429:
+            # Healthy turn: tiny SSE-shaped body
+            body = (
+                "event: response.created\n"
+                'data: {"type":"response.created","response":{"id":"resp-stub"}}\n\n'
+                "event: response.completed\n"
+                'data: {"type":"response.completed","response":{"id":"resp-stub","output":[]}}\n\n'
+            )
+            return 200, {"_text": body, "_ct": "text/event-stream"}
+        # 429 path. Body shape selected by OMUX_STUB_429_TYPE so the
+        # harness can drive the swap-eligible (usage_limit_reached)
+        # vs non-swap (usage_not_included, rate_limited) paths through
+        # the same fixture surface.
+        if ERROR_TYPE == "usage_not_included":
+            body = {
+                "error": {
+                    "type": "usage_not_included",
+                    "plan_type": "free",
+                },
+            }
+        elif ERROR_TYPE == "rate_limited":
+            body = {"detail": "Too Many Requests"}
+        else:
+            body = {
+                "error": {
+                    "type": "usage_limit_reached",
+                    "plan_type": "pro",
+                    "resets_at": int(time.time()) + 86400,
+                },
+            }
+        return 429, body
+
+    def _serve(self) -> None:
+        path = urlparse(self.path).path
+        if not path.startswith("/backend-api/codex"):
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.send_header("Connection", "close")
+            self.end_headers()
+            return
+
+        body_bytes = self._read_body()
+        _ = body_bytes  # request bodies are unused; we don't echo
+
+        status, body = self._classify_for_account()
+        if "_text" in body:
+            text = body["_text"]
+            payload = text.encode("utf-8")
+            ct = body["_ct"]
+        else:
+            payload = json.dumps(body).encode("utf-8")
+            ct = "application/json"
+
+        self.send_response(status)
+        self.send_header("Content-Type", ct)
+        self.send_header("Content-Length", str(len(payload)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(payload)
+
+        _log({
+            "path": path,
+            "method": self.command,
+            "account_id": self._account_id(),
+            "auth_prefix": self._auth_prefix(),
+            "status_returned": status,
+            "response_classification": "ok" if status == 200 else "quota_exhausted" if status == 429 else "other",
+        })
+
+    def do_POST(self):  # noqa: N802
+        self._serve()
+
+    def do_GET(self):  # noqa: N802
+        self._serve()
+
+
+def main() -> int:
+    LOGFILE.unlink(missing_ok=True)
+    httpd = http.server.HTTPServer(("127.0.0.1", PORT), StubHandler)
+    actual_port = httpd.server_address[1]
+    PORTFILE.write_text(f"{actual_port}\n")
+    print(f"stub-upstream: listening on 127.0.0.1:{actual_port}", file=sys.stderr, flush=True)
+    print(f"stub-upstream: portfile={PORTFILE}", file=sys.stderr, flush=True)
+    print(f"stub-upstream: logfile={LOGFILE}", file=sys.stderr, flush=True)
+    print(f"stub-upstream: ok_before_429={OK_BEFORE_429} per account", file=sys.stderr, flush=True)
+    print(f"stub-upstream: 429_type={ERROR_TYPE}", file=sys.stderr, flush=True)
+    if ALWAYS_STATUS:
+        print(f"stub-upstream: always_status={ALWAYS_STATUS} (overrides classification)", file=sys.stderr, flush=True)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/adapters/codex/app_server_client.zig
+++ b/src/adapters/codex/app_server_client.zig
@@ -1,0 +1,308 @@
+//! JSON-RPC stdio client for `codex app-server --listen stdio://`.
+//!
+//! Anchor: docs/spec/codex-adapter-contract-2026-05-03.md §2.1 + §3.
+//! The Codex adapter spawns the app-server as a child, then talks
+//! line-delimited JSON-RPC 2.0 over stdin/stdout. The app-server
+//! reserves stdout for protocol messages; logs go to stderr.
+//!
+//! Phase 1 scope: spawn, initialize round-trip, account/login/start
+//! with type=chatgptAuthTokens, observe account/login/completed +
+//! account/updated, then close cleanly. Turn driving and
+//! chatgptAuthTokens/refresh handling land in tasks #21 / #25.
+
+const std = @import("std");
+const broker_types = @import("../../broker/types.zig");
+
+/// A spawned `codex app-server` child plus the framing we wrap around
+/// its stdin/stdout. Caller owns the temp `codex_home` directory.
+pub const AppServerClient = struct {
+    allocator: std.mem.Allocator,
+    child: std.process.Child,
+    /// Monotonic counter for outbound request ids. Server-initiated
+    /// requests carry their own ids; we mirror them on response.
+    next_id: u64 = 1,
+    /// Read-side line buffer. Allocates against `allocator`.
+    line_buf: std.ArrayListUnmanaged(u8) = .{},
+    /// Stderr accumulator (stderr is not protocol; we drain to keep
+    /// the pipe from blocking the child).
+    stderr_buf: std.ArrayListUnmanaged(u8) = .{},
+
+    pub const SpawnOptions = struct {
+        /// Path to the codex binary (`codex` by default, overridable
+        /// via OMUX_CODEX_APP_SERVER for dev).
+        codex_bin: ?[]const u8 = null,
+        /// CODEX_HOME directory — typically a per-session tempdir
+        /// containing the materialized auth.json and a config.toml
+        /// pointing at the wire proxy (Phase 2).
+        codex_home: []const u8,
+    };
+
+    pub fn spawn(allocator: std.mem.Allocator, opts: SpawnOptions) !AppServerClient {
+        const default_bin = "codex";
+        const env_bin = std.process.getEnvVarOwned(allocator, "OMUX_CODEX_APP_SERVER") catch null;
+        defer if (env_bin) |b| allocator.free(b);
+        const bin = opts.codex_bin orelse env_bin orelse default_bin;
+
+        var env_map = try std.process.getEnvMap(allocator);
+        errdefer env_map.deinit();
+        try env_map.put("CODEX_HOME", opts.codex_home);
+
+        const argv = [_][]const u8{ bin, "app-server", "--listen", "stdio://" };
+        var child = std.process.Child.init(&argv, allocator);
+        child.stdin_behavior = .Pipe;
+        child.stdout_behavior = .Pipe;
+        child.stderr_behavior = .Pipe;
+        // env_map lives on stack here, so we copy it into a heap-owned
+        // map the child holds for its lifetime via setEnv.
+        // std.process.Child accepts an env_map pointer; we keep it
+        // alive by storing it in the returned struct via a wrapper.
+        // Simpler: pass the map directly; std.process.Child borrows.
+        child.env_map = &env_map;
+
+        try child.spawn();
+
+        // Once spawned, child no longer needs our env_map view, but we
+        // can't deinit it before the child reads it — std.process
+        // copies on the spawn syscall path. Safe to drop here.
+        env_map.deinit();
+
+        return AppServerClient{
+            .allocator = allocator,
+            .child = child,
+        };
+    }
+
+    pub fn deinit(self: *AppServerClient) void {
+        self.line_buf.deinit(self.allocator);
+        self.stderr_buf.deinit(self.allocator);
+        if (self.child.stdin) |s| s.close();
+        self.child.stdin = null;
+        // Caller is expected to .wait() for the child explicitly via
+        // .closeAndWait. deinit just frees buffers.
+    }
+
+    /// Close stdin and wait for the child to exit. Returns the term.
+    pub fn closeAndWait(self: *AppServerClient) !std.process.Child.Term {
+        if (self.child.stdin) |s| {
+            s.close();
+            self.child.stdin = null;
+        }
+        return try self.child.wait();
+    }
+
+    /// Send a JSON-RPC request line. Returns the id used.
+    pub fn sendRequest(
+        self: *AppServerClient,
+        method: []const u8,
+        params_json: []const u8,
+    ) !u64 {
+        const id = self.next_id;
+        self.next_id += 1;
+        const stdin = self.child.stdin orelse return error.StdinClosed;
+
+        var buf = std.ArrayListUnmanaged(u8){};
+        defer buf.deinit(self.allocator);
+        const w = buf.writer(self.allocator);
+        try w.writeAll("{\"jsonrpc\":\"2.0\",\"id\":");
+        try std.fmt.formatInt(id, 10, .lower, .{}, w);
+        try w.writeAll(",\"method\":");
+        try std.json.stringify(method, .{}, w);
+        try w.writeAll(",\"params\":");
+        try w.writeAll(params_json);
+        try w.writeAll("}\n");
+        try stdin.writeAll(buf.items);
+        return id;
+    }
+
+    /// Send a JSON-RPC response line for a server-initiated request.
+    pub fn sendResponse(
+        self: *AppServerClient,
+        id: std.json.Value,
+        result_json: []const u8,
+    ) !void {
+        const stdin = self.child.stdin orelse return error.StdinClosed;
+        var buf = std.ArrayListUnmanaged(u8){};
+        defer buf.deinit(self.allocator);
+        const w = buf.writer(self.allocator);
+        try w.writeAll("{\"jsonrpc\":\"2.0\",\"id\":");
+        try std.json.stringify(id, .{}, w);
+        try w.writeAll(",\"result\":");
+        try w.writeAll(result_json);
+        try w.writeAll("}\n");
+        try stdin.writeAll(buf.items);
+    }
+
+    /// Read the next JSON-RPC frame from stdout. Returns the parsed
+    /// JSON value (caller owns the std.json.Parsed wrapper). Drains
+    /// stderr opportunistically into self.stderr_buf so the child's
+    /// pipe doesn't fill.
+    ///
+    /// `timeout_ms` bounds the blocking poll. Returns
+    /// error.Timeout if the deadline passes before a complete line.
+    pub fn recvFrame(
+        self: *AppServerClient,
+        timeout_ms: u64,
+    ) !std.json.Parsed(std.json.Value) {
+        var poller = std.io.poll(self.allocator, enum { stdout, stderr }, .{
+            .stdout = self.child.stdout.?,
+            .stderr = self.child.stderr.?,
+        });
+        defer poller.deinit();
+
+        const deadline_ns = std.time.nanoTimestamp() + @as(i128, @intCast(timeout_ms)) * std.time.ns_per_ms;
+
+        while (true) {
+            // Drain whatever is buffered into our line/stderr buffers.
+            try drainFifoInto(self.allocator, &self.line_buf, poller.fifo(.stdout));
+            try drainFifoInto(self.allocator, &self.stderr_buf, poller.fifo(.stderr));
+
+            // Look for a complete line in line_buf.
+            if (std.mem.indexOfScalar(u8, self.line_buf.items, '\n')) |nl| {
+                const line = self.line_buf.items[0..nl];
+                if (line.len == 0) {
+                    // Skip empty line and keep going.
+                    _ = try self.consumeLine(nl + 1);
+                    continue;
+                }
+                const parsed = try std.json.parseFromSlice(std.json.Value, self.allocator, line, .{});
+                _ = try self.consumeLine(nl + 1);
+                return parsed;
+            }
+
+            const now = std.time.nanoTimestamp();
+            if (now >= deadline_ns) return error.Timeout;
+            const remaining_ns = deadline_ns - now;
+            const poll_ns: u64 = @intCast(@min(remaining_ns, @as(i128, 50 * std.time.ns_per_ms)));
+            const keep_going = try poller.pollTimeout(poll_ns);
+            if (!keep_going and self.line_buf.items.len == 0) return error.ChildClosed;
+        }
+    }
+
+    fn consumeLine(self: *AppServerClient, end: usize) !void {
+        const remaining = self.line_buf.items[end..];
+        std.mem.copyForwards(u8, self.line_buf.items[0..remaining.len], remaining);
+        self.line_buf.shrinkRetainingCapacity(remaining.len);
+    }
+};
+
+fn drainFifoInto(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    fifo: anytype,
+) !void {
+    const len = fifo.readableLength();
+    if (len == 0) return;
+    try out.ensureUnusedCapacity(allocator, len);
+    const slice = fifo.readableSlice(0);
+    out.appendSliceAssumeCapacity(slice);
+    fifo.discard(len);
+}
+
+/// Write the params for the `initialize` request. The codex
+/// app-server's chatgptAuthTokens login mode requires
+/// `capabilities.experimentalApi: true` (per the inplace-broker proof
+/// spec §"Local stdio protocol smoke on 2026-05-02").
+pub fn writeInitializeParams(writer: anytype) !void {
+    try writer.writeAll(
+        \\{"capabilities":{"experimentalApi":true},"clientInfo":{"name":"oauth-mux","version":"0.2.0"}}
+    );
+}
+
+/// Write the params for `account/login/start` with
+/// `type:"chatgptAuthTokens"`. The shape mirrors the codex schema at
+/// app-server-protocol/schema/json/AccountLoginStartParams.json.
+pub fn writeLoginStartParams(
+    writer: anytype,
+    tokens: broker_types.ChatgptAuthTokens,
+) !void {
+    try writer.writeAll("{\"loginType\":{\"type\":\"chatgptAuthTokens\",\"tokens\":{");
+    try writer.writeAll("\"accessToken\":");
+    try std.json.stringify(tokens.access_token, .{}, writer);
+    try writer.writeAll(",\"chatgptAccountId\":");
+    try std.json.stringify(tokens.account_id, .{}, writer);
+    if (tokens.plan_type) |pt| {
+        try writer.writeAll(",\"chatgptPlanType\":");
+        try std.json.stringify(pt, .{}, writer);
+    }
+    try writer.writeAll("}}}");
+}
+
+/// Decide whether a parsed JSON-RPC frame is a notification with the
+/// given method name (no `id` field, `method` matches).
+pub fn frameIsNotification(frame: std.json.Value, method: []const u8) bool {
+    if (frame != .object) return false;
+    if (frame.object.contains("id")) return false;
+    const m = frame.object.get("method") orelse return false;
+    return m == .string and std.mem.eql(u8, m.string, method);
+}
+
+/// Decide whether a parsed JSON-RPC frame is the response to a request
+/// with the given id (success or error).
+pub fn frameIsResponseTo(frame: std.json.Value, id: u64) bool {
+    if (frame != .object) return false;
+    const id_v = frame.object.get("id") orelse return false;
+    if (id_v != .integer) return false;
+    return @as(u64, @intCast(id_v.integer)) == id;
+}
+
+test "writeInitializeParams shape" {
+    var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(std.testing.allocator);
+    try writeInitializeParams(buf.writer(std.testing.allocator));
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, buf.items, .{});
+    defer parsed.deinit();
+    const caps = parsed.value.object.get("capabilities").?;
+    const exp = caps.object.get("experimentalApi").?;
+    try std.testing.expect(exp.bool);
+}
+
+test "frameIsNotification matches method, rejects requests with id" {
+    var parsed_n = try std.json.parseFromSlice(std.json.Value, std.testing.allocator,
+        \\{"jsonrpc":"2.0","method":"account/updated","params":{"x":1}}
+    , .{});
+    defer parsed_n.deinit();
+    try std.testing.expect(frameIsNotification(parsed_n.value, "account/updated"));
+    try std.testing.expect(!frameIsNotification(parsed_n.value, "other/method"));
+
+    var parsed_r = try std.json.parseFromSlice(std.json.Value, std.testing.allocator,
+        \\{"jsonrpc":"2.0","id":42,"method":"account/updated"}
+    , .{});
+    defer parsed_r.deinit();
+    try std.testing.expect(!frameIsNotification(parsed_r.value, "account/updated"));
+}
+
+test "frameIsResponseTo matches integer id, rejects mismatched id" {
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator,
+        \\{"jsonrpc":"2.0","id":7,"result":{}}
+    , .{});
+    defer parsed.deinit();
+    try std.testing.expect(frameIsResponseTo(parsed.value, 7));
+    try std.testing.expect(!frameIsResponseTo(parsed.value, 8));
+
+    var no_id = try std.json.parseFromSlice(std.json.Value, std.testing.allocator,
+        \\{"jsonrpc":"2.0","method":"x"}
+    , .{});
+    defer no_id.deinit();
+    try std.testing.expect(!frameIsResponseTo(no_id.value, 7));
+}
+
+test "writeLoginStartParams round-trip" {
+    var buf = std.ArrayListUnmanaged(u8){};
+    defer buf.deinit(std.testing.allocator);
+    try writeLoginStartParams(buf.writer(std.testing.allocator), .{
+        .access_token = "AT-1",
+        .account_id = "acc-1",
+        .plan_type = "pro",
+        .fedramp = false,
+    });
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, buf.items, .{});
+    defer parsed.deinit();
+    const lt = parsed.value.object.get("loginType").?;
+    try std.testing.expectEqualStrings("chatgptAuthTokens", lt.object.get("type").?.string);
+    const tokens = lt.object.get("tokens").?;
+    try std.testing.expectEqualStrings("AT-1", tokens.object.get("accessToken").?.string);
+    try std.testing.expectEqualStrings("acc-1", tokens.object.get("chatgptAccountId").?.string);
+    try std.testing.expectEqualStrings("pro", tokens.object.get("chatgptPlanType").?.string);
+}

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -1,0 +1,284 @@
+//! Codex adapter — `oauth-mux codex run`.
+//!
+//! Anchor: docs/spec/codex-adapter-contract-2026-05-03.md.
+//!
+//! Skeleton model: child-owned codex session. This gives
+//! users the unmodified codex TUI/exec experience — we don't render a
+//! TUI, don't drive JSON-RPC, don't spawn `codex app-server`. We:
+//!   1. broker.populatePool from the active oauth-mux Config (profile
+//!      filtered).
+//!   2. account/select to pick a credited account.
+//!   3. Find that account's per-account CODEX_HOME (already managed by
+//!      oauth-mux at enroll time).
+//!   4. spawn `codex` with CODEX_HOME pointed at that directory.
+//!      The user sees real codex while oauth-mux keeps owning the
+//!      proxy/broker boundary.
+//!
+//! The adapter writes a generated config.toml that points Codex at a
+//! localhost wire proxy owned by oauth-mux. The parent process stays
+//! alive to broker HTTP traffic and account selection while the Codex
+//! child keeps the same process id.
+//!
+//! The JSON-RPC IDE-role client in app_server_client.zig stays for
+//! future broker-mediated automation (the broker-* surfaces, scripted
+//! use, Phase 4 demolition follow-ups). It is not on the
+//! `oauth-mux codex run` default path.
+
+const std = @import("std");
+const broker = @import("../../broker/mod.zig");
+const broker_types = @import("../../broker/types.zig");
+const broker_loader = @import("../../broker_loader.zig");
+const config_mod = @import("../../config.zig");
+const shell = @import("../../shell.zig");
+const wire_proxy = @import("wire_proxy.zig");
+
+pub const RunOptions = struct {
+    profile: ?[]const u8 = null,
+    account: ?[]const u8 = null,
+    /// If true, emit NDJSON status frames to stderr.
+    json_status: bool = false,
+    /// Args after `--` to forward to codex unchanged.
+    forward_argv: []const []const u8 = &.{},
+};
+
+pub const RunError = error{
+    NoConfig,
+    PoolPopulateFailed,
+    NoAccountSelectable,
+    NoCodexHome,
+};
+
+/// Resolve the per-account CODEX_HOME directory. Order:
+///   1. AccountConfig.config_dir if set.
+///   2. dirname(secret.path) when secret.backend == "file" (the
+///      common case: oauth-mux's enrollment placed auth.json inside
+///      a per-account directory we can use as CODEX_HOME directly).
+fn resolveCodexHome(
+    allocator: std.mem.Allocator,
+    cfg: config_mod.Config,
+    account_id: []const u8,
+) !?[]u8 {
+    const colon = std.mem.indexOfScalar(u8, account_id, ':') orelse return null;
+    const provider = account_id[0..colon];
+    const account = account_id[colon + 1 ..];
+
+    const provider_cfg = cfg.providers.map.get(provider) orelse return null;
+    const acct_cfg = provider_cfg.accounts.map.get(account) orelse return null;
+
+    if (acct_cfg.config_dir) |cd| {
+        return try expandTilde(allocator, cd);
+    }
+    if (std.mem.eql(u8, acct_cfg.secret.backend, "file")) {
+        const path = acct_cfg.secret.path orelse return null;
+        const expanded = try expandTilde(allocator, path);
+        defer allocator.free(expanded);
+        const dir = std.fs.path.dirname(expanded) orelse return null;
+        return try allocator.dupe(u8, dir);
+    }
+    return null;
+}
+
+fn expandTilde(allocator: std.mem.Allocator, p: []const u8) ![]u8 {
+    if (!std.mem.startsWith(u8, p, "~/")) return try allocator.dupe(u8, p);
+    const home = try std.process.getEnvVarOwned(allocator, "HOME");
+    defer allocator.free(home);
+    return try std.fmt.allocPrint(allocator, "{s}{s}", .{ home, p[1..] });
+}
+
+pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
+    const stderr = std.io.getStdErr().writer();
+
+    // 1. Load oauth-mux config + populate broker pool.
+    const parsed = config_mod.load(allocator) catch |e| {
+        try stderr.print("oauth-mux codex: config load: {s}\n", .{@errorName(e)});
+        return RunError.NoConfig;
+    };
+    defer parsed.deinit();
+
+    var server = broker.Server.init(allocator);
+    defer server.deinit();
+    broker_loader.populatePool(&server.pool, parsed.value, opts.profile) catch {
+        return RunError.PoolPopulateFailed;
+    };
+
+    // 2. Elect an account (honoring --account pin if set).
+    const elected = if (opts.account) |pin| pin: {
+        for (server.pool.accounts.items) |a| {
+            if (std.mem.eql(u8, a.id, pin)) break :pin a;
+        }
+        try stderr.print("oauth-mux codex: --account {s} not in profile\n", .{pin});
+        return RunError.NoAccountSelectable;
+    } else server.pool.elect(opts.profile, null, &.{}) catch |e| switch (e) {
+        broker_types.BrokerError.NoAccountSelectable => {
+            try stderr.writeAll("oauth-mux codex: no selectable account in profile\n");
+            return RunError.NoAccountSelectable;
+        },
+        else => return e,
+    };
+
+    // 3. Resolve the per-account CODEX_HOME.
+    const codex_home = (try resolveCodexHome(allocator, parsed.value, elected.id)) orelse {
+        try stderr.print(
+            "oauth-mux codex: cannot resolve CODEX_HOME for {s}; account needs config_dir or file secret\n",
+            .{elected.id},
+        );
+        return RunError.NoCodexHome;
+    };
+    defer allocator.free(codex_home);
+
+    // 4. Bind the wire-layer reverse proxy. The adapter stays alive
+    // as the broker/proxy owner while the codex child runs with
+    // inherited stdio. This is not a restart fallback; the same child
+    // process makes the synthetic post-swap request in the smoke.
+    var mat_ctx = broker_loader.ChatgptMaterializerCtx{ .cfg = &parsed.value };
+    var proxy = wire_proxy.Proxy.bind(
+        allocator,
+        &server.pool,
+        mat_ctx.vtable(),
+        stderr.any(),
+    ) catch |e| {
+        try stderr.print("oauth-mux codex: proxy bind: {s}\n", .{@errorName(e)});
+        return e;
+    };
+    defer proxy.deinit();
+    proxy.profile = opts.profile;
+    const proxy_port = proxy.port();
+
+    // 5. Write a managed config.toml in the per-account CODEX_HOME
+    // pointing model_providers.openai at the local proxy.
+    try writeManagedConfigToml(allocator, codex_home, proxy_port);
+
+    if (opts.json_status) {
+        try stderr.print(
+            "{{\"kind\":\"session_started\",\"adapter\":\"codex\",\"selected_account\":\"{s}\",\"codex_home_path_printed\":false,\"proxy_port\":{d},\"claim_level\":\"broker_owned\"}}\n",
+            .{ elected.id, proxy_port },
+        );
+    }
+
+    // 6. Build argv: `codex` plus any forwarded user args.
+    const codex_bin = std.process.getEnvVarOwned(allocator, "OMUX_CODEX_BIN") catch
+        try allocator.dupe(u8, "codex");
+    defer allocator.free(codex_bin);
+
+    var argv = std.ArrayListUnmanaged([]const u8){};
+    defer argv.deinit(allocator);
+    try argv.append(allocator, codex_bin);
+    for (opts.forward_argv) |a| try argv.append(allocator, a);
+
+    // 7. Build env: copy current, set CODEX_HOME and OMUX_ACTIVE_*.
+    var env_map = try std.process.getEnvMap(allocator);
+    defer env_map.deinit();
+    try env_map.put("CODEX_HOME", codex_home);
+    try env_map.put("OMUX_ACTIVE_PROVIDER", "codex");
+    const account_only = elected.id[std.mem.indexOfScalar(u8, elected.id, ':').? + 1 ..];
+    try env_map.put("OMUX_ACTIVE_ACCOUNT", account_only);
+    if (opts.profile) |p| try env_map.put("OMUX_ACTIVE_PROFILE", p);
+
+    // 8. Spawn codex as child with inherited stdio (so the user gets
+    // the real codex TUI). The adapter stays alive in parent.
+    var child = std.process.Child.init(argv.items, allocator);
+    child.stdin_behavior = .Inherit;
+    child.stdout_behavior = .Inherit;
+    child.stderr_behavior = .Inherit;
+    child.env_map = &env_map;
+    child.spawn() catch |e| {
+        try stderr.print("oauth-mux codex: spawn: {s}\n", .{@errorName(e)});
+        return e;
+    };
+
+    // 9. Start the proxy thread. It loops on serveOne until the
+    // shutdown flag is set after the child exits.
+    var shutdown = std.atomic.Value(bool).init(false);
+    const proxy_thread = try std.Thread.spawn(
+        .{},
+        proxyThreadMain,
+        .{ &proxy, &shutdown },
+    );
+
+    // 10. Wait for codex to exit; signal proxy to stop.
+    const term = child.wait() catch |e| {
+        try stderr.print("oauth-mux codex: child wait: {s}\n", .{@errorName(e)});
+        shutdown.store(true, .release);
+        proxy_thread.join();
+        return e;
+    };
+
+    shutdown.store(true, .release);
+    // Tickle the proxy thread out of accept() by connecting once.
+    tickleProxy(proxy_port);
+    proxy_thread.join();
+
+    if (opts.json_status) {
+        const exit_code: i32 = switch (term) {
+            .Exited => |c| c,
+            else => -1,
+        };
+        try stderr.print(
+            "{{\"kind\":\"session_ended\",\"adapter\":\"codex\",\"exit_code\":{d},\"final_claim_level\":\"{s}\",\"synthetic_swap_observed\":{any}}}\n",
+            .{ exit_code, proxy.peakClaimLevel().toString(), proxy.syntheticSwapSeen() },
+        );
+    }
+
+    // Propagate exit code.
+    switch (term) {
+        .Exited => |c| if (c != 0) std.process.exit(c),
+        else => std.process.exit(1),
+    }
+}
+
+fn proxyThreadMain(p: *wire_proxy.Proxy, shutdown: *std.atomic.Value(bool)) void {
+    while (!shutdown.load(.acquire)) {
+        p.serveOne() catch |e| {
+            // Server error or accept failure; if shutting down, exit.
+            if (shutdown.load(.acquire)) return;
+            std.debug.print("proxy: serveOne: {s}\n", .{@errorName(e)});
+            // Continue serving; transient errors should not kill the
+            // proxy mid-session.
+        };
+    }
+}
+
+/// Open a TCP connection to the proxy and immediately close it. This
+/// wakes the proxy thread out of a blocking accept() during shutdown.
+fn tickleProxy(port: u16) void {
+    const addr = std.net.Address.parseIp("127.0.0.1", port) catch return;
+    const sock = std.net.tcpConnectToAddress(addr) catch return;
+    sock.close();
+}
+
+fn writeManagedConfigToml(
+    allocator: std.mem.Allocator,
+    codex_home: []const u8,
+    proxy_port: u16,
+) !void {
+    const path = try std.fmt.allocPrint(allocator, "{s}/config.toml", .{codex_home});
+    defer allocator.free(path);
+
+    var contents = std.ArrayListUnmanaged(u8){};
+    defer contents.deinit(allocator);
+    const w = contents.writer(allocator);
+    try w.writeAll("# Managed by oauth-mux. Phase 2 wire proxy override.\n");
+    try w.writeAll("# Anchor: docs/spec/codex-adapter-contract-2026-05-03.md §4\n\n");
+    try w.print("[model_providers.openai]\n", .{});
+    try w.print("name = \"openai\"\n", .{});
+    try w.print("base_url = \"http://127.0.0.1:{d}/backend-api/codex\"\n", .{proxy_port});
+    try w.writeAll("wire_api = \"responses\"\n");
+    try w.writeAll("requires_openai_auth = true\n");
+
+    const f = try std.fs.cwd().createFile(path, .{ .mode = 0o600, .truncate = true });
+    defer f.close();
+    try f.writeAll(contents.items);
+}
+
+test "RunOptions defaults" {
+    const opts = RunOptions{};
+    try std.testing.expect(opts.profile == null);
+    try std.testing.expect(!opts.json_status);
+    try std.testing.expectEqual(@as(usize, 0), opts.forward_argv.len);
+}
+
+test "expandTilde no-op when no tilde" {
+    const a = try expandTilde(std.testing.allocator, "/no/tilde/here");
+    defer std.testing.allocator.free(a);
+    try std.testing.expectEqualStrings("/no/tilde/here", a);
+}

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -1,0 +1,948 @@
+//! Localhost HTTP/1.1 reverse proxy for Codex's
+//! `/backend-api/codex/...` endpoints.
+//!
+//! Anchor: docs/spec/codex-adapter-contract-2026-05-03.md §4 (Wire-Layer
+//! Proxy Spec) + §3 (401-vs-429 Handling Matrix).
+//!
+//! The proxy is the load-bearing piece that lets account swap happen
+//! without restarting the unmodified `codex` child process. It sits at
+//! 127.0.0.1:<dynamic-port> with codex's `[model_providers.openai].base_url`
+//! pointed at it (via a generated config.toml in the per-session
+//! CODEX_HOME). On every request:
+//!
+//!   1. Read the inbound request from codex.
+//!   2. Substitute the three account-bound headers (Authorization,
+//!      ChatGPT-Account-ID, X-OpenAI-Fedramp) with the broker's
+//!      currently-elected account's values.
+//!   3. Forward all other headers UNCHANGED — including the eight
+//!      load-bearing ones from §4.2 (User-Agent, originator,
+//!      x-codex-installation-id, x-codex-turn-state,
+//!      x-codex-turn-metadata, OpenAI-Beta, traceparent, tracestate).
+//!   4. Send to chatgpt.com over TLS.
+//!   5. Classify the response (200 / 401 / 429+usage_limit_reached /
+//!      429+usage_not_included / other-429 / 5xx).
+//!   6. Report quota/observe to the broker pool. On
+//!      quota_exhausted, mark the current account exhausted —
+//!      the NEXT request from codex will go to a fresh account
+//!      (synthetic between-turn swap evidence in this slice).
+//!   7. Stream the response body verbatim back to codex (SSE works
+//!      because chunked-transfer is forwarded byte-for-byte).
+//!
+//! Phase 2 scope (honestly labelled limitations):
+//!   - Synchronous, single-connection-at-a-time (codex sends one
+//!     request per turn). No request pipelining.
+//!   - **Streaming for 200/3xx/401/5xx; buffered for 429.** SSE turns
+//!     stream byte-for-byte from upstream to codex via Connection:close
+//!     framing — the TUI animation moves in real time. 429 responses
+//!     are small JSON and need the body for classification, so they
+//!     stay buffered (with a 64 KiB cap). Phase 2.1 added this.
+//!   - No WebSocket upgrade support; if codex requests a WS upgrade
+//!     we propagate the upstream's response (which on `chatgpt.com`
+//!     is HTTP 426 / falls back to chunked). Phase 2.2 adds WS.
+//!   - Path (a) silent in-flight swap is intentionally NOT done
+//!     (likely blocked by per-sub server-side thread state — see
+//!     codex-adapter-contract §3 reality-check decision). Between-turn
+//!     swap with x-codex-turn-state dropped on the post-swap turn
+//!     IS done; in synthetic tests this demonstrates the structural
+//!     next-turn swap path without making a live provider claim.
+
+const std = @import("std");
+const broker_types = @import("../../broker/types.zig");
+const account_pool_mod = @import("../../broker/account_pool.zig");
+
+const DEFAULT_UPSTREAM_HOST = "chatgpt.com";
+const DEFAULT_UPSTREAM_SCHEME = "https";
+const UPSTREAM_BASE_PATH = "/backend-api/codex";
+
+/// Resolve the upstream host. `OMUX_UPSTREAM_HOST` overrides for
+/// in-session integration tests (the smoke harness binds a stub
+/// upstream on 127.0.0.1:<port> and points the proxy at it).
+/// Production: falls back to chatgpt.com.
+fn upstreamHost(allocator: std.mem.Allocator) []const u8 {
+    if (std.process.getEnvVarOwned(allocator, "OMUX_UPSTREAM_HOST")) |v| {
+        return v;
+    } else |_| {
+        return allocator.dupe(u8, DEFAULT_UPSTREAM_HOST) catch DEFAULT_UPSTREAM_HOST;
+    }
+}
+
+fn upstreamScheme(allocator: std.mem.Allocator) []const u8 {
+    if (std.process.getEnvVarOwned(allocator, "OMUX_UPSTREAM_SCHEME")) |v| {
+        return v;
+    } else |_| {
+        return allocator.dupe(u8, DEFAULT_UPSTREAM_SCHEME) catch DEFAULT_UPSTREAM_SCHEME;
+    }
+}
+
+pub const Proxy = struct {
+    allocator: std.mem.Allocator,
+    server: std.net.Server,
+    addr: std.net.Address,
+
+    /// Borrowed reference to the broker's account pool. The proxy
+    /// elects/marks against this pool directly rather than over MCP
+    /// because the embedded broker is in-process for `oauth-mux codex run`.
+    /// In a daemon-attached topology (post-Phase 5) this would become
+    /// MCP calls.
+    pool: *account_pool_mod.AccountPool,
+
+    /// Borrowed materializer used to resolve `provider:account` ->
+    /// chatgpt_auth_tokens tuple per request. Owned by the adapter.
+    materializer: broker_types.CredentialMaterializer,
+
+    /// Restrict materialization (and election) to this profile name's
+    /// allow-list. Owned by the adapter for the proxy lifetime.
+    profile: ?[]const u8 = null,
+
+    /// stderr writer for redacted diagnostic logs. Never carries token
+    /// material; emits NDJSON status frames the adapter can correlate.
+    log_writer: std.io.AnyWriter,
+
+    /// The account we signed the previous request with, if any. Used
+    /// to detect account changes between turns. On the very NEXT
+    /// request after the elected account changes, the proxy drops the
+    /// `x-codex-turn-state` sticky-routing token from the outbound
+    /// headers — that token binds a conversation thread to the prior
+    /// account's `sub` server-side (per issue openai/codex#16894), and
+    /// carrying it across a swap surfaces "previous account's usage
+    /// limit" warnings even though the new account had room.
+    /// Owned by self.allocator.
+    previous_account: ?[]const u8 = null,
+
+    /// The strongest claim level this skeleton is allowed to publish.
+    /// TIN-948 is synthetic structural evidence only, so the adapter
+    /// stays at `.broker_owned`. Live provider-originated acceptance
+    /// can promote this in a later slice.
+    peak_claim: broker_types.ClaimLevel = .broker_owned,
+
+    /// True once the proxy observed an account change inside one
+    /// adapter-owned child process. This is useful synthetic evidence,
+    /// but is deliberately separate from the live claim ladder.
+    synthetic_swap_seen: bool = false,
+
+    pub fn bind(
+        allocator: std.mem.Allocator,
+        pool: *account_pool_mod.AccountPool,
+        materializer: broker_types.CredentialMaterializer,
+        log_writer: std.io.AnyWriter,
+    ) !Proxy {
+        const loopback = try std.net.Address.parseIp("127.0.0.1", 0);
+        var server = try loopback.listen(.{ .reuse_address = true });
+        errdefer server.deinit();
+        const bound = server.listen_address;
+        return Proxy{
+            .allocator = allocator,
+            .server = server,
+            .addr = bound,
+            .pool = pool,
+            .materializer = materializer,
+            .log_writer = log_writer,
+        };
+    }
+
+    pub fn deinit(self: *Proxy) void {
+        self.server.deinit();
+        if (self.previous_account) |a| self.allocator.free(a);
+        self.previous_account = null;
+    }
+
+    pub fn port(self: *const Proxy) u16 {
+        return self.addr.getPort();
+    }
+
+    /// Returns the highest claim level any turn through this proxy
+    /// has actually achieved. Adapter reads this at session_ended.
+    pub fn peakClaimLevel(self: *const Proxy) broker_types.ClaimLevel {
+        return self.peak_claim;
+    }
+
+    pub fn syntheticSwapSeen(self: *const Proxy) bool {
+        return self.synthetic_swap_seen;
+    }
+
+    /// Accept one connection, handle one HTTP/1.1 transaction, close.
+    /// Returns when the transaction is complete (or fails). Caller
+    /// invokes this in a loop while the codex child is alive.
+    pub fn serveOne(self: *Proxy) !void {
+        var conn = try self.server.accept();
+        defer conn.stream.close();
+        try self.handleConnection(conn);
+    }
+
+    fn handleConnection(self: *Proxy, conn: std.net.Server.Connection) !void {
+        const reader = conn.stream.reader();
+        const writer = conn.stream.writer();
+
+        var arena = std.heap.ArenaAllocator.init(self.allocator);
+        defer arena.deinit();
+        const a = arena.allocator();
+
+        // ── 1. Parse inbound request ────────────────────────────
+        const req = parseRequest(a, reader) catch |err| {
+            // EndOfStream on accept is the shutdown tickle from the
+            // adapter — silently bail without writing a response.
+            if (err == error.EndOfStream) return;
+            self.logEvent("proxy_request_parse_error", .{ .err = @errorName(err) });
+            try writeStatus(writer, 400, "Bad Request");
+            return;
+        };
+
+        // ── 2. Elect an account ─────────────────────────────────
+        const elected = self.pool.elect(self.profile, null, &.{}) catch {
+            self.logEvent("proxy_no_account_selectable", .{});
+            try writeStatus(writer, 503, "No Account Selectable");
+            return;
+        };
+
+        var tokens = self.materializer.materialize_chatgpt(
+            self.materializer.ctx,
+            a,
+            elected.id,
+        ) catch |err| {
+            self.logEvent("proxy_materialize_failed", .{ .account = elected.id, .err = @errorName(err) });
+            try writeStatus(writer, 500, "Materialize Failed");
+            return;
+        };
+        // tokens lives in arena `a`; deinit-on-arena-drop.
+        _ = &tokens;
+
+        // ── 3. Build outbound request with substituted headers ──
+        var out_headers = HeaderList.init(a);
+        try copyForwardingHeaders(&req.headers, &out_headers);
+        try out_headers.set("Authorization", try std.fmt.allocPrint(a, "Bearer {s}", .{tokens.access_token}));
+        try out_headers.set("ChatGPT-Account-ID", tokens.account_id);
+        if (tokens.fedramp) {
+            try out_headers.set("X-OpenAI-Fedramp", "true");
+        }
+        const host_for_header = upstreamHost(a);
+        try out_headers.set("Host", host_for_header);
+
+        // Detect account change since the previous request. If this is
+        // a post-swap turn, drop x-codex-turn-state — the token is the
+        // server-side sticky-routing handle for the prior account's
+        // conversation thread; carrying it across a swap is the most
+        // likely way to break the post-swap turn (issue
+        // openai/codex#16894). Dropping it forces a fresh thread on
+        // the new account, which is the explicit Phase 2 default
+        // (synthetic next-turn swap structure, NOT Level 5 thread continuity).
+        const account_changed = if (self.previous_account) |prev|
+            !std.mem.eql(u8, prev, elected.id)
+        else
+            false;
+        if (account_changed) {
+            out_headers.remove("x-codex-turn-state");
+            self.logEvent("proxy_post_swap_turn", .{
+                .from = self.previous_account.?,
+                .to = elected.id,
+                .dropped = "x-codex-turn-state",
+            });
+            self.synthetic_swap_seen = true;
+        }
+        // Inbound body length is preserved; chunked → chunked, fixed →
+        // fixed. We don't transform the body.
+
+        // ── 4. Forward to upstream + stream/buffer response ────
+        const status_and_class = forwardAndStream(a, req, out_headers, writer) catch |err| {
+            self.logEvent("proxy_upstream_failed", .{ .account = elected.id, .err = @errorName(err) });
+            try writeStatus(writer, 502, "Upstream Error");
+            return;
+        };
+
+        // ── 5. Apply classification + log ──────────────────────
+        self.applyClassification(elected.id, status_and_class.classification) catch |err| {
+            self.logEvent("proxy_apply_classification_failed", .{ .err = @errorName(err) });
+        };
+        self.logEvent("proxy_turn", .{
+            .account = elected.id,
+            .status = status_and_class.status,
+            .classification = @tagName(status_and_class.classification.kind),
+            .claim_level = self.peak_claim.toString(),
+            .streamed = status_and_class.streamed,
+        });
+
+        // Track previous_account for next-request swap detection.
+        if (self.previous_account) |old| self.allocator.free(old);
+        self.previous_account = self.allocator.dupe(u8, elected.id) catch null;
+    }
+
+    fn applyClassification(
+        self: *Proxy,
+        account_id: []const u8,
+        c: Classification,
+    ) !void {
+        const now_unix = std.time.timestamp();
+        switch (c.kind) {
+            .ok => self.pool.refreshTimeBased(now_unix),
+            .quota_exhausted => {
+                const until = c.resets_at orelse (now_unix + 7 * 24 * 60 * 60);
+                try self.pool.markQuotaExhausted(account_id, until);
+            },
+            .rate_limited => {
+                const until = c.resets_at orelse (now_unix + 60);
+                try self.pool.markRateLimited(account_id, until);
+            },
+            .auth_unauthorized => {
+                // DO NOT mark the account dead on a first 401.
+                //
+                // In the adapter-owned child topology, the 401 is
+                // propagated to codex (writeStreamedResponse forwards
+                // the upstream status verbatim). Codex's AuthManager
+                // then runs UnauthorizedRecovery::Reload →
+                // UnauthorizedRecovery::RefreshToken which:
+                //   1. POSTs to https://auth.openai.com/oauth/token
+                //      with the account's refresh_token to mint a
+                //      fresh access_token.
+                //   2. persist_tokens writes the new tokens back to
+                //      auth.json on disk.
+                //   3. Codex retries the original request.
+                //
+                // The proxy's NEXT materialize call re-reads
+                // auth.json and picks up the fresh access_token —
+                // so the retried request succeeds without oauth-mux
+                // doing any refresh work itself.
+                //
+                // Marking the account dead here would defeat that
+                // recovery loop by removing the account from the
+                // pool before codex got a chance to refresh.
+                //
+                // True credential death (revoked refresh token,
+                // account deleted) surfaces inside codex via
+                // classify_refresh_token_failure → the user sees
+                // the standard codex re-login prompt; oauth-mux
+                // doesn't need to second-guess that.
+                self.logEvent("proxy_observed_401_codex_handles", .{
+                    .account = account_id,
+                });
+            },
+            .tier_insufficient, .provider_5xx => {
+                // Recorded for telemetry only; no pool mutation.
+            },
+        }
+    }
+
+    fn logEvent(self: *Proxy, kind: []const u8, fields: anytype) void {
+        // Minimal NDJSON log frame; never includes token material.
+        var buf = std.ArrayListUnmanaged(u8){};
+        defer buf.deinit(self.allocator);
+        const w = buf.writer(self.allocator);
+        w.writeAll("{\"kind\":\"") catch return;
+        w.writeAll(kind) catch return;
+        w.writeAll("\"") catch return;
+
+        // Emit any fields the call site provided. Compile-time
+        // reflection over the anytype struct.
+        const T = @TypeOf(fields);
+        const info = @typeInfo(T);
+        if (info == .@"struct") {
+            inline for (info.@"struct".fields) |f| {
+                w.writeAll(",\"") catch return;
+                w.writeAll(f.name) catch return;
+                w.writeAll("\":") catch return;
+                const value = @field(fields, f.name);
+                std.json.stringify(value, .{}, w) catch return;
+            }
+        }
+        w.writeAll("}\n") catch return;
+        self.log_writer.writeAll(buf.items) catch {};
+    }
+};
+
+// ── Request parsing ──────────────────────────────────────────────────
+
+const Request = struct {
+    method: []const u8,
+    path: []const u8,
+    headers: HeaderList,
+    body: []const u8,
+};
+
+const HeaderList = struct {
+    allocator: std.mem.Allocator,
+    items: std.ArrayListUnmanaged(struct { name: []const u8, value: []const u8 }) = .{},
+
+    fn init(a: std.mem.Allocator) HeaderList {
+        return .{ .allocator = a };
+    }
+
+    fn append(self: *HeaderList, name: []const u8, value: []const u8) !void {
+        try self.items.append(self.allocator, .{ .name = name, .value = value });
+    }
+
+    /// Replace any prior value(s) of `name` with `value` (case-insensitive).
+    fn set(self: *HeaderList, name: []const u8, value: []const u8) !void {
+        var i: usize = 0;
+        while (i < self.items.items.len) {
+            if (asciiEqlIgnoreCase(self.items.items[i].name, name)) {
+                _ = self.items.swapRemove(i);
+            } else {
+                i += 1;
+            }
+        }
+        try self.append(name, value);
+    }
+
+    fn find(self: *const HeaderList, name: []const u8) ?[]const u8 {
+        for (self.items.items) |h| {
+            if (asciiEqlIgnoreCase(h.name, name)) return h.value;
+        }
+        return null;
+    }
+
+    /// Remove all headers matching `name` (case-insensitive).
+    fn remove(self: *HeaderList, name: []const u8) void {
+        var i: usize = 0;
+        while (i < self.items.items.len) {
+            if (asciiEqlIgnoreCase(self.items.items[i].name, name)) {
+                _ = self.items.swapRemove(i);
+            } else {
+                i += 1;
+            }
+        }
+    }
+};
+
+fn asciiEqlIgnoreCase(a: []const u8, b: []const u8) bool {
+    if (a.len != b.len) return false;
+    for (a, b) |x, y| {
+        if (std.ascii.toLower(x) != std.ascii.toLower(y)) return false;
+    }
+    return true;
+}
+
+fn parseRequest(a: std.mem.Allocator, reader: anytype) !Request {
+    // Request line: METHOD SP PATH SP HTTP/1.1 CRLF
+    const start_line = try readLine(a, reader, 8 * 1024);
+    const sp1 = std.mem.indexOfScalar(u8, start_line, ' ') orelse return error.BadRequestLine;
+    const sp2 = std.mem.indexOfScalarPos(u8, start_line, sp1 + 1, ' ') orelse return error.BadRequestLine;
+    const method = start_line[0..sp1];
+    const path = start_line[sp1 + 1 .. sp2];
+
+    var headers = HeaderList.init(a);
+    while (true) {
+        const line = try readLine(a, reader, 16 * 1024);
+        if (line.len == 0) break;
+        const colon = std.mem.indexOfScalar(u8, line, ':') orelse return error.BadHeader;
+        const name = line[0..colon];
+        var v_start = colon + 1;
+        while (v_start < line.len and (line[v_start] == ' ' or line[v_start] == '\t')) v_start += 1;
+        try headers.append(name, line[v_start..]);
+    }
+
+    // Body: Content-Length only; chunked-transfer-decoded would require
+    // unchunking which we instead pass through unchanged at forward
+    // time. For the inbound side we read Content-Length bytes if present.
+    var body: []const u8 = &.{};
+    if (headers.find("content-length")) |cl_str| {
+        const cl = try std.fmt.parseInt(usize, cl_str, 10);
+        const body_buf = try a.alloc(u8, cl);
+        try reader.readNoEof(body_buf);
+        body = body_buf;
+    } else if (headers.find("transfer-encoding")) |te| {
+        if (asciiEqlIgnoreCase(te, "chunked")) {
+            body = try readChunked(a, reader);
+        }
+    }
+
+    return Request{
+        .method = try a.dupe(u8, method),
+        .path = try a.dupe(u8, path),
+        .headers = headers,
+        .body = body,
+    };
+}
+
+fn readLine(a: std.mem.Allocator, reader: anytype, max: usize) ![]u8 {
+    var buf = std.ArrayListUnmanaged(u8){};
+    while (true) {
+        if (buf.items.len >= max) return error.LineTooLong;
+        const b = try reader.readByte();
+        if (b == '\r') {
+            const next = try reader.readByte();
+            if (next != '\n') return error.BadLineEnding;
+            return try buf.toOwnedSlice(a);
+        }
+        try buf.append(a, b);
+    }
+}
+
+fn readChunked(a: std.mem.Allocator, reader: anytype) ![]u8 {
+    var out = std.ArrayListUnmanaged(u8){};
+    while (true) {
+        const size_line = try readLine(a, reader, 32);
+        const semi = std.mem.indexOfScalar(u8, size_line, ';') orelse size_line.len;
+        const size = try std.fmt.parseInt(usize, size_line[0..semi], 16);
+        if (size == 0) {
+            _ = try readLine(a, reader, 8); // trailer line
+            break;
+        }
+        const chunk = try a.alloc(u8, size);
+        try reader.readNoEof(chunk);
+        try out.appendSlice(a, chunk);
+        _ = try readLine(a, reader, 8); // CRLF after chunk
+    }
+    return try out.toOwnedSlice(a);
+}
+
+/// Forward selected headers from inbound to outbound; drop hop-by-hop
+/// headers and the three we substitute. Per RFC 7230 §6.1, hop-by-hop
+/// headers MUST NOT be forwarded by intermediaries.
+fn copyForwardingHeaders(in: *const HeaderList, out: *HeaderList) !void {
+    const skip_substituted = [_][]const u8{
+        "authorization",       "chatgpt-account-id", "x-openai-fedramp",
+        // hop-by-hop:
+        "connection",          "keep-alive",         "proxy-authenticate",
+        "proxy-authorization", "te",                 "trailers",
+        "transfer-encoding",   "upgrade",            "host",
+    };
+    outer: for (in.items.items) |h| {
+        for (skip_substituted) |s| {
+            if (asciiEqlIgnoreCase(h.name, s)) continue :outer;
+        }
+        try out.append(h.name, h.value);
+    }
+}
+
+// ── Forwarding + streaming (uses std.http.Client for TLS) ────────────
+
+const StatusAndClassification = struct {
+    status: u16,
+    classification: Classification,
+    /// True if the body was streamed verbatim to the client (no buffer);
+    /// false if it was buffered for classification (429 path) or never
+    /// arrived (early failure).
+    streamed: bool,
+};
+
+/// Forward the inbound request to chatgpt.com and write the response
+/// directly to the client writer.
+///
+/// 429 responses are buffered (small JSON, need body to classify
+/// usage_limit_reached vs usage_not_included).
+///
+/// All other responses (200 streaming SSE, 401, 5xx) are streamed
+/// byte-for-byte from upstream's reader to the client. Connection-close
+/// framing is used so we don't have to re-chunk std.http.Client's
+/// already-decoded body bytes.
+fn forwardAndStream(
+    a: std.mem.Allocator,
+    req: Request,
+    out_headers: HeaderList,
+    client_writer: anytype,
+) !StatusAndClassification {
+    var client = std.http.Client{ .allocator = a };
+    defer client.deinit();
+
+    const scheme = upstreamScheme(a);
+    defer if (!std.mem.eql(u8, scheme, DEFAULT_UPSTREAM_SCHEME)) a.free(scheme);
+    const host = upstreamHost(a);
+    defer if (!std.mem.eql(u8, host, DEFAULT_UPSTREAM_HOST)) a.free(host);
+    const url = try std.fmt.allocPrint(a, "{s}://{s}{s}", .{ scheme, host, req.path });
+    defer a.free(url);
+    const uri = try std.Uri.parse(url);
+
+    var extra = std.ArrayListUnmanaged(std.http.Header){};
+    defer extra.deinit(a);
+    for (out_headers.items.items) |h| {
+        try extra.append(a, .{ .name = h.name, .value = h.value });
+    }
+
+    var server_header_buf: [16 * 1024]u8 = undefined;
+    var http_req = try client.open(parseMethod(req.method), uri, .{
+        .server_header_buffer = &server_header_buf,
+        .extra_headers = extra.items,
+    });
+    defer http_req.deinit();
+
+    if (req.body.len > 0) {
+        http_req.transfer_encoding = .{ .content_length = req.body.len };
+    }
+    try http_req.send();
+    if (req.body.len > 0) {
+        try http_req.writeAll(req.body);
+        try http_req.finish();
+    }
+    try http_req.wait();
+
+    const status_u16: u16 = @intFromEnum(http_req.response.status);
+
+    // 429 is the only path that needs the body for classification.
+    // Every other status classifies on the status code alone.
+    if (status_u16 == 429) {
+        // Cap at 64 KiB — chatgpt.com's 429 JSON bodies are small.
+        const body = try http_req.reader().readAllAlloc(a, 64 * 1024);
+        defer a.free(body);
+        const classification = classify(a, status_u16, body);
+        try writeBufferedResponse(client_writer, http_req.response, body);
+        return .{ .status = status_u16, .classification = classification, .streamed = false };
+    }
+
+    const classification = classify(a, status_u16, &.{});
+    try writeStreamedResponse(client_writer, http_req.response, http_req.reader());
+    return .{ .status = status_u16, .classification = classification, .streamed = true };
+}
+
+fn parseMethod(s: []const u8) std.http.Method {
+    if (std.mem.eql(u8, s, "GET")) return .GET;
+    if (std.mem.eql(u8, s, "POST")) return .POST;
+    if (std.mem.eql(u8, s, "PUT")) return .PUT;
+    if (std.mem.eql(u8, s, "DELETE")) return .DELETE;
+    if (std.mem.eql(u8, s, "PATCH")) return .PATCH;
+    if (std.mem.eql(u8, s, "HEAD")) return .HEAD;
+    if (std.mem.eql(u8, s, "OPTIONS")) return .OPTIONS;
+    return .POST;
+}
+
+// ── Classification ───────────────────────────────────────────────────
+
+pub const Classification = struct {
+    kind: broker_types.QuotaKind,
+    /// Unix seconds when the account becomes eligible again, if known.
+    resets_at: ?i64 = null,
+    /// Free-form body class label (for telemetry only).
+    body_class: ?[]const u8 = null,
+};
+
+/// Inspect the response status + body to derive a typed quota event.
+/// Per codex-rs/codex-api/src/api_bridge.rs L80–104:
+///   429 + body.error.type == "usage_limit_reached" → quota_exhausted
+///   429 + body.error.type == "usage_not_included" → tier_insufficient
+///   429 (other)                                    → rate_limited
+///   401                                            → auth_unauthorized
+///   5xx                                            → provider_5xx
+///   2xx / 3xx / 4xx (other)                        → ok
+pub fn classify(
+    a: std.mem.Allocator,
+    status: u16,
+    body_preview: []const u8,
+) Classification {
+    if (status == 401) return .{ .kind = .auth_unauthorized };
+    if (status >= 500 and status < 600) return .{ .kind = .provider_5xx };
+
+    if (status == 429) {
+        const parsed = std.json.parseFromSlice(std.json.Value, a, body_preview, .{
+            .ignore_unknown_fields = true,
+        }) catch {
+            return .{ .kind = .rate_limited };
+        };
+        defer parsed.deinit();
+        if (parsed.value != .object) return .{ .kind = .rate_limited };
+        const err_v = parsed.value.object.get("error") orelse return .{ .kind = .rate_limited };
+        if (err_v != .object) return .{ .kind = .rate_limited };
+        const type_v = err_v.object.get("type") orelse return .{ .kind = .rate_limited };
+        if (type_v != .string) return .{ .kind = .rate_limited };
+
+        if (std.mem.eql(u8, type_v.string, "usage_limit_reached")) {
+            var resets: ?i64 = null;
+            if (err_v.object.get("resets_at")) |rv| {
+                if (rv == .integer) resets = rv.integer;
+            }
+            return .{ .kind = .quota_exhausted, .resets_at = resets, .body_class = "usage_limit_reached" };
+        }
+        if (std.mem.eql(u8, type_v.string, "usage_not_included")) {
+            return .{ .kind = .tier_insufficient, .body_class = "usage_not_included" };
+        }
+        return .{ .kind = .rate_limited };
+    }
+
+    return .{ .kind = .ok };
+}
+
+// ── Response writing ─────────────────────────────────────────────────
+
+fn writeStatus(writer: anytype, code: u16, reason: []const u8) !void {
+    try writer.print("HTTP/1.1 {d} {s}\r\n", .{ code, reason });
+    try writer.writeAll("Content-Length: 0\r\nConnection: close\r\n\r\n");
+}
+
+/// Write headers that are safe to forward to the client unchanged.
+/// Drops hop-by-hop headers (RFC 7230 §6.1) and transfer-coding
+/// metadata since we manage framing ourselves below.
+fn writeForwardingResponseHeaders(writer: anytype, response: std.http.Client.Response) !void {
+    var hi = response.iterateHeaders();
+    while (hi.next()) |h| {
+        if (asciiEqlIgnoreCase(h.name, "connection")) continue;
+        if (asciiEqlIgnoreCase(h.name, "transfer-encoding")) continue;
+        if (asciiEqlIgnoreCase(h.name, "keep-alive")) continue;
+        if (asciiEqlIgnoreCase(h.name, "content-length")) continue;
+        try writer.print("{s}: {s}\r\n", .{ h.name, h.value });
+    }
+}
+
+/// 429 path: write status + headers + Content-Length + buffered body.
+fn writeBufferedResponse(
+    writer: anytype,
+    response: std.http.Client.Response,
+    body: []const u8,
+) !void {
+    try writer.print("HTTP/1.1 {d} \r\n", .{@intFromEnum(response.status)});
+    try writeForwardingResponseHeaders(writer, response);
+    try writer.print("Content-Length: {d}\r\n", .{body.len});
+    try writer.writeAll("Connection: close\r\n\r\n");
+    try writer.writeAll(body);
+}
+
+/// Streaming path: write status + headers (no Content-Length, no
+/// Transfer-Encoding) + Connection: close, then pump bytes from
+/// upstream reader to client writer in 64 KiB chunks. The client
+/// reads-until-EOF per RFC 7230 §3.3.3 case 7. Real-time SSE works.
+fn writeStreamedResponse(
+    writer: anytype,
+    response: std.http.Client.Response,
+    upstream_reader: anytype,
+) !void {
+    try writer.print("HTTP/1.1 {d} \r\n", .{@intFromEnum(response.status)});
+    try writeForwardingResponseHeaders(writer, response);
+    try writer.writeAll("Connection: close\r\n\r\n");
+
+    var buf: [64 * 1024]u8 = undefined;
+    while (true) {
+        const n = upstream_reader.read(&buf) catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => return err,
+        };
+        if (n == 0) break;
+        try writer.writeAll(buf[0..n]);
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+test "classify 200 OK -> .ok" {
+    const c = classify(std.testing.allocator, 200, "");
+    try std.testing.expectEqual(broker_types.QuotaKind.ok, c.kind);
+}
+
+test "classify 401 -> auth_unauthorized" {
+    const c = classify(std.testing.allocator, 401, "{}");
+    try std.testing.expectEqual(broker_types.QuotaKind.auth_unauthorized, c.kind);
+}
+
+test "classify 503 -> provider_5xx" {
+    const c = classify(std.testing.allocator, 503, "{}");
+    try std.testing.expectEqual(broker_types.QuotaKind.provider_5xx, c.kind);
+}
+
+test "classify 429 + usage_limit_reached -> quota_exhausted with resets_at" {
+    const body =
+        \\{"error":{"type":"usage_limit_reached","plan_type":"pro","resets_at":1788000000}}
+    ;
+    const c = classify(std.testing.allocator, 429, body);
+    try std.testing.expectEqual(broker_types.QuotaKind.quota_exhausted, c.kind);
+    try std.testing.expectEqual(@as(?i64, 1788000000), c.resets_at);
+}
+
+test "classify 429 + usage_not_included -> tier_insufficient (NOT swap)" {
+    const body =
+        \\{"error":{"type":"usage_not_included","plan_type":"free"}}
+    ;
+    const c = classify(std.testing.allocator, 429, body);
+    try std.testing.expectEqual(broker_types.QuotaKind.tier_insufficient, c.kind);
+}
+
+test "classify 429 with no error.type -> rate_limited" {
+    const body = "{\"foo\":1}";
+    const c = classify(std.testing.allocator, 429, body);
+    try std.testing.expectEqual(broker_types.QuotaKind.rate_limited, c.kind);
+}
+
+test "classify 429 with non-JSON body -> rate_limited" {
+    const c = classify(std.testing.allocator, 429, "Too Many Requests");
+    try std.testing.expectEqual(broker_types.QuotaKind.rate_limited, c.kind);
+}
+
+test "parseRequest reads start line + headers + content-length body" {
+    const wire =
+        "POST /backend-api/codex/responses HTTP/1.1\r\n" ++
+        "Host: chatgpt.com\r\n" ++
+        "Authorization: Bearer XYZ\r\n" ++
+        "Content-Length: 5\r\n" ++
+        "X-Codex-Turn-State: turn-abc\r\n" ++
+        "\r\n" ++
+        "hello";
+    var fbs = std.io.fixedBufferStream(wire);
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const req = try parseRequest(a, fbs.reader());
+    try std.testing.expectEqualStrings("POST", req.method);
+    try std.testing.expectEqualStrings("/backend-api/codex/responses", req.path);
+    try std.testing.expectEqualStrings("Bearer XYZ", req.headers.find("Authorization").?);
+    try std.testing.expectEqualStrings("turn-abc", req.headers.find("x-codex-turn-state").?);
+    try std.testing.expectEqualStrings("hello", req.body);
+}
+
+test "parseRequest reads chunked body" {
+    const wire =
+        "POST /backend-api/codex/responses HTTP/1.1\r\n" ++
+        "Transfer-Encoding: chunked\r\n" ++
+        "\r\n" ++
+        "5\r\nhello\r\n" ++
+        "6\r\n world\r\n" ++
+        "0\r\n\r\n";
+    var fbs = std.io.fixedBufferStream(wire);
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const req = try parseRequest(arena.allocator(), fbs.reader());
+    try std.testing.expectEqualStrings("hello world", req.body);
+}
+
+test "parseRequest rejects malformed start line" {
+    const wire = "BAD\r\n\r\n";
+    var fbs = std.io.fixedBufferStream(wire);
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    try std.testing.expectError(error.BadRequestLine, parseRequest(arena.allocator(), fbs.reader()));
+}
+
+test "writeStatus writes a complete HTTP/1.1 status response" {
+    var buf: [256]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    try writeStatus(fbs.writer(), 503, "No Account Selectable");
+    const out = fbs.getWritten();
+    try std.testing.expect(std.mem.startsWith(u8, out, "HTTP/1.1 503 No Account Selectable\r\n"));
+    try std.testing.expect(std.mem.indexOf(u8, out, "Content-Length: 0\r\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "Connection: close\r\n") != null);
+    try std.testing.expect(std.mem.endsWith(u8, out, "\r\n\r\n"));
+}
+
+test "HeaderList.remove drops matching headers, case-insensitive" {
+    var hl = HeaderList.init(std.testing.allocator);
+    defer hl.items.deinit(std.testing.allocator);
+    try hl.append("X-Codex-Turn-State", "abc");
+    try hl.append("X-Foo", "1");
+    try hl.append("x-codex-turn-state", "def"); // duplicate, different case
+
+    hl.remove("X-Codex-Turn-State");
+    try std.testing.expect(hl.find("x-codex-turn-state") == null);
+    try std.testing.expectEqualStrings("1", hl.find("X-Foo").?);
+    try std.testing.expectEqual(@as(usize, 1), hl.items.items.len);
+}
+
+test "HeaderList.set replaces existing values, case-insensitive" {
+    var hl = HeaderList.init(std.testing.allocator);
+    defer hl.items.deinit(std.testing.allocator);
+    try hl.append("Authorization", "Bearer A");
+    try hl.append("X-Foo", "1");
+    try hl.set("authorization", "Bearer B");
+
+    try std.testing.expectEqualStrings("Bearer B", hl.find("Authorization").?);
+    try std.testing.expectEqualStrings("1", hl.find("X-Foo").?);
+    try std.testing.expectEqual(@as(usize, 2), hl.items.items.len);
+}
+
+test "copyForwardingHeaders property: 50 random header sets preserve load-bearing 8" {
+    // PBT: regardless of what other headers are mixed in, the eight
+    // load-bearing headers (User-Agent, originator,
+    // x-codex-installation-id, x-codex-turn-state, x-codex-turn-metadata,
+    // OpenAI-Beta, traceparent, tracestate) MUST always survive
+    // copyForwardingHeaders. The three substituted (Authorization,
+    // ChatGPT-Account-ID, X-OpenAI-Fedramp) and the hop-by-hop set
+    // MUST always be dropped. Catches the regression where someone
+    // adds a new "drop" rule that accidentally matches a load-bearing
+    // header by case-insensitive prefix.
+    var prng = std.Random.DefaultPrng.init(0xBEEF1234);
+    const r = prng.random();
+
+    const load_bearing = [_][]const u8{
+        "User-Agent",
+        "originator",
+        "x-codex-installation-id",
+        "x-codex-turn-state",
+        "x-codex-turn-metadata",
+        "OpenAI-Beta",
+        "traceparent",
+        "tracestate",
+    };
+    const must_drop = [_][]const u8{
+        "Authorization",
+        "ChatGPT-Account-ID",
+        "X-OpenAI-Fedramp",
+        "Connection",
+        "Transfer-Encoding",
+        "Host",
+        "Keep-Alive",
+        "Upgrade",
+    };
+    const noise = [_][]const u8{ "X-Random-1", "X-Foo", "Accept", "Cookie" };
+
+    var iter: usize = 0;
+    while (iter < 50) : (iter += 1) {
+        var in = HeaderList.init(std.testing.allocator);
+        defer in.items.deinit(std.testing.allocator);
+
+        // Always include all 8 load-bearing.
+        for (load_bearing) |h| try in.append(h, "x");
+        // Always include all 8 must-drop.
+        for (must_drop) |h| try in.append(h, "y");
+        // Add 0..3 noise headers.
+        const noise_count = r.uintLessThan(usize, noise.len + 1);
+        var n: usize = 0;
+        while (n < noise_count) : (n += 1) {
+            try in.append(noise[r.uintLessThan(usize, noise.len)], "n");
+        }
+
+        var out = HeaderList.init(std.testing.allocator);
+        defer out.items.deinit(std.testing.allocator);
+        try copyForwardingHeaders(&in, &out);
+
+        // Property A: every load-bearing header is preserved.
+        for (load_bearing) |h| {
+            if (out.find(h) == null) {
+                std.debug.print("iter {d}: load-bearing header {s} was dropped\n", .{ iter, h });
+                return error.LoadBearingDropped;
+            }
+        }
+        // Property B: every must-drop header is gone.
+        for (must_drop) |h| {
+            if (out.find(h) != null) {
+                std.debug.print("iter {d}: must-drop header {s} survived\n", .{ iter, h });
+                return error.MustDropSurvived;
+            }
+        }
+    }
+}
+
+test "copyForwardingHeaders preserves the load-bearing 8 + drops hop-by-hop" {
+    var in = HeaderList.init(std.testing.allocator);
+    defer in.items.deinit(std.testing.allocator);
+    try in.append("User-Agent", "codex/1");
+    try in.append("originator", "codex_cli_rs");
+    try in.append("x-codex-installation-id", "iid");
+    try in.append("x-codex-turn-state", "turn");
+    try in.append("x-codex-turn-metadata", "meta");
+    try in.append("OpenAI-Beta", "responses_websockets=2026-02-06");
+    try in.append("traceparent", "tp");
+    try in.append("tracestate", "ts");
+    try in.append("Authorization", "Bearer leaked");
+    try in.append("ChatGPT-Account-ID", "leaked");
+    try in.append("X-OpenAI-Fedramp", "true");
+    try in.append("Connection", "keep-alive");
+    try in.append("Transfer-Encoding", "chunked");
+    try in.append("Host", "example");
+
+    var out = HeaderList.init(std.testing.allocator);
+    defer out.items.deinit(std.testing.allocator);
+    try copyForwardingHeaders(&in, &out);
+
+    // 8 forward-unchanged survive
+    try std.testing.expect(out.find("User-Agent") != null);
+    try std.testing.expect(out.find("originator") != null);
+    try std.testing.expect(out.find("x-codex-installation-id") != null);
+    try std.testing.expect(out.find("x-codex-turn-state") != null);
+    try std.testing.expect(out.find("x-codex-turn-metadata") != null);
+    try std.testing.expect(out.find("OpenAI-Beta") != null);
+    try std.testing.expect(out.find("traceparent") != null);
+    try std.testing.expect(out.find("tracestate") != null);
+
+    // 3 substituted-elsewhere are dropped here (proxy adds them back)
+    try std.testing.expect(out.find("Authorization") == null);
+    try std.testing.expect(out.find("ChatGPT-Account-ID") == null);
+    try std.testing.expect(out.find("X-OpenAI-Fedramp") == null);
+
+    // hop-by-hop are dropped
+    try std.testing.expect(out.find("Connection") == null);
+    try std.testing.expect(out.find("Transfer-Encoding") == null);
+    try std.testing.expect(out.find("Host") == null);
+}

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -30,6 +30,7 @@ pub const Command = union(enum) {
     completions: CompletionsArgs,
     daemon_run: DaemonRunArgs,
     mcp: McpArgs,
+    codex_adapter: CodexAdapterArgs,
     daemon_start,
     daemon_stop,
     daemon_status: DaemonStatusArgs,
@@ -43,6 +44,14 @@ pub const Command = union(enum) {
     pub const McpArgs = struct {
         profile: ?[]const u8 = null,
         capability: ?[]const u8 = null,
+    };
+
+    pub const CodexAdapterArgs = struct {
+        profile: ?[]const u8 = null,
+        account: ?[]const u8 = null,
+        json_status: bool = false,
+        /// Args after `--` forwarded to codex unchanged.
+        forward_argv: []const []const u8 = &.{},
     };
 
     pub const ExecArgs = struct {
@@ -319,7 +328,13 @@ pub fn parse(args: []const []const u8) Command {
     if (eql(cmd, "config")) return parseConfig(rest);
     if (eql(cmd, "init")) return parseInit(rest);
     if (eql(cmd, "setup")) return parseSetup(rest);
-    if (eql(cmd, "codex")) return parseCodex(rest);
+    if (eql(cmd, "codex")) {
+        // Broker-mediated session entrypoint. Other `codex ...`
+        // subcommands continue through the legacy parser until the
+        // adapter path is ready to replace them.
+        if (rest.len > 0 and eql(rest[0], "run")) return parseCodexAdapter(rest[1..]);
+        return parseCodex(rest);
+    }
     if (eql(cmd, "mcp")) return parseMcp(rest);
     if (eql(cmd, "version") or eql(cmd, "--version") or eql(cmd, "-v")) return .version_cmd;
     if (eql(cmd, "daemon")) {
@@ -347,6 +362,26 @@ pub fn parse(args: []const []const u8) Command {
 
 fn parseExec(args: []const []const u8) Command {
     return .{ .exec = parseExecArgs(args) };
+}
+
+fn parseCodexAdapter(args: []const []const u8) Command {
+    var result = Command.CodexAdapterArgs{};
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        if (eql(args[i], "--")) {
+            result.forward_argv = args[i + 1 ..];
+            break;
+        } else if ((eql(args[i], "--profile") or eql(args[i], "-p")) and i + 1 < args.len) {
+            i += 1;
+            result.profile = args[i];
+        } else if (eql(args[i], "--account") and i + 1 < args.len) {
+            i += 1;
+            result.account = args[i];
+        } else if (eql(args[i], "--json-status")) {
+            result.json_status = true;
+        }
+    }
+    return .{ .codex_adapter = result };
 }
 
 fn parseMcp(args: []const []const u8) Command {
@@ -1193,6 +1228,9 @@ pub fn printUsage(writer: anytype) !void {
         \\
         \\  mcp [--profile <name>] [--capability <name>]
         \\      Run the broker MCP/JSON-RPC server on stdio for harness adapters.
+        \\
+        \\  codex run [--profile name] [--account provider:account] [--json-status] [-- codex-args...]
+        \\      Run a broker-mediated Codex adapter session with a local wire proxy.
         \\
         \\  init [--interactive] [--codex-max]
         \\      Generate a starter config file.
@@ -2163,6 +2201,22 @@ test "parse mcp broker server profile" {
     }
 }
 
+test "parse codex run adapter args" {
+    const args = [_][]const u8{ "codex", "run", "--profile", "codex-max", "--account", "codex:max-1", "--json-status", "--", "--model", "gpt-5.5" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex_adapter => |adapter| {
+            try std.testing.expectEqualStrings("codex-max", adapter.profile.?);
+            try std.testing.expectEqualStrings("codex:max-1", adapter.account.?);
+            try std.testing.expect(adapter.json_status);
+            try std.testing.expectEqual(@as(usize, 2), adapter.forward_argv.len);
+            try std.testing.expectEqualStrings("--model", adapter.forward_argv[0]);
+            try std.testing.expectEqualStrings("gpt-5.5", adapter.forward_argv[1]);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
     if (eql(shell_name, "fish")) {
         try writer.writeAll(
@@ -2249,7 +2303,10 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'setup onboard canary live-qa revalidate-exhausted probe-all managed-plan managed broker-plan broker-session-plan broker-session-smoke broker-run broker-fallback-drill broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'run setup onboard canary live-qa revalidate-exhausted probe-all managed-plan managed broker-plan broker-session-plan broker-session-smoke broker-run broker-fallback-drill broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l profile -s p -d 'Profile name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l account -d 'Route account id' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l json-status -d 'Emit redacted adapter status frames'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run loop start stop status events handoffs tick' -d 'Daemon subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l stay-afloat -d 'Host foreground stay-afloat tick loop'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l json -d 'JSON output'

--- a/src/main.zig
+++ b/src/main.zig
@@ -16,11 +16,15 @@ const runtime_mod = @import("runtime.zig");
 const secret_mod = @import("secret.zig");
 const broker = @import("broker/mod.zig");
 const broker_loader = @import("broker_loader.zig");
+const codex_adapter = @import("adapters/codex/main.zig");
 
 comptime {
-    // Pull broker + loader modules into the test build.
+    // Pull broker + adapter modules into the test build.
     _ = broker;
     _ = broker_loader;
+    _ = codex_adapter;
+    _ = @import("adapters/codex/app_server_client.zig");
+    _ = @import("adapters/codex/wire_proxy.zig");
 }
 
 pub fn main() !void {
@@ -42,6 +46,21 @@ pub fn main() !void {
         .version_cmd => try stdout.print("oauth-mux {s}\n", .{cli.version}),
         .help => try cli.printUsage(stdout),
         .codex_help => try cli.printCodexUsage(stdout),
+
+        .codex_adapter => |adapter_args| {
+            // `oauth-mux codex run`: broker-mediated Codex adapter
+            // session. Anchor:
+            // docs/spec/codex-adapter-contract-2026-05-03.md.
+            codex_adapter.run(allocator, .{
+                .profile = adapter_args.profile,
+                .account = adapter_args.account,
+                .json_status = adapter_args.json_status,
+                .forward_argv = adapter_args.forward_argv,
+            }) catch |e| {
+                log.err("codex run: {s}", .{@errorName(e)});
+                std.process.exit(types.ExitCode.general_error.int());
+            };
+        },
 
         .mcp => |mcp_args| {
             // Broker MCP server on stdio. Anchor:


### PR DESCRIPTION
## Summary

Adds the bounded Codex adapter/proxy skeleton for TIN-948 / #174:

- `oauth-mux codex run` parser and main dispatch
- Codex adapter module that starts a Codex child with proxy-backed `CODEX_HOME`
- localhost wire proxy that substitutes account-bound headers, classifies 429 quota bodies, marks route health in the broker pool, and uses the next selected fixture account on the next request
- synthetic stub Codex and stub upstream fixtures
- `scripts/smoke-codex-acceptance.sh`, wired into `check-local`, proving account A -> quota observe/swap -> account B while the stub Codex PID stays stable
- spec checkpoint that labels this as synthetic structural evidence only

## Boundary

This PR does not make live provider calls. It uses local stubs and fake fixture token strings only. Adapter status stays at `claim_level:"broker_owned"` and reports `synthetic_swap_observed:true`; it does not claim live `next_turn_seamless`, provider-originated quota handling, same-thread recovery, unmanaged Codex TUI hot-swap, or restart-based fallback.

## Validation

- `just test`
- `just smoke-codex-acceptance`
- `just check`
- `git diff --check`

Refs #174. Builds on #178 / #172. Related #175, #176, #177.
