### PR TITLE
[codex] Add Codex wire cassette tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ dist/soak/
 *.tar.gz
 *.deb
 *.rpm
+
+# Operator wire captures. Commit only reviewed, scrubbed fixtures.
+captures/

--- a/docs/spec/codex-wire-evidence-2026-05-03.md
+++ b/docs/spec/codex-wire-evidence-2026-05-03.md
@@ -1,0 +1,428 @@
+# Codex Wire Evidence — Phase 0 Capture
+Date: 2026-05-03
+Status: TOOLING LANDED; OPERATOR CAPTURE PENDING. Source-confirmed
+entries are pre-populated from the 2026-05-03 reality-check pass against
+`openai/codex@67849d95`. Live operator-confirmed entries
+(`OPERATOR-CONFIRM`) get filled by running
+`scripts/capture-codex-wire.sh proxy` against a real authenticated
+`codex` session and a real quota-exhausted account.
+
+Anchor: `docs/spec/broker-mcp-contract-2026-05-03.md` §5 Phase 0.
+Adapter consumer: `docs/spec/codex-adapter-contract-2026-05-03.md` §3
+(401-vs-429 handling matrix), §4 (wire-layer proxy spec).
+
+This document distills the wire-shape evidence the wire-layer proxy
+and IDE-role JSON-RPC client implement against. Source-confirmed
+entries flow from `openai/codex` source review at the cited
+file:line; operator-confirm entries become observed shapes after
+the live capture lands.
+
+TIN-950 adds the capture/replay tooling only:
+
+- `scripts/capture-codex-wire.sh` starts the operator-controlled
+  mitmproxy HTTP capture path.
+- `scripts/codex-wire-addon.py` writes reviewed, redacted per-flow JSON
+  from that capture path.
+- `scripts/test-cassette-upstream.py` replays reviewed capture JSON by
+  `(method, path)`.
+- `just smoke-codex-cassette-replay` proves the replayer on a tiny
+  synthetic cassette without provider traffic.
+
+The existing in-session smoke (`just smoke-codex-acceptance`) proves the
+adapter/proxy can classify and substitute against synthetic versions of
+these shapes. The cassette replay smoke proves the replay layer can
+serve captured shapes once they exist. Live capture's job is still to
+confirm the shapes themselves match upstream reality.
+
+## Capture Provenance
+
+- codex version: _OPERATOR-CONFIRM_  (`codex --version` of binary used)
+- codex-rs commit: _OPERATOR-CONFIRM_  (from upstream tag matching the binary)
+- ChatGPT subscription tier of capturing account: _OPERATOR-CONFIRM_
+  (Free / Plus / Pro / Business / Enterprise — affects which 429 body
+  type fires)
+- Capture timestamp range: _OPERATOR-CONFIRM_
+- Capture run directory: `captures/codex-wire-<TS>/`
+- mitmdump version: _OPERATOR-CONFIRM_
+- Replay tooling: `scripts/test-cassette-upstream.py`
+- Synthetic replay smoke: `just smoke-codex-cassette-replay`
+
+## 1. Endpoints Observed
+
+**Source-confirmed list (per `codex-rs/core/src/client.rs` L132–134):**
+
+| Method | Path (relative to base_url) | Trigger | Streaming? | Auth headers |
+|---|---|---|---|---|
+| POST | `/responses` | every model turn | Yes (SSE) | `Authorization`, `ChatGPT-Account-ID`, optional `X-OpenAI-Fedramp` |
+| POST | `/responses/compact` | conversation compaction | Likely streaming | same |
+| POST | `/memories/trace_summarize` | memory summarization | Likely non-streaming | same |
+| Upgrade | (same base) WS | `responses_websockets=2026-02-06` Beta | Bidirectional WS | same headers on upgrade request |
+
+Adjacent endpoints (file uploads, cloud-tasks) carry the same auth
+headers and are pass-through targets too: see `codex-rs/codex-api/src/files.rs`
+and `codex-rs/backend-client/src/client.rs`.
+
+`base_url` defaults to `https://chatgpt.com/backend-api/codex` for
+ChatGPT-subscription auth (per
+`codex-rs/model-provider-info/src/lib.rs` L233–242). Single field
+override for both subscription and API-key paths.
+
+_OPERATOR-CONFIRM_: capture wire shows EXACTLY these paths and no
+others under `/backend-api/codex/`.
+
+## 2. Request Header Set on a Normal Turn
+
+**Source-confirmed full forward-unchanged set** (per
+`codex-rs/login/src/auth/default_client.rs` L149–165 +
+`codex-rs/core/src/client.rs` L114–117 +
+`codex-rs/model-provider/src/bearer_auth_provider.rs` L33–47):
+
+```
+# Three auth-bound (the proxy substitutes these per-account)
+Authorization: Bearer <id_token | access_token>
+ChatGPT-Account-ID: <chatgpt_account_id>
+X-OpenAI-Fedramp: true                  # only when account.fedramp
+
+# Eight forward-unchanged (proxy MUST forward verbatim)
+User-Agent: <originator>/<version> (<os> <ver>; <arch>) <terminal> (<suffix>)
+originator: codex_cli_rs                # or other client identifier
+x-codex-installation-id: <stable per-install id>
+x-codex-turn-state: <STICKY-ROUTING TOKEN — DO NOT rotate mid-thread>
+x-codex-turn-metadata: <per-turn blob>
+OpenAI-Beta: responses_websockets=2026-02-06   # WS upgrades + other gates
+traceparent: <W3C trace id>
+tracestate: <W3C trace state>
+x-openai-internal-codex-residency: us   # conditional
+```
+
+`x-codex-turn-state` is the load-bearing one. The wire proxy DROPS
+this header on the post-swap turn (per `wire_proxy.zig`) — every
+other header in this set is forwarded verbatim.
+
+NOT sent (do not forge):
+- `Sec-Fetch-Site` / `Sec-Fetch-Mode` (browser-only)
+- `Origin` (browser-only)
+- `x-stainless-*` (Stainless SDK; not the Rust client)
+
+_OPERATOR-CONFIRM_: capture a normal turn; verify exactly this header
+set, no surprise additions.
+
+## 3. Normal-Turn Response Frames
+
+**Source-confirmed** (per `codex-rs/exec/tests/fixtures/cli_responses_fixture.sse`):
+
+SSE with explicit `event:` / `data:` framing. Empty-line event
+separator. Parsed by `eventsource_stream` (per `core/src/client.rs`
+L55).
+
+```
+event: response.created
+data: {"type":"response.created","response":{"id":"resp1"}}
+<blank line>
+event: response.output_item.done
+data: {"type":"response.output_item.done","item":{...}}
+<blank line>
+event: response.completed
+data: {"type":"response.completed","response":{"id":"resp1","output":[]}}
+<blank line>
+```
+
+Final boundary: `event: response.completed`.
+
+The proxy MUST preserve byte-exact CRLFs and the empty-line event
+terminator. Phase 2.1 streaming pumps bytes through verbatim via
+Connection: close framing — the proxy never re-encodes SSE.
+
+_OPERATOR-CONFIRM_: capture a normal turn; verify SSE framing matches
+fixture shape.
+
+## 4. 401 Unauthorized — Frame Sequence
+
+**Source-confirmed**:
+
+- HTTP request that triggered: any normal `POST /responses` with an
+  expired or revoked access_token bearer.
+- HTTP response status: 401, body usually empty or short JSON.
+- Codex's behavior: `AuthManager` runs `UnauthorizedRecovery` step
+  machine: `Reload` → `RefreshToken` → `ExternalRefresh`
+  (per `codex-rs/login/src/auth/manager.rs` L1169–1221):
+  1. Reload reads `auth.json` from disk in case external mutation.
+  2. RefreshToken POSTs to `https://auth.openai.com/oauth/token`
+     with refresh_token grant; persists fresh tokens via
+     `persist_tokens` → `storage.save()`.
+  3. Codex retries the original request with the fresh access_token.
+- ExternalRefresh (the `chatgptAuthTokens/refresh` JSON-RPC bridge)
+  is reachable only from `codex app-server` clients, NOT from the
+  TUI's in-process app-server (per `tui/src/app/app_server_requests.rs`
+  L136 + `exec/src/lib.rs` L1580–1588).
+
+In the current adapter-owned child + wire-proxy topology:
+- The proxy propagates the 401 to codex unchanged (streamed response).
+- Codex's RefreshToken path runs entirely inside codex; oauth-mux
+  doesn't see it.
+- Proxy's NEXT materialize call re-reads `auth.json` from disk and
+  picks up the refreshed token (no proxy-side state needed).
+- Proxy emits `proxy_observed_401_codex_handles` for telemetry.
+- DOES NOT call `pool.markUnauthorized` (would defeat refresh loop).
+
+_OPERATOR-CONFIRM_: revoke a refresh_token externally, drive a turn,
+verify (a) codex's AuthManager logs RefreshToken, (b) auth.json mtime
+advances after the refresh, (c) the next turn through the proxy uses
+the new access_token.
+
+## 5. 429 + `usage_limit_reached` — Frame Sequence
+
+**Source-confirmed body shape** (per `codex-rs/codex-api/src/api_bridge.rs`
+L80–104, struct `UsageErrorBody` L127–138):
+
+```json
+{
+  "error": {
+    "type": "usage_limit_reached",
+    "plan_type": "pro",
+    "resets_at": 1788000000
+  }
+}
+```
+
+- Field casing: **snake_case** (`plan_type`, `resets_at`)
+- `resets_at`: **unix-seconds (i64)** — decoded via
+  `DateTime::<Utc>::from_timestamp(seconds, 0)`
+- `plan_type` ∈ free/plus/pro/business/enterprise/edu
+
+Headers seen on 429:
+- `Retry-After` (sometimes; standard HTTP)
+- `x-codex-active-limit` (active limit id, parsed by api_bridge L86–90)
+- `x-codex-rate-limit-*` per-limit headers (parsed via
+  `parse_rate_limit_for_limit`)
+
+Codex's behavior on this status: typed `CodexErr::UsageLimitReached`,
+NOT-retryable, surfaced to the user. Does NOT call `ExternalAuth` /
+`chatgptAuthTokens/refresh` (per source review, confirmed).
+
+The wire proxy:
+- Buffers the response body (small JSON).
+- Classifies as `quota_exhausted` with `resets_at` parsed from body.
+- Calls `pool.markQuotaExhausted(account_id, resets_at)`.
+- Returns the 429 to codex unchanged.
+- On NEXT request from codex, elects a different account.
+- Drops `x-codex-turn-state` on the post-swap turn.
+
+_OPERATOR-CONFIRM_: drive an account to weekly quota; capture the
+exact body bytes; verify field names + casing match.
+
+## 6. Other 429 Variants
+
+**Source-confirmed `usage_not_included`** (sibling type per same
+`UsageErrorBody` enum):
+
+```json
+{
+  "error": {
+    "type": "usage_not_included",
+    "plan_type": "free"
+  }
+}
+```
+
+Means: this account's plan tier does not include Codex. NOT
+swap-eligible (rotating won't fix a tier gap; the user needs to
+upgrade or use a different account explicitly).
+
+The wire proxy:
+- Classifies as `tier_insufficient`.
+- Does NOT mutate the pool.
+- Does NOT swap accounts.
+- Returns the 429 to codex so codex can surface the upgrade prompt.
+
+This behavior is specified but not yet pinned by a dedicated smoke in
+main. `smoke-codex-acceptance` covers the swap-eligible
+`usage_limit_reached` path; a tier-insufficient smoke is a follow-up if
+we need a dedicated regression catch.
+
+**Bare 429 (no `error.type`)**: rate-limited; classified as
+`rate_limited`. Proxy honors `Retry-After`, optionally swaps if
+`Retry-After` exceeds a policy threshold (Phase 2.2+). Default
+behavior: propagate.
+
+_OPERATOR-CONFIRM_: capture both variants if both are reachable
+with available accounts; verify body shapes match.
+
+## 7. WebSocket Upgrade
+
+**Source-confirmed correction** (per `codex-rs/core/src/client.rs`
+L131): `responses_websockets=2026-02-06` is sent as the HTTP header
+`OpenAI-Beta: responses_websockets=2026-02-06` on the upgrade
+request, **NOT as a `Sec-WebSocket-Protocol` value.** The original
+spec was wrong on this; the wire proxy must not advertise it as a
+WS subprotocol upstream.
+
+The Phase 2 v1 wire proxy does NOT support WS upgrade; codex falls
+back to chunked HTTP / SSE when the upgrade is rejected. Phase 2.2
+adds WS pass-through.
+
+_OPERATOR-CONFIRM_: capture an upgrade attempt (force WS via codex
+config or the env that triggers it); verify `OpenAI-Beta` header
+shape.
+
+## 8. ID-Token Presence
+
+**Source-confirmed**:
+- `auth.json` always carries an `id_token` alongside `access_token`
+  (per `codex-rs/login/src/auth/storage.rs` `AuthDotJson` L84–141).
+- `id_token` is a JWT whose payload contains the
+  `https://api.openai.com/auth` custom claim with
+  `chatgpt_plan_type`, `chatgpt_user_id`, `chatgpt_account_id`,
+  `chatgpt_account_is_fedramp` (per `codex-rs/login/src/token_data.rs`
+  `parse_chatgpt_jwt_claims`).
+- `Authorization` bearer is `tokens.access_token` (NOT `id_token`)
+  per `bearer_auth_provider.rs` L33–47 — the id_token is consumed
+  client-side for claim parsing only.
+
+So: only the `access_token` rides the wire, but cross-account swaps
+must carry consistent (access_token, account_id, plan_type) tuples
+because the proxy's `ChatGPT-Account-ID` header is sourced from the
+id_token's `chatgpt_account_id` claim. The materializer
+(`broker_loader.zig::materializeChatgpt`) decodes both correctly.
+
+_OPERATOR-CONFIRM_: capture the wire; verify `Authorization` carries
+access_token only (not id_token); verify `ChatGPT-Account-ID`
+matches the id_token's `chatgpt_account_id` claim.
+
+## 9. DPoP / cnf-Claim Presence
+
+**Source-confirmed: NO DPoP/cnf handling** (per repo-wide search of
+`codex-rs/login` and `codex-rs/model-provider` for `DPoP`, `dpop`,
+`cnf`: zero hits in Rust auth code). `bearer_auth_provider.rs`
+treats the access_token as opaque bytes; no JWK thumbprint
+computation; no `htm`/`htu`/`jti` proof construction.
+
+This means: bearers are wire-portable across processes. The proxy
+substituting `Authorization` headers per request is sound; no
+`cnf`-claim mismatch risk.
+
+If chatgpt.com edge enforced DPoP, the bare codex CLI would already
+be broken. Therefore this is settled.
+
+_OPERATOR-CONFIRM_: decode an access_token JWT (base64url-no-pad
+the second segment); verify NO `cnf` claim in the payload. Verify
+chatgpt.com responses never carry `WWW-Authenticate: DPoP`.
+
+## 10. JSON-RPC Stdio Framing — `codex app-server`
+
+**Source-confirmed contract** (per `codex-rs/app-server-protocol/schema/json/`):
+
+- `account/login/start` with `type:"chatgptAuthTokens"`:
+  ```json
+  {
+    "method": "account/login/start",
+    "params": {
+      "loginType": {
+        "type": "chatgptAuthTokens",
+        "tokens": {
+          "accessToken": "<JWT>",
+          "chatgptAccountId": "<id>",
+          "chatgptPlanType": "pro"   // optional
+        }
+      }
+    }
+  }
+  ```
+  Gated behind `initialize.params.capabilities.experimentalApi: true`
+  (per spec §0.1).
+
+- Server emits `account/login/completed` then `account/updated` with
+  `authMode:"chatgptAuthTokens"`.
+
+- Server-initiated refresh request:
+  ```json
+  {
+    "method": "account/chatgptAuthTokens/refresh",
+    "params": { "reason": "unauthorized", "previousAccountId": "..." }
+  }
+  ```
+
+- Client response shape:
+  ```json
+  {
+    "result": {
+      "accessToken": "...",
+      "chatgptAccountId": "...",
+      "chatgptPlanType": "..."
+    }
+  }
+  ```
+
+- 10-second `EXTERNAL_AUTH_REFRESH_TIMEOUT` per
+  `codex-rs/app-server/src/message_processor.rs` L96–161.
+
+The current `oauth-mux codex run` child+proxy path does NOT use this
+protocol. It is available for broker-mediated automation and future
+adapter modes (`app_server_client.zig`).
+
+_OPERATOR-CONFIRM_ (only if exercising broker-mediated path): capture
+JSON-RPC stdio frames during a real `codex app-server --listen
+stdio://` run; verify method names + params shapes match.
+
+## 11. Open Questions Resolved
+
+Per the truthing pass on `jess/broker-mcp-codex-adapter`. Cross-ref
+broker-mcp-contract §8 + codex-adapter-contract §15.
+
+- **Q1** (mid-turn account header rewrite acceptance): RESOLVED —
+  leaning contradicted. Issue `openai/codex#16894` plus
+  `x-codex-turn-state` sticky-routing token at `core/client.rs:116`
+  give strong evidence per-`sub` server-side thread state. Phase 2
+  default is between-turn swap (Level 3); Level 4 mid-turn is
+  gated on positive _OPERATOR-CONFIRM_ capture.
+- **Q2** (cross-account thread id reuse): STANDING — Level 5 not
+  claimed. Honest negative result.
+- **Q3** (TUI-embedded app-server response to refresh): MOOT in the
+  current child+proxy topology. We don't drive
+  `chatgptAuthTokens/refresh` through the TUI's embedded
+  app-server; codex owns its own UnauthorizedRecovery on
+  propagated 401s.
+- **Q4** (id_token cache vs login/start re-derive): STANDING but
+  non-blocking. The current child+proxy topology sidesteps
+  `account/login/start` at runtime.
+- **Q5** (DPoP/cnf): RESOLVED — no DPoP/cnf in codex-rs auth code.
+  Bearers are wire-portable.
+- **A1** (synthesized-401 retries current vs next turn): MOOT in the
+  current child+proxy topology. We don't synthesize 401; the wire
+  proxy returns the upstream 429 unchanged and codex starts a new
+  turn on the next user input.
+- **A2** (mid-session `chatgptAuthTokens` re-login): STANDING but
+  non-blocking. The current child+proxy topology doesn't re-login at
+  runtime.
+- **A3** (TUI feature gap for thin-passthrough): MOOT — we don't
+  thin-passthrough; we exec real codex.
+- **A4** (additional headers required by chatgpt.com): RESOLVED —
+  the eight-header forward-unchanged set is the source-confirmed
+  answer. _OPERATOR-CONFIRM_ that the captured wire shows no
+  header NOT in this list (which would indicate hidden CF/abuse
+  signal we're missing).
+
+## 12. Implications for Phase 2
+
+The current child+proxy topology is what has shipped so far. Source
+review answered most questions; live capture's job is to confirm the
+wire shapes match these assumptions.
+
+If live capture surfaces:
+
+- **Header NOT in §2's list that the wire proxy strips**: add to the
+  forward-unchanged copy in `wire_proxy.zig::copyForwardingHeaders`.
+- **Header NOT in §2's list that the proxy needs to substitute**:
+  add to the substitute set (§2's auth-bound trio currently).
+- **429 body shape divergent from §5/§6**: update
+  `wire_proxy.zig::classify` to match.
+- **WS upgrade traffic actually goes through `Sec-WebSocket-Protocol`**:
+  contradicts source review; rerun source check before changing
+  proxy behavior.
+
+The in-session smoke (`smoke-codex-acceptance`) proves the proxy
+correctly classifies and substitutes against a synthetic
+`usage_limit_reached` shape. The cassette replay smoke proves reviewed
+captures can be replayed deterministically once operator evidence lands.
+Live capture is for "do the actual chatgpt.com responses match these
+shapes byte-for-byte" not "what shapes does the proxy support."

--- a/justfile
+++ b/justfile
@@ -173,7 +173,7 @@ check:
     nix develop --command just check-local
 
 check-local:
-    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh && ./scripts/stay-afloat-wrapper-doc-smoke.sh && ./scripts/smoke-broker.sh && ./scripts/smoke-codex-acceptance.sh'
+    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh && ./scripts/stay-afloat-wrapper-doc-smoke.sh && ./scripts/smoke-broker.sh && ./scripts/smoke-codex-acceptance.sh && ./scripts/smoke-codex-cassette-replay.sh'
     @echo "all checks passed"
 
 e2e:
@@ -210,6 +210,14 @@ smoke-codex-acceptance:
 smoke-codex-acceptance-local:
     zig build
     ./scripts/smoke-codex-acceptance.sh
+
+# ── Codex cassette replay smoke (no provider traffic) ──
+
+smoke-codex-cassette-replay:
+    nix develop --command just smoke-codex-cassette-replay-local
+
+smoke-codex-cassette-replay-local:
+    ./scripts/smoke-codex-cassette-replay.sh
 
 # ── Config ──
 

--- a/scripts/capture-codex-wire.sh
+++ b/scripts/capture-codex-wire.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Phase 0: capture Codex wire traffic for the broker MCP contract.
+#
+# Anchor: docs/spec/broker-mcp-contract-2026-05-03.md section 5 Phase 0.
+# Goal:   replace assumptions with observed traffic before any Phase 2
+#         wire-proxy code lands.
+#
+# Captures HTTP traffic, including any WebSocket upgrade request metadata,
+# to chatgpt.com/backend-api/codex via mitmdump.
+#
+# Outputs land under captures/codex-wire-<UTC-timestamp>/ with:
+#   - http/   - mitmdump flows (.flows binary + per-flow redacted JSON)
+#   - meta.json - codex version, plan_type, capture metadata
+#
+# Captured evidence fills in docs/spec/codex-wire-evidence-2026-05-03.md.
+
+set -euo pipefail
+
+cmd="${1:-help}"
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CAP_DIR="$ROOT/captures"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="$CAP_DIR/codex-wire-$TS"
+
+usage() {
+  cat <<'__USAGE_END__'
+capture-codex-wire.sh - Phase 0 evidence capture for the Codex adapter.
+
+USAGE
+  scripts/capture-codex-wire.sh init             # one-time mitmproxy CA install check
+  scripts/capture-codex-wire.sh proxy            # start the HTTP capture proxy in foreground
+  scripts/capture-codex-wire.sh help
+
+WORKFLOW
+  1. Run `init` once. If your system trust store does not yet have the
+     mitmproxy CA, follow the instructions it prints. macOS:
+       security add-trusted-cert -d -r trustRoot \
+         -k ~/Library/Keychains/login.keychain-db ~/.mitmproxy/mitmproxy-ca-cert.cer
+  2. In one shell:
+       scripts/capture-codex-wire.sh proxy
+     The proxy listens on 127.0.0.1:9080 as a normal HTTP proxy.
+  3. In another shell:
+       export HTTPS_PROXY=http://127.0.0.1:9080
+       export HTTP_PROXY=http://127.0.0.1:9080
+       export NO_PROXY=
+       codex
+     Drive a normal turn, force a 401 (revoke a token externally), and
+     drive an account to weekly quota exhaustion to capture the 429 +
+     usage_limit_reached body.
+  4. Stop the proxy with ^C. Find captures under captures/.
+  5. Distill findings into docs/spec/codex-wire-evidence-2026-05-03.md.
+
+REDACTION
+  The mitmproxy addon redacts Authorization, Cookie, and ChatGPT-Account-
+  ID values, and replaces tokens.access_token/refresh_token/id_token in
+  any JSON body with the SHA-256 prefix of their bytes. Raw capture
+  directories are ignored by git. Commit only operator-reviewed,
+  scrubbed, fixture-sized per-flow JSON evidence; do NOT commit the
+  .flows binary, which retains raw bytes.
+__USAGE_END__
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: missing dependency '$1'." >&2
+    echo "       hint: $2" >&2
+    exit 64
+  fi
+}
+
+cmd_init() {
+  require_cmd mitmdump "install mitmproxy via 'brew install mitmproxy' or 'pipx install mitmproxy'"
+  echo "mitmdump: $(mitmdump --version | head -1)"
+
+  local ca="$HOME/.mitmproxy/mitmproxy-ca-cert.cer"
+  if [[ ! -f "$ca" ]]; then
+    echo "info: mitmproxy CA not yet generated. Run 'mitmdump' once briefly to mint it." >&2
+    exit 1
+  fi
+
+  echo "ca: $ca"
+  echo
+  echo "Verify trust:"
+  echo "  macOS:  security verify-cert -c $ca || (you must add it to login.keychain-db)"
+  echo "  Linux:  sudo cp $ca /usr/local/share/ca-certificates/mitmproxy-ca.crt && sudo update-ca-certificates"
+  echo "  rustls clients (codex CLI is rustls): also export"
+  echo "    SSL_CERT_FILE=$ca"
+  echo "  before running codex behind the proxy."
+}
+
+cmd_proxy() {
+  require_cmd mitmdump "install mitmproxy via 'brew install mitmproxy'"
+  mkdir -p "$RUN_DIR/http"
+  local addon="$ROOT/scripts/codex-wire-addon.py"
+  if [[ ! -f "$addon" ]]; then
+    echo "error: missing $addon" >&2
+    exit 65
+  fi
+  cat >"$RUN_DIR/meta.json" <<META
+{
+  "ts_utc": "$TS",
+  "kind": "phase_0_wire_capture",
+  "addon": "scripts/codex-wire-addon.py",
+  "host_filter": "chatgpt.com",
+  "ports": { "http": 9080, "https": 9080 }
+}
+META
+  echo "capture run dir: $RUN_DIR"
+  echo "proxy listening on 127.0.0.1:9080 (combined HTTP+HTTPS)"
+  echo "stop with ^C"
+  exec mitmdump \
+    --listen-host 127.0.0.1 \
+    --listen-port 9080 \
+    --set "confdir=$HOME/.mitmproxy" \
+    --set "capture_run_dir=$RUN_DIR" \
+    -s "$addon" \
+    -w "$RUN_DIR/http/flows.binary"
+}
+
+case "$cmd" in
+  help|-h|--help) usage ;;
+  init)           cmd_init ;;
+  proxy)          cmd_proxy ;;
+  *)              usage; exit 64 ;;
+esac

--- a/scripts/codex-wire-addon.py
+++ b/scripts/codex-wire-addon.py
@@ -1,0 +1,167 @@
+"""mitmproxy addon for Phase 0 Codex wire-evidence capture.
+
+Anchor: docs/spec/broker-mcp-contract-2026-05-03.md section 5 Phase 0.
+
+Filters traffic for chatgpt.com/backend-api/codex/* (the target endpoint
+of the future Codex adapter wire-layer proxy) and emits a per-flow JSON
+file with redacted headers and body shape. Operator-reviewed,
+fixture-sized per-flow JSON can be committed as evidence; raw
+mitmproxy .flows files must not be committed.
+
+Redactions:
+  - Authorization values: keep scheme + first 6 chars + sha256(value)[:10]
+  - Cookie values: keep names only, replace values with "<redacted>"
+  - ChatGPT-Account-ID: keep first 6 chars + sha256(value)[:10]
+  - Body fields tokens.access_token / refresh_token / id_token: replace
+    with sha256(value)[:10] (so swap-correctness can be argued from the
+    capture without leaking material)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from mitmproxy import ctx, http
+
+
+# Hosts we care about. Anything else we let pass without writing a per-
+# flow JSON (the .flows binary still records it).
+TARGET_HOST_SUFFIXES = (
+    "chatgpt.com",
+    "auth.openai.com",
+    "auth0.openai.com",
+)
+
+# JSON keys whose values we hash-redact instead of removing entirely (so
+# we can still argue cross-account swaps by hash equality).
+HASH_REDACT_KEYS = {
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "chatgptAccountId",
+    "chatgpt_account_id",
+    "accountId",
+    "account_id",
+}
+
+
+def _hash10(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()[:10]
+
+
+def _redact_header(name: str, value: str) -> str:
+    name_low = name.lower()
+    if name_low == "authorization":
+        # keep scheme + first 6 chars of token + hash
+        parts = value.split(" ", 1)
+        if len(parts) == 2:
+            scheme, tok = parts
+            head = tok[:6]
+            return f"{scheme} {head}-<{_hash10(tok)}>"
+        return f"<{_hash10(value)}>"
+    if name_low == "cookie":
+        # keep cookie names only
+        names = []
+        for chunk in value.split(";"):
+            kv = chunk.strip().split("=", 1)
+            if kv:
+                names.append(kv[0])
+        return "; ".join(f"{n}=<redacted>" for n in names)
+    if name_low == "chatgpt-account-id":
+        return f"{value[:6]}-<{_hash10(value)}>"
+    return value
+
+
+def _redact_obj(node: Any) -> Any:
+    if isinstance(node, dict):
+        out = {}
+        for k, v in node.items():
+            if isinstance(v, str) and k in HASH_REDACT_KEYS:
+                out[k] = f"<{_hash10(v)}>"
+            else:
+                out[k] = _redact_obj(v)
+        return out
+    if isinstance(node, list):
+        return [_redact_obj(x) for x in node]
+    return node
+
+
+def _safe_json(b: bytes) -> Any:
+    try:
+        return json.loads(b.decode("utf-8"))
+    except Exception:
+        return {"__non_json__": True, "len": len(b), "head_hex": b[:64].hex()}
+
+
+class CodexWireAddon:
+    def __init__(self) -> None:
+        self.run_dir: Path | None = None
+        self.flow_count = 0
+
+    def load(self, loader) -> None:  # mitmproxy lifecycle
+        loader.add_option(
+            name="capture_run_dir",
+            typespec=str,
+            default="",
+            help="oauth-mux Codex wire capture run directory",
+        )
+
+    def configure(self, updated):  # mitmproxy lifecycle
+        d = getattr(ctx.options, "capture_run_dir", "") or None
+        if not d:
+            d = os.environ.get("OMUX_CAPTURE_RUN_DIR")
+        if d:
+            self.run_dir = Path(d)
+            (self.run_dir / "http").mkdir(parents=True, exist_ok=True)
+
+    def request(self, flow: http.HTTPFlow) -> None:  # noqa: D401
+        # nothing: we record on response so we get full pair
+        return
+
+    def response(self, flow: http.HTTPFlow) -> None:
+        host = flow.request.pretty_host or ""
+        if not any(host.endswith(s) for s in TARGET_HOST_SUFFIXES):
+            return
+        if self.run_dir is None:
+            return
+
+        self.flow_count += 1
+        idx = f"{self.flow_count:05d}"
+        path_safe = flow.request.path.replace("/", "_").replace("?", "_").lstrip("_") or "root"
+        out = self.run_dir / "http" / f"{idx}-{flow.request.method}-{path_safe[:80]}.json"
+
+        req_headers = [(k, _redact_header(k, v)) for k, v in flow.request.headers.items()]
+        resp_headers = [(k, _redact_header(k, v)) for k, v in flow.response.headers.items()]
+
+        req_body = _redact_obj(_safe_json(flow.request.raw_content or b""))
+        resp_body = _redact_obj(_safe_json(flow.response.raw_content or b""))
+
+        record = {
+            "captured_at": time.time(),
+            "host": host,
+            "scheme": flow.request.scheme,
+            "method": flow.request.method,
+            "path": flow.request.path,
+            "request": {
+                "headers": req_headers,
+                "body": req_body,
+            },
+            "response": {
+                "status": flow.response.status_code,
+                "reason": flow.response.reason,
+                "headers": resp_headers,
+                "body": resp_body,
+            },
+            "timing_ms": int(((flow.response.timestamp_end or 0) - (flow.request.timestamp_start or 0)) * 1000),
+        }
+
+        out.write_text(json.dumps(record, indent=2, ensure_ascii=False, default=str))
+        ctx.log.info(f"codex-wire: recorded {idx} {flow.request.method} {flow.request.path} -> {flow.response.status_code}")
+
+
+addons = [CodexWireAddon()]

--- a/scripts/smoke-codex-cassette-replay.sh
+++ b/scripts/smoke-codex-cassette-replay.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Synthetic replay smoke for the Codex wire cassette layer.
+#
+# This does not require mitmproxy, real Codex, or provider traffic. It writes
+# a tiny scrubbed cassette in the same format as codex-wire-addon.py, starts
+# test-cassette-upstream.py, and verifies method/path matching, per-key cursor
+# cycling, query stripping, 429 body replay, and diagnostic misses.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "smoke-codex-cassette-replay: python3 required" >&2
+    exit 64
+fi
+
+TMP="$(mktemp -d -t omux-cassette.XXXXXX)"
+CASSETTE="$TMP/cassette"
+PORTFILE="$TMP/cassette.port"
+LOGFILE="$TMP/cassette.log"
+SERVER_ERR="$TMP/cassette.stderr"
+
+cleanup() {
+    if [[ -n "${SERVER_PID:-}" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+mkdir -p "$CASSETTE"
+
+python3 - "$CASSETTE" <<'PY'
+import json
+import pathlib
+import sys
+
+d = pathlib.Path(sys.argv[1])
+
+flows = [
+    {
+        "captured_at": 1788000000.001,
+        "host": "chatgpt.com",
+        "scheme": "https",
+        "method": "POST",
+        "path": "/backend-api/codex/responses",
+        "request": {
+            "headers": [
+                ["Authorization", "Bearer synth-<redacted>"],
+                ["ChatGPT-Account-ID", "acct-a-<redacted>"],
+            ],
+            "body": {"model": "gpt-5.5"},
+        },
+        "response": {
+            "status": 200,
+            "reason": "OK",
+            "headers": [["Content-Type", "text/event-stream"]],
+            "body": "event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n",
+        },
+        "timing_ms": 12,
+    },
+    {
+        "captured_at": 1788000000.002,
+        "host": "chatgpt.com",
+        "scheme": "https",
+        "method": "POST",
+        "path": "/backend-api/codex/responses",
+        "request": {
+            "headers": [
+                ["Authorization", "Bearer synth-<redacted>"],
+                ["ChatGPT-Account-ID", "acct-a-<redacted>"],
+            ],
+            "body": {"model": "gpt-5.5"},
+        },
+        "response": {
+            "status": 429,
+            "reason": "Too Many Requests",
+            "headers": [
+                ["Content-Type", "application/json"],
+                ["x-codex-active-limit", "weekly"],
+            ],
+            "body": {
+                "error": {
+                    "type": "usage_limit_reached",
+                    "plan_type": "pro",
+                    "resets_at": 1788003600,
+                }
+            },
+        },
+        "timing_ms": 8,
+    },
+]
+
+for i, flow in enumerate(flows, 1):
+    (d / f"{i:05d}-POST-backend-api-codex-responses.json").write_text(
+        json.dumps(flow, indent=2) + "\n"
+    )
+PY
+
+OMUX_CASSETTE_DIR="$CASSETTE" \
+  OMUX_STUB_PORT=0 \
+  OMUX_STUB_PORTFILE="$PORTFILE" \
+  OMUX_STUB_LOGFILE="$LOGFILE" \
+  python3 "$ROOT/scripts/test-cassette-upstream.py" 2>"$SERVER_ERR" &
+SERVER_PID=$!
+
+python3 - "$PORTFILE" "$LOGFILE" "$SERVER_ERR" <<'PY'
+import http.client
+import json
+import pathlib
+import sys
+import time
+
+portfile = pathlib.Path(sys.argv[1])
+logfile = pathlib.Path(sys.argv[2])
+server_err = pathlib.Path(sys.argv[3])
+
+deadline = time.monotonic() + 5
+while time.monotonic() < deadline:
+    if portfile.exists() and portfile.read_text().strip():
+        break
+    time.sleep(0.05)
+else:
+    print("smoke-codex-cassette-replay: cassette server did not write port", file=sys.stderr)
+    print(server_err.read_text() if server_err.exists() else "", file=sys.stderr)
+    raise SystemExit(1)
+
+port = int(portfile.read_text().strip())
+
+def post(path: str):
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        conn.request(
+            "POST",
+            path,
+            body=b'{"input":"synthetic"}',
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer not-real",
+                "ChatGPT-Account-ID": "not-real",
+            },
+        )
+        resp = conn.getresponse()
+        body = resp.read().decode("utf-8", "replace")
+        return resp.status, body
+    finally:
+        conn.close()
+
+status1, body1 = post("/backend-api/codex/responses")
+assert status1 == 200, (status1, body1)
+assert "response.completed" in body1, body1
+
+status2, body2 = post("/backend-api/codex/responses")
+assert status2 == 429, (status2, body2)
+err = json.loads(body2)["error"]
+assert err["type"] == "usage_limit_reached", err
+assert err["plan_type"] == "pro", err
+assert err["resets_at"] == 1788003600, err
+
+status3, body3 = post("/backend-api/codex/responses?ignored=query")
+assert status3 == 200, (status3, body3)
+assert "response.completed" in body3, body3
+
+status4, body4 = post("/backend-api/codex/missing")
+assert status4 == 599, (status4, body4)
+miss = json.loads(body4)
+assert miss["error"] == "no_cassette_match", miss
+assert miss["path"] == "/backend-api/codex/missing", miss
+
+records = [json.loads(line) for line in logfile.read_text().splitlines() if line.strip()]
+matches = [r for r in records if r.get("match") is True]
+misses = [r for r in records if r.get("match") is False]
+assert len(matches) == 3, records
+assert [r["status_replayed"] for r in matches] == [200, 429, 200], records
+assert len(misses) == 1, records
+
+print("smoke-codex-cassette-replay: all 12 assertions passed.")
+print(f"  cassette dir: {portfile.parent / 'cassette'}")
+print(f"  replay log: {logfile}")
+PY

--- a/scripts/test-cassette-upstream.py
+++ b/scripts/test-cassette-upstream.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Cassette-replay upstream for in-session testing against real
+chatgpt.com response shapes.
+
+Bridges the cassette gap identified in
+`docs/spec/test-and-coverage-review-2026-05-03.md` section 3: the
+synthetic test-stub-upstream.py uses hand-crafted shapes derived
+from source review, which can drift if upstream adds fields. This
+script replays REAL response bytes captured from chatgpt.com via
+`scripts/capture-codex-wire.sh proxy` (which uses the
+codex-wire-addon.py mitmproxy filter to redact tokens before
+writing).
+
+Cassette format: a directory of JSON files, one per captured flow,
+matching what `codex-wire-addon.py` writes. Each file:
+
+    {
+      "captured_at": <unix_ts>,
+      "host": "chatgpt.com",
+      "scheme": "https",
+      "method": "POST",
+      "path": "/backend-api/codex/responses",
+      "request": {
+        "headers": [["Name", "redacted-value"], ...],
+        "body": <json or {"__non_json__": true, ...}>
+      },
+      "response": {
+        "status": 200,
+        "reason": "OK",
+        "headers": [["Name", "value"], ...],
+        "body": <json or {"__non_json__": true, ...}>
+      },
+      "timing_ms": <int>
+    }
+
+Replay strategy: match incoming requests to captures by
+(method, path) tuple. If multiple captures match the same key,
+cycle through them in capture-time order so a session that
+captured "200, 200, 429" can be replayed in the same sequence.
+
+Env (matching test-stub-upstream.py for harness compatibility):
+  OMUX_CASSETTE_DIR        - required, path to directory of flow JSON
+  OMUX_STUB_PORT           - bind port (default 0 = ephemeral)
+  OMUX_STUB_PORTFILE       - port file (default /tmp/omux-cassette-upstream.port)
+  OMUX_STUB_LOGFILE        - per-request log file
+
+Failure modes:
+  - No matching cassette for (method, path): returns 599 with body
+    {"error":"no_cassette_match","method":...,"path":...}
+  - Cassette dir is empty: server starts but every request errors
+    (the harness should treat this as a setup failure)
+
+This script does NOT generate cassettes. Use
+`scripts/capture-codex-wire.sh proxy` for that. Once captures
+exist under captures/codex-wire-<TS>/http/, point OMUX_CASSETTE_DIR
+at that path.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import os
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+
+CASSETTE_DIR = os.environ.get("OMUX_CASSETTE_DIR")
+PORT = int(os.environ.get("OMUX_STUB_PORT", "0"))
+PORTFILE = Path(os.environ.get("OMUX_STUB_PORTFILE", "/tmp/omux-cassette-upstream.port"))
+LOGFILE = Path(os.environ.get("OMUX_STUB_LOGFILE", "/tmp/omux-cassette-upstream.log"))
+
+
+def _log(record: dict) -> None:
+    record["ts"] = time.time()
+    with LOGFILE.open("a") as f:
+        f.write(json.dumps(record) + "\n")
+
+
+def _load_cassettes(d: Path) -> dict[tuple[str, str], list[dict]]:
+    """Load all flow JSON files; group by (method, path); sort by ts."""
+    by_key: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    if not d.is_dir():
+        return by_key
+    for f in sorted(d.glob("*.json")):
+        try:
+            flow = json.loads(f.read_text())
+        except Exception as e:
+            print(f"cassette: skipping malformed {f.name}: {e}", file=sys.stderr)
+            continue
+        key = (flow.get("method", "GET"), flow.get("path", "/"))
+        by_key[key].append(flow)
+    for k in by_key:
+        by_key[k].sort(key=lambda f: f.get("captured_at", 0))
+    return by_key
+
+
+# Per-key replay cursor. Each (method, path) advances independently;
+# wraps around at the end of the captured sequence.
+CURSORS: dict[tuple[str, str], int] = defaultdict(int)
+
+
+class CassetteHandler(http.server.BaseHTTPRequestHandler):
+    cassettes: dict[tuple[str, str], list[dict]] = {}
+
+    def log_message(self, format, *args):  # noqa: A002
+        return
+
+    def _read_body(self) -> bytes:
+        cl = self.headers.get("Content-Length")
+        if cl:
+            return self.rfile.read(int(cl))
+        return b""
+
+    def _serve(self) -> None:
+        path = self.path
+        # Strip query string for matching
+        if "?" in path:
+            path = path.split("?", 1)[0]
+        body_in = self._read_body()
+        _ = body_in
+
+        key = (self.command, path)
+        flows = self.cassettes.get(key, [])
+        if not flows:
+            self._send_error_no_match(key)
+            return
+
+        cursor = CURSORS[key] % len(flows)
+        CURSORS[key] += 1
+        flow = flows[cursor]
+        resp = flow.get("response", {})
+        status = resp.get("status", 200)
+        body_obj = resp.get("body")
+        if isinstance(body_obj, str):
+            payload = body_obj.encode("utf-8")
+            ct = "text/plain"
+        elif isinstance(body_obj, dict) and body_obj.get("__non_json__"):
+            # Non-JSON original; we have head_hex but not full bytes.
+            # For replay we send a minimal body of the same length.
+            payload = b"\x00" * body_obj.get("len", 0)
+            ct = "application/octet-stream"
+        else:
+            payload = json.dumps(body_obj or {}).encode("utf-8")
+            ct = "application/json"
+
+        self.send_response(status)
+        # Replay headers verbatim except framing-related ones we control
+        for name, value in resp.get("headers", []):
+            n = name.lower()
+            if n in ("content-length", "transfer-encoding", "connection", "keep-alive"):
+                continue
+            self.send_header(name, value)
+        self.send_header("Content-Type", ct)
+        self.send_header("Content-Length", str(len(payload)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(payload)
+
+        _log({
+            "match": True,
+            "key": list(key),
+            "cursor": cursor,
+            "captured_at": flow.get("captured_at"),
+            "status_replayed": status,
+        })
+
+    def _send_error_no_match(self, key: tuple[str, str]) -> None:
+        body = json.dumps({
+            "error": "no_cassette_match",
+            "method": key[0],
+            "path": key[1],
+            "available_keys": [list(k) for k in self.cassettes.keys()],
+        }).encode("utf-8")
+        self.send_response(599)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
+
+        _log({
+            "match": False,
+            "key": list(key),
+            "available": [list(k) for k in self.cassettes.keys()],
+        })
+
+    def do_POST(self):  # noqa: N802
+        self._serve()
+
+    def do_GET(self):  # noqa: N802
+        self._serve()
+
+
+def main() -> int:
+    if not CASSETTE_DIR:
+        print("cassette: OMUX_CASSETTE_DIR is required", file=sys.stderr)
+        return 64
+    d = Path(CASSETTE_DIR)
+    cassettes = _load_cassettes(d)
+    if not cassettes:
+        print(f"cassette: no flows loaded from {d} - server will 599 every request", file=sys.stderr)
+
+    LOGFILE.unlink(missing_ok=True)
+    CassetteHandler.cassettes = cassettes
+    httpd = http.server.HTTPServer(("127.0.0.1", PORT), CassetteHandler)
+    actual_port = httpd.server_address[1]
+    PORTFILE.write_text(f"{actual_port}\n")
+    print(f"cassette-upstream: listening on 127.0.0.1:{actual_port}", file=sys.stderr, flush=True)
+    print(f"cassette-upstream: loaded {sum(len(v) for v in cassettes.values())} flows across {len(cassettes)} (method,path) keys", file=sys.stderr, flush=True)
+    print(f"cassette-upstream: portfile={PORTFILE} logfile={LOGFILE}", file=sys.stderr, flush=True)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds the Codex wire cassette tooling slice for TIN-950 / #176:

- `scripts/capture-codex-wire.sh` for operator-controlled mitmproxy HTTP capture against `chatgpt.com/backend-api/codex`.
- `scripts/codex-wire-addon.py` for redacted per-flow JSON capture output.
- `scripts/test-cassette-upstream.py` for replaying reviewed capture JSON by `(method, path)`.
- `scripts/smoke-codex-cassette-replay.sh` plus `just smoke-codex-cassette-replay` for a no-provider synthetic replay smoke.
- `docs/spec/codex-wire-evidence-2026-05-03.md` to separate source-confirmed wire assumptions from pending operator-confirmed evidence.
- `.gitignore` ignores raw `captures/` output; only reviewed, scrubbed, fixture-sized evidence should be committed elsewhere.

## Boundary

This PR does not include live Codex provider traffic or real captured cassettes. It lands the capture and replay harness so the next operator step can record redacted real wire evidence without mixing raw captures into git or normal CI.

It does not claim live seamless fallback, provider-originated quota proof, same-thread recovery, unmanaged TUI hot-swap, or restart fallback.

## Validation

- `scripts/capture-codex-wire.sh help`
- `python3 -m py_compile scripts/codex-wire-addon.py scripts/test-cassette-upstream.py`
- `./scripts/smoke-codex-cassette-replay.sh`
- `just check`

Refs #176.
