### PR TITLE
Truth current Codex evidence state

### DIFF
--- a/docs/spec/broker-mcp-contract-2026-05-03.md
+++ b/docs/spec/broker-mcp-contract-2026-05-03.md
@@ -24,6 +24,13 @@ External anchors used for this contract:
   RFC 7636 PKCE, RFC 8252 native apps, RFC 8693 token exchange, and RFC 9449
   DPoP.
 
+Current evidence review:
+
+- `docs/spec/test-and-coverage-review-2026-05-05.md` is the
+  current-main assessment of tests, synthetic evidence, live route truth,
+  and remaining Level 3 gaps. It is descriptive only; this broker
+  contract remains the product source of truth.
+
 ## 0. The One Success Metric
 
 The product succeeds when, and only when, this is true:

--- a/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
+++ b/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
@@ -21,31 +21,23 @@ prepared fallback, and synthetic smokes are evidence or diagnostics only.
 
 ## Current Live State
 
-Observed on 2026-05-05 around 10:44 EDT:
+Observed on 2026-05-05 around 15:37 EDT:
 
-- Repository: clean on `main...origin/main` at `83b23cf`.
-- Selected live `codex-max` route: `max-4`.
-- Selected route local token claim: `chatgpt_plan_type = "pro"`,
-  subscription active until `2026-06-02T20:12:47Z`, last subscription
-  check `2026-05-02T21:06:42Z`.
-- All four configured Max routes locally claim `pro`; that proves tier
-  metadata only, not available quota.
-- Planner surfaces still mark `max-1`, `max-2`, and `max-3` as
-  `quota_exhausted`.
-- Their stored reset timestamps are in the past:
-  - `max-3`: 2026-05-05 06:15 EDT
-  - `max-1`: 2026-05-05 09:20 EDT
-  - `max-2`: 2026-05-05 10:30 EDT
-- `spare_fallback_ready:false` and `single_route_at_risk:true`.
+- Repository: clean on `main...origin/main` at `59c2f69`.
+- Selected live `codex-max` route: `max-1`.
+- Spend-gated exhausted-route revalidation after the reset window found
+  `max-1`, `max-2`, and `max-3` available again; `max-4` was already
+  selectable.
+- `broker-session-plan` reports `routes_total:4`,
+  `selectable_broker_routes:4`, `selectable_fallback_routes:3`,
+  `spare_fallback_ready:true`, and `single_route_at_risk:false`.
+- `route explain` agrees: `max-1` selected; `max-2`, `max-3`, and
+  `max-4` selectable fallbacks.
 
-Next live action after the operator's expected quota reset window:
-
-```bash
-./zig-out/bin/oauth-mux codex revalidate-exhausted --profile codex-max --capability codex-max --confirm-spend --json
-```
-
-If this revalidates at least one additional `codex-max` route as
-available, run the Level 3 live acceptance path under TIN-951.
+This unblocks fallback capacity for Level 3. It still does not satisfy
+Level 3 acceptance: no provider-originated `usage_limit_reached` event
+has occurred inside a live `oauth-mux codex` session during this
+checkpoint.
 
 ## Mainline Reality
 
@@ -135,9 +127,11 @@ the branch as-is:
 
 5. `docs/spec/test-and-coverage-review-2026-05-03.md`
    - Valuable as an assessment, but stale in counts and conclusions.
-   - Rewrite from current main rather than copying.
-   - It should explicitly separate structural synthetic evidence,
-     cassette replay readiness, and live Level 3 evidence.
+   - Status: rewritten from current main as
+     `docs/spec/test-and-coverage-review-2026-05-05.md`.
+   - The rewrite explicitly separates structural synthetic evidence,
+     cassette replay readiness, live route readiness, and the missing
+     live Level 3 evidence.
 
 6. `docs/policy/tos-posture-2026-05-03.md`
    - Policy posture is needed before public promotion.
@@ -182,9 +176,11 @@ These need review before public promotion:
   contract claim ladder where possible.
 - `broker-*` proof commands: keep as diagnostic regression surfaces, not
   product UX.
-- Expired quota health: TIN-973 / GitHub #183 should make past reset
-  windows show as `revalidation_needed` or equivalent, not indistinct
-  active `quota_exhausted`.
+- Expired quota health: TIN-973 / GitHub #183 landed in PR #185
+  (`562d478`). Past reset windows now surface as
+  `revalidation_needed` instead of indistinct active
+  `quota_exhausted`, and routes remain non-selectable until explicit
+  provider revalidation refreshes truth.
 - Linear/GitHub tracker drift: TIN-941 / GitHub #172 and TIN-948 /
   GitHub #174 were confirmed satisfied by PR #178 (`9a8aea6`) and PR #179
   (`c7c6512`), then closed/marked Done during this hygiene pass.
@@ -229,21 +225,19 @@ These need review before public promotion:
 
 ## Local Todo Order
 
-1. Keep main clean until after the 2:30 PM EDT quota window.
-2. Revalidate exhausted `codex-max` routes with explicit spend
-   confirmation.
-3. If at least one fallback is selectable, run live Level 3 acceptance for
-   TIN-951.
-4. Fix TIN-973 / GitHub #183 so expired quota windows become
-   revalidation-needed in planner output.
-5. Rewrite the test/coverage review from current main and link it from the
-   broker contract as an assessment, not a contract.
-6. Review policy posture doc and add only if it does not market quota
+1. Keep main clean and preserve all four selectable `codex-max` routes.
+2. Run live Level 3 acceptance for TIN-951 only when the operator is
+   ready to spend and there is a realistic way to observe
+   provider-originated quota exhaustion in an active `oauth-mux codex`
+   session.
+3. Capture real Codex wire cassettes for TIN-950 / GitHub #176:
+   normal 200 flow first, then 401 and 429 only when safely available.
+4. Review policy posture doc and add only if it does not market quota
    evasion.
-7. Keep demoting route-warming/restart surfaces from product language.
-8. Start the Claude adapter only after the Codex Level 3 proof is recorded
+5. Keep demoting route-warming/restart surfaces from product language.
+6. Start the Claude adapter only after the Codex Level 3 proof is recorded
    or explicitly parked.
-9. Re-run `just check-local` after each code/test slice.
+7. Re-run `just check-local` after each code/test slice.
 
 ## Hygiene Pass Notes
 
@@ -258,3 +252,14 @@ These need review before public promotion:
 - Added the current-main concurrent-session smoke to the repo-managed
   local gate.
 - `just check-local` passed with the new smokes included.
+- Spend-gated exhausted-route revalidation after the reset window restored
+  all four `codex-max` routes to selectable state.
+- PR #185 (`562d478`) landed expired-quota `revalidation_needed`
+  semantics and closed GitHub #183 / Linear TIN-973.
+- PR #186 (`2858810`) removed the retired `supervised_restart` claim
+  field.
+- PR #187 (`59c2f69`) reports legacy restart-shaped aliases as
+  compatibility classification only.
+- Rewrote the stale quarry test/coverage review from current main as
+  `docs/spec/test-and-coverage-review-2026-05-05.md` and linked it from
+  the broker contract as a descriptive assessment.

--- a/docs/spec/codex-wire-evidence-2026-05-03.md
+++ b/docs/spec/codex-wire-evidence-2026-05-03.md
@@ -235,10 +235,10 @@ The wire proxy:
 - Does NOT swap accounts.
 - Returns the 429 to codex so codex can surface the upgrade prompt.
 
-This behavior is specified but not yet pinned by a dedicated smoke in
-main. `smoke-codex-acceptance` covers the swap-eligible
-`usage_limit_reached` path; a tier-insufficient smoke is a follow-up if
-we need a dedicated regression catch.
+This behavior is pinned by `just smoke-codex-tier-insufficient`.
+`smoke-codex-acceptance` covers the swap-eligible
+`usage_limit_reached` path; the tier-insufficient smoke is the
+non-swap regression catch.
 
 **Bare 429 (no `error.type`)**: rate-limited; classified as
 `rate_limited`. Proxy honors `Retry-After`, optionally swaps if

--- a/docs/spec/test-and-coverage-review-2026-05-05.md
+++ b/docs/spec/test-and-coverage-review-2026-05-05.md
@@ -1,0 +1,146 @@
+# Test, Coverage, Architecture, and Story Review
+Date: 2026-05-05
+Status: current-main assessment; not a product contract.
+
+Anchor: `docs/spec/broker-mcp-contract-2026-05-03.md`.
+Codex adapter contract: `docs/spec/codex-adapter-contract-2026-05-03.md`.
+
+This review replaces the stale quarry-branch assessment from
+`/Users/jess/git/oauth-mux-broker`. It describes current `main` at
+`59c2f69`, after the route-health truthing, Codex quarry smokes,
+expired-quota revalidation state, and restart-claim demotion work.
+
+## Product Bar
+
+The only product success metric is Level 3 or better from the broker
+contract: `oauth-mux <harness>` runs the harness, the active account
+exhausts quota, another credited account is substituted in place, the
+harness process is not restarted, and the user is not prompted.
+
+Everything below Level 3 is evidence or diagnostic scaffolding.
+`prepared_fallback`, managed launches, route warming, restart-shaped
+flags, and synthetic smokes are not success.
+
+## Current Evidence Stack
+
+`just check-local` currently runs:
+
+- `zig build test` and `zig build`.
+- Config validation for every `examples/*.config.json`.
+- `scripts/e2e-local.sh`.
+- `scripts/first-run-e2e.sh`.
+- `scripts/stay-afloat-wrapper-doc-smoke.sh`.
+- `scripts/smoke-broker.sh`.
+- `scripts/smoke-codex-acceptance.sh`.
+- `scripts/smoke-codex-concurrent-sessions.sh`.
+- `scripts/smoke-codex-tier-insufficient.sh`.
+- `scripts/smoke-codex-all-exhausted.sh`.
+- `scripts/smoke-codex-401-propagation.sh`.
+- `scripts/smoke-codex-cassette-replay.sh`.
+
+Validation status for this review: `just check-local` passed on
+2026-05-05 after the doc update.
+
+Repo-wide Zig test inventory is broad (`rg '^test "' src` finds 306
+in-file tests). The broker/Codex-adapter subset is materially covered
+by in-file tests plus seven shell smokes.
+
+The shell smoke suite covers these adapter stories:
+
+- `smoke-broker`: 22 assertions. Broker MCP method composition:
+  handshake, account listing, selection, materialization, quota
+  observation, swap, and status.
+- `smoke-codex-acceptance`: 15 assertions. Synthetic Codex A-to-B
+  swap: account A succeeds, then returns `usage_limit_reached`, then
+  account B handles the next turn in one stable child PID.
+- `smoke-codex-concurrent-sessions`: 16 assertions. Per-session
+  `CODEX_HOME` overlays prevent the old account-local `config.toml`
+  clobber race.
+- `smoke-codex-tier-insufficient`: 10 assertions.
+  `usage_not_included` is classified as `tier_insufficient`; no swap.
+- `smoke-codex-all-exhausted`: 10 assertions. All accounts exhausted
+  returns a clean no-account-selectable failure.
+- `smoke-codex-401-propagation`: 12 assertions. Upstream 401 is left
+  for Codex's own refresh path; oauth-mux does not prematurely kill the
+  route.
+- `smoke-codex-cassette-replay`: 12 assertions. Captured-flow JSON can
+  be replayed by `(method, path)` with diagnostic misses.
+
+## Live Route Truth
+
+As of 2026-05-05 15:37 EDT, no-spend route surfaces report:
+
+- `codex-max` selected route: `max-1`.
+- Selectable fallbacks: `max-2`, `max-3`, and `max-4`.
+- `selectable_broker_routes:4`.
+- `selectable_fallback_routes:3`.
+- `spare_fallback_ready:true`.
+- `single_route_at_risk:false`.
+
+That unblocks fallback capacity for TIN-951 / GitHub #177. It does not
+prove Level 3, because no provider-originated quota event was observed
+inside a live `oauth-mux codex` session during that check.
+
+## What Current Main Proves
+
+- The broker MCP core can select accounts, materialize Codex credential
+  tuples, observe quota, swap accounts, and report status in-process.
+- The Codex adapter/proxy skeleton can run synthetic in-session flows
+  without restarting its child process.
+- Route-health state now distinguishes expired reset windows as
+  `revalidation_needed` until explicit provider revalidation refreshes
+  truth.
+- Restart-shaped surfaces are diagnostic-only. `supervised_restart` is
+  no longer emitted in claim JSON, and legacy restart aliases report
+  `compatibility_classification_only`.
+- Real wire capture and replay tooling exists, but only synthetic replay
+  data is checked in.
+
+## What Current Main Does Not Prove
+
+- Live provider-originated Level 3 account swap.
+- Same-thread continuity across account swap.
+- Mid-turn recovery.
+- Bare `codex` plus a separate background oauth-mux daemon seamlessly
+  swapping account state.
+- Real `chatgpt.com/backend-api/codex` cassette shapes for normal 200,
+  401, 429 `usage_limit_reached`, WebSocket upgrade, or compact/memory
+  endpoints.
+- Claude, Cursor, Pi, or any non-Codex harness adapter.
+
+## Architecture Decisions Worth Keeping Honest
+
+1. **Broker MCP plus harness adapters is still the right frame.**
+   Codex is the first adapter, not the whole product.
+2. **Synthetic swap evidence is structural, not live evidence.**
+   It is valuable because it pins the intended state machine, but it
+   must not be labeled as Level 3.
+3. **The Codex path depends on wire interposition.** Codex's 401 path
+   can refresh; quota is a 429 and must be observed at the wire layer.
+4. **The current child/proxy topology is the user-facing near path.**
+   `oauth-mux codex` owns the mediation point. Bare `codex` with a
+   background daemon remains a harder future sidecar problem.
+5. **Restart diagnostics should keep shrinking.** They are useful for
+   incident capture, not for product claims.
+
+## Next Gates
+
+1. Run the live TIN-951 acceptance only when the operator is ready to
+   spend and has a credible way to observe provider-originated quota
+   exhaustion in an active `oauth-mux codex` session.
+2. Run TIN-950 / GitHub #176 capture for at least one normal 200 turn.
+   Capture 401 and 429 only when safely available. Commit only reviewed,
+   scrubbed, fixture-sized JSON.
+3. Keep quarry work as quarry. The stale branch still has useful policy
+   and review ideas, but main already supersedes much of its source diff.
+4. Review policy posture before public promotion. Do not market account
+   rotation as unlimited usage or quota evasion.
+5. Start the Claude adapter only after Codex Level 3 is recorded or the
+   Codex blocker is explicitly parked.
+
+## Definition of Done for This Review
+
+This review is complete when it is linked from the broker contract and
+kept subordinate to that contract. It should be updated or replaced
+whenever the evidence stack changes materially, especially after real
+cassette capture or live Level 3 acceptance.

--- a/scripts/test-cassette-upstream.py
+++ b/scripts/test-cassette-upstream.py
@@ -3,7 +3,7 @@
 chatgpt.com response shapes.
 
 Bridges the cassette gap identified in
-`docs/spec/test-and-coverage-review-2026-05-03.md` section 3: the
+`docs/spec/test-and-coverage-review-2026-05-05.md`: the
 synthetic test-stub-upstream.py uses hand-crafted shapes derived
 from source review, which can drift if upstream adds fields. This
 script replays REAL response bytes captured from chatgpt.com via


### PR DESCRIPTION
## Summary

- Adds a current-main test/coverage/architecture/story review for the Codex broker path.
- Updates the quarry todo with the post-revalidation live route state: max-1 selected, max-2/max-3/max-4 selectable fallbacks, spare_fallback_ready true.
- Links the review from the broker MCP contract and updates cassette docs now that tier-insufficient is pinned by a smoke.

## Validation

- python3 -m py_compile scripts/test-cassette-upstream.py scripts/codex-wire-addon.py
- just smoke-codex-cassette-replay-local
- git diff --check
- just check-local

## Boundary

This is a truthing/docs PR only. It does not claim live Level 3 acceptance, provider-originated quota handoff, same-thread continuity, mid-turn recovery, or bare-codex background muxing.