### PR TITLE
Add Codex policy posture

### DIFF
--- a/docs/policy/tos-posture-2026-05-05.md
+++ b/docs/policy/tos-posture-2026-05-05.md
@@ -1,0 +1,132 @@
+# OpenAI/Codex Terms Posture
+Date: 2026-05-05
+Status: operator posture; not legal advice; not a product claim.
+
+Anchor: `docs/spec/broker-mcp-contract-2026-05-03.md`.
+Codex adapter contract: `docs/spec/codex-adapter-contract-2026-05-03.md`.
+
+This document exists to keep the Codex adapter honest before any public
+promotion. It describes the policy boundary the repo must respect while
+building account muxing. It does not decide whether any operator's use is
+permitted; the operator must read current provider terms and make that
+decision.
+
+## Current Official Sources Checked
+
+Checked on 2026-05-05:
+
+- OpenAI Terms & Policies index:
+  https://openai.com/policies/
+- OpenAI Terms of Use, effective 2026-01-01:
+  https://openai.com/policies/terms-of-use/
+- OpenAI Account Sharing Policy, updated 2026-04-23:
+  https://help.openai.com/en/articles/10471989-openai-account-sharing-policy
+- Using Codex with your ChatGPT plan, updated 2026-05-04:
+  https://help.openai.com/en/articles/11369540-using-codex-with-your-chatgpt-plan
+- Codex CLI docs:
+  https://developers.openai.com/codex/cli
+
+Facts from those sources that matter for this repo:
+
+- OpenAI's terms say users may not share account credentials or make an
+  account available to someone else, and may not interfere with or
+  disrupt OpenAI services, including circumventing rate limits,
+  restrictions, protective measures, or safety mitigations.
+- OpenAI's account-sharing policy says an account is meant for the
+  individual who created it; account sharing is not allowed; usage
+  limits may apply based on activity and subscription level.
+- Codex is included with specified ChatGPT plans, and Codex usage limits
+  depend on plan and task shape.
+- Codex with a ChatGPT account is governed by ChatGPT Terms of Use and
+  Privacy Policy, or the applicable business/enterprise agreement.
+- Codex CLI is an OpenAI local terminal agent that prompts the user to
+  authenticate with a ChatGPT account or API key.
+
+## Repo Posture
+
+oauth-mux must not market, document, or implement Codex account muxing as
+"unlimited Codex", rate-limit bypass, anti-detection, resale, or shared
+credential pooling. Those framings are wrong for the product and risky
+against the official terms above.
+
+The only acceptable repo framing is narrower:
+
+- The operator enrolls accounts they are authorized to use.
+- Account material stays local to the operator-controlled machine.
+- The tool exposes which route is selected through redacted evidence.
+- Provider quota, tier, auth, and policy failures remain typed states.
+- Provider-originated restrictions are observed and classified; they are
+  not hidden as success.
+- Public docs must say that account muxing is policy-sensitive and that
+  operators must evaluate provider terms for their own use.
+
+## Hard Product Guardrails
+
+The Codex adapter and public-facing docs MUST NOT:
+
+- Encourage credential sharing across humans.
+- Offer any API-key-reseller, hosted proxy, team credential pool, or
+  third-party access service.
+- Claim unlimited usage or avoidance of OpenAI limits.
+- Forge browser-only headers, defeat Cloudflare or other protective
+  systems, or implement anti-detection behavior.
+- Silently spend provider calls without explicit operator confirmation
+  on live/spend paths.
+- Print tokens, account IDs, raw JWTs, credential paths, raw protocol, or
+  prompt/assistant transcript text in normal evidence output.
+- Promote `prepared_fallback`, restart, supervised relaunch, or synthetic
+  smokes as the product success metric.
+
+The Codex adapter SHOULD:
+
+- Provide an explicit account-pin mode that disables rotation for
+  operators who want single-account behavior.
+- Keep live provider probes and captures behind explicit confirmation.
+- Preserve redacted event artifacts for live acceptance and operator
+  review.
+- Keep terms-sensitive wording out of marketing and first-run copy until
+  Level 3 acceptance is real and the posture has been re-reviewed.
+- Re-check official terms before any public release, package promotion,
+  or hosted service discussion.
+
+## Technical Boundary
+
+The current product bar is still technical, not legal:
+
+> `oauth-mux codex` runs a real Codex session. The selected account hits
+> provider-originated quota exhaustion. Another credited, operator-enrolled
+> account continues in place without restart or prompt.
+
+That bar is not yet live-proven. Synthetic smokes, route readiness,
+`prepared_fallback`, and restart diagnostics remain partial evidence only.
+
+## Operator Decision Points
+
+Before using Codex account muxing outside local development, an operator
+must decide:
+
+1. Whether every enrolled account is theirs or otherwise authorized for
+   their individual use.
+2. Whether rotating among authorized accounts is consistent with their
+   reading of OpenAI's current terms, account-sharing policy, and plan
+   limits.
+3. Whether their organization has business, enterprise, workspace, or
+   compliance terms that differ from individual ChatGPT Terms of Use.
+4. Whether they want account rotation at all; if not, they should pin a
+   single account and treat oauth-mux as route-state and evidence tooling.
+
+## Review Triggers
+
+Update this document before:
+
+- Public README or website copy is restored.
+- npm/Homebrew/package promotion.
+- Any first-run banner mentions account muxing.
+- A second harness adapter is promoted.
+- OpenAI changes Terms of Use, account-sharing policy, Codex plan limits,
+  Codex auth, or Codex local usage docs.
+
+If future provider terms explicitly disallow this workflow, the repo
+posture must change. The implementation may remain useful as diagnostic
+or single-account tooling, but public account-rotation claims must be
+removed.

--- a/docs/spec/broker-mcp-contract-2026-05-03.md
+++ b/docs/spec/broker-mcp-contract-2026-05-03.md
@@ -415,9 +415,10 @@ No restart. No prompt. **This is the metric.**
 - Documented policy posture: subscription/account rotation is policy-sensitive
   and must be labeled as operator-owned behavior. We implement the mechanism
   only with explicit account enrollment and redacted evidence; we do not
-  market it as quota evasion. The doc lives in
-  `docs/policy/tos-posture-2026-05-XX.md` and is linked from the
-  `oauth-mux codex` first-run banner.
+  market it as quota evasion. Current posture lives in
+  `docs/policy/tos-posture-2026-05-05.md`; it should not be linked from
+  first-run or public promotion copy until Level 3 is live-proven and the
+  posture is re-reviewed.
 - Paid-cohort soak proof of Level 3 across at least 3 enrolled accounts and
   at least one observed real exhaustion-then-swap.
 

--- a/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
+++ b/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
@@ -135,9 +135,11 @@ the branch as-is:
 
 6. `docs/policy/tos-posture-2026-05-03.md`
    - Policy posture is needed before public promotion.
-   - Review for wording that could be read as quota evasion marketing.
-   - Link from first-run/operator docs only after the mechanism is stated
-     as operator-owned account enrollment and redacted evidence.
+   - Status: rewritten from current official OpenAI sources as
+     `docs/policy/tos-posture-2026-05-05.md`.
+   - The rewrite avoids "unlimited" / bypass framing and says not to
+     link from first-run or public promotion copy until Level 3 is
+     live-proven and the posture is re-reviewed.
 
 ### Already Absorbed or Superseded
 
@@ -232,12 +234,10 @@ These need review before public promotion:
    session.
 3. Capture real Codex wire cassettes for TIN-950 / GitHub #176:
    normal 200 flow first, then 401 and 429 only when safely available.
-4. Review policy posture doc and add only if it does not market quota
-   evasion.
-5. Keep demoting route-warming/restart surfaces from product language.
-6. Start the Claude adapter only after the Codex Level 3 proof is recorded
+4. Keep demoting route-warming/restart surfaces from product language.
+5. Start the Claude adapter only after the Codex Level 3 proof is recorded
    or explicitly parked.
-7. Re-run `just check-local` after each code/test slice.
+6. Re-run `just check-local` after each code/test slice.
 
 ## Hygiene Pass Notes
 
@@ -263,3 +263,6 @@ These need review before public promotion:
 - Rewrote the stale quarry test/coverage review from current main as
   `docs/spec/test-and-coverage-review-2026-05-05.md` and linked it from
   the broker contract as a descriptive assessment.
+- Rewrote the quarry ToS posture into
+  `docs/policy/tos-posture-2026-05-05.md` from current official OpenAI
+  sources, with public-promotion links gated until Level 3 is live-proven.

--- a/docs/spec/test-and-coverage-review-2026-05-05.md
+++ b/docs/spec/test-and-coverage-review-2026-05-05.md
@@ -133,8 +133,9 @@ inside a live `oauth-mux codex` session during that check.
    scrubbed, fixture-sized JSON.
 3. Keep quarry work as quarry. The stale branch still has useful policy
    and review ideas, but main already supersedes much of its source diff.
-4. Review policy posture before public promotion. Do not market account
-   rotation as unlimited usage or quota evasion.
+4. Keep `docs/policy/tos-posture-2026-05-05.md` current before public
+   promotion. Do not market account rotation as unlimited usage or quota
+   evasion.
 5. Start the Claude adapter only after Codex Level 3 is recorded or the
    Codex blocker is explicitly parked.
 


### PR DESCRIPTION
## Summary

- Adds `docs/policy/tos-posture-2026-05-05.md`, a conservative OpenAI/Codex account-muxing posture doc based on current official OpenAI sources.
- Updates the broker contract to point at the concrete posture doc and keep first-run/public promotion links gated until Level 3 is live-proven and re-reviewed.
- Marks the quarry ToS posture item as rewritten and keeps the current-main review pointed at the policy boundary.

## Validation

- `git diff --check`
- `just check-local`

## Boundary

This is policy/truthing only. It is not legal advice, not public marketing copy, and not a live Level 3 claim. It explicitly rejects unlimited-usage, bypass, resale, shared-credential, anti-detection, and silent-spend framing.

Official sources checked on 2026-05-05:

- OpenAI Terms & Policies index: https://openai.com/policies/
- OpenAI Terms of Use: https://openai.com/policies/terms-of-use/
- OpenAI Account Sharing Policy: https://help.openai.com/en/articles/10471989-openai-account-sharing-policy
- Using Codex with your ChatGPT plan: https://help.openai.com/en/articles/11369540-using-codex-with-your-chatgpt-plan
- Codex CLI docs: https://developers.openai.com/codex/cli
