### PR TITLE
Plan harness session authority bridge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,10 +22,12 @@ delete and re-anchor on the broker contract.
 1. This file (AGENTS.md)
 2. `docs/spec/broker-mcp-contract-2026-05-03.md` — the product anchor
 3. `docs/spec/codex-adapter-contract-2026-05-03.md` — Codex adapter spec
-4. `justfile` — operator entrypoint for all build/test/release tasks
-5. `flake.nix` — Nix devShell and package definitions
-6. `build.zig` / `build.zig.zon` — Zig build system
-7. `src/` — implementation
+4. `docs/spec/harness-session-authority-bridge-2026-05-05.md` — auth/config
+   overlays must not hide or fork harness session authority
+5. `justfile` — operator entrypoint for all build/test/release tasks
+6. `flake.nix` — Nix devShell and package definitions
+7. `build.zig` / `build.zig.zon` — Zig build system
+8. `src/` — implementation
 
 ## Build
 

--- a/docs/spec/broker-mcp-contract-2026-05-03.md
+++ b/docs/spec/broker-mcp-contract-2026-05-03.md
@@ -30,6 +30,10 @@ Current evidence review:
   current-main assessment of tests, synthetic evidence, live route truth,
   and remaining Level 3 gaps. It is descriptive only; this broker
   contract remains the product source of truth.
+- `docs/spec/harness-session-authority-bridge-2026-05-05.md` records the
+  managed-frame store split required for normal `resume`/history behavior:
+  oauth-mux owns auth/config overlays, but adapters must retain or bridge
+  harness session authority instead of hiding or copying it wholesale.
 
 ## 0. The One Success Metric
 
@@ -465,10 +469,12 @@ relapse into restart-as-success.
    default.
 3. `docs/spec/codex-adapter-contract-2026-05-03.md` — Codex adapter
    contract for the first harness implementation.
-4. `docs/spec/harness-adapter-pattern-2026-05-03.md` — general adapter
+4. `docs/spec/harness-session-authority-bridge-2026-05-05.md` — harness
+   store-boundary contract for auth/config/session/cache/evidence state.
+5. `docs/spec/harness-adapter-pattern-2026-05-03.md` — general adapter
    pattern for non-Codex harnesses.
-5. `justfile`, `flake.nix`, `build.zig`, `src/`
-6. Other docs/spec/ files. The following are explicitly demoted to
+6. `justfile`, `flake.nix`, `build.zig`, `src/`
+7. Other docs/spec/ files. The following are explicitly demoted to
    historical/diagnostic-only and must carry that label in their preamble:
    - `docs/spec/observed-child-diagnostic-contract-2026-05-02.md`
      (diagnostic child observation only; restart is not a product behavior)

--- a/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
+++ b/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
@@ -7,6 +7,7 @@ Anchor docs:
 - `AGENTS.md`
 - `docs/spec/broker-mcp-contract-2026-05-03.md`
 - `docs/spec/codex-adapter-contract-2026-05-03.md`
+- `docs/spec/harness-session-authority-bridge-2026-05-05.md`
 - `docs/spec/codex-wire-evidence-2026-05-03.md`
 
 ## Product Bar
@@ -65,6 +66,9 @@ Not yet proven:
 - Mid-turn recovery.
 - Bare `codex` plus a separate background oauth-mux daemon seamlessly
   handing off account state.
+- Managed-frame resume parity. The adapter-owned temporary `CODEX_HOME`
+  currently owns auth/config correctly but hides canonical Codex session
+  authority unless a session bridge is added.
 
 ## Quarry Worktree
 
@@ -214,13 +218,20 @@ These need review before public promotion:
    - Multi-session, multi-harness route truth wants daemon-attached state
      later.
 
-5. Bare `codex` path
+5. Session authority bridge
+   - `oauth-mux codex run -- ... resume <id>` must see the same canonical
+     Codex session authority as bare `codex` while keeping auth/config
+     mux-owned.
+   - Full-store copies are rejected; use a bridge/reference model per
+     `docs/spec/harness-session-authority-bridge-2026-05-05.md`.
+
+6. Bare `codex` path
    - The aspirational background daemon plus bare `codex` remains harder
-     than `oauth-mux codex`.
+   than `oauth-mux codex`.
    - Treat as future adapter/sidecar research, not the current acceptance
      gate.
 
-6. Claude adapter
+7. Claude adapter
    - Important to prove broker contract generality.
    - Start only after Codex Level 3 acceptance or after the Codex blocker is
      explicitly parked.
@@ -234,10 +245,12 @@ These need review before public promotion:
    session.
 3. Capture real Codex wire cassettes for TIN-950 / GitHub #176:
    normal 200 flow first, then 401 and 429 only when safely available.
-4. Keep demoting route-warming/restart surfaces from product language.
-5. Start the Claude adapter only after the Codex Level 3 proof is recorded
+4. Add the session-authority bridge for managed Codex resume before
+   promoting managed-frame dogfood as parity with bare Codex.
+5. Keep demoting route-warming/restart surfaces from product language.
+6. Start the Claude adapter only after the Codex Level 3 proof is recorded
    or explicitly parked.
-6. Re-run `just check-local` after each code/test slice.
+7. Re-run `just check-local` after each code/test slice.
 
 ## Hygiene Pass Notes
 

--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -32,6 +32,12 @@ request with a different account's fixture credentials. Runtime
 auth source; the adapter does not rewrite the account-local
 `config.toml`.
 
+Known gap, 2026-05-05: this overlay currently separates auth/config
+authority correctly but does not yet bridge Codex's canonical session
+authority. A managed run can therefore hide `~/.codex/sessions` from
+`codex resume`. `docs/spec/harness-session-authority-bridge-2026-05-05.md`
+is the P1 plan for fixing that without copying the whole session store.
+
 That smoke is structural evidence only. It uses local stubs and fake
 fixture tokens, makes no provider calls, and keeps the adapter output at
 `claim_level:"broker_owned"` while reporting
@@ -101,7 +107,9 @@ both layers, Level 3 is the default and Level 4 is reachable.
    selected custom provider (`model_provider = "oauth_mux_openai"` and
    `[model_providers.oauth_mux_openai]`) points at the wire-layer proxy.
    Codex 0.128+ rejects overriding the reserved built-in `openai`
-   provider id.
+   provider id. Session-authority paths must be bridged per
+   `docs/spec/harness-session-authority-bridge-2026-05-05.md`, not copied
+   wholesale into this overlay.
 5. Binds the wire-layer proxy on `127.0.0.1:<dynamic-port>`, with the
    proxy holding the account pool reference and the broker session id.
 6. Spawns `codex app-server --listen stdio://` as a child, with
@@ -527,3 +535,7 @@ The adapter is acceptable when:
   Cloudflare-relevant headers to chatgpt.com, or do bare `Authorization +
   ChatGPT-Account-ID` headers suffice? (`bearer_auth_provider.rs` only
   shows the latter; capture confirms.)
+- **A5.** Which Codex files are required for managed resume parity:
+  `sessions/` only, or also `session_index.jsonl`, `history.jsonl`, and
+  `shell_snapshots/`? The answer belongs in the session-authority bridge
+  smoke before live managed-frame resume is treated as parity.

--- a/docs/spec/harness-adapter-pattern-2026-05-03.md
+++ b/docs/spec/harness-adapter-pattern-2026-05-03.md
@@ -3,6 +3,8 @@ Date: 2026-05-03
 Status: design pattern doc for non-Codex adapters. Anchor:
 `docs/spec/broker-mcp-contract-2026-05-03.md`. Codex-specific worked
 example: `docs/spec/codex-adapter-contract-2026-05-03.md`.
+Store-boundary companion:
+`docs/spec/harness-session-authority-bridge-2026-05-05.md`.
 
 ## What an adapter is, in one sentence
 
@@ -19,7 +21,7 @@ harness's native auth/IPC surface on the other.
 ## What every adapter MUST decide
 
 Every harness has a different surface area. Before writing an adapter,
-answer these eleven questions in a per-harness contract spec (the way
+answer these twelve questions in a per-harness contract spec (the way
 `codex-adapter-contract-2026-05-03.md` answers them for Codex):
 
 1. **Token shape.** What is the credential the harness consumes? Bearer
@@ -59,8 +61,14 @@ answer these eleven questions in a per-harness contract spec (the way
     multiple subscription accounts in rotation? The adapter must honestly
     label this; we implement what is technically possible, we name what
     is policy-controversial, we do not advocate.
+12. **Session authority.** Which local files or service APIs implement
+    resume/history/session continuity? Can the adapter retain that
+    authority while keeping auth/config mux-owned? If the harness exposes
+    only one home directory, follow
+    `docs/spec/harness-session-authority-bridge-2026-05-05.md` before
+    claiming managed-session parity.
 
-If any of these eleven cannot be answered from public source / docs /
+If any of these cannot be answered from public source / docs /
 captured wire evidence, that gap is a Phase 0 capture task before the
 adapter is written. Adapters MUST NOT be written against assumed shapes.
 
@@ -204,7 +212,7 @@ Start a new adapter when, and only when:
    in-place mux meaningfully changes their workflow. (If quotas hit
    monthly, not weekly, a wrapper tells them to manually switch is
    probably enough.)
-2. The eleven questions above are answerable from public source +
+2. The twelve questions above are answerable from public source +
    captured wire evidence.
 3. The harness's architecture maps to A, B, or C, and you are honest
    about which.

--- a/docs/spec/harness-session-authority-bridge-2026-05-05.md
+++ b/docs/spec/harness-session-authority-bridge-2026-05-05.md
@@ -1,0 +1,359 @@
+# Harness Session Authority Bridge
+Date: 2026-05-05
+Status: planning contract. This is a P1 product/architecture issue until
+`oauth-mux <harness>` can preserve ordinary harness session continuity while
+oauth-mux owns muxed auth/config state.
+
+Anchor: `docs/spec/broker-mcp-contract-2026-05-03.md`.
+Codex implementation anchor: `docs/spec/codex-adapter-contract-2026-05-03.md`.
+
+## 0. Problem
+
+`oauth-mux codex run` currently creates a temporary `CODEX_HOME` overlay so
+oauth-mux can own the selected account auth material and generated proxy
+`config.toml` without mutating the user's normal Codex home. That fixed the
+account-local `config.toml` clobber race.
+
+It also exposed a separate bug: Codex stores auth, config, sessions, history,
+shell snapshots, logs, and caches under the same `CODEX_HOME` root. When
+oauth-mux points Codex at a temporary home, `codex resume <id>` cannot see a
+session that exists under the canonical Codex session store. The operator
+observed this directly: the session file existed under `~/.codex/sessions`,
+but `oauth-mux codex run -- ... resume <id>` failed with "No saved session
+found" because the temporary `CODEX_HOME` did not include that session
+authority.
+
+Blindly copying `~/.codex/sessions` into each temporary overlay is rejected.
+The operator's local Codex session store was several GiB. Copying it would be
+slow, racy, confusing, and wrong: oauth-mux would fork the user's session
+authority instead of retaining it.
+
+## 1. Product Bar
+
+This problem does not change the product metric:
+
+> The user runs `oauth-mux <harness>`. The active subscription account exhausts
+> its quota. Another credited account is substituted in place. The harness
+> process is not restarted. The user is not prompted.
+
+Session authority is a prerequisite for the UX around that metric. A managed
+`oauth-mux codex` frame must be able to resume the same sessions a normal
+Codex user expects, without handing auth/config control back to bare Codex.
+
+## 2. Store Taxonomy
+
+Every harness adapter MUST classify its local state into these buckets before
+claiming managed-session parity.
+
+### 2.1 Auth Authority Store
+
+Account-bound secrets and identity material:
+
+- access tokens, refresh tokens, id tokens, account ids;
+- provider-specific auth cookies or bearer material;
+- installation ids when they participate in auth;
+- any per-account state that can authorize provider requests.
+
+oauth-mux owns this boundary during a brokered session. It may materialize a
+copy into an adapter overlay, but it must not mutate the user's canonical auth
+store unless the user is explicitly enrolling or reauthing that account.
+
+For Codex today: `auth.json` and likely `installation_id` are auth-authority
+inputs for the managed overlay.
+
+### 2.2 Managed Config Overlay
+
+Adapter-controlled configuration needed to interpose the broker:
+
+- model provider/base URL override;
+- proxy transport settings;
+- mux instrumentation flags;
+- account/profile policy settings that belong to oauth-mux.
+
+oauth-mux owns this boundary. For Codex, this is the generated
+`config.toml` selecting `model_provider = "oauth_mux_openai"` and a
+localhost proxy base URL. The adapter must not write that configuration into
+the canonical `~/.codex/config.toml` by default.
+
+### 2.3 Session Authority Store
+
+User-visible conversation/session continuity:
+
+- transcript/session files;
+- session indexes;
+- history files;
+- shell snapshots or command-resume artifacts;
+- any provider/harness metadata needed for `resume`, `resume --last`, or
+  equivalent user workflows.
+
+oauth-mux SHOULD retain this authority by reference, not copy it. The default
+managed frame should see the same session authority as the ordinary harness
+unless the user explicitly requests an isolated session namespace.
+
+For Codex today, candidate session-authority files are:
+
+- `~/.codex/sessions/`
+- `~/.codex/session_index.jsonl`
+- `~/.codex/history.jsonl`
+- `~/.codex/shell_snapshots/`
+
+The exact set must be proven by fixtures and live resume checks before
+implementation is called complete.
+
+### 2.4 Cache, Log, and Runtime State
+
+Local state that may be large, private, or not required for session continuity:
+
+- model caches;
+- SQLite logs/state;
+- telemetry/debug logs;
+- temporary files.
+
+Default: do not bridge unless evidence shows the harness requires it for
+normal operation. Keep this state local to the managed overlay or to an
+oauth-mux-owned runtime directory. If a harness needs a cache bridge, it must
+be explicit and documented separately from session authority.
+
+For Codex, `logs_*.sqlite`, `state_*.sqlite`, and model caches are not part of
+the initial bridge acceptance.
+
+### 2.5 oauth-mux Evidence Store
+
+Redacted oauth-mux status and proof artifacts:
+
+- NDJSON status files;
+- cassette captures and replay metadata;
+- route-health/quota evidence;
+- broker event logs.
+
+This state is oauth-mux-owned and MUST remain separate from harness session
+authority. It must not leak token material, raw JWTs, credential paths, or
+session file contents.
+
+## 3. Design Principle
+
+oauth-mux owns auth/config. The harness owns user session continuity.
+
+For adapters that only expose a single home directory environment variable,
+oauth-mux must build a composed home:
+
+1. auth/config entries are adapter-generated and mux-owned;
+2. session-authority entries are references to the canonical session store;
+3. cache/log/runtime entries are isolated unless proven necessary;
+4. evidence entries live outside the harness home.
+
+This is a bridge, not a full copy. If the adapter cannot safely bridge session
+authority, it must refuse or clearly report `session_authority:"isolated"`
+instead of pretending managed resume parity exists.
+
+## 4. Codex-Specific Options
+
+### Option A: Upstream Split Session Paths
+
+Best long-term shape: Codex accepts separate session/history paths while
+`CODEX_HOME` continues to point at the mux-owned auth/config overlay.
+
+Possible upstream surfaces:
+
+- `CODEX_SESSION_HOME`
+- `CODEX_HISTORY_PATH`
+- `CODEX_SHELL_SNAPSHOTS_DIR`
+- equivalent `config.toml` keys
+
+This is the cleanest design because it avoids filesystem tricks and makes the
+boundary explicit in Codex itself. It requires upstream Codex support.
+
+### Option B: Local Session Bridge by Reference
+
+Near-term shape: the temporary `CODEX_HOME` contains mux-owned `auth.json` and
+`config.toml`, while session-authority paths are symlinks, directory links, or
+adapter-managed references to the canonical Codex store.
+
+For Codex on Unix-like systems, a candidate overlay is:
+
+```text
+<tmp>/oauth-mux-codex-XXXX/
+  auth.json                 # copied from selected account auth source
+  installation_id           # copied if auth-relevant
+  config.toml               # generated proxy config
+  sessions -> ~/.codex/sessions
+  session_index.jsonl -> ~/.codex/session_index.jsonl
+  history.jsonl -> ~/.codex/history.jsonl
+  shell_snapshots -> ~/.codex/shell_snapshots
+```
+
+This keeps `resume <id>` and `resume --last` pointed at the canonical session
+authority without mutating canonical auth/config.
+
+Risks to resolve:
+
+- symlink/junction behavior on Windows;
+- file creation if `session_index.jsonl` or `history.jsonl` does not exist;
+- concurrent writes from bare `codex` and `oauth-mux codex`;
+- privacy expectations when a user wants isolated managed sessions;
+- whether any Codex session entry embeds account identity that makes
+  cross-account continuation impossible at the provider layer.
+
+### Option C: Targeted Resume Import/Export
+
+Fallback if Option B is unsafe: for an explicit `resume <id>`, locate only the
+matching session file and bridge or import that one session into the overlay,
+then export any updated session file back on clean exit.
+
+This is worse than Option B because it creates writeback and conflict
+questions. It is acceptable only as an explicit compatibility mode, not as the
+default user experience.
+
+### Option D: Copy the Whole Session Store
+
+Rejected. It is too large, too slow, racy under concurrent sessions, and
+creates a forked session authority that neither bare Codex nor oauth-mux can
+explain cleanly.
+
+## 5. Default Policy
+
+Recommended default after tests are green:
+
+- `oauth-mux codex run` uses canonical Codex session authority by reference.
+- `--isolated-session-store` or equivalent opts into a managed-only session
+  namespace for tests/privacy.
+- `--session-home <path>` is an advanced override for operators who keep
+  Codex sessions outside `~/.codex`.
+- Normal output reports booleans such as
+  `session_authority:"canonical_bridge"` and
+  `canonical_session_paths_printed:false`. It does not print session ids,
+  full paths, or transcript content.
+
+This default matches user expectation: if they can run `codex resume <id>`,
+then `oauth-mux codex run -- ... resume <id>` should see the same session
+authority unless they deliberately isolated it.
+
+## 6. Harness-General Contract
+
+Each adapter must define:
+
+- `auth_authority`: what files/env/keychain entries authorize provider calls;
+- `managed_config`: what oauth-mux must generate or override;
+- `session_authority`: what files or service APIs implement resume/history;
+- `runtime_state`: what caches/logs are safe to isolate;
+- `bridge_mode`: `canonical_bridge`, `isolated`, `targeted_import`, or
+  `unsupported`;
+- `writeback_policy`: canonical, isolated, import_export, or read_only.
+
+The broker MCP contract should gain a session-authority status field so future
+adapters can report this consistently:
+
+```jsonc
+{
+  "kind": "session_started",
+  "adapter": "codex",
+  "claim_level": "broker_owned",
+  "session_authority": "canonical_bridge",
+  "auth_authority": "mux_owned_overlay",
+  "managed_config": "mux_owned_overlay",
+  "session_paths_printed": false
+}
+```
+
+## 7. Acceptance Criteria
+
+P1 is satisfied for Codex when all of these are true:
+
+1. `oauth-mux codex run -- ... resume <existing-id>` finds a session that
+   exists only in the canonical Codex session authority, without copying the
+   full session store.
+2. `oauth-mux codex run -- ... resume --last` resolves against the same
+   canonical session authority bare `codex` would use.
+3. A new session started under `oauth-mux codex run` writes to the chosen
+   session authority and can later be found by bare `codex resume` unless the
+   user opted into isolation.
+4. The adapter does not mutate canonical `~/.codex/auth.json` or
+   `~/.codex/config.toml`.
+5. Concurrent `oauth-mux codex run` sessions do not clobber auth/config
+   overlays and can both read/write session authority safely.
+6. Tests prove no full-store copy happens.
+7. Normal output and status frames do not print token material, credential
+   paths, raw JWTs, transcript contents, full session paths, or session ids by
+   default.
+8. If Codex/provider refuses cross-account continuation for a resumed thread,
+   oauth-mux reports that as provider/thread continuity evidence, not as a
+   session-authority bridge failure.
+
+## 8. Test Plan
+
+1. Fixture layout smoke:
+   - create a fake canonical Codex home with `sessions/`, `history.jsonl`,
+     `session_index.jsonl`, and `shell_snapshots/`;
+   - create an oauth-mux managed overlay with mux-owned auth/config and
+     canonical session bridge references;
+   - prove the overlay exposes the fixture session without copying the store.
+2. Resume command smoke:
+   - run a stub `codex resume <id>` under `CODEX_HOME=<overlay>`;
+   - stub asserts it can read the bridged canonical session file and that
+     `auth.json`/`config.toml` came from the overlay.
+3. Concurrent sessions:
+   - start two managed overlays against the same canonical session authority;
+   - prove both use distinct generated proxy configs and neither mutates
+     canonical auth/config.
+4. Redaction check:
+   - status output must report bridge mode, not raw paths or ids.
+5. Live operator proof:
+   - run `oauth-mux codex run --profile codex-max -- ... resume <known-id>`;
+   - verify the same session is available without copying `~/.codex/sessions`.
+
+## 9. Decision Points
+
+- Do we implement Option B locally first, or open an upstream Codex request for
+  Option A before local bridge code? Recommendation: implement Option B as the
+  near-term P1 and file the upstream split-path request in parallel.
+- Should canonical session bridge be default immediately? Recommendation:
+  yes, after smoke coverage; provide an isolated opt-out.
+- Which Codex files are required for `resume --last`: only `sessions/`, or
+  also `history.jsonl` / `session_index.jsonl` / `shell_snapshots/`?
+  Recommendation: test before deciding.
+- Should managed sessions write new transcripts to canonical `~/.codex`
+  by default? Recommendation: yes, because the user expects `codex resume` and
+  `oauth-mux codex resume` to describe the same work history.
+
+## 10. Phase Plan
+
+### Phase 0: Reproduce and Spec
+
+- Add this plan.
+- Add a failing/diagnostic smoke that documents `resume <id>` invisibility
+  under isolated temporary `CODEX_HOME`.
+- Record current Codex state layout without logging paths in normal output.
+
+### Phase 1: Adapter Store Classification
+
+- Add Codex adapter metadata for auth/config/session/cache/evidence stores.
+- Emit redacted `session_authority` and `auth_authority` status fields.
+- Keep behavior unchanged until the bridge smoke exists.
+
+### Phase 2: Codex Canonical Session Bridge
+
+- Build the composed `CODEX_HOME` overlay:
+  mux-owned auth/config, canonical session-authority references, isolated
+  cache/log state.
+- Add fixture and concurrent-session tests.
+- Support `--isolated-session-store` and optional `--session-home`.
+
+### Phase 3: Managed Resume Acceptance
+
+- Prove `resume <id>` and `resume --last` work through
+  `oauth-mux codex run`.
+- Run one live managed-frame resume dogfood with redacted status artifact.
+
+### Phase 4: Harness-Generalization
+
+- Promote the store taxonomy into `docs/spec/harness-adapter-pattern-2026-05-03.md`.
+- Require every future adapter (`oauth-mux claude`, etc.) to declare its
+  session-authority bridge before claiming managed-session parity.
+
+## 11. Non-Goals
+
+- This does not prove provider thread continuity across accounts.
+- This does not prove same-thread quota recovery.
+- This does not make bare `codex` plus a background oauth-mux daemon seamless.
+- This does not justify restart or manual resume as product success.
+- This does not copy or inspect user transcript content.


### PR DESCRIPTION
## What changed

- Adds `docs/spec/harness-session-authority-bridge-2026-05-05.md` as the P1 store-boundary contract.
- Links it from `AGENTS.md`, broker MCP contract, Codex adapter contract, harness adapter pattern, and quarry todo.
- Tracks the work in GitHub #191 and Linear TIN-979.

## Why

Managed `oauth-mux codex run` must own mux auth/config overlays, but the current temporary `CODEX_HOME` hides canonical Codex session authority. Full copying is rejected; the plan requires a reference/bridge model so `resume <id>` and `resume --last` behave like bare Codex while auth/config stay mux-owned.

## Validation

- `git diff --check`
- `just check-local`