### PR TITLE
[codex] Add Codex adapter status artifact file

### DIFF
--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -354,6 +354,7 @@ oauth-mux codex --                                    # explicit args separator 
 oauth-mux codex resume --last                         # forwarded to codex
 oauth-mux codex exec "..."                            # forwarded; Phase 1 may not support exec
 oauth-mux codex --json-status                         # JSON status frames to stderr while running
+oauth-mux codex --json-status-file ./omux.ndjson      # JSON status frames to a file
 ```
 
 `--no-broker` runs bare `codex` directly with no adapter (`execvp`); it
@@ -364,8 +365,11 @@ errors; broker connection failure is a hard error.
 ## 9. JSON Status Frames
 
 When `--json-status` is set, the adapter emits NDJSON to stderr, one frame
-per significant event. Frame shapes are stable under broker
-`surface_version: 1`:
+per significant event. When `--json-status-file <path>` is set, those
+same frames go to the named file instead; this is the required artifact
+path for live acceptance so real Codex terminal output cannot corrupt
+oauth-mux evidence. Frame shapes are stable under broker `surface_version:
+1`:
 
 ```jsonc
 // adapter startup

--- a/scripts/smoke-codex-acceptance.sh
+++ b/scripts/smoke-codex-acceptance.sh
@@ -12,12 +12,12 @@
 #                                      POSTs through the proxy, records
 #                                      its own PID for stability check
 #
-# Drives: oauth-mux codex run --profile codex-max --json-status with:
+# Drives: oauth-mux codex run --profile codex-max --json-status-file with:
 #   OMUX_UPSTREAM_HOST=127.0.0.1:<stub-port>
 #   OMUX_UPSTREAM_SCHEME=http
 #   OMUX_CODEX_BIN=path/to/test-stub-codex.py
 #
-# Asserts the full NDJSON sequence on stderr:
+# Asserts the full NDJSON sequence in the status file:
 #   session_started        (account A elected)
 #   proxy_turn 200 ok      (account A, multiple times)
 #   proxy_turn 429 quota_exhausted (account A)
@@ -54,6 +54,7 @@ TMP="$(mktemp -d -t omux-acceptance.XXXXXX)"
 PORTFILE="$TMP/upstream.port"
 UPLOG="$TMP/upstream.log"
 NDJSON="$TMP/adapter.ndjson"
+ADAPTER_STDERR="$TMP/adapter.stderr"
 STUB_PIDFILE="$TMP/stub-codex.pid"
 STUB_REPORT="$TMP/stub-codex.report"
 
@@ -128,10 +129,12 @@ OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_STUB_CODEX_TURNS=5 \
   OMUX_STUB_CODEX_PIDFILE="$STUB_PIDFILE" \
   OMUX_STUB_CODEX_REPORT="$STUB_REPORT" \
-  "$BIN" codex run --profile codex-max --json-status 2>"$NDJSON" || {
+  "$BIN" codex run --profile codex-max --json-status-file "$NDJSON" 2>"$ADAPTER_STDERR" || {
     echo "smoke-codex-acceptance: adapter exited nonzero" >&2
     echo "---NDJSON---" >&2
     cat "$NDJSON" >&2
+    echo "---stderr---" >&2
+    cat "$ADAPTER_STDERR" >&2
     echo "---upstream log---" >&2
     cat "$UPLOG" >&2 || true
     exit 1
@@ -162,6 +165,13 @@ assert_grep "post-swap dropped x-codex-turn-state" '"dropped":"x-codex-turn-stat
 assert_grep "claim_level remains broker_owned" '"claim_level":"broker_owned"' "$NDJSON"
 assert_grep "session_ended final_claim_level broker_owned" '"kind":"session_ended".*"final_claim_level":"broker_owned"' "$NDJSON"
 assert_grep "session_ended records synthetic swap" '"kind":"session_ended".*"synthetic_swap_observed":true' "$NDJSON"
+
+if grep -q '"kind":"session_started"' "$ADAPTER_STDERR"; then
+    echo "  ✗ adapter status frames leaked to stderr despite --json-status-file" >&2
+    exit 1
+else
+    echo "  ✓ --json-status-file keeps adapter status frames out of stderr"
+fi
 
 ACCOUNT_HITS=$(grep -oE '"account":"codex:max-[12]"' "$NDJSON" | sort -u | wc -l | tr -d ' ')
 if [[ "$ACCOUNT_HITS" -ge 2 ]]; then
@@ -202,7 +212,7 @@ else
 fi
 
 echo
-echo "smoke-codex-acceptance: all 14 assertions passed."
+echo "smoke-codex-acceptance: all 15 assertions passed."
 echo "  full ndjson: $NDJSON"
 echo "  stub upstream log: $UPLOG"
 echo "  stub codex report: $STUB_REPORT"

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -39,6 +39,10 @@ pub const RunOptions = struct {
     account: ?[]const u8 = null,
     /// If true, emit NDJSON status frames to stderr.
     json_status: bool = false,
+    /// Optional file path for NDJSON status frames. When set, status
+    /// frames are written here instead of stderr so real Codex terminal
+    /// output cannot corrupt the evidence stream.
+    json_status_file: ?[]const u8 = null,
     /// Args after `--` to forward to codex unchanged.
     forward_argv: []const []const u8 = &.{},
 };
@@ -87,6 +91,15 @@ fn expandTilde(allocator: std.mem.Allocator, p: []const u8) ![]u8 {
 
 pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     const stderr = std.io.getStdErr().writer();
+    const emit_status = opts.json_status or opts.json_status_file != null;
+
+    var status_file: ?std.fs.File = null;
+    defer if (status_file) |*file| file.close();
+    var status_writer = stderr.any();
+    if (opts.json_status_file) |path| {
+        status_file = try std.fs.cwd().createFile(path, .{ .mode = 0o600, .truncate = true });
+        status_writer = status_file.?.writer().any();
+    }
 
     // 1. Load oauth-mux config + populate broker pool.
     const parsed = config_mod.load(allocator) catch |e| {
@@ -136,7 +149,7 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         allocator,
         &server.pool,
         mat_ctx.vtable(),
-        stderr.any(),
+        status_writer,
     ) catch |e| {
         try stderr.print("oauth-mux codex: proxy bind: {s}\n", .{@errorName(e)});
         return e;
@@ -155,8 +168,8 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         allocator.free(codex_home);
     }
 
-    if (opts.json_status) {
-        try stderr.print(
+    if (emit_status) {
+        try status_writer.print(
             "{{\"kind\":\"session_started\",\"adapter\":\"codex\",\"selected_account\":\"{s}\",\"codex_home_path_printed\":false,\"proxy_port\":{d},\"claim_level\":\"broker_owned\"}}\n",
             .{ elected.id, proxy_port },
         );
@@ -215,12 +228,12 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     tickleProxy(proxy_port);
     proxy_thread.join();
 
-    if (opts.json_status) {
+    if (emit_status) {
         const exit_code: i32 = switch (term) {
             .Exited => |c| c,
             else => -1,
         };
-        try stderr.print(
+        try status_writer.print(
             "{{\"kind\":\"session_ended\",\"adapter\":\"codex\",\"exit_code\":{d},\"final_claim_level\":\"{s}\",\"synthetic_swap_observed\":{any}}}\n",
             .{ exit_code, proxy.peakClaimLevel().toString(), proxy.syntheticSwapSeen() },
         );
@@ -340,6 +353,7 @@ test "RunOptions defaults" {
     const opts = RunOptions{};
     try std.testing.expect(opts.profile == null);
     try std.testing.expect(!opts.json_status);
+    try std.testing.expect(opts.json_status_file == null);
     try std.testing.expectEqual(@as(usize, 0), opts.forward_argv.len);
 }
 

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -50,6 +50,7 @@ pub const Command = union(enum) {
         profile: ?[]const u8 = null,
         account: ?[]const u8 = null,
         json_status: bool = false,
+        json_status_file: ?[]const u8 = null,
         /// Args after `--` forwarded to codex unchanged.
         forward_argv: []const []const u8 = &.{},
     };
@@ -378,6 +379,10 @@ fn parseCodexAdapter(args: []const []const u8) Command {
             i += 1;
             result.account = args[i];
         } else if (eql(args[i], "--json-status")) {
+            result.json_status = true;
+        } else if (eql(args[i], "--json-status-file") and i + 1 < args.len) {
+            i += 1;
+            result.json_status_file = args[i];
             result.json_status = true;
         }
     }
@@ -1229,7 +1234,7 @@ pub fn printUsage(writer: anytype) !void {
         \\  mcp [--profile <name>] [--capability <name>]
         \\      Run the broker MCP/JSON-RPC server on stdio for harness adapters.
         \\
-        \\  codex run [--profile name] [--account provider:account] [--json-status] [-- codex-args...]
+        \\  codex run [--profile name] [--account provider:account] [--json-status] [--json-status-file path] [-- codex-args...]
         \\      Run a broker-mediated Codex adapter session with a local wire proxy.
         \\
         \\  init [--interactive] [--codex-max]
@@ -2202,13 +2207,14 @@ test "parse mcp broker server profile" {
 }
 
 test "parse codex run adapter args" {
-    const args = [_][]const u8{ "codex", "run", "--profile", "codex-max", "--account", "codex:max-1", "--json-status", "--", "--model", "gpt-5.5" };
+    const args = [_][]const u8{ "codex", "run", "--profile", "codex-max", "--account", "codex:max-1", "--json-status-file", "/tmp/omux-status.ndjson", "--", "--model", "gpt-5.5" };
     const cmd = parse(&args);
     switch (cmd) {
         .codex_adapter => |adapter| {
             try std.testing.expectEqualStrings("codex-max", adapter.profile.?);
             try std.testing.expectEqualStrings("codex:max-1", adapter.account.?);
             try std.testing.expect(adapter.json_status);
+            try std.testing.expectEqualStrings("/tmp/omux-status.ndjson", adapter.json_status_file.?);
             try std.testing.expectEqual(@as(usize, 2), adapter.forward_argv.len);
             try std.testing.expectEqualStrings("--model", adapter.forward_argv[0]);
             try std.testing.expectEqualStrings("gpt-5.5", adapter.forward_argv[1]);
@@ -2307,6 +2313,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l profile -s p -d 'Profile name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l account -d 'Route account id' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l json-status -d 'Emit redacted adapter status frames'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l json-status-file -d 'Write redacted adapter status frames to a file' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run loop start stop status events handoffs tick' -d 'Daemon subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l stay-afloat -d 'Host foreground stay-afloat tick loop'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l json -d 'JSON output'

--- a/src/main.zig
+++ b/src/main.zig
@@ -55,6 +55,7 @@ pub fn main() !void {
                 .profile = adapter_args.profile,
                 .account = adapter_args.account,
                 .json_status = adapter_args.json_status,
+                .json_status_file = adapter_args.json_status_file,
                 .forward_argv = adapter_args.forward_argv,
             }) catch |e| {
                 log.err("codex run: {s}", .{@errorName(e)});


### PR DESCRIPTION
## Summary

Adds a clean artifact channel for the upcoming TIN-951 live Level 3 acceptance run:

- `oauth-mux codex run --json-status-file <path>` writes redacted adapter/proxy NDJSON frames to a dedicated file.
- `--json-status-file` implies status emission and keeps those frames out of stderr.
- `smoke-codex-acceptance` now uses the file path and asserts status frames do not leak to stderr.
- Codex adapter docs now mark `--json-status-file` as the required live acceptance evidence path.

## Why

Real Codex owns terminal output. For live acceptance, we need oauth-mux evidence that is parseable and redacted even while the child harness writes normal terminal streams. Stderr-only `--json-status` is useful for synthetic smokes but too fragile for the operator acceptance artifact.

## Boundary

This PR does not run live provider acceptance and does not promote any claim level. It only makes the future live run auditable without transcript/status interleaving.

## Validation

- `zig build`
- `./scripts/smoke-codex-acceptance.sh`
- `just check`
- `git diff --check`

Refs #177.
