### PR TITLE
Use custom Codex proxy provider

### DIFF
--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -98,7 +98,10 @@ both layers, Level 3 is the default and Level 4 is reachable.
 3. Materializes that account's `auth.json`-equivalent tuple.
 4. Writes a temporary, adapter-owned `CODEX_HOME` directory containing the
    selected account's `auth.json` and a generated `config.toml` whose
-   `[model_providers.openai]` block points at the wire-layer proxy.
+   selected custom provider (`model_provider = "oauth_mux_openai"` and
+   `[model_providers.oauth_mux_openai]`) points at the wire-layer proxy.
+   Codex 0.128+ rejects overriding the reserved built-in `openai`
+   provider id.
 5. Binds the wire-layer proxy on `127.0.0.1:<dynamic-port>`, with the
    proxy holding the account pool reference and the broker session id.
 6. Spawns `codex app-server --listen stdio://` as a child, with
@@ -401,10 +404,10 @@ The adapter MUST refuse to start in these conditions:
   user-mediated repair handoff is available.
 - `codex` binary is not on `PATH` or does not respond to `app-server
   --listen stdio://`.
-- The user's `~/.codex/config.toml` already has a non-managed
-  `[model_providers.openai]` block with a custom base_url AND the user
-  did not pass `--allow-config-shadow`. (We will not silently override
-  user config.)
+- The user's `~/.codex/config.toml` already has a non-managed provider
+  block with a custom base_url that would be selected by the session AND
+  the user did not pass `--allow-config-shadow`. (We will not silently
+  override user config.)
 
 The adapter MUST surface, not retry, on these:
 

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -338,8 +338,9 @@ fn writeManagedConfigToml(
     const w = contents.writer(allocator);
     try w.writeAll("# Managed by oauth-mux. Phase 2 wire proxy override.\n");
     try w.writeAll("# Anchor: docs/spec/codex-adapter-contract-2026-05-03.md §4\n\n");
-    try w.print("[model_providers.openai]\n", .{});
-    try w.print("name = \"openai\"\n", .{});
+    try w.writeAll("model_provider = \"oauth_mux_openai\"\n\n");
+    try w.print("[model_providers.oauth_mux_openai]\n", .{});
+    try w.print("name = \"oauth-mux OpenAI proxy\"\n", .{});
     try w.print("base_url = \"http://127.0.0.1:{d}/backend-api/codex\"\n", .{proxy_port});
     try w.writeAll("wire_api = \"responses\"\n");
     try w.writeAll("requires_openai_auth = true\n");
@@ -412,6 +413,9 @@ test "createSessionCodexHomeUnder copies auth and does not clobber source config
     const generated_config = try std.fs.cwd().readFileAlloc(std.testing.allocator, session_config, 4096);
     defer std.testing.allocator.free(generated_config);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "127.0.0.1:45678") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "model_provider = \"oauth_mux_openai\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "[model_providers.oauth_mux_openai]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "[model_providers.openai]") == null);
 
     const source_config = try std.fs.path.join(std.testing.allocator, &.{ root_path, "account", "config.toml" });
     defer std.testing.allocator.free(source_config);

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -6,9 +6,12 @@
 //!
 //! The proxy is the load-bearing piece that lets account swap happen
 //! without restarting the unmodified `codex` child process. It sits at
-//! 127.0.0.1:<dynamic-port> with codex's `[model_providers.openai].base_url`
+//! 127.0.0.1:<dynamic-port> with codex's generated
+//! `model_provider = "oauth_mux_openai"` / custom model provider block
 //! pointed at it (via a generated config.toml in the per-session
-//! CODEX_HOME). On every request:
+//! CODEX_HOME). Codex 0.128+ rejects overriding the reserved built-in
+//! `openai` provider id, so the adapter must select a custom provider id.
+//! On every request:
 //!
 //!   1. Read the inbound request from codex.
 //!   2. Substitute the three account-bound headers (Authorization,


### PR DESCRIPTION
## What changed

Codex 0.128 rejects generated configs that override the reserved built-in provider id `openai`:

```text
model_providers contains reserved built-in provider IDs: `openai`
```

This updates the managed `oauth-mux codex run` CODEX_HOME overlay to select a custom provider id instead:

```toml
model_provider = "oauth_mux_openai"

[model_providers.oauth_mux_openai]
name = "oauth-mux OpenAI proxy"
base_url = "http://127.0.0.1:<port>/backend-api/codex"
wire_api = "responses"
requires_openai_auth = true
```

It also updates the Codex adapter spec and wire-proxy comments so future work does not reintroduce `[model_providers.openai]`.

## Validation

- `codex debug models` direct config-load check: reserved `openai` provider fails; `oauth_mux_openai` succeeds.
- `just build` passed.
- `just smoke-codex-acceptance-local` passed.
- `just smoke-codex-concurrent-sessions-local` passed.
- `./zig-out/bin/oauth-mux codex run --profile codex-max --json-status-file <tmp>/status.ndjson -- debug models` passed with child exit 0 and proxy status 200.
- `git diff --check` passed.
- `just check-local` passed.

## Boundary

This fixes the managed-frame startup blocker. It does not claim Level 3 quota handoff; that still requires provider-originated quota exhaustion and account swap in a live `oauth-mux codex` session.
