### PR TITLE
Surface expired quota revalidation state

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -227,6 +227,9 @@ provider probes, and persists the fresh provider evidence. Use it after credits
 or plan changes instead of manually resetting health keys. It may make a route
 selectable again, or it may confirm that the provider still rejects that exact
 capability.
+Expired local reset windows surface as `revalidation_needed`: the route is no
+longer presented as an active wait, but it also is not trusted until a
+spend-gated revalidation records fresh provider evidence.
 
 `oauth-mux codex broker-fallback-drill --profile codex-max --capability
 codex-max --from-account max-3 --confirm-drill --json` is the controlled

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -289,6 +289,9 @@ re-probes only routes already recorded as exhausted or rate-limited for that
 capability, updates route health from provider evidence, and avoids hand-resetting
 health keys. If the provider still returns quota exhaustion, the route remains
 blocked even if dashboard copy suggests credits are available elsewhere.
+When a stored quota reset window is already in the past, planning surfaces mark
+the route `revalidation_needed` instead of treating it as actively waiting or
+silently selectable.
 Use
 `oauth-mux codex broker-fallback-drill --profile codex-max --capability
 codex-max --from-account max-3 --confirm-drill --json` when you need to observe

--- a/docs/provider-repair-contracts.md
+++ b/docs/provider-repair-contracts.md
@@ -56,6 +56,8 @@ The current typed action kinds are:
 - `none`: route is selectable.
 - `probe_needed`: no recorded evidence exists; probe admission decides whether
   to run.
+- `revalidation_needed`: recorded quota/rate-limit evidence has aged past its
+  reset window; run an explicit provider probe before selecting the route.
 - `fix_runtime`: local binary, permission, sandbox, store, or session shape is
   not ready.
 - `wait_for_repair`: an account-scoped repair lock is active.

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -1113,6 +1113,59 @@ expect_contains "$broker_route_explain_text_after_drill" 'next: revalidate exhau
 broker_stay_afloat_text_after_drill="$(PATH="$broker_session_bin:$PATH" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" stay-afloat --once --profile codex-max --capability codex-max)"
 expect_contains "$broker_stay_afloat_text_after_drill" 'next: revalidate exhausted routes, enroll another Codex account, or wait for quota reset' "stay-afloat text after drill includes Codex risk actions"
 
+printf 'e2e: expired Codex quota windows surface revalidation-needed\n'
+expired_quota_state="$tmp/broker-expired-quota-state"
+mkdir -p "$expired_quota_state"
+cat >"$expired_quota_state/health.json" <<'EOF'
+{
+  "version": 2,
+  "accounts": [
+    {
+      "key": "codex:max-1#codex-max",
+      "last_probe_source": "capability_probe",
+      "last_probe_hint_class": "quota_exhausted",
+      "last_probe_decision": "try_next_account",
+      "liveness": {
+        "state": "live",
+        "availability": "quota_exhausted",
+        "window_resets_at": 1000,
+        "exhausted_at": 1
+      }
+    },
+    {
+      "key": "codex:max-2#codex-max",
+      "last_probe_source": "capability_probe",
+      "last_probe_hint_class": "quota_exhausted",
+      "last_probe_decision": "try_next_account",
+      "liveness": {
+        "state": "live",
+        "availability": "quota_exhausted",
+        "window_resets_at": 1000,
+        "exhausted_at": 1
+      }
+    },
+    {
+      "key": "codex:max-3#codex-max",
+      "last_probe_source": "capability_probe",
+      "last_probe_hint_class": "none",
+      "last_probe_decision": "use_this",
+      "liveness": {
+        "state": "live",
+        "availability": "available"
+      }
+    }
+  ]
+}
+EOF
+expired_quota_plan="$(PATH="$broker_session_bin:$PATH" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$expired_quota_state" "$bin" codex broker-session-plan --profile codex-max --capability codex-max --json)"
+expect_contains "$expired_quota_plan" '"selected":{"provider":"codex","account":"max-3"' "expired quota plan keeps stale routes blocked until revalidated"
+expect_contains "$expired_quota_plan" '"skip_reason":"revalidation_needed"' "expired quota plan distinguishes stale quota block"
+expect_contains "$expired_quota_plan" '"kind":"revalidation_needed"' "expired quota plan emits revalidation-needed route action"
+expect_contains "$expired_quota_plan" '"revalidation_needed":true' "expired quota liveness marks revalidation needed"
+expect_contains "$expired_quota_plan" '"reset_window_state":"expired"' "expired quota liveness marks reset window expired"
+expect_contains "$expired_quota_plan" '"route_role":"revalidation_needed"' "expired quota plan uses explicit route role"
+expect_contains "$expired_quota_plan" '"resilience_actions":[{"kind":"revalidate_exhausted_routes"' "expired quota plan still recommends spend-gated revalidation"
+
 printf 'e2e: codex broker-session-smoke requires explicit confirmation before starting app-server\n'
 broker_session_smoke_prompt="$(OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex broker-session-smoke --profile codex-max --capability codex-max --json)"
 expect_contains "$broker_session_smoke_prompt" '"mode":"codex_broker_owned_session_smoke"' "broker-session-smoke reports session smoke mode"

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -250,7 +250,7 @@ jq -e '
   .profile == "codex-max"
   and (.routes | length) == 3
   and all(.routes[]; .provider == "codex" and .capability == "codex-max" and .action.mutating == false)
-  and all(.routes[]; .action.kind == "fix_runtime" or .action.kind == "probe_needed" or .action.kind == "none" or .action.kind == "wait_and_retry" or .action.kind == "wait_for_quota" or .action.kind == "wait_for_cooldown")
+  and all(.routes[]; .action.kind == "fix_runtime" or .action.kind == "probe_needed" or .action.kind == "revalidation_needed" or .action.kind == "none" or .action.kind == "wait_and_retry" or .action.kind == "wait_for_quota" or .action.kind == "wait_for_cooldown")
   and all(.routes[]; if .action.kind == "fix_runtime" then
     .action.command == null
     and (.action.diagnostic_command | startswith("oauth-mux doctor runtime --provider codex --account "))

--- a/src/health.zig
+++ b/src/health.zig
@@ -624,6 +624,14 @@ pub const HealthStore = struct {
                         try writeOptI64Field(writer, "window_resets_at", q.window_resets_at);
                         try writeOptU8Field(writer, "usage_pct", q.usage_pct);
                         try writer.print(",\"exhausted_at\":{d}", .{q.exhausted_at});
+                        try writer.writeAll(",\"revalidation_needed\":");
+                        try writer.writeAll(if (quotaWindowRevalidationNeeded(q)) "true" else "false");
+                        try writer.writeAll(",\"reset_window_state\":");
+                        if (q.window_resets_at) |reset| {
+                            try writeJsonString(writer, if (std.time.timestamp() >= reset) "expired" else "active");
+                        } else {
+                            try writeJsonString(writer, "unknown");
+                        }
                     },
                     .cooldown => |c| {
                         try writer.writeAll(",\"availability\":\"cooldown\"");
@@ -905,6 +913,11 @@ pub const HealthStore = struct {
         auth_failure,
     };
 };
+
+fn quotaWindowRevalidationNeeded(quota: types.Availability.QuotaInfo) bool {
+    const reset = quota.window_resets_at orelse return false;
+    return std.time.timestamp() >= reset;
+}
 
 test "HealthStore basic lifecycle" {
     var store = HealthStore.init(std.testing.allocator, .{});

--- a/src/main.zig
+++ b/src/main.zig
@@ -2530,6 +2530,7 @@ const RepairCommandKind = enum {
 const RepairActionKind = enum {
     none,
     probe_needed,
+    revalidation_needed,
     fix_runtime,
     wait_for_repair,
     wait_and_retry,
@@ -3438,7 +3439,14 @@ fn repairActionFor(
                 .budget = .free_local,
                 .retry_after_s = rl.retry_after_s,
             },
-            .quota_exhausted => |quota| .{
+            .quota_exhausted => |quota| if (quotaWindowRevalidationNeeded(quota)) .{
+                .kind = .revalidation_needed,
+                .severity = "warning",
+                .message = "quota reset window has passed; revalidate route health before using this route",
+                .mediation = .probe,
+                .command = .probe,
+                .budget = budget,
+            } else .{
                 .kind = .wait_for_quota,
                 .severity = "warning",
                 .message = "quota window is exhausted; use another account until reset",
@@ -3458,6 +3466,11 @@ fn repairActionFor(
         .degraded => |degraded| degradedAction(route, def, degraded.reason, budget),
         .dead => reauthAction(route, def),
     };
+}
+
+fn quotaWindowRevalidationNeeded(quota: types.Availability.QuotaInfo) bool {
+    const reset = quota.window_resets_at orelse return false;
+    return std.time.timestamp() >= reset;
 }
 
 fn degradedAction(
@@ -4960,7 +4973,10 @@ fn routeSkipReason(runtime: types.RuntimeReadiness, health: ?health_mod.AccountH
         .live => |live| switch (live.availability) {
             .available => "available",
             .rate_limited => "rate_limited",
-            .quota_exhausted => "quota_exhausted",
+            .quota_exhausted => |quota| if (quotaWindowRevalidationNeeded(quota))
+                "revalidation_needed"
+            else
+                "quota_exhausted",
             .cooldown => "cooldown",
         },
         .degraded => |degraded| @tagName(degraded.reason),
@@ -7888,6 +7904,14 @@ fn writeLivenessJson(writer: anytype, liveness: types.CredentialLiveness) !void 
                     } else {
                         try writer.writeAll("null");
                     }
+                    try writer.writeAll(",\"revalidation_needed\":");
+                    try writer.writeAll(if (quotaWindowRevalidationNeeded(q)) "true" else "false");
+                    try writer.writeAll(",\"reset_window_state\":");
+                    if (q.window_resets_at) |reset| {
+                        try std.json.stringify(if (std.time.timestamp() >= reset) "expired" else "active", .{}, writer);
+                    } else {
+                        try std.json.stringify("unknown", .{}, writer);
+                    }
                 },
                 .cooldown => |c| try writer.print(",\"availability\":\"cooldown\",\"until\":{d}", .{c.until}),
             }
@@ -8462,6 +8486,7 @@ fn isCodexExhaustedRevalidationCandidate(
     const route_capability = evaluation.route.capability orelse return false;
     if (!std.mem.eql(u8, route_capability, capability)) return false;
     return std.mem.eql(u8, evaluation.skip_reason, "quota_exhausted") or
+        std.mem.eql(u8, evaluation.skip_reason, "revalidation_needed") or
         std.mem.eql(u8, evaluation.skip_reason, "rate_limited");
 }
 
@@ -10072,6 +10097,7 @@ fn codexBrokerSessionRouteRole(evaluation: RouteEvaluation, selected: bool, plan
     if (selected) return "selected";
     if (evaluation.selectable) return "selectable_fallback";
     if (std.mem.eql(u8, evaluation.skip_reason, "quota_exhausted")) return "quota_blocked";
+    if (std.mem.eql(u8, evaluation.skip_reason, "revalidation_needed")) return "revalidation_needed";
     if (std.mem.eql(u8, evaluation.skip_reason, "rate_limited")) return "rate_limited";
     if (std.mem.eql(u8, evaluation.skip_reason, "unrecorded")) return "probe_needed";
     return "not_selectable";
@@ -14928,7 +14954,7 @@ test "repairActionFor classifies quota exhaustion as wait action" {
     const health = health_mod.AccountHealth{
         .liveness = .{ .live = .{
             .availability = .{ .quota_exhausted = .{
-                .window_resets_at = 1_777_777,
+                .window_resets_at = std.time.timestamp() + 7200,
                 .exhausted_at = 1_700_000,
             } },
         } },
@@ -14944,8 +14970,33 @@ test "repairActionFor classifies quota exhaustion as wait action" {
     try std.testing.expectEqual(RepairActionKind.wait_for_quota, action.kind);
     try std.testing.expectEqual(RepairMediation.wait, action.mediation);
     try std.testing.expectEqualStrings("warning", action.severity);
-    try std.testing.expectEqual(@as(?i64, 1_777_777), action.wait_until);
+    try std.testing.expect(action.wait_until.? > std.time.timestamp());
     try std.testing.expect(action.command == .none);
+}
+
+test "repairActionFor surfaces expired quota window as revalidation needed" {
+    const def = provider_schema.ProviderDefinition{
+        .name = "toy",
+        .display_name = "Toy Provider",
+        .repair = .{ .owner = .manual_only },
+    };
+    const health = health_mod.AccountHealth{
+        .liveness = .{ .live = .{
+            .availability = .{ .quota_exhausted = .{
+                .window_resets_at = std.time.timestamp() - 60,
+                .exhausted_at = std.time.timestamp() - 7200,
+            } },
+        } },
+    };
+    const route = RepairPlanRoute{ .provider = "toy", .account = "default", .capability = "chat" };
+    const action = repairActionFor(route, def, .ready, health, .spend_provider);
+
+    try std.testing.expectEqual(RepairActionKind.revalidation_needed, action.kind);
+    try std.testing.expectEqual(RepairMediation.probe, action.mediation);
+    try std.testing.expectEqual(types.ActionBudget.spend_provider, action.budget.?);
+    try std.testing.expectEqual(RepairCommandKind.probe, action.command);
+    try std.testing.expect(action.wait_until == null);
+    try std.testing.expectEqualStrings("revalidation_needed", routeSkipReason(.ready, health));
 }
 
 test "writeRepairActionJson emits codex reauth command without running it" {


### PR DESCRIPTION
## Summary

- classify quota blocks whose reset window has passed as `revalidation_needed` instead of an active wait
- keep expired quota routes non-selectable until explicit revalidation refreshes provider truth
- expose `revalidation_needed` and `reset_window_state` in liveness JSON and broker-session route roles
- add e2e coverage for expired Codex quota windows plus first-run allowance for the new action kind

## Validation

- `zig build`
- `zig build test`
- `./scripts/e2e-local.sh`
- `./scripts/first-run-e2e.sh`
- `just check-local`
- `git diff --check`

## Boundary

This fixes stale quota-window truthing. It does not mark routes available automatically and it does not claim Level 3 live provider-originated in-session fallback. Operators still need spend-gated `codex revalidate-exhausted` before using formerly exhausted routes.