### PR TITLE
Retire supervised restart claim field

### DIFF
--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -102,8 +102,8 @@ prepared-fallback claim.
 That snapshot includes `claim.level`. `prepared_fallback` means the next
 mediated launch can select an account; it does not mean an already-running
 harness process will be hot-swapped. The same claim object keeps
-`current_process_hotswap:false`, `supervised_restart:false`, and
-`per_request_muxing:false`. Restart is not a stronger success level; only a
+`current_process_hotswap:false` and `per_request_muxing:false`; the retired
+`supervised_restart` field is no longer emitted. Restart is not a stronger success level; only a
 live reload, auth broker, proxy, or in-agent adapter that preserves the active
 session can move this beyond prepared fallback.
 
@@ -162,7 +162,7 @@ session can move this beyond prepared fallback.
 - `oauth-mux stay-afloat observe --classify-exit-code <code> -- <command>` as a diagnostic child-boundary
   observation path. It can spawn a selected child, observe the configured exit
   code, and record redacted evidence. It must not be treated as a product
-  fallback or a `supervised_restart:true` claim.
+  fallback or a restart claim.
 - `oauth-mux stay-afloat observe --classify-codex-usage-limit -- <command>`
   as a Codex-specific instrumentation path for wrapper-owned sessions. It
   captures child output, classifies the native usage-limit screen without

--- a/docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md
+++ b/docs/spec/background-stay-afloat-daemon-contract-2026-05-02.md
@@ -316,9 +316,9 @@ repair decisions.
 The snapshot now includes a `claim` object. `claim.level:"prepared_fallback"`
 is Level 1: route state is warm enough for the next mediated
 `stay-afloat launch` / `exec` boundary. The object explicitly keeps
-`current_process_hotswap:false`, `supervised_restart:false`, and
-`per_request_muxing:false` so agents and websites do not overclaim daemon
-behavior from a healthy snapshot.
+`current_process_hotswap:false` and `per_request_muxing:false` so agents and
+websites do not overclaim daemon behavior from a healthy snapshot. The retired
+`supervised_restart` flag is no longer emitted.
 
 ### D2: foreground stay-afloat loop
 

--- a/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
+++ b/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
@@ -205,7 +205,6 @@ A future broker status should be explicit:
     "broker_owned_session": true,
     "current_process_auth_broker": false,
     "prepared_fallback": true,
-    "supervised_restart": false,
     "current_process_hotswap": false,
     "unmanaged_tui_hotswap": false,
     "per_request_muxing": false
@@ -386,8 +385,8 @@ For quota-driven account changes, use a different action name, such as
 - Quota/rate-limit behavior is separately classified as next-turn account
   switching unless same-turn proof exists.
 - Existing `prepared_fallback` claims remain unchanged for unmanaged Codex
-  launches; `supervised_restart` remains false because restart is not an
-  acceptable product handoff.
+  launches; the retired `supervised_restart` field is omitted because restart
+  is not an acceptable product handoff.
 
 ## Immediate Dogfood Procedure
 

--- a/docs/spec/observed-child-diagnostic-contract-2026-05-02.md
+++ b/docs/spec/observed-child-diagnostic-contract-2026-05-02.md
@@ -32,8 +32,9 @@ shape:
   fresh fallback route;
 - `daemon status --json` could prove `current_loop_observed:true`,
   `stale:false`, selected `codex:max-3`, and `claim.level:"prepared_fallback"`;
-- the claim still correctly kept `current_process_hotswap:false`,
-  `supervised_restart:false`, and `per_request_muxing:false`.
+- the claim still correctly kept `current_process_hotswap:false` and
+  `per_request_muxing:false`, with the retired `supervised_restart` field
+  omitted.
 
 The next portable claim level is therefore not "background daemon magically
 fixes the current process" and not "oauth-mux restarts the harness." Restart
@@ -150,7 +151,6 @@ The diagnostic result exposes:
   "claim": {
     "level": "observed_child_process",
     "prepared_fallback": true,
-    "supervised_restart": false,
     "acceptable_seamless_behavior": false,
     "current_process_hotswap": false,
     "per_request_muxing": false
@@ -241,8 +241,8 @@ When the extra paid Codex account is ready:
 9. Run Codex dogfood with one exhausted account and one credited fallback
    account under the real success metric: normal `codex` plus background
    oauth-mux, no restart/logout/manual resume/lost thread.
-10. Never promote `claim.supervised_restart:true`; restart is explicitly not an
-    acceptable success path.
+10. Never reintroduce a `claim.supervised_restart` field; restart is
+    explicitly not an acceptable success path.
 
 ## Open Decisions
 

--- a/docs/stay-afloat-wrappers.md
+++ b/docs/stay-afloat-wrappers.md
@@ -79,8 +79,9 @@ Use `stay-afloat observe --classify-exit-code <code>
 -- <command>` when oauth-mux should observe the child process boundary. The
 legacy restart-shaped flags now admit classification only; the command does
 not relaunch the child or attempt fallback execution. Its claim remains
-diagnostic: `claim.supervised_restart` stays false because restart is not
-acceptable seamless stay-afloat behavior.
+diagnostic: `acceptable_seamless_behavior:false`, and the retired
+`supervised_restart` claim field is omitted rather than carried as a negative
+product promise.
 
 For Codex dogfood, add `--classify-codex-usage-limit`. That path captures
 child stdout/stderr, classifies known Codex usage-limit text, records the
@@ -151,7 +152,6 @@ fields shaped like:
     "claim": {
       "level": "prepared_fallback",
       "current_process_hotswap": false,
-      "supervised_restart": false,
       "per_request_muxing": false
     }
   }

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -418,7 +418,7 @@ expect_contains "$supervise_json" '"mode":"stay_afloat_observe"' "stay-afloat ob
 expect_contains "$supervise_json" '"ok":false' "stay-afloat observe reports failed child without relaunch success"
 expect_contains "$supervise_json" '"reason":"target_failed"' "stay-afloat observe reports target failure"
 expect_contains "$supervise_json" '"level":"observed_child_process"' "stay-afloat observe reports diagnostic child-observation claim level"
-expect_contains "$supervise_json" '"supervised_restart":false' "stay-afloat observe does not claim supervised restart as acceptable stay-afloat"
+expect_not_contains "$supervise_json" '"supervised_restart"' "stay-afloat observe omits retired supervised restart claim field"
 expect_contains "$supervise_json" '"diagnostic_relaunch_observed":false' "stay-afloat observe reports no restart observed"
 expect_contains "$supervise_json" '"acceptable_seamless_behavior":false' "stay-afloat observe rejects restart as seamless behavior"
 expect_contains "$supervise_json" '"current_process_hotswap":false' "stay-afloat observe refuses current-process hot swap"

--- a/src/main.zig
+++ b/src/main.zig
@@ -4131,7 +4131,7 @@ fn writeStayAfloatObserveJson(
     try writer.writeAll(",\"claim\":{\"claim_version\":1,\"level\":\"observed_child_process\"");
     try writer.writeAll(",\"prepared_fallback\":");
     try writer.writeAll(if (prepared_fallback) "true" else "false");
-    try writer.writeAll(",\"supervised_restart\":false,\"diagnostic_relaunch_observed\":");
+    try writer.writeAll(",\"diagnostic_relaunch_observed\":");
     try writer.writeAll(if (relaunch_count > 0) "true" else "false");
     try writer.writeAll(",\"acceptable_seamless_behavior\":false");
     try writer.writeAll(",\"child_process_observed\":true,\"classification_source\":");
@@ -4562,7 +4562,6 @@ fn writeStayAfloatClaimJson(
     try writer.writeAll(",\"mediation_point\":\"stay-afloat launch\"");
     try writer.writeAll(",\"target_boundary\":\"process_start\"");
     try writer.writeAll(",\"current_process_hotswap\":false");
-    try writer.writeAll(",\"supervised_restart\":false");
     try writer.writeAll(",\"per_request_muxing\":false");
     try writer.writeAll(",\"launch_argv\":");
     try writeStayAfloatLaunchArgvJson(writer, selector);
@@ -8906,7 +8905,7 @@ fn writeCodexBrokerPlanJson(
     try writer.writeAll(",\"superseded_by\":\"codex broker-session-plan\"");
     try writer.writeAll(",\"claim\":{\"claim_version\":1,\"level\":\"auth_material_readiness\",\"auth_broker_ready\":");
     try writer.writeAll(if (summary.ready_routes > 0) "true" else "false");
-    try writer.writeAll(",\"route_liveness_considered\":false,\"prepared_fallback\":false,\"broker_owned_session\":false,\"supervised_restart\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false,\"proof_status\":\"auth_material_planning_only\",\"superseded_by\":\"codex broker-session-plan\"}");
+    try writer.writeAll(",\"route_liveness_considered\":false,\"prepared_fallback\":false,\"broker_owned_session\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false,\"proof_status\":\"auth_material_planning_only\",\"superseded_by\":\"codex broker-session-plan\"}");
     try writer.writeAll(",\"profile\":");
     if (profile) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"capability\":");
@@ -9342,7 +9341,7 @@ fn writeCodexManagedPlanJson(
     try writer.writeAll(if (prepared_fallback) "true" else "false");
     try writer.writeAll(",\"selectable_fallback_routes\":");
     try writer.print("{d}", .{fallback_count});
-    try writer.writeAll(",\"same_turn_quota_recovery\":false,\"same_thread_quota_recovery\":false,\"current_process_auth_broker\":false,\"broker_owned_app_server\":false,\"supervised_restart\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
+    try writer.writeAll(",\"same_turn_quota_recovery\":false,\"same_thread_quota_recovery\":false,\"current_process_auth_broker\":false,\"broker_owned_app_server\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
     try writer.writeAll(",\"profile\":");
     if (profile) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"capability\":");
@@ -9791,7 +9790,7 @@ fn writeCodexBrokerFallbackDrillJson(
     try std.json.stringify(reason, .{}, writer);
     try writer.writeAll(",\"claim\":{\"claim_version\":1,\"level\":\"controlled_route_health_drill\",\"proof_status\":\"controlled_route_state_fallback_drill\",\"broker_owned_session\":true,\"route_selection_source\":\"route_health_after_controlled_mutation\",\"provider_originated_quota\":false,\"next_turn_route_state_fallback\":");
     try writer.writeAll(if (ok) "true" else "false");
-    try writer.writeAll(",\"same_turn_quota_recovery\":false,\"same_thread_quota_recovery\":false,\"supervised_restart\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
+    try writer.writeAll(",\"same_turn_quota_recovery\":false,\"same_thread_quota_recovery\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
     try writer.writeAll(",\"profile\":");
     if (profile) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"capability\":");
@@ -9958,7 +9957,7 @@ fn writeCodexBrokerSessionPlanJson(
     try writer.writeAll(if (codexBrokerSessionSpareFallbackReady(session_start_ready, summary.selectable_fallback_routes)) "true" else "false");
     try writer.writeAll(",\"single_route_at_risk\":");
     try writer.writeAll(if (codexBrokerSessionSingleRouteAtRisk(session_start_ready, summary.selectable_fallback_routes)) "true" else "false");
-    try writer.writeAll(",\"same_turn_quota_recovery\":false,\"same_thread_quota_recovery\":false,\"supervised_restart\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
+    try writer.writeAll(",\"same_turn_quota_recovery\":false,\"same_thread_quota_recovery\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
     try writer.writeAll(",\"policy\":");
     try writePolicyJson(writer, cfg.policy);
     try writer.writeAll(",\"profile\":");
@@ -10245,7 +10244,7 @@ fn writeCodexBrokerSessionSmokeJson(
     try writer.writeAll(",\"confirmed\":true,\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mutates_route_health\":false");
     try writer.writeAll(",\"reason\":");
     try std.json.stringify(codexBrokerSessionSmokeReason(result), .{}, writer);
-    try writer.writeAll(",\"claim\":{\"claim_version\":1,\"level\":\"broker_owned_app_server\",\"proof_status\":\"local_broker_owned_session_smoke\",\"broker_owned_session\":true,\"auth_broker_scope\":\"broker_owned_app_server\",\"current_process_auth_broker\":false,\"route_selection_source\":\"broker_session_plan\",\"session_start_ready\":true,\"prepared_fallback\":true,\"next_thread_quota_fallback_proven\":true,\"same_turn_quota_recovery\":false,\"same_thread_quota_recovery\":false,\"supervised_restart\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
+    try writer.writeAll(",\"claim\":{\"claim_version\":1,\"level\":\"broker_owned_app_server\",\"proof_status\":\"local_broker_owned_session_smoke\",\"broker_owned_session\":true,\"auth_broker_scope\":\"broker_owned_app_server\",\"current_process_auth_broker\":false,\"route_selection_source\":\"broker_session_plan\",\"session_start_ready\":true,\"prepared_fallback\":true,\"next_thread_quota_fallback_proven\":true,\"same_turn_quota_recovery\":false,\"same_thread_quota_recovery\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
     try writer.writeAll(",\"selected\":");
     try writeRouteSelectionJson(writer, route);
     try writer.writeAll(",\"fallback_selected\":");
@@ -10626,7 +10625,7 @@ fn writeCodexBrokerRunJson(
     try writer.writeAll(if (codexBrokerSessionSingleRouteAtRisk(session_start_ready, summary.selectable_fallback_routes)) "true" else "false");
     try writer.writeAll(",\"next_session_continuation\":");
     try writer.writeAll(if (continuation != null) "true" else "false");
-    try writer.writeAll(",\"next_thread_quota_fallback_proven\":false,\"same_turn_quota_recovery\":false,\"same_thread_quota_recovery\":false,\"supervised_restart\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
+    try writer.writeAll(",\"next_thread_quota_fallback_proven\":false,\"same_turn_quota_recovery\":false,\"same_thread_quota_recovery\":false,\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
     try writer.writeAll(",\"selected\":");
     try writeRouteSelectionJson(writer, route);
     try writer.writeAll(",\"capability\":");


### PR DESCRIPTION
## Summary

- remove the retired `supervised_restart` field from JSON claim emissions
- keep diagnostic observe output honest through `acceptable_seamless_behavior:false`, `diagnostic_relaunch_observed:false`, and `relaunch_enabled:false`
- update wrapper/daemon docs and historical specs to say the field is omitted, not carried as a negative product promise
- update e2e coverage to assert the retired field is absent from observe claims

## Validation

- `zig build`
- `just check-local`
- `git diff --check`
- spot-check `stay-afloat observe --json` output omits `supervised_restart`

## Boundary

Legacy restart-shaped CLI aliases are still accepted as compatibility input, per the broker contract. This PR only removes the claim field so restart stops being represented as a product claim dimension.