### PR TITLE
Report legacy restart aliases as diagnostics

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -250,7 +250,9 @@ also prints mediation text and exits nonzero without starting the target.
 `oauth-mux stay-afloat observe --classify-exit-code <code> -- <command>` is a diagnostic child-boundary
 surface. It keeps oauth-mux as the parent process, injects the selected route
 into a child, observes typed failure, and stops. The legacy restart-shaped flags
-do not make restart an acceptable stay-afloat path.
+do not make restart an acceptable stay-afloat path; if used, JSON marks them as
+`legacy_restart_aliases_used:true` and scopes their effect to compatibility
+classification only.
 For Codex dogfood, add `--classify-codex-usage-limit`. That mode captures
 child output, classifies the native usage-limit screen, records the selected
 route as quota-exhausted, appends a redacted `stay_afloat_observe` event, and

--- a/docs/spec/observed-child-diagnostic-contract-2026-05-02.md
+++ b/docs/spec/observed-child-diagnostic-contract-2026-05-02.md
@@ -140,6 +140,10 @@ The current implementation uses the explicit `--classify-exit-code` path and
 the Codex usage-limit classifier. It inherits child output in text mode and
 suppresses it in JSON mode unless `--stream-capture` is set with the Codex
 classifier, so JSON evidence remains redacted.
+Legacy restart-shaped inputs (`stay-afloat supervise`, `--max-restarts`,
+`--restart-on-exit-code`, and `--restart-on-codex-usage-limit`) remain
+compatibility aliases until a breaking CLI window. JSON reports their use with
+`legacy_restart_aliases_used:true`; it does not relaunch.
 
 ## JSON Shape
 
@@ -170,7 +174,9 @@ The diagnostic result exposes:
     }
   ],
   "relaunch_count": 0,
-  "legacy_max_restarts": 0
+  "legacy_max_restarts": 0,
+  "legacy_restart_aliases_used": false,
+  "legacy_restart_aliases_effect": "none"
 }
 ```
 

--- a/docs/stay-afloat-wrappers.md
+++ b/docs/stay-afloat-wrappers.md
@@ -82,6 +82,10 @@ not relaunch the child or attempt fallback execution. Its claim remains
 diagnostic: `acceptable_seamless_behavior:false`, and the retired
 `supervised_restart` claim field is omitted rather than carried as a negative
 product promise.
+If an operator still uses `stay-afloat supervise`, `--max-restarts`,
+`--restart-on-exit-code`, or `--restart-on-codex-usage-limit`, JSON reports
+`legacy_restart_aliases_used:true` with
+`legacy_restart_aliases_effect:"compatibility_classification_only"`.
 
 For Codex dogfood, add `--classify-codex-usage-limit`. That path captures
 child stdout/stderr, classifies known Codex usage-limit text, records the

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -419,6 +419,7 @@ expect_contains "$supervise_json" '"ok":false' "stay-afloat observe reports fail
 expect_contains "$supervise_json" '"reason":"target_failed"' "stay-afloat observe reports target failure"
 expect_contains "$supervise_json" '"level":"observed_child_process"' "stay-afloat observe reports diagnostic child-observation claim level"
 expect_not_contains "$supervise_json" '"supervised_restart"' "stay-afloat observe omits retired supervised restart claim field"
+expect_contains "$supervise_json" '"legacy_restart_aliases_used":false' "stay-afloat observe canonical flags report no legacy restart aliases"
 expect_contains "$supervise_json" '"diagnostic_relaunch_observed":false' "stay-afloat observe reports no restart observed"
 expect_contains "$supervise_json" '"acceptable_seamless_behavior":false' "stay-afloat observe rejects restart as seamless behavior"
 expect_contains "$supervise_json" '"current_process_hotswap":false' "stay-afloat observe refuses current-process hot swap"
@@ -428,6 +429,17 @@ expect_contains "$supervise_json" '"relaunch_admitted":false' "stay-afloat obser
 expect_contains "$supervise_json" '"selected":{"provider":"toy","account":"a1"' "stay-afloat observe records observed child route"
 expect_not_contains "$supervise_json" "omux-e2e-a1" "stay-afloat observe JSON does not expose first token"
 expect_not_contains "$supervise_json" "omux-e2e-a2" "stay-afloat observe JSON does not expose fallback token"
+
+printf 'e2e: legacy stay-afloat supervise aliases are compatibility diagnostics only\n'
+legacy_supervise_json="$(omux stay-afloat supervise --profile expensive --capability expensive --max-restarts 2 --restart-on-exit-code 42 --restart-on-codex-usage-limit --json -- sh -c 'exit 42' || true)"
+expect_contains "$legacy_supervise_json" '"mode":"stay_afloat_observe"' "legacy supervise maps to observe mode"
+expect_contains "$legacy_supervise_json" '"legacy_restart_aliases_used":true' "legacy supervise reports legacy restart aliases"
+expect_contains "$legacy_supervise_json" '"legacy_restart_aliases_effect":"compatibility_classification_only"' "legacy supervise scopes alias effect"
+expect_contains "$legacy_supervise_json" '"legacy_max_restarts":2' "legacy supervise preserves ignored max-restarts value for diagnostics"
+expect_contains "$legacy_supervise_json" '"relaunch_enabled":false' "legacy supervise still keeps relaunch disabled"
+expect_contains "$legacy_supervise_json" '"relaunch_count":0' "legacy supervise reports zero relaunch count"
+expect_contains "$legacy_supervise_json" '"acceptable_seamless_behavior":false' "legacy supervise rejects restart as seamless behavior"
+expect_not_contains "$legacy_supervise_json" '"supervised_restart"' "legacy supervise does not reintroduce supervised restart claim"
 
 printf 'e2e: stay-afloat observe classifies Codex usage-limit output\n'
 printf '%s\n' 'expensive:a1:ok' >"$probe_mode_file"

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -71,6 +71,7 @@ pub const Command = union(enum) {
         capability: ?[]const u8 = null,
         target_argv: []const []const u8 = &.{},
         legacy_max_restarts: u32 = 0,
+        legacy_restart_aliases_used: bool = false,
         classify_exit_code: ?u8 = null,
         classify_codex_usage_limit: bool = false,
         stream_capture: bool = false,
@@ -807,7 +808,16 @@ fn parseDaemonTick(args: []const []const u8) Command {
 
 fn parseStayAfloat(args: []const []const u8) Command {
     if (args.len > 0 and eql(args[0], "launch")) return .{ .stay_afloat_launch = parseExecArgs(args[1..]) };
-    if (args.len > 0 and (eql(args[0], "observe") or eql(args[0], "supervise"))) return parseStayAfloatObserve(args[1..]);
+    if (args.len > 0 and (eql(args[0], "observe") or eql(args[0], "supervise"))) {
+        var cmd = parseStayAfloatObserve(args[1..]);
+        if (eql(args[0], "supervise")) {
+            switch (cmd) {
+                .stay_afloat_observe => |*observe| observe.legacy_restart_aliases_used = true,
+                else => {},
+            }
+        }
+        return cmd;
+    }
     if (args.len > 0 and eql(args[0], "next")) return parseStayAfloatNext(args[1..]);
     if (args.len > 0 and eql(args[0], "handoffs")) return parseDaemonHandoffs(args[1..]);
     if (args.len > 0 and eql(args[0], "handoff")) return parseStayAfloatHandoff(args[1..]);
@@ -844,12 +854,20 @@ fn parseStayAfloatObserve(args: []const []const u8) Command {
             i += 1;
             if (i < args.len) result.capability = args[i];
         } else if (eql(args[i], "--max-restarts")) {
+            result.legacy_restart_aliases_used = true;
             i += 1;
             if (i < args.len) result.legacy_max_restarts = std.fmt.parseInt(u32, args[i], 10) catch result.legacy_max_restarts;
-        } else if (eql(args[i], "--classify-exit-code") or eql(args[i], "--restart-on-exit-code")) {
+        } else if (eql(args[i], "--classify-exit-code")) {
             i += 1;
             if (i < args.len) result.classify_exit_code = std.fmt.parseInt(u8, args[i], 10) catch result.classify_exit_code;
-        } else if (eql(args[i], "--classify-codex-usage-limit") or eql(args[i], "--restart-on-codex-usage-limit")) {
+        } else if (eql(args[i], "--restart-on-exit-code")) {
+            result.legacy_restart_aliases_used = true;
+            i += 1;
+            if (i < args.len) result.classify_exit_code = std.fmt.parseInt(u8, args[i], 10) catch result.classify_exit_code;
+        } else if (eql(args[i], "--classify-codex-usage-limit")) {
+            result.classify_codex_usage_limit = true;
+        } else if (eql(args[i], "--restart-on-codex-usage-limit")) {
+            result.legacy_restart_aliases_used = true;
             result.classify_codex_usage_limit = true;
         } else if (eql(args[i], "--stream-capture")) {
             result.stream_capture = true;
@@ -2080,6 +2098,7 @@ test "parse stay-afloat observe selector diagnostic policy and target" {
             try std.testing.expect(observe.classify_codex_usage_limit);
             try std.testing.expect(observe.stream_capture);
             try std.testing.expect(observe.json);
+            try std.testing.expect(!observe.legacy_restart_aliases_used);
             try std.testing.expectEqual(@as(usize, 2), observe.target_argv.len);
             try std.testing.expectEqualStrings("codex", observe.target_argv[0]);
             try std.testing.expectEqualStrings("--ask-for-approval=never", observe.target_argv[1]);
@@ -2111,6 +2130,7 @@ test "parse legacy stay-afloat supervise as observe" {
     switch (cmd) {
         .stay_afloat_observe => |observe| {
             try std.testing.expectEqual(@as(u32, 2), observe.legacy_max_restarts);
+            try std.testing.expect(observe.legacy_restart_aliases_used);
             try std.testing.expectEqual(@as(u8, 42), observe.classify_exit_code.?);
             try std.testing.expect(observe.classify_codex_usage_limit);
             try std.testing.expectEqualStrings("codex", observe.target_argv[0]);

--- a/src/main.zig
+++ b/src/main.zig
@@ -4141,6 +4141,10 @@ fn writeStayAfloatObserveJson(
     try writer.writeAll(",\"current_process_hotswap\":false,\"unmanaged_tui_hotswap\":false,\"per_request_muxing\":false}");
     try writer.writeAll(",\"legacy_max_restarts\":");
     try writer.print("{d}", .{args.legacy_max_restarts});
+    try writer.writeAll(",\"legacy_restart_aliases_used\":");
+    try writer.writeAll(if (args.legacy_restart_aliases_used) "true" else "false");
+    try writer.writeAll(",\"legacy_restart_aliases_effect\":");
+    try std.json.stringify(if (args.legacy_restart_aliases_used) "compatibility_classification_only" else "none", .{}, writer);
     try writer.writeAll(",\"relaunch_enabled\":false");
     try writer.writeAll(",\"classify_exit_code\":");
     if (args.classify_exit_code) |code| try writer.print("{d}", .{code}) else try writer.writeAll("null");
@@ -4193,6 +4197,11 @@ fn writeStayAfloatObserveText(
     try writer.print("  ok: {s}\n", .{if (ok) "true" else "false"});
     try writer.print("  reason: {s}\n", .{reason});
     try writer.print("  legacy max restarts: {d} (relaunch disabled)\n", .{args.legacy_max_restarts});
+    try writer.print("  legacy restart aliases: {s}", .{if (args.legacy_restart_aliases_used) "true" else "false"});
+    if (args.legacy_restart_aliases_used) {
+        try writer.writeAll(" (compatibility classification only)");
+    }
+    try writer.writeByte('\n');
     try writer.writeAll("  classify exit code: ");
     if (args.classify_exit_code) |code| try writer.print("{d}\n", .{code}) else try writer.writeAll("not configured\n");
     try writer.print("  classify Codex usage limit: {s}\n", .{if (args.classify_codex_usage_limit) "true" else "false"});


### PR DESCRIPTION
## Summary

- track legacy restart-shaped observe inputs: `stay-afloat supervise`, `--max-restarts`, `--restart-on-exit-code`, and `--restart-on-codex-usage-limit`
- emit `legacy_restart_aliases_used` and `legacy_restart_aliases_effect` in `stay-afloat observe` JSON/text output
- keep relaunch disabled and compatibility aliases scoped to classification only
- add e2e coverage for canonical observe vs legacy supervise alias behavior
- update operator docs/spec text

## Validation

- `zig build test`
- `zig build`
- `./scripts/e2e-local.sh`
- `just check-local`
- `git diff --check`

## Boundary

This remains non-breaking: legacy restart-shaped inputs still parse. They are now explicit diagnostics and still do not relaunch or claim seamless stay-afloat.