### PR TITLE
Add Codex quarry smoke coverage

### DIFF
--- a/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
+++ b/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
@@ -1,0 +1,260 @@
+# Broker Worktree Quarry Todo
+Date: 2026-05-05
+Status: local todo and quarry map; not a product contract.
+
+Anchor docs:
+
+- `AGENTS.md`
+- `docs/spec/broker-mcp-contract-2026-05-03.md`
+- `docs/spec/codex-adapter-contract-2026-05-03.md`
+- `docs/spec/codex-wire-evidence-2026-05-03.md`
+
+## Product Bar
+
+The product succeeds only when the user runs `oauth-mux <harness>`, the
+active subscription account exhausts, and another credited account is
+substituted in place without restart, logout, manual resume, prompt, or
+provider-owned session relaunch.
+
+Everything below is in service of that bar. Route warming, restart,
+prepared fallback, and synthetic smokes are evidence or diagnostics only.
+
+## Current Live State
+
+Observed on 2026-05-05 around 10:44 EDT:
+
+- Repository: clean on `main...origin/main` at `83b23cf`.
+- Selected live `codex-max` route: `max-4`.
+- Selected route local token claim: `chatgpt_plan_type = "pro"`,
+  subscription active until `2026-06-02T20:12:47Z`, last subscription
+  check `2026-05-02T21:06:42Z`.
+- All four configured Max routes locally claim `pro`; that proves tier
+  metadata only, not available quota.
+- Planner surfaces still mark `max-1`, `max-2`, and `max-3` as
+  `quota_exhausted`.
+- Their stored reset timestamps are in the past:
+  - `max-3`: 2026-05-05 06:15 EDT
+  - `max-1`: 2026-05-05 09:20 EDT
+  - `max-2`: 2026-05-05 10:30 EDT
+- `spare_fallback_ready:false` and `single_route_at_risk:true`.
+
+Next live action after the operator's expected quota reset window:
+
+```bash
+./zig-out/bin/oauth-mux codex revalidate-exhausted --profile codex-max --capability codex-max --confirm-spend --json
+```
+
+If this revalidates at least one additional `codex-max` route as
+available, run the Level 3 live acceptance path under TIN-951.
+
+## Mainline Reality
+
+Already merged on main:
+
+- Broker MCP core.
+- Codex adapter/proxy skeleton.
+- Per-session `CODEX_HOME` overlay; account-local `config.toml` is not
+  clobbered by adapter sessions.
+- Synthetic Codex acceptance smoke: account A succeeds, then returns
+  `usage_limit_reached`, then account B handles a post-swap turn in one
+  stable child PID.
+- Cassette capture/replay tooling; real operator capture data is still
+  pending.
+- `--json-status-file` artifact path, so oauth-mux status frames do not
+  corrupt real Codex stderr/stdout.
+- Unit and property tests for broker/session ids, credential handle
+  parsing, header forwarding, quota classification, and per-session
+  overlay behavior.
+
+Not yet proven:
+
+- Live provider-originated Level 3 account swap.
+- Same-thread continuity across account swap.
+- Mid-turn recovery.
+- Bare `codex` plus a separate background oauth-mux daemon seamlessly
+  handing off account state.
+
+## Quarry Worktree
+
+Worktree:
+
+```text
+/Users/jess/git/oauth-mux-broker  jess/broker-mcp-codex-adapter
+```
+
+State at review time:
+
+- `ahead 33, behind 5`.
+- Clean worktree.
+- Not a merge candidate.
+- Treat as a quarry for small reviewed slices only.
+
+The branch is stale relative to main and would regress important merged
+work if merged wholesale. In particular, it would remove the current
+cassette replay smoke, weaken status artifact behavior, and reintroduce
+shared account-local `CODEX_HOME` assumptions that main already replaced
+with per-session overlays.
+
+## Quarry Classification
+
+### Cherry-pick, With Adaptation
+
+These are valuable but must be applied onto current main, not merged from
+the branch as-is:
+
+1. `scripts/smoke-codex-tier-insufficient.sh`
+   - Goal: prove `usage_not_included` is classified as
+     `tier_insufficient` and does not trigger account swap.
+   - Status: adapted onto main with main's redaction/status-file
+     conventions.
+   - Added as `just smoke-codex-tier-insufficient`.
+
+2. `scripts/smoke-codex-all-exhausted.sh`
+   - Goal: prove all accounts exhausted returns a clean
+     `proxy_no_account_selectable` / 503 path without restart or loop.
+   - Status: adapted onto main with current claim and status semantics.
+   - Added as `just smoke-codex-all-exhausted`.
+
+3. `scripts/smoke-codex-401-propagation.sh`
+   - Goal: pin the important behavior that upstream 401 is propagated so
+     Codex's own refresh path can run; oauth-mux must not mark the account
+     dead before Codex gets a chance to refresh.
+   - Status: adapted onto main and verified against the current
+     `wire_proxy.zig` behavior and status artifact path.
+   - Added as `just smoke-codex-401-propagation`.
+
+4. Concurrent-session smoke concept
+   - The quarry script documents the old `config.toml` clobber race.
+   - Main already fixed that with per-session overlays.
+   - Status: adapted onto current main as
+     `just smoke-codex-concurrent-sessions`.
+   - The expected result is stronger than the quarry version: both
+     concurrent sessions get their own proxy traffic, both child PIDs
+     remain stable, proxy ports are distinct, and account-local config
+     files are not mutated.
+
+5. `docs/spec/test-and-coverage-review-2026-05-03.md`
+   - Valuable as an assessment, but stale in counts and conclusions.
+   - Rewrite from current main rather than copying.
+   - It should explicitly separate structural synthetic evidence,
+     cassette replay readiness, and live Level 3 evidence.
+
+6. `docs/policy/tos-posture-2026-05-03.md`
+   - Policy posture is needed before public promotion.
+   - Review for wording that could be read as quota evasion marketing.
+   - Link from first-run/operator docs only after the mechanism is stated
+     as operator-owned account enrollment and redacted evidence.
+
+### Already Absorbed or Superseded
+
+- Broker MCP core and Codex adapter skeleton are already on main.
+- Per-session `CODEX_HOME` overlay is already on main.
+- Status-file artifact path is already on main and is stronger than the
+  quarry branch.
+- Cassette replay tooling is already on main; the quarry branch's deletion
+  of `scripts/smoke-codex-cassette-replay.sh` is wrong.
+- Header forwarding, request parsing, quota classification, and PBT
+  coverage are partially already on main; cherry-pick only missing tests
+  after checking current `zig build test` inventory.
+
+### Reject
+
+- Any source diff that reverts `--json-status-file`.
+- Any source diff that prints `CODEX_HOME`, credential paths, token
+  material, raw JWT bodies, or upstream account ids in normal output.
+- Any source diff that promotes synthetic mock swap evidence to
+  `next_turn_seamless`.
+- Any docs or code that describe restart/supervision as a product success
+  path.
+- Any direct deletion of main's cassette replay smoke.
+- Any shared account-local `config.toml` mutation model for adapter
+  sessions.
+
+## Dead Code / Stale Surface Watchlist
+
+These need review before public promotion:
+
+- `stay-afloat launch`, `codex managed`, and supervised wrapper language:
+  keep as diagnostic/Level 1 surfaces only; do not let docs frame them as
+  stay-afloat success.
+- JSON claim flag soup (`supervised_restart`, `current_process_hotswap`,
+  `per_request_muxing`, `unmanaged_tui_hotswap`): migrate toward the broker
+  contract claim ladder where possible.
+- `broker-*` proof commands: keep as diagnostic regression surfaces, not
+  product UX.
+- Expired quota health: TIN-973 / GitHub #183 should make past reset
+  windows show as `revalidation_needed` or equivalent, not indistinct
+  active `quota_exhausted`.
+- Linear/GitHub tracker drift: TIN-941 / GitHub #172 and TIN-948 /
+  GitHub #174 were confirmed satisfied by PR #178 (`9a8aea6`) and PR #179
+  (`c7c6512`), then closed/marked Done during this hygiene pass.
+- TIN-949 / GitHub #175 is intentionally still open: PR #180 (`3a3da0f`)
+  fixed the per-session overlay implementation, but the stronger
+  concurrent-session smoke remains pending until this hygiene branch lands.
+
+## Architectural Uncertainties
+
+1. Live Level 3 acceptance
+   - Need a second selectable `codex-max` route after spend-gated
+     revalidation.
+   - Then run TIN-951 and record artifacts.
+
+2. Real wire capture
+   - `docs/spec/codex-wire-evidence-2026-05-03.md` still has
+     `OPERATOR-CONFIRM` fields.
+   - Need one real capture with normal turn, 401 if safely triggerable,
+     and quota exhaustion when available.
+
+3. 429 recovery mode
+   - Main currently proves synthetic between-turn A-to-B behavior.
+   - Still need real evidence for whether same conversation thread survives
+     account swap.
+   - Do not claim mid-turn or same-thread recovery until captured.
+
+4. Daemon-attached broker mode
+   - In-process broker is good enough for current adapter smokes.
+   - Multi-session, multi-harness route truth wants daemon-attached state
+     later.
+
+5. Bare `codex` path
+   - The aspirational background daemon plus bare `codex` remains harder
+     than `oauth-mux codex`.
+   - Treat as future adapter/sidecar research, not the current acceptance
+     gate.
+
+6. Claude adapter
+   - Important to prove broker contract generality.
+   - Start only after Codex Level 3 acceptance or after the Codex blocker is
+     explicitly parked.
+
+## Local Todo Order
+
+1. Keep main clean until after the 2:30 PM EDT quota window.
+2. Revalidate exhausted `codex-max` routes with explicit spend
+   confirmation.
+3. If at least one fallback is selectable, run live Level 3 acceptance for
+   TIN-951.
+4. Fix TIN-973 / GitHub #183 so expired quota windows become
+   revalidation-needed in planner output.
+5. Rewrite the test/coverage review from current main and link it from the
+   broker contract as an assessment, not a contract.
+6. Review policy posture doc and add only if it does not market quota
+   evasion.
+7. Keep demoting route-warming/restart surfaces from product language.
+8. Start the Claude adapter only after the Codex Level 3 proof is recorded
+   or explicitly parked.
+9. Re-run `just check-local` after each code/test slice.
+
+## Hygiene Pass Notes
+
+2026-05-05:
+
+- Added the tier-insufficient, all-exhausted, and 401-propagation Codex
+  negative-path smokes to the repo-managed local gate.
+- Closed GitHub #172 / #174 and marked Linear TIN-941 / TIN-948 Done
+  after confirming their merged PR coverage.
+- Left GitHub #175 / TIN-949 open and annotated the remaining
+  concurrent-session smoke acceptance gap.
+- Added the current-main concurrent-session smoke to the repo-managed
+  local gate.
+- `just check-local` passed with the new smokes included.

--- a/justfile
+++ b/justfile
@@ -173,7 +173,7 @@ check:
     nix develop --command just check-local
 
 check-local:
-    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh && ./scripts/stay-afloat-wrapper-doc-smoke.sh && ./scripts/smoke-broker.sh && ./scripts/smoke-codex-acceptance.sh && ./scripts/smoke-codex-cassette-replay.sh'
+    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh && ./scripts/stay-afloat-wrapper-doc-smoke.sh && ./scripts/smoke-broker.sh && ./scripts/smoke-codex-acceptance.sh && ./scripts/smoke-codex-concurrent-sessions.sh && ./scripts/smoke-codex-tier-insufficient.sh && ./scripts/smoke-codex-all-exhausted.sh && ./scripts/smoke-codex-401-propagation.sh && ./scripts/smoke-codex-cassette-replay.sh'
     @echo "all checks passed"
 
 e2e:
@@ -210,6 +210,38 @@ smoke-codex-acceptance:
 smoke-codex-acceptance-local:
     zig build
     ./scripts/smoke-codex-acceptance.sh
+
+# ── Codex adapter concurrent-session smoke (no provider traffic) ──
+
+smoke-codex-concurrent-sessions:
+    nix develop --command just smoke-codex-concurrent-sessions-local
+
+smoke-codex-concurrent-sessions-local:
+    zig build
+    ./scripts/smoke-codex-concurrent-sessions.sh
+
+# ── Codex adapter negative-path smokes (no provider traffic) ──
+
+smoke-codex-tier-insufficient:
+    nix develop --command just smoke-codex-tier-insufficient-local
+
+smoke-codex-tier-insufficient-local:
+    zig build
+    ./scripts/smoke-codex-tier-insufficient.sh
+
+smoke-codex-all-exhausted:
+    nix develop --command just smoke-codex-all-exhausted-local
+
+smoke-codex-all-exhausted-local:
+    zig build
+    ./scripts/smoke-codex-all-exhausted.sh
+
+smoke-codex-401-propagation:
+    nix develop --command just smoke-codex-401-propagation-local
+
+smoke-codex-401-propagation-local:
+    zig build
+    ./scripts/smoke-codex-401-propagation.sh
 
 # ── Codex cassette replay smoke (no provider traffic) ──
 

--- a/scripts/smoke-codex-401-propagation.sh
+++ b/scripts/smoke-codex-401-propagation.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# 401 propagation smoke: upstream 401 is auth refresh territory owned by
+# Codex. The proxy must classify it, emit the diagnostic event, and
+# propagate the 401 unchanged without rotating accounts.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$ROOT/zig-out/bin/oauth-mux"
+
+if [[ ! -x "$BIN" ]]; then
+    echo "smoke-codex-401-propagation: oauth-mux binary not built at $BIN" >&2
+    echo "  run: just build" >&2
+    exit 64
+fi
+
+if ! command -v jq >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then
+    echo "smoke-codex-401-propagation: jq and python3 required" >&2
+    exit 64
+fi
+
+TMP="$(mktemp -d -t omux-401.XXXXXX)"
+PORTFILE="$TMP/upstream.port"
+NDJSON="$TMP/adapter.ndjson"
+ADAPTER_STDERR="$TMP/adapter.stderr"
+STUB_REPORT="$TMP/stub-codex.report"
+
+cleanup() {
+    if [[ -n "${UPSTREAM_PID:-}" ]] && kill -0 "$UPSTREAM_PID" 2>/dev/null; then
+        kill "$UPSTREAM_PID" 2>/dev/null || true
+        wait "$UPSTREAM_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP/account-A" "$TMP/account-B"
+ID_TOKEN="h.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9wbGFuX3R5cGUiOiJwcm8iLCJjaGF0Z3B0X2FjY291bnRfaXNfZmVkcmFtcCI6dHJ1ZX19.s"
+cat >"$TMP/account-A/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"AT-401-A","refresh_token":"RT-A","account_id":"acc-A-id"},"auth_mode":"Chatgpt"}
+EOF
+cat >"$TMP/account-B/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"AT-401-B","refresh_token":"RT-B","account_id":"acc-B-id"},"auth_mode":"Chatgpt"}
+EOF
+
+cat >"$TMP/oauth-mux.config.json" <<EOF
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "kind": "codex",
+      "accounts": {
+        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "$TMP/account-A/auth.json" } },
+        "max-2": { "priority": 20, "secret": { "backend": "file", "path": "$TMP/account-B/auth.json" } }
+      }
+    }
+  },
+  "profiles": {
+    "codex-max": { "providers": ["codex:max-1#codex-max", "codex:max-2#codex-max"] }
+  }
+}
+EOF
+
+OMUX_STUB_PORT=0 \
+  OMUX_STUB_PORTFILE="$PORTFILE" \
+  OMUX_STUB_ALWAYS_STATUS=401 \
+  python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$TMP/upstream.stderr" &
+UPSTREAM_PID=$!
+
+for _ in {1..40}; do
+    [[ -s "$PORTFILE" ]] && break
+    sleep 0.05
+done
+[[ -s "$PORTFILE" ]] || { echo "stub upstream did not bind" >&2; exit 1; }
+UPSTREAM_PORT="$(cat "$PORTFILE" | tr -d '[:space:]')"
+echo "smoke-codex-401-propagation: stub upstream pid=$UPSTREAM_PID port=$UPSTREAM_PORT always_status=401"
+
+OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+  OMUX_UPSTREAM_HOST="127.0.0.1:$UPSTREAM_PORT" \
+  OMUX_UPSTREAM_SCHEME="http" \
+  OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+  OMUX_STUB_CODEX_TURNS=4 \
+  OMUX_STUB_CODEX_REPORT="$STUB_REPORT" \
+  "$BIN" codex run --profile codex-max --json-status-file "$NDJSON" 2>"$ADAPTER_STDERR" || {
+    echo "adapter exited nonzero" >&2
+    cat "$NDJSON" >&2 || true
+    cat "$ADAPTER_STDERR" >&2 || true
+    exit 1
+}
+
+echo "smoke-codex-401-propagation: assertions"
+
+assert_grep() {
+    local label=$1 pattern=$2 file=$3
+    if grep -q -E "$pattern" "$file"; then
+        echo "  ✓ $label"
+    else
+        echo "  ✗ $label" >&2
+        echo "    pattern: $pattern" >&2
+        cat "$file" >&2
+        return 1
+    fi
+}
+
+assert_no_grep() {
+    local label=$1 pattern=$2 file=$3
+    if grep -q -E "$pattern" "$file"; then
+        echo "  ✗ $label (unexpected match for: $pattern)" >&2
+        cat "$file" >&2
+        return 1
+    else
+        echo "  ✓ $label"
+    fi
+}
+
+assert_grep "session_started" '"kind":"session_started"' "$NDJSON"
+assert_grep "session_started redacts CODEX_HOME path" '"codex_home_path_printed":false' "$NDJSON"
+assert_grep "proxy_turn 401 classified auth_unauthorized" '"kind":"proxy_turn".*"status":401.*"classification":"auth_unauthorized"' "$NDJSON"
+assert_grep "proxy_observed_401_codex_handles diagnostic emitted" '"kind":"proxy_observed_401_codex_handles"' "$NDJSON"
+
+assert_no_grep "no swap fired" '"kind":"proxy_post_swap_turn"' "$NDJSON"
+assert_no_grep "no quota_exhausted misclassification" '"classification":"quota_exhausted"' "$NDJSON"
+assert_no_grep "claim_level not promoted" '"claim_level":"next_turn_seamless"' "$NDJSON"
+assert_grep "session_ended final_claim_level remains broker_owned" '"kind":"session_ended".*"final_claim_level":"broker_owned"' "$NDJSON"
+
+if grep -q '"kind":"session_started"' "$ADAPTER_STDERR"; then
+    echo "  ✗ adapter status frames leaked to stderr despite --json-status-file" >&2
+    exit 1
+else
+    echo "  ✓ --json-status-file keeps adapter status frames out of stderr"
+fi
+
+DISTINCT_ACCT=$(grep -oE '"account":"codex:max-[12]"' "$NDJSON" | sort -u | wc -l | tr -d ' ')
+if [[ "$DISTINCT_ACCT" -eq 1 ]]; then
+    echo "  ✓ exactly one account elected throughout"
+else
+    echo "  ✗ 401 caused account rotation across $DISTINCT_ACCT accounts" >&2
+    grep -oE '"account":"codex:max-[12]"' "$NDJSON" | sort -u >&2
+    exit 1
+fi
+
+GOT_401=$(jq -r '.turns | map(select(.status == 401)) | length' "$STUB_REPORT")
+if [[ "$GOT_401" -eq 4 ]]; then
+    echo "  ✓ stub-codex saw all 4 turns return 401"
+else
+    echo "  ✗ stub-codex saw $GOT_401 401s (expected 4)" >&2
+    jq .turns "$STUB_REPORT" >&2
+    exit 1
+fi
+
+PID_STABLE=$(jq -r .pid_stable "$STUB_REPORT")
+if [[ "$PID_STABLE" == "true" ]]; then
+    echo "  ✓ stub-codex PID stable through 401 storm"
+else
+    echo "  ✗ PID changed across 401s" >&2
+    exit 1
+fi
+
+echo
+echo "smoke-codex-401-propagation: all 12 assertions passed."
+echo "  full ndjson: $NDJSON"

--- a/scripts/smoke-codex-all-exhausted.sh
+++ b/scripts/smoke-codex-all-exhausted.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Edge-case smoke: when every account in the profile is quota-exhausted,
+# the proxy must return a clean no-account-selectable response without
+# restart, loop, or crash.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$ROOT/zig-out/bin/oauth-mux"
+
+if [[ ! -x "$BIN" ]]; then
+    echo "smoke-codex-all-exhausted: oauth-mux binary not built at $BIN" >&2
+    echo "  run: just build" >&2
+    exit 64
+fi
+
+if ! command -v jq >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then
+    echo "smoke-codex-all-exhausted: jq and python3 required" >&2
+    exit 64
+fi
+
+TMP="$(mktemp -d -t omux-allexh.XXXXXX)"
+PORTFILE="$TMP/upstream.port"
+UPLOG="$TMP/upstream.log"
+NDJSON="$TMP/adapter.ndjson"
+ADAPTER_STDERR="$TMP/adapter.stderr"
+STUB_REPORT="$TMP/stub-codex.report"
+
+cleanup() {
+    if [[ -n "${UPSTREAM_PID:-}" ]] && kill -0 "$UPSTREAM_PID" 2>/dev/null; then
+        kill "$UPSTREAM_PID" 2>/dev/null || true
+        wait "$UPSTREAM_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP/account-A" "$TMP/account-B"
+ID_TOKEN="h.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9wbGFuX3R5cGUiOiJwcm8iLCJjaGF0Z3B0X2FjY291bnRfaXNfZmVkcmFtcCI6dHJ1ZX19.s"
+cat >"$TMP/account-A/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"AT-allexh-A","refresh_token":"RT-A","account_id":"acc-A-id"},"auth_mode":"Chatgpt"}
+EOF
+cat >"$TMP/account-B/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"AT-allexh-B","refresh_token":"RT-B","account_id":"acc-B-id"},"auth_mode":"Chatgpt"}
+EOF
+
+cat >"$TMP/oauth-mux.config.json" <<EOF
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "kind": "codex",
+      "accounts": {
+        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "$TMP/account-A/auth.json" } },
+        "max-2": { "priority": 20, "secret": { "backend": "file", "path": "$TMP/account-B/auth.json" } }
+      }
+    }
+  },
+  "profiles": {
+    "codex-max": { "providers": ["codex:max-1#codex-max", "codex:max-2#codex-max"] }
+  }
+}
+EOF
+
+OMUX_STUB_PORT=0 \
+  OMUX_STUB_PORTFILE="$PORTFILE" \
+  OMUX_STUB_OK_BEFORE_429=1 \
+  OMUX_STUB_LOGFILE="$UPLOG" \
+  OMUX_STUB_429_TYPE=usage_limit_reached \
+  python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$TMP/upstream.stderr" &
+UPSTREAM_PID=$!
+
+for _ in {1..40}; do
+    [[ -s "$PORTFILE" ]] && break
+    sleep 0.05
+done
+[[ -s "$PORTFILE" ]] || { echo "stub upstream did not bind" >&2; exit 1; }
+UPSTREAM_PORT="$(cat "$PORTFILE" | tr -d '[:space:]')"
+echo "smoke-codex-all-exhausted: stub upstream pid=$UPSTREAM_PID port=$UPSTREAM_PORT ok_before_429=1"
+
+OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+  OMUX_UPSTREAM_HOST="127.0.0.1:$UPSTREAM_PORT" \
+  OMUX_UPSTREAM_SCHEME="http" \
+  OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+  OMUX_STUB_CODEX_TURNS=5 \
+  OMUX_STUB_CODEX_REPORT="$STUB_REPORT" \
+  "$BIN" codex run --profile codex-max --json-status-file "$NDJSON" 2>"$ADAPTER_STDERR" || {
+    echo "adapter exited nonzero" >&2
+    cat "$NDJSON" >&2 || true
+    cat "$ADAPTER_STDERR" >&2 || true
+    exit 1
+}
+
+echo "smoke-codex-all-exhausted: assertions"
+
+assert_grep() {
+    local label=$1 pattern=$2 file=$3
+    if grep -q -E "$pattern" "$file"; then
+        echo "  ✓ $label"
+    else
+        echo "  ✗ $label" >&2
+        echo "    pattern: $pattern" >&2
+        cat "$file" >&2
+        return 1
+    fi
+}
+
+assert_grep "account A had at least one 200 ok" '"kind":"proxy_turn".*"account":"codex:max-1".*"status":200.*"classification":"ok"' "$NDJSON"
+assert_grep "account B had at least one 200 ok" '"kind":"proxy_turn".*"account":"codex:max-2".*"status":200.*"classification":"ok"' "$NDJSON"
+assert_grep "account A returned 429 quota_exhausted" '"kind":"proxy_turn".*"account":"codex:max-1".*"status":429.*"classification":"quota_exhausted"' "$NDJSON"
+assert_grep "account B returned 429 quota_exhausted" '"kind":"proxy_turn".*"account":"codex:max-2".*"status":429.*"classification":"quota_exhausted"' "$NDJSON"
+assert_grep "proxy_post_swap_turn fired" '"kind":"proxy_post_swap_turn"' "$NDJSON"
+assert_grep "proxy_no_account_selectable event fired" '"kind":"proxy_no_account_selectable"' "$NDJSON"
+
+if grep -q '"kind":"session_started"' "$ADAPTER_STDERR"; then
+    echo "  ✗ adapter status frames leaked to stderr despite --json-status-file" >&2
+    exit 1
+else
+    echo "  ✓ --json-status-file keeps adapter status frames out of stderr"
+fi
+
+GOT_503=$(jq -r '.turns | map(select(.status == 503)) | length' "$STUB_REPORT")
+if [[ "$GOT_503" -ge 1 ]]; then
+    echo "  ✓ stub-codex saw $GOT_503 503 response(s) on all-exhausted turn(s)"
+else
+    echo "  ✗ stub-codex did not see any 503" >&2
+    jq .turns "$STUB_REPORT" >&2
+    exit 1
+fi
+
+PID_STABLE=$(jq -r .pid_stable "$STUB_REPORT")
+if [[ "$PID_STABLE" == "true" ]]; then
+    echo "  ✓ stub-codex PID stable through all-exhausted state"
+else
+    echo "  ✗ stub-codex PID changed across all-exhausted" >&2
+    exit 1
+fi
+
+assert_grep "session_ended final_claim_level broker_owned" '"kind":"session_ended".*"final_claim_level":"broker_owned"' "$NDJSON"
+
+echo
+echo "smoke-codex-all-exhausted: all 10 assertions passed."
+echo "  full ndjson: $NDJSON"

--- a/scripts/smoke-codex-concurrent-sessions.sh
+++ b/scripts/smoke-codex-concurrent-sessions.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# Concurrent-session smoke for `oauth-mux codex run`.
+#
+# This is the current-main version of the old quarry smoke. The old
+# boundary was "at least one session gets proxy traffic" because shared
+# account-local CODEX_HOME/config.toml mutation could make one child point
+# at the other session's proxy. Main now uses a per-session CODEX_HOME
+# overlay, so the expected behavior is stronger:
+#
+#   - two concurrent adapter sessions exit cleanly
+#   - each session gets a distinct proxy port
+#   - each stub-codex child reads its own proxy port from its overlay
+#   - each session independently produces proxy_turn frames
+#   - account-local config.toml files are not clobbered
+#
+# No provider traffic is made. The upstream and codex processes are local
+# stubs, and status frames are written to --json-status-file to avoid
+# corrupting real harness stderr/stdout.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$ROOT/zig-out/bin/oauth-mux"
+
+if [[ ! -x "$BIN" ]]; then
+    echo "smoke-codex-concurrent-sessions: oauth-mux binary not built at $BIN" >&2
+    echo "  run: just build" >&2
+    exit 64
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "smoke-codex-concurrent-sessions: jq required" >&2
+    exit 64
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "smoke-codex-concurrent-sessions: python3 required" >&2
+    exit 64
+fi
+
+TMP="$(mktemp -d -t omux-concurrent.XXXXXX)"
+PORTFILE="$TMP/upstream.port"
+UPLOG="$TMP/upstream.log"
+NDJSON_A="$TMP/adapter-A.ndjson"
+NDJSON_B="$TMP/adapter-B.ndjson"
+STDOUT_A="$TMP/adapter-A.stdout"
+STDOUT_B="$TMP/adapter-B.stdout"
+STDERR_A="$TMP/adapter-A.stderr"
+STDERR_B="$TMP/adapter-B.stderr"
+PIDFILE_A="$TMP/stub-codex-A.pid"
+PIDFILE_B="$TMP/stub-codex-B.pid"
+REPORT_A="$TMP/stub-codex-A.report"
+REPORT_B="$TMP/stub-codex-B.report"
+
+cleanup() {
+    if [[ -n "${UPSTREAM_PID:-}" ]] && kill -0 "$UPSTREAM_PID" 2>/dev/null; then
+        kill "$UPSTREAM_PID" 2>/dev/null || true
+        wait "$UPSTREAM_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP/account-A" "$TMP/account-B"
+ID_TOKEN="h.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9wbGFuX3R5cGUiOiJwcm8iLCJjaGF0Z3B0X2FjY291bnRfaXNfZmVkcmFtcCI6dHJ1ZX19.s"
+
+cat >"$TMP/account-A/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"AT-concurrent-A","refresh_token":"RT-A","account_id":"acc-A-id"},"auth_mode":"Chatgpt"}
+EOF
+cat >"$TMP/account-B/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"AT-concurrent-B","refresh_token":"RT-B","account_id":"acc-B-id"},"auth_mode":"Chatgpt"}
+EOF
+printf '%s\n' 'preexisting = "account-A"' >"$TMP/account-A/config.toml"
+printf '%s\n' 'preexisting = "account-B"' >"$TMP/account-B/config.toml"
+
+cat >"$TMP/oauth-mux.config.json" <<EOF
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "kind": "codex",
+      "accounts": {
+        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "$TMP/account-A/auth.json" } },
+        "max-2": { "priority": 20, "secret": { "backend": "file", "path": "$TMP/account-B/auth.json" } }
+      }
+    }
+  },
+  "profiles": {
+    "codex-max": { "providers": ["codex:max-1#codex-max", "codex:max-2#codex-max"] }
+  }
+}
+EOF
+
+OMUX_STUB_PORT=0 \
+  OMUX_STUB_PORTFILE="$PORTFILE" \
+  OMUX_STUB_OK_BEFORE_429=100 \
+  OMUX_STUB_LOGFILE="$UPLOG" \
+  python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$TMP/upstream.stderr" &
+UPSTREAM_PID=$!
+
+for _ in {1..40}; do
+    [[ -s "$PORTFILE" ]] && break
+    sleep 0.05
+done
+if [[ ! -s "$PORTFILE" ]]; then
+    echo "smoke-codex-concurrent-sessions: stub upstream did not write port" >&2
+    cat "$TMP/upstream.stderr" >&2
+    exit 1
+fi
+UPSTREAM_PORT="$(cat "$PORTFILE" | tr -d '[:space:]')"
+echo "smoke-codex-concurrent-sessions: stub upstream pid=$UPSTREAM_PID port=$UPSTREAM_PORT"
+echo "smoke-codex-concurrent-sessions: launching two concurrent sessions..."
+
+OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+  OMUX_UPSTREAM_HOST="127.0.0.1:$UPSTREAM_PORT" \
+  OMUX_UPSTREAM_SCHEME="http" \
+  OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+  OMUX_STUB_CODEX_TURNS=6 \
+  OMUX_STUB_CODEX_PIDFILE="$PIDFILE_A" \
+  OMUX_STUB_CODEX_REPORT="$REPORT_A" \
+  "$BIN" codex run --profile codex-max --json-status-file "$NDJSON_A" >"$STDOUT_A" 2>"$STDERR_A" &
+PID_A=$!
+
+OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+  OMUX_UPSTREAM_HOST="127.0.0.1:$UPSTREAM_PORT" \
+  OMUX_UPSTREAM_SCHEME="http" \
+  OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+  OMUX_STUB_CODEX_TURNS=6 \
+  OMUX_STUB_CODEX_PIDFILE="$PIDFILE_B" \
+  OMUX_STUB_CODEX_REPORT="$REPORT_B" \
+  "$BIN" codex run --profile codex-max --json-status-file "$NDJSON_B" >"$STDOUT_B" 2>"$STDERR_B" &
+PID_B=$!
+
+if wait "$PID_A"; then EXIT_A=0; else EXIT_A=$?; fi
+if wait "$PID_B"; then EXIT_B=0; else EXIT_B=$?; fi
+
+echo "smoke-codex-concurrent-sessions: assertions"
+
+fail_dump() {
+    echo "--- adapter A ndjson ---" >&2
+    cat "$NDJSON_A" >&2 || true
+    echo "--- adapter A stderr ---" >&2
+    cat "$STDERR_A" >&2 || true
+    echo "--- adapter B ndjson ---" >&2
+    cat "$NDJSON_B" >&2 || true
+    echo "--- adapter B stderr ---" >&2
+    cat "$STDERR_B" >&2 || true
+    echo "--- upstream log ---" >&2
+    cat "$UPLOG" >&2 || true
+}
+
+assert_grep() {
+    local label=$1 pattern=$2 file=$3
+    if grep -q -E "$pattern" "$file"; then
+        echo "  ✓ $label"
+    else
+        echo "  ✗ $label" >&2
+        echo "    pattern: $pattern" >&2
+        echo "    file: $file" >&2
+        fail_dump
+        return 1
+    fi
+}
+
+if [[ "$EXIT_A" -eq 0 && "$EXIT_B" -eq 0 ]]; then
+    echo "  ✓ both adapter sessions exited 0"
+else
+    echo "  ✗ exit codes A=$EXIT_A B=$EXIT_B" >&2
+    fail_dump
+    exit 1
+fi
+
+assert_grep "session A session_started" '"kind":"session_started"' "$NDJSON_A"
+assert_grep "session B session_started" '"kind":"session_started"' "$NDJSON_B"
+assert_grep "session A session_ended" '"kind":"session_ended".*"exit_code":0' "$NDJSON_A"
+assert_grep "session B session_ended" '"kind":"session_ended".*"exit_code":0' "$NDJSON_B"
+assert_grep "session A redacts CODEX_HOME path" '"codex_home_path_printed":false' "$NDJSON_A"
+assert_grep "session B redacts CODEX_HOME path" '"codex_home_path_printed":false' "$NDJSON_B"
+
+PORT_A="$(jq -r 'select(.kind=="session_started") | .proxy_port' "$NDJSON_A" | head -n 1)"
+PORT_B="$(jq -r 'select(.kind=="session_started") | .proxy_port' "$NDJSON_B" | head -n 1)"
+if [[ -n "$PORT_A" && -n "$PORT_B" && "$PORT_A" != "$PORT_B" ]]; then
+    echo "  ✓ sessions used distinct proxy ports (A=$PORT_A, B=$PORT_B)"
+else
+    echo "  ✗ expected distinct proxy ports; A=$PORT_A B=$PORT_B" >&2
+    fail_dump
+    exit 1
+fi
+
+CHILD_PORT_A="$(sed -nE 's/.*proxy=http:\/\/127\.0\.0\.1:([0-9]+)\/.*/\1/p' "$STDERR_A" | head -n 1)"
+CHILD_PORT_B="$(sed -nE 's/.*proxy=http:\/\/127\.0\.0\.1:([0-9]+)\/.*/\1/p' "$STDERR_B" | head -n 1)"
+if [[ "$CHILD_PORT_A" == "$PORT_A" && "$CHILD_PORT_B" == "$PORT_B" ]]; then
+    echo "  ✓ each stub-codex child read its own session proxy port"
+else
+    echo "  ✗ child proxy ports did not match session ports; child A=$CHILD_PORT_A session A=$PORT_A child B=$CHILD_PORT_B session B=$PORT_B" >&2
+    fail_dump
+    exit 1
+fi
+
+A_TURNS=$(grep -c '"kind":"proxy_turn"' "$NDJSON_A" || true)
+B_TURNS=$(grep -c '"kind":"proxy_turn"' "$NDJSON_B" || true)
+if [[ "$A_TURNS" -eq 6 && "$B_TURNS" -eq 6 ]]; then
+    echo "  ✓ both sessions independently produced expected proxy_turn frames (A=$A_TURNS, B=$B_TURNS)"
+else
+    echo "  ✗ expected 6 proxy_turn frames per session; A=$A_TURNS B=$B_TURNS" >&2
+    fail_dump
+    exit 1
+fi
+
+assert_grep "session A proxy_turns are 200 ok" '"kind":"proxy_turn".*"status":200.*"classification":"ok"' "$NDJSON_A"
+assert_grep "session B proxy_turns are 200 ok" '"kind":"proxy_turn".*"status":200.*"classification":"ok"' "$NDJSON_B"
+
+if grep -q '"kind":"session_started"' "$STDERR_A" || grep -q '"kind":"session_started"' "$STDERR_B"; then
+    echo "  ✗ adapter status frames leaked to stderr despite --json-status-file" >&2
+    fail_dump
+    exit 1
+else
+    echo "  ✓ --json-status-file keeps adapter status frames out of stderr"
+fi
+
+if [[ ! -s "$REPORT_A" || ! -s "$REPORT_B" ]]; then
+    echo "  ✗ stub-codex report missing" >&2
+    fail_dump
+    exit 1
+fi
+
+PID_STABLE_A=$(jq -r .pid_stable "$REPORT_A")
+PID_STABLE_B=$(jq -r .pid_stable "$REPORT_B")
+START_A=$(jq -r .start_pid "$REPORT_A")
+START_B=$(jq -r .start_pid "$REPORT_B")
+if [[ "$PID_STABLE_A" == "true" && "$PID_STABLE_B" == "true" && "$START_A" != "$START_B" ]]; then
+    echo "  ✓ both child PIDs are stable and distinct (A=$START_A, B=$START_B)"
+else
+    echo "  ✗ PID check failed: stable A=$PID_STABLE_A stable B=$PID_STABLE_B start A=$START_A start B=$START_B" >&2
+    fail_dump
+    exit 1
+fi
+
+UPSTREAM_TURNS=$(jq -r 'select(.method=="POST") | .path' "$UPLOG" 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$UPSTREAM_TURNS" -eq 12 ]]; then
+    echo "  ✓ stub upstream received all 12 proxied turns"
+else
+    echo "  ✗ expected 12 upstream turns, saw $UPSTREAM_TURNS" >&2
+    fail_dump
+    exit 1
+fi
+
+if [[ "$(cat "$TMP/account-A/config.toml")" == 'preexisting = "account-A"' && "$(cat "$TMP/account-B/config.toml")" == 'preexisting = "account-B"' ]]; then
+    echo "  ✓ account-local config.toml files were not clobbered"
+else
+    echo "  ✗ account-local config.toml was clobbered" >&2
+    fail_dump
+    exit 1
+fi
+
+echo
+echo "smoke-codex-concurrent-sessions: all 16 assertions passed."
+echo "  full ndjson A: $NDJSON_A"
+echo "  full ndjson B: $NDJSON_B"
+echo "  stub upstream log: $UPLOG"

--- a/scripts/smoke-codex-tier-insufficient.sh
+++ b/scripts/smoke-codex-tier-insufficient.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Negative-path smoke: usage_not_included is a plan-tier problem, not a
+# quota handoff signal. The proxy must classify it as tier_insufficient
+# and must not rotate accounts or promote the claim.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$ROOT/zig-out/bin/oauth-mux"
+
+if [[ ! -x "$BIN" ]]; then
+    echo "smoke-codex-tier-insufficient: oauth-mux binary not built at $BIN" >&2
+    echo "  run: just build" >&2
+    exit 64
+fi
+
+if ! command -v jq >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then
+    echo "smoke-codex-tier-insufficient: jq and python3 required" >&2
+    exit 64
+fi
+
+TMP="$(mktemp -d -t omux-tier.XXXXXX)"
+PORTFILE="$TMP/upstream.port"
+UPLOG="$TMP/upstream.log"
+NDJSON="$TMP/adapter.ndjson"
+ADAPTER_STDERR="$TMP/adapter.stderr"
+STUB_REPORT="$TMP/stub-codex.report"
+
+cleanup() {
+    if [[ -n "${UPSTREAM_PID:-}" ]] && kill -0 "$UPSTREAM_PID" 2>/dev/null; then
+        kill "$UPSTREAM_PID" 2>/dev/null || true
+        wait "$UPSTREAM_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP/account-A" "$TMP/account-B"
+ID_TOKEN="h.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9wbGFuX3R5cGUiOiJwcm8iLCJjaGF0Z3B0X2FjY291bnRfaXNfZmVkcmFtcCI6dHJ1ZX19.s"
+cat >"$TMP/account-A/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"AT-tier-A","refresh_token":"RT-A","account_id":"acc-A-id"},"auth_mode":"Chatgpt"}
+EOF
+cat >"$TMP/account-B/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"AT-tier-B","refresh_token":"RT-B","account_id":"acc-B-id"},"auth_mode":"Chatgpt"}
+EOF
+
+cat >"$TMP/oauth-mux.config.json" <<EOF
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "kind": "codex",
+      "accounts": {
+        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "$TMP/account-A/auth.json" } },
+        "max-2": { "priority": 20, "secret": { "backend": "file", "path": "$TMP/account-B/auth.json" } }
+      }
+    }
+  },
+  "profiles": {
+    "codex-max": { "providers": ["codex:max-1#codex-max", "codex:max-2#codex-max"] }
+  }
+}
+EOF
+
+OMUX_STUB_PORT=0 \
+  OMUX_STUB_PORTFILE="$PORTFILE" \
+  OMUX_STUB_OK_BEFORE_429=2 \
+  OMUX_STUB_LOGFILE="$UPLOG" \
+  OMUX_STUB_429_TYPE=usage_not_included \
+  python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$TMP/upstream.stderr" &
+UPSTREAM_PID=$!
+
+for _ in {1..40}; do
+    [[ -s "$PORTFILE" ]] && break
+    sleep 0.05
+done
+[[ -s "$PORTFILE" ]] || { echo "stub upstream did not bind" >&2; exit 1; }
+UPSTREAM_PORT="$(cat "$PORTFILE" | tr -d '[:space:]')"
+echo "smoke-codex-tier-insufficient: stub upstream pid=$UPSTREAM_PID port=$UPSTREAM_PORT 429_type=usage_not_included"
+
+OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+  OMUX_UPSTREAM_HOST="127.0.0.1:$UPSTREAM_PORT" \
+  OMUX_UPSTREAM_SCHEME="http" \
+  OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+  OMUX_STUB_CODEX_TURNS=4 \
+  OMUX_STUB_CODEX_REPORT="$STUB_REPORT" \
+  "$BIN" codex run --profile codex-max --json-status-file "$NDJSON" 2>"$ADAPTER_STDERR" || {
+    echo "adapter exited nonzero" >&2
+    cat "$NDJSON" >&2 || true
+    cat "$ADAPTER_STDERR" >&2 || true
+    exit 1
+}
+
+echo "smoke-codex-tier-insufficient: assertions"
+
+assert_grep() {
+    local label=$1 pattern=$2 file=$3
+    if grep -q -E "$pattern" "$file"; then
+        echo "  ✓ $label"
+    else
+        echo "  ✗ $label" >&2
+        echo "    pattern: $pattern" >&2
+        cat "$file" >&2
+        return 1
+    fi
+}
+
+assert_no_grep() {
+    local label=$1 pattern=$2 file=$3
+    if grep -q -E "$pattern" "$file"; then
+        echo "  ✗ $label (unexpected match for: $pattern)" >&2
+        cat "$file" >&2
+        return 1
+    else
+        echo "  ✓ $label"
+    fi
+}
+
+assert_grep "session_started" '"kind":"session_started"' "$NDJSON"
+assert_grep "session_started redacts CODEX_HOME path" '"codex_home_path_printed":false' "$NDJSON"
+assert_grep "proxy_turn 200 ok at least once" '"kind":"proxy_turn".*"status":200.*"classification":"ok"' "$NDJSON"
+assert_grep "proxy_turn 429 classified tier_insufficient" '"kind":"proxy_turn".*"status":429.*"classification":"tier_insufficient"' "$NDJSON"
+
+assert_no_grep "no swap fired" '"kind":"proxy_post_swap_turn"' "$NDJSON"
+assert_no_grep "no quota_exhausted misclassification" '"classification":"quota_exhausted"' "$NDJSON"
+assert_no_grep "claim_level not promoted" '"claim_level":"next_turn_seamless"' "$NDJSON"
+assert_grep "session_ended final_claim_level remains broker_owned" '"kind":"session_ended".*"final_claim_level":"broker_owned"' "$NDJSON"
+
+if grep -q '"kind":"session_started"' "$ADAPTER_STDERR"; then
+    echo "  ✗ adapter status frames leaked to stderr despite --json-status-file" >&2
+    exit 1
+else
+    echo "  ✓ --json-status-file keeps adapter status frames out of stderr"
+fi
+
+DISTINCT_ACCT=$(grep -oE '"account":"codex:max-[12]"' "$NDJSON" | sort -u | wc -l | tr -d ' ')
+if [[ "$DISTINCT_ACCT" -eq 1 ]]; then
+    echo "  ✓ exactly one account elected throughout"
+else
+    echo "  ✗ tier_insufficient triggered rotation across $DISTINCT_ACCT accounts" >&2
+    grep -oE '"account":"codex:max-[12]"' "$NDJSON" | sort -u >&2
+    exit 1
+fi
+
+UP_DISTINCT=$(jq -r .account_id "$UPLOG" | sort -u | wc -l | tr -d ' ')
+if [[ "$UP_DISTINCT" -eq 1 ]]; then
+    echo "  ✓ stub upstream saw exactly 1 ChatGPT-Account-ID"
+else
+    echo "  ✗ upstream saw $UP_DISTINCT distinct account ids" >&2
+    cat "$UPLOG" >&2
+    exit 1
+fi
+
+echo
+echo "smoke-codex-tier-insufficient: all 10 assertions passed."
+echo "  full ndjson: $NDJSON"


### PR DESCRIPTION
## Summary

- Adds a local quarry/todo map for the stale `jess/broker-mcp-codex-adapter` worktree.
- Ports four no-provider Codex smoke surfaces onto current main: concurrent sessions, tier insufficient, all exhausted, and 401 propagation.
- Wires the new smokes into `just check-local` and individual `just` targets.

## Truth boundary

- No provider calls.
- No live Level 3 acceptance claim.
- No restart/supervision success claim.
- Concurrent-session coverage now expects the fixed per-session overlay behavior: distinct proxy ports, independent proxy turns, stable child PIDs, and unchanged account-local `config.toml`.

## Validation

- `just smoke-codex-concurrent-sessions-local`
- `just check-local`

Tracking: #175 / TIN-949, #183 / TIN-973, #177 / TIN-951.
