### PR TITLE
Bridge Codex session authority

### DIFF
--- a/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
+++ b/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
@@ -67,8 +67,9 @@ Not yet proven:
 - Bare `codex` plus a separate background oauth-mux daemon seamlessly
   handing off account state.
 - Managed-frame resume parity. The adapter-owned temporary `CODEX_HOME`
-  currently owns auth/config correctly but hides canonical Codex session
-  authority unless a session bridge is added.
+  now bridges canonical Codex session authority by reference, but live
+  `resume <id>` / `resume --last` dogfood is still pending before this is
+  treated as parity with bare Codex.
 
 ## Quarry Worktree
 
@@ -222,8 +223,10 @@ These need review before public promotion:
    - `oauth-mux codex run -- ... resume <id>` must see the same canonical
      Codex session authority as bare `codex` while keeping auth/config
      mux-owned.
-   - Full-store copies are rejected; use a bridge/reference model per
+   - Full-store copies are rejected; the current adapter uses a
+     bridge/reference model per
      `docs/spec/harness-session-authority-bridge-2026-05-05.md`.
+   - Remaining acceptance: live managed-frame resume dogfood.
 
 6. Bare `codex` path
    - The aspirational background daemon plus bare `codex` remains harder
@@ -245,8 +248,8 @@ These need review before public promotion:
    session.
 3. Capture real Codex wire cassettes for TIN-950 / GitHub #176:
    normal 200 flow first, then 401 and 429 only when safely available.
-4. Add the session-authority bridge for managed Codex resume before
-   promoting managed-frame dogfood as parity with bare Codex.
+4. Run live managed-frame resume dogfood before promoting managed-frame
+   resume as parity with bare Codex.
 5. Keep demoting route-warming/restart surfaces from product language.
 6. Start the Claude adapter only after the Codex Level 3 proof is recorded
    or explicitly parked.

--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -32,11 +32,12 @@ request with a different account's fixture credentials. Runtime
 auth source; the adapter does not rewrite the account-local
 `config.toml`.
 
-Known gap, 2026-05-05: this overlay currently separates auth/config
-authority correctly but does not yet bridge Codex's canonical session
-authority. A managed run can therefore hide `~/.codex/sessions` from
-`codex resume`. `docs/spec/harness-session-authority-bridge-2026-05-05.md`
-is the P1 plan for fixing that without copying the whole session store.
+Implementation update, 2026-05-05: the overlay now separates auth/config
+authority from session authority. Auth/config remain mux-owned in the
+temporary `CODEX_HOME`; `sessions/`, `history.jsonl`, `session_index.jsonl`,
+and `shell_snapshots/` are bridged by reference to canonical Codex session
+authority by default. `docs/spec/harness-session-authority-bridge-2026-05-05.md`
+tracks the remaining live resume acceptance.
 
 That smoke is structural evidence only. It uses local stubs and fake
 fixture tokens, makes no provider calls, and keeps the adapter output at
@@ -107,9 +108,11 @@ both layers, Level 3 is the default and Level 4 is reachable.
    selected custom provider (`model_provider = "oauth_mux_openai"` and
    `[model_providers.oauth_mux_openai]`) points at the wire-layer proxy.
    Codex 0.128+ rejects overriding the reserved built-in `openai`
-   provider id. Session-authority paths must be bridged per
+   provider id. Session-authority paths are bridged per
    `docs/spec/harness-session-authority-bridge-2026-05-05.md`, not copied
-   wholesale into this overlay.
+   wholesale into this overlay. Operators may pass `--isolated-session-store`
+   for a test/private namespace or `--session-home <path>` for an explicit
+   canonical session authority.
 5. Binds the wire-layer proxy on `127.0.0.1:<dynamic-port>`, with the
    proxy holding the account pool reference and the broker session id.
 6. Spawns `codex app-server --listen stdio://` as a child, with
@@ -360,6 +363,8 @@ fresh attempt). Adapters must accept that policy without retry.
 oauth-mux codex                                       # default: pick from default profile
 oauth-mux codex --profile codex-max                   # specific profile
 oauth-mux codex --account codex:max-1                 # pin to one account (no swap)
+oauth-mux codex --session-home ~/.codex               # explicit session authority
+oauth-mux codex --isolated-session-store              # test/private session namespace
 oauth-mux codex --no-broker                           # bypass: bare codex, no mux (degraded)
 oauth-mux codex --                                    # explicit args separator passes everything to codex
 oauth-mux codex resume --last                         # forwarded to codex

--- a/docs/spec/harness-session-authority-bridge-2026-05-05.md
+++ b/docs/spec/harness-session-authority-bridge-2026-05-05.md
@@ -7,6 +7,21 @@ oauth-mux owns muxed auth/config state.
 Anchor: `docs/spec/broker-mcp-contract-2026-05-03.md`.
 Codex implementation anchor: `docs/spec/codex-adapter-contract-2026-05-03.md`.
 
+## 0.0 Current Implementation Checkpoint
+
+The first Codex slice is implemented: `oauth-mux codex run` now builds a
+composed managed `CODEX_HOME` with mux-owned `auth.json` and generated
+`config.toml`, while session-authority entries are bridged by reference.
+Default session authority is the parent `CODEX_HOME` when set, otherwise
+`~/.codex`; `OMUX_CODEX_SESSION_HOME` and `--session-home <path>` can override
+that authority; `--isolated-session-store` opts out for tests/privacy.
+
+The synthetic acceptance smoke proves the managed overlay exposes the canonical
+`sessions/`, `history.jsonl`, `session_index.jsonl`, and `shell_snapshots/`
+entries by reference without printing paths. This is structural evidence only.
+The remaining P1 acceptance is live managed-frame resume dogfood with real
+Codex sessions.
+
 ## 0. Problem
 
 `oauth-mux codex run` currently creates a temporary `CODEX_HOME` overlay so

--- a/scripts/smoke-codex-401-propagation.sh
+++ b/scripts/smoke-codex-401-propagation.sh
@@ -81,7 +81,7 @@ OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
   OMUX_STUB_CODEX_TURNS=4 \
   OMUX_STUB_CODEX_REPORT="$STUB_REPORT" \
-  "$BIN" codex run --profile codex-max --json-status-file "$NDJSON" 2>"$ADAPTER_STDERR" || {
+  "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$NDJSON" 2>"$ADAPTER_STDERR" || {
     echo "adapter exited nonzero" >&2
     cat "$NDJSON" >&2 || true
     cat "$ADAPTER_STDERR" >&2 || true

--- a/scripts/smoke-codex-acceptance.sh
+++ b/scripts/smoke-codex-acceptance.sh
@@ -57,6 +57,7 @@ NDJSON="$TMP/adapter.ndjson"
 ADAPTER_STDERR="$TMP/adapter.stderr"
 STUB_PIDFILE="$TMP/stub-codex.pid"
 STUB_REPORT="$TMP/stub-codex.report"
+CANONICAL_SESSION_HOME="$TMP/canonical-codex"
 
 cleanup() {
     if [[ -n "${UPSTREAM_PID:-}" ]] && kill -0 "$UPSTREAM_PID" 2>/dev/null; then
@@ -71,6 +72,7 @@ trap cleanup EXIT
 # and chatgpt_account_is_fedramp=true so credential/materialize
 # exercises the JWT decode path on each account.
 mkdir -p "$TMP/account-A" "$TMP/account-B"
+mkdir -p "$CANONICAL_SESSION_HOME/sessions/2026/05/05" "$CANONICAL_SESSION_HOME/shell_snapshots"
 ID_TOKEN="h.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9wbGFuX3R5cGUiOiJwcm8iLCJjaGF0Z3B0X2FjY291bnRfaXNfZmVkcmFtcCI6dHJ1ZX19.s"
 
 cat >"$TMP/account-A/auth.json" <<EOF
@@ -81,6 +83,8 @@ cat >"$TMP/account-B/auth.json" <<EOF
 EOF
 printf '%s\n' 'preexisting = "account-A"' >"$TMP/account-A/config.toml"
 printf '%s\n' 'preexisting = "account-B"' >"$TMP/account-B/config.toml"
+printf '%s\n' '{"fixture":"canonical-session"}' >"$CANONICAL_SESSION_HOME/sessions/2026/05/05/session.jsonl"
+touch "$CANONICAL_SESSION_HOME/history.jsonl" "$CANONICAL_SESSION_HOME/session_index.jsonl"
 
 cat >"$TMP/oauth-mux.config.json" <<EOF
 {
@@ -126,6 +130,8 @@ OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_UPSTREAM_HOST="127.0.0.1:$UPSTREAM_PORT" \
   OMUX_UPSTREAM_SCHEME="http" \
   OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+  OMUX_CODEX_SESSION_HOME="$CANONICAL_SESSION_HOME" \
+  OMUX_STUB_CANONICAL_SESSION_HOME="$CANONICAL_SESSION_HOME" \
   OMUX_STUB_CODEX_TURNS=5 \
   OMUX_STUB_CODEX_PIDFILE="$STUB_PIDFILE" \
   OMUX_STUB_CODEX_REPORT="$STUB_REPORT" \
@@ -158,6 +164,8 @@ echo "smoke-codex-acceptance: assertions"
 assert_grep "session_started"           '"kind":"session_started"'           "$NDJSON"
 assert_grep "session_started has proxy_port" '"proxy_port":[0-9]+'           "$NDJSON"
 assert_grep "session_started redacts CODEX_HOME path" '"codex_home_path_printed":false' "$NDJSON"
+assert_grep "session_started reports canonical session bridge" '"session_authority":"canonical_bridge"' "$NDJSON"
+assert_grep "session_started redacts session paths" '"session_paths_printed":false' "$NDJSON"
 assert_grep "proxy_turn 200 ok"         '"kind":"proxy_turn".*"status":200.*"classification":"ok"' "$NDJSON"
 assert_grep "proxy_turn 429 quota_exhausted" '"kind":"proxy_turn".*"status":429.*"classification":"quota_exhausted"' "$NDJSON"
 assert_grep "proxy_post_swap_turn fired" '"kind":"proxy_post_swap_turn"'     "$NDJSON"
@@ -183,6 +191,19 @@ fi
 
 if [[ ! -s "$STUB_REPORT" ]]; then
     echo "  ✗ stub-codex report missing" >&2
+    exit 1
+fi
+if [[ "$(jq -r .session_bridge.checked "$STUB_REPORT")" == "true" \
+      && "$(jq -r .session_bridge.sessions_samefile "$STUB_REPORT")" == "true" \
+      && "$(jq -r .session_bridge.history_samefile "$STUB_REPORT")" == "true" \
+      && "$(jq -r .session_bridge.session_index_samefile "$STUB_REPORT")" == "true" \
+      && "$(jq -r .session_bridge.shell_snapshots_samefile "$STUB_REPORT")" == "true" \
+      && "$(jq -r .session_bridge.canonical_marker_exists "$STUB_REPORT")" == "true" \
+      && "$(jq -r .session_bridge.paths_printed "$STUB_REPORT")" == "false" ]]; then
+    echo "  ✓ session authority is bridged by reference without path output"
+else
+    echo "  ✗ session authority bridge report failed" >&2
+    cat "$STUB_REPORT" >&2
     exit 1
 fi
 PID_STABLE=$(jq -r .pid_stable "$STUB_REPORT")
@@ -212,7 +233,7 @@ else
 fi
 
 echo
-echo "smoke-codex-acceptance: all 15 assertions passed."
+echo "smoke-codex-acceptance: all 18 assertions passed."
 echo "  full ndjson: $NDJSON"
 echo "  stub upstream log: $UPLOG"
 echo "  stub codex report: $STUB_REPORT"

--- a/scripts/smoke-codex-all-exhausted.sh
+++ b/scripts/smoke-codex-all-exhausted.sh
@@ -84,7 +84,7 @@ OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
   OMUX_STUB_CODEX_TURNS=5 \
   OMUX_STUB_CODEX_REPORT="$STUB_REPORT" \
-  "$BIN" codex run --profile codex-max --json-status-file "$NDJSON" 2>"$ADAPTER_STDERR" || {
+  "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$NDJSON" 2>"$ADAPTER_STDERR" || {
     echo "adapter exited nonzero" >&2
     cat "$NDJSON" >&2 || true
     cat "$ADAPTER_STDERR" >&2 || true

--- a/scripts/smoke-codex-concurrent-sessions.sh
+++ b/scripts/smoke-codex-concurrent-sessions.sh
@@ -118,7 +118,7 @@ OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_STUB_CODEX_TURNS=6 \
   OMUX_STUB_CODEX_PIDFILE="$PIDFILE_A" \
   OMUX_STUB_CODEX_REPORT="$REPORT_A" \
-  "$BIN" codex run --profile codex-max --json-status-file "$NDJSON_A" >"$STDOUT_A" 2>"$STDERR_A" &
+  "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$NDJSON_A" >"$STDOUT_A" 2>"$STDERR_A" &
 PID_A=$!
 
 OMUX_CONFIG="$TMP/oauth-mux.config.json" \
@@ -128,7 +128,7 @@ OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_STUB_CODEX_TURNS=6 \
   OMUX_STUB_CODEX_PIDFILE="$PIDFILE_B" \
   OMUX_STUB_CODEX_REPORT="$REPORT_B" \
-  "$BIN" codex run --profile codex-max --json-status-file "$NDJSON_B" >"$STDOUT_B" 2>"$STDERR_B" &
+  "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$NDJSON_B" >"$STDOUT_B" 2>"$STDERR_B" &
 PID_B=$!
 
 if wait "$PID_A"; then EXIT_A=0; else EXIT_A=$?; fi

--- a/scripts/smoke-codex-tier-insufficient.sh
+++ b/scripts/smoke-codex-tier-insufficient.sh
@@ -84,7 +84,7 @@ OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
   OMUX_STUB_CODEX_TURNS=4 \
   OMUX_STUB_CODEX_REPORT="$STUB_REPORT" \
-  "$BIN" codex run --profile codex-max --json-status-file "$NDJSON" 2>"$ADAPTER_STDERR" || {
+  "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$NDJSON" 2>"$ADAPTER_STDERR" || {
     echo "adapter exited nonzero" >&2
     cat "$NDJSON" >&2 || true
     cat "$ADAPTER_STDERR" >&2 || true

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -20,6 +20,9 @@ Env (set by the smoke harness):
                             /tmp/omux-stub-codex.pid)
   OMUX_STUB_CODEX_REPORT  — JSON summary path (default
                             /tmp/omux-stub-codex.report)
+  OMUX_STUB_CANONICAL_SESSION_HOME — optional canonical session authority
+                            home; when set, the stub verifies the managed
+                            CODEX_HOME exposes sessions by reference.
 """
 
 from __future__ import annotations
@@ -70,6 +73,36 @@ def _post(proxy_url: str, body: bytes) -> tuple[int, str]:
         conn.close()
 
 
+def _session_bridge_report(codex_home: Path) -> dict:
+    canonical_raw = os.environ.get("OMUX_STUB_CANONICAL_SESSION_HOME")
+    if not canonical_raw:
+        return {"checked": False}
+
+    canonical = Path(canonical_raw)
+    sessions_overlay = codex_home / "sessions"
+    sessions_canonical = canonical / "sessions"
+    history_overlay = codex_home / "history.jsonl"
+    history_canonical = canonical / "history.jsonl"
+    index_overlay = codex_home / "session_index.jsonl"
+    index_canonical = canonical / "session_index.jsonl"
+    snapshots_overlay = codex_home / "shell_snapshots"
+    snapshots_canonical = canonical / "shell_snapshots"
+
+    marker = sessions_overlay / "omux-session-bridge-smoke.jsonl"
+    marker.write_text('{"bridge":"ok"}\n')
+
+    return {
+        "checked": True,
+        "sessions_samefile": os.path.samefile(sessions_overlay, sessions_canonical),
+        "history_samefile": os.path.samefile(history_overlay, history_canonical),
+        "session_index_samefile": os.path.samefile(index_overlay, index_canonical),
+        "shell_snapshots_samefile": os.path.samefile(snapshots_overlay, snapshots_canonical),
+        "marker_written_via_overlay": marker.exists(),
+        "canonical_marker_exists": (sessions_canonical / marker.name).exists(),
+        "paths_printed": False,
+    }
+
+
 def main() -> int:
     pid = os.getpid()
     pidfile = Path(os.environ.get("OMUX_STUB_CODEX_PIDFILE", "/tmp/omux-stub-codex.pid"))
@@ -80,6 +113,7 @@ def main() -> int:
 
     codex_home = Path(os.environ["CODEX_HOME"])
     proxy_url = _read_proxy_url(codex_home)
+    session_bridge = _session_bridge_report(codex_home)
 
     started_at = time.time()
     print(
@@ -107,6 +141,7 @@ def main() -> int:
         "turns": turn_results,
         "codex_home_path_printed": False,
         "active_account_at_start": os.environ.get("OMUX_ACTIVE_ACCOUNT"),
+        "session_bridge": session_bridge,
     }
     report_path.write_text(json.dumps(report, indent=2))
     print(f"stub-codex: pid_stable={report['pid_stable']} turns={turns}", file=sys.stderr, flush=True)

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -10,8 +10,8 @@
 //!   2. account/select to pick a credited account.
 //!   3. Resolve that account's auth.json source from the oauth-mux
 //!      account store.
-//!   4. Create a per-session CODEX_HOME overlay with a copied auth.json
-//!      and generated proxy config.toml.
+//!   4. Create a per-session CODEX_HOME overlay with copied auth material,
+//!      generated proxy config.toml, and bridged session-authority paths.
 //!   5. spawn `codex` with CODEX_HOME pointed at that overlay.
 //!      The user sees real codex while oauth-mux keeps owning the
 //!      proxy/broker boundary.
@@ -37,6 +37,12 @@ const wire_proxy = @import("wire_proxy.zig");
 pub const RunOptions = struct {
     profile: ?[]const u8 = null,
     account: ?[]const u8 = null,
+    /// Optional canonical Codex session authority home. Defaults to the
+    /// parent CODEX_HOME when set, otherwise ~/.codex.
+    session_home: ?[]const u8 = null,
+    /// If true, do not bridge canonical sessions/history into the
+    /// managed CODEX_HOME overlay.
+    isolated_session_store: bool = false,
     /// If true, emit NDJSON status frames to stderr.
     json_status: bool = false,
     /// Optional file path for NDJSON status frames. When set, status
@@ -52,6 +58,41 @@ pub const RunError = error{
     PoolPopulateFailed,
     NoAccountSelectable,
     NoCodexHome,
+    SessionAuthorityUnavailable,
+};
+
+const SessionAuthorityMode = enum {
+    canonical_bridge,
+    isolated,
+
+    fn toString(self: SessionAuthorityMode) []const u8 {
+        return switch (self) {
+            .canonical_bridge => "canonical_bridge",
+            .isolated => "isolated",
+        };
+    }
+};
+
+const SessionCodexHome = struct {
+    path: []u8,
+    session_authority: SessionAuthorityMode,
+};
+
+const SessionAuthorityEntryKind = enum {
+    directory,
+    file,
+};
+
+const SessionAuthorityEntry = struct {
+    name: []const u8,
+    kind: SessionAuthorityEntryKind,
+};
+
+const codex_session_authority_entries = [_]SessionAuthorityEntry{
+    .{ .name = "sessions", .kind = .directory },
+    .{ .name = "shell_snapshots", .kind = .directory },
+    .{ .name = "history.jsonl", .kind = .file },
+    .{ .name = "session_index.jsonl", .kind = .file },
 };
 
 /// Resolve the account's source auth.json path. Order:
@@ -159,19 +200,27 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     const proxy_port = proxy.port();
 
     // 5. Create a per-session CODEX_HOME overlay containing copied
-    // auth material and generated proxy config. This prevents two
-    // concurrent adapter sessions from clobbering the same account
-    // store's config.toml.
-    const codex_home = try makeSessionCodexHome(allocator, source_auth_path, proxy_port);
+    // auth material, generated proxy config, and canonical session
+    // authority references unless isolation was explicitly requested.
+    // This prevents concurrent adapter sessions from clobbering
+    // auth/config while keeping resume/history behavior aligned with
+    // bare Codex.
+    const codex_home = try makeSessionCodexHome(
+        allocator,
+        source_auth_path,
+        proxy_port,
+        opts.session_home,
+        opts.isolated_session_store,
+    );
     defer {
-        std.fs.cwd().deleteTree(codex_home) catch {};
-        allocator.free(codex_home);
+        std.fs.cwd().deleteTree(codex_home.path) catch {};
+        allocator.free(codex_home.path);
     }
 
     if (emit_status) {
         try status_writer.print(
-            "{{\"kind\":\"session_started\",\"adapter\":\"codex\",\"selected_account\":\"{s}\",\"codex_home_path_printed\":false,\"proxy_port\":{d},\"claim_level\":\"broker_owned\"}}\n",
-            .{ elected.id, proxy_port },
+            "{{\"kind\":\"session_started\",\"adapter\":\"codex\",\"selected_account\":\"{s}\",\"codex_home_path_printed\":false,\"proxy_port\":{d},\"claim_level\":\"broker_owned\",\"auth_authority\":\"mux_owned_overlay\",\"managed_config\":\"mux_owned_overlay\",\"session_authority\":\"{s}\",\"session_paths_printed\":false}}\n",
+            .{ elected.id, proxy_port, codex_home.session_authority.toString() },
         );
     }
 
@@ -188,7 +237,7 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     // 7. Build env: copy current, set CODEX_HOME and OMUX_ACTIVE_*.
     var env_map = try std.process.getEnvMap(allocator);
     defer env_map.deinit();
-    try env_map.put("CODEX_HOME", codex_home);
+    try env_map.put("CODEX_HOME", codex_home.path);
     try env_map.put("OMUX_ACTIVE_PROVIDER", "codex");
     const account_only = elected.id[std.mem.indexOfScalar(u8, elected.id, ':').? + 1 ..];
     try env_map.put("OMUX_ACTIVE_ACCOUNT", account_only);
@@ -270,11 +319,15 @@ fn makeSessionCodexHome(
     allocator: std.mem.Allocator,
     source_auth_path: []const u8,
     proxy_port: u16,
-) ![]u8 {
+    session_home_override: ?[]const u8,
+    isolated_session_store: bool,
+) !SessionCodexHome {
     const tmp_root = std.process.getEnvVarOwned(allocator, "TMPDIR") catch
         try allocator.dupe(u8, "/tmp");
     defer allocator.free(tmp_root);
-    return try createSessionCodexHomeUnder(allocator, tmp_root, source_auth_path, proxy_port);
+    const session_authority_home = try resolveCodexSessionAuthorityHome(allocator, session_home_override, isolated_session_store);
+    defer if (session_authority_home) |path| allocator.free(path);
+    return try createSessionCodexHomeUnder(allocator, tmp_root, source_auth_path, proxy_port, session_authority_home);
 }
 
 fn createSessionCodexHomeUnder(
@@ -282,7 +335,8 @@ fn createSessionCodexHomeUnder(
     tmp_root: []const u8,
     source_auth_path: []const u8,
     proxy_port: u16,
-) ![]u8 {
+    session_authority_home: ?[]const u8,
+) !SessionCodexHome {
     var nonce: [8]u8 = undefined;
     std.crypto.random.bytes(&nonce);
     const hex = std.fmt.bytesToHex(nonce, .lower);
@@ -310,7 +364,71 @@ fn createSessionCodexHomeUnder(
     }
 
     try writeManagedConfigToml(allocator, session_home, proxy_port);
-    return session_home;
+    const session_authority = if (session_authority_home) |home| mode: {
+        try bridgeCodexSessionAuthority(allocator, session_home, home);
+        break :mode SessionAuthorityMode.canonical_bridge;
+    } else SessionAuthorityMode.isolated;
+
+    return .{
+        .path = session_home,
+        .session_authority = session_authority,
+    };
+}
+
+fn resolveCodexSessionAuthorityHome(
+    allocator: std.mem.Allocator,
+    session_home_override: ?[]const u8,
+    isolated_session_store: bool,
+) !?[]u8 {
+    if (isolated_session_store) return null;
+    if (session_home_override) |path| return try expandTilde(allocator, path);
+    if (std.process.getEnvVarOwned(allocator, "OMUX_CODEX_SESSION_HOME")) |path| {
+        return path;
+    } else |_| {}
+    if (std.process.getEnvVarOwned(allocator, "CODEX_HOME")) |path| {
+        return path;
+    } else |_| {}
+    const home = try std.process.getEnvVarOwned(allocator, "HOME");
+    defer allocator.free(home);
+    return try std.fs.path.join(allocator, &.{ home, ".codex" });
+}
+
+fn bridgeCodexSessionAuthority(
+    allocator: std.mem.Allocator,
+    session_home: []const u8,
+    authority_home: []const u8,
+) !void {
+    try ensureCodexSessionAuthority(allocator, authority_home);
+    for (codex_session_authority_entries) |entry| {
+        const target = try std.fs.path.join(allocator, &.{ authority_home, entry.name });
+        defer allocator.free(target);
+        const link = try std.fs.path.join(allocator, &.{ session_home, entry.name });
+        defer allocator.free(link);
+        try std.fs.symLinkAbsolute(target, link, .{ .is_directory = entry.kind == .directory });
+    }
+}
+
+fn ensureCodexSessionAuthority(
+    allocator: std.mem.Allocator,
+    authority_home: []const u8,
+) !void {
+    try std.fs.cwd().makePath(authority_home);
+    for (codex_session_authority_entries) |entry| {
+        const target = try std.fs.path.join(allocator, &.{ authority_home, entry.name });
+        defer allocator.free(target);
+        switch (entry.kind) {
+            .directory => try std.fs.cwd().makePath(target),
+            .file => try ensureFileExists(target),
+        }
+    }
+}
+
+fn ensureFileExists(path: []const u8) !void {
+    const file = std.fs.cwd().openFile(path, .{ .mode = .read_write }) catch |e| switch (e) {
+        error.FileNotFound => try std.fs.cwd().createFile(path, .{ .mode = 0o600, .truncate = false }),
+        else => return e,
+    };
+    file.close();
 }
 
 fn copyFileContents(
@@ -353,6 +471,8 @@ fn writeManagedConfigToml(
 test "RunOptions defaults" {
     const opts = RunOptions{};
     try std.testing.expect(opts.profile == null);
+    try std.testing.expect(opts.session_home == null);
+    try std.testing.expect(!opts.isolated_session_store);
     try std.testing.expect(!opts.json_status);
     try std.testing.expect(opts.json_status_file == null);
     try std.testing.expectEqual(@as(usize, 0), opts.forward_argv.len);
@@ -390,25 +510,26 @@ test "createSessionCodexHomeUnder copies auth and does not clobber source config
     const auth_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "account", "auth.json" });
     defer std.testing.allocator.free(auth_path);
 
-    const session_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678);
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null);
     defer {
-        std.fs.cwd().deleteTree(session_home) catch {};
-        std.testing.allocator.free(session_home);
+        std.fs.cwd().deleteTree(codex_home.path) catch {};
+        std.testing.allocator.free(codex_home.path);
     }
+    try std.testing.expectEqual(SessionAuthorityMode.isolated, codex_home.session_authority);
 
-    const session_auth = try std.fs.path.join(std.testing.allocator, &.{ session_home, "auth.json" });
+    const session_auth = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "auth.json" });
     defer std.testing.allocator.free(session_auth);
     const copied_auth = try std.fs.cwd().readFileAlloc(std.testing.allocator, session_auth, 1024);
     defer std.testing.allocator.free(copied_auth);
     try std.testing.expectEqualStrings("{\"tokens\":{\"access_token\":\"fixture\"}}\n", copied_auth);
 
-    const session_install = try std.fs.path.join(std.testing.allocator, &.{ session_home, "installation_id" });
+    const session_install = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "installation_id" });
     defer std.testing.allocator.free(session_install);
     const copied_install = try std.fs.cwd().readFileAlloc(std.testing.allocator, session_install, 1024);
     defer std.testing.allocator.free(copied_install);
     try std.testing.expectEqualStrings("install-fixture\n", copied_install);
 
-    const session_config = try std.fs.path.join(std.testing.allocator, &.{ session_home, "config.toml" });
+    const session_config = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "config.toml" });
     defer std.testing.allocator.free(session_config);
     const generated_config = try std.fs.cwd().readFileAlloc(std.testing.allocator, session_config, 4096);
     defer std.testing.allocator.free(generated_config);
@@ -422,4 +543,69 @@ test "createSessionCodexHomeUnder copies auth and does not clobber source config
     const original_config = try std.fs.cwd().readFileAlloc(std.testing.allocator, source_config, 1024);
     defer std.testing.allocator.free(original_config);
     try std.testing.expectEqualStrings("preexisting = true\n", original_config);
+}
+
+test "createSessionCodexHomeUnder bridges canonical session authority without copying" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("account");
+    {
+        const auth = try tmp.dir.createFile("account/auth.json", .{ .mode = 0o600 });
+        defer auth.close();
+        try auth.writeAll("{\"tokens\":{\"access_token\":\"fixture\"}}\n");
+    }
+    try tmp.dir.makePath("canonical/sessions/2026/05/05");
+    try tmp.dir.makePath("canonical/shell_snapshots");
+    {
+        const session = try tmp.dir.createFile("canonical/sessions/2026/05/05/session.jsonl", .{ .mode = 0o600 });
+        defer session.close();
+        try session.writeAll("{\"fixture\":true}\n");
+    }
+
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const auth_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "account", "auth.json" });
+    defer std.testing.allocator.free(auth_path);
+    const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
+    defer std.testing.allocator.free(canonical_path);
+
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, canonical_path);
+    defer {
+        std.fs.cwd().deleteTree(codex_home.path) catch {};
+        std.testing.allocator.free(codex_home.path);
+    }
+    try std.testing.expectEqual(SessionAuthorityMode.canonical_bridge, codex_home.session_authority);
+
+    var link_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const sessions_link = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "sessions" });
+    defer std.testing.allocator.free(sessions_link);
+    const sessions_target = try std.fs.readLinkAbsolute(sessions_link, &link_buf);
+    const expected_sessions_target = try std.fs.path.join(std.testing.allocator, &.{ canonical_path, "sessions" });
+    defer std.testing.allocator.free(expected_sessions_target);
+    try std.testing.expectEqualStrings(expected_sessions_target, sessions_target);
+
+    const bridged_session = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "sessions", "2026", "05", "05", "session.jsonl" });
+    defer std.testing.allocator.free(bridged_session);
+    const session_bytes = try std.fs.cwd().readFileAlloc(std.testing.allocator, bridged_session, 1024);
+    defer std.testing.allocator.free(session_bytes);
+    try std.testing.expectEqualStrings("{\"fixture\":true}\n", session_bytes);
+
+    const overlay_marker = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "sessions", "managed-write.jsonl" });
+    defer std.testing.allocator.free(overlay_marker);
+    {
+        const marker = try std.fs.cwd().createFile(overlay_marker, .{ .mode = 0o600 });
+        defer marker.close();
+        try marker.writeAll("via overlay\n");
+    }
+    const canonical_marker = try std.fs.path.join(std.testing.allocator, &.{ canonical_path, "sessions", "managed-write.jsonl" });
+    defer std.testing.allocator.free(canonical_marker);
+    const marker_bytes = try std.fs.cwd().readFileAlloc(std.testing.allocator, canonical_marker, 1024);
+    defer std.testing.allocator.free(marker_bytes);
+    try std.testing.expectEqualStrings("via overlay\n", marker_bytes);
+
+    try std.fs.cwd().deleteTree(codex_home.path);
+    const marker_after_overlay_delete = try std.fs.cwd().readFileAlloc(std.testing.allocator, canonical_marker, 1024);
+    defer std.testing.allocator.free(marker_after_overlay_delete);
+    try std.testing.expectEqualStrings("via overlay\n", marker_after_overlay_delete);
 }

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -49,6 +49,8 @@ pub const Command = union(enum) {
     pub const CodexAdapterArgs = struct {
         profile: ?[]const u8 = null,
         account: ?[]const u8 = null,
+        session_home: ?[]const u8 = null,
+        isolated_session_store: bool = false,
         json_status: bool = false,
         json_status_file: ?[]const u8 = null,
         /// Args after `--` forwarded to codex unchanged.
@@ -379,6 +381,11 @@ fn parseCodexAdapter(args: []const []const u8) Command {
         } else if (eql(args[i], "--account") and i + 1 < args.len) {
             i += 1;
             result.account = args[i];
+        } else if (eql(args[i], "--session-home") and i + 1 < args.len) {
+            i += 1;
+            result.session_home = args[i];
+        } else if (eql(args[i], "--isolated-session-store")) {
+            result.isolated_session_store = true;
         } else if (eql(args[i], "--json-status")) {
             result.json_status = true;
         } else if (eql(args[i], "--json-status-file") and i + 1 < args.len) {
@@ -1252,7 +1259,7 @@ pub fn printUsage(writer: anytype) !void {
         \\  mcp [--profile <name>] [--capability <name>]
         \\      Run the broker MCP/JSON-RPC server on stdio for harness adapters.
         \\
-        \\  codex run [--profile name] [--account provider:account] [--json-status] [--json-status-file path] [-- codex-args...]
+        \\  codex run [--profile name] [--account provider:account] [--session-home path] [--isolated-session-store] [--json-status] [--json-status-file path] [-- codex-args...]
         \\      Run a broker-mediated Codex adapter session with a local wire proxy.
         \\
         \\  init [--interactive] [--codex-max]
@@ -2227,12 +2234,14 @@ test "parse mcp broker server profile" {
 }
 
 test "parse codex run adapter args" {
-    const args = [_][]const u8{ "codex", "run", "--profile", "codex-max", "--account", "codex:max-1", "--json-status-file", "/tmp/omux-status.ndjson", "--", "--model", "gpt-5.5" };
+    const args = [_][]const u8{ "codex", "run", "--profile", "codex-max", "--account", "codex:max-1", "--session-home", "/tmp/codex-sessions", "--isolated-session-store", "--json-status-file", "/tmp/omux-status.ndjson", "--", "--model", "gpt-5.5" };
     const cmd = parse(&args);
     switch (cmd) {
         .codex_adapter => |adapter| {
             try std.testing.expectEqualStrings("codex-max", adapter.profile.?);
             try std.testing.expectEqualStrings("codex:max-1", adapter.account.?);
+            try std.testing.expectEqualStrings("/tmp/codex-sessions", adapter.session_home.?);
+            try std.testing.expect(adapter.isolated_session_store);
             try std.testing.expect(adapter.json_status);
             try std.testing.expectEqualStrings("/tmp/omux-status.ndjson", adapter.json_status_file.?);
             try std.testing.expectEqual(@as(usize, 2), adapter.forward_argv.len);
@@ -2332,6 +2341,8 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'run setup onboard canary live-qa revalidate-exhausted probe-all managed-plan managed broker-plan broker-session-plan broker-session-smoke broker-run broker-fallback-drill broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l profile -s p -d 'Profile name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l account -d 'Route account id' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l session-home -d 'Canonical Codex session authority home' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l isolated-session-store -d 'Use isolated session authority for this run'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l json-status -d 'Emit redacted adapter status frames'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l json-status-file -d 'Write redacted adapter status frames to a file' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run loop start stop status events handoffs tick' -d 'Daemon subcommand'

--- a/src/main.zig
+++ b/src/main.zig
@@ -54,6 +54,8 @@ pub fn main() !void {
             codex_adapter.run(allocator, .{
                 .profile = adapter_args.profile,
                 .account = adapter_args.account,
+                .session_home = adapter_args.session_home,
+                .isolated_session_store = adapter_args.isolated_session_store,
                 .json_status = adapter_args.json_status,
                 .json_status_file = adapter_args.json_status_file,
                 .forward_argv = adapter_args.forward_argv,


### PR DESCRIPTION
## What changed

- Composes the managed Codex `CODEX_HOME` from mux-owned auth/config plus bridged session-authority entries.
- Defaults the session authority to parent `CODEX_HOME` when set, otherwise `~/.codex`; adds `OMUX_CODEX_SESSION_HOME`, `--session-home`, and `--isolated-session-store` controls.
- Emits redacted `session_authority`, `auth_authority`, and `managed_config` status fields.
- Extends the Codex acceptance smoke so the stub child proves `sessions/`, `history.jsonl`, `session_index.jsonl`, and `shell_snapshots/` are bridged by reference and that writes land in the canonical session store.

## Why

The previous temp `CODEX_HOME` correctly protected mux-owned auth/config, but it hid canonical Codex sessions from `resume <id>`. This implements the #191/TIN-979 direction without copying the full session store.

## Boundary

This proves structural session-authority bridging with local fixtures and smokes. It does not yet prove live managed-frame `resume <id>` dogfood, provider thread continuity across account swap, or same-thread quota recovery.

## Validation

- `zig build test`
- `zig build`
- `./scripts/smoke-codex-acceptance.sh`
- `./scripts/smoke-codex-concurrent-sessions.sh`
- `git diff --check`
- `just check-local`