### PR TITLE
[codex] Add managed Codex resume UX

### DIFF
--- a/docs/spec/broker-mcp-contract-2026-05-03.md
+++ b/docs/spec/broker-mcp-contract-2026-05-03.md
@@ -34,6 +34,11 @@ Current evidence review:
   managed-frame store split required for normal `resume`/history behavior:
   oauth-mux owns auth/config overlays, but adapters must retain or bridge
   harness session authority instead of hiding or copying it wholesale.
+- `docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md` records the
+  managed Codex daily-use refactor required after the first live resume
+  attempt failed before exercising the bridge: first-class
+  `oauth-mux codex resume ...`, strict parser behavior, status-file parent
+  creation, and regression guards.
 
 ## 0. The One Success Metric
 

--- a/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
+++ b/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
@@ -9,6 +9,7 @@ Anchor docs:
 - `docs/spec/codex-adapter-contract-2026-05-03.md`
 - `docs/spec/harness-session-authority-bridge-2026-05-05.md`
 - `docs/spec/codex-wire-evidence-2026-05-03.md`
+- `docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md`
 
 ## Product Bar
 
@@ -69,7 +70,10 @@ Not yet proven:
 - Managed-frame resume parity. The adapter-owned temporary `CODEX_HOME`
   now bridges canonical Codex session authority by reference, but live
   `resume <id>` / `resume --last` dogfood is still pending before this is
-  treated as parity with bare Codex.
+  treated as parity with bare Codex. The 2026-05-06 UX refactor spec adds
+  the missing command contract: first-class `oauth-mux codex resume ...`,
+  strict `codex run` parsing, status-file parent creation, and PBT/e2e/
+  cassette guards.
 
 ## Quarry Worktree
 
@@ -226,7 +230,9 @@ These need review before public promotion:
    - Full-store copies are rejected; the current adapter uses a
      bridge/reference model per
      `docs/spec/harness-session-authority-bridge-2026-05-05.md`.
-   - Remaining acceptance: live managed-frame resume dogfood.
+   - Remaining acceptance: daily-use managed resume UX and live
+     managed-frame resume dogfood per
+     `docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md`.
 
 6. Bare `codex` path
    - The aspirational background daemon plus bare `codex` remains harder

--- a/docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md
+++ b/docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md
@@ -1,0 +1,478 @@
+# Codex Managed Resume UX Refactor
+Date: 2026-05-06
+Status: P0/P1 planning contract. This is a refactor and regression plan,
+not an implementation record.
+
+Anchors:
+
+- `AGENTS.md`
+- `docs/spec/broker-mcp-contract-2026-05-03.md`
+- `docs/spec/codex-adapter-contract-2026-05-03.md`
+- `docs/spec/harness-session-authority-bridge-2026-05-05.md`
+
+## 0. Product Bar
+
+This work exists only to support the broker product bar:
+
+> The user runs `oauth-mux <harness>`. The active subscription account
+> exhausts its quota. Another credited account is substituted in place. The
+> harness process is not restarted. The user is not prompted.
+
+For Codex, the daily-use spelling must feel like Codex:
+
+```bash
+oauth-mux codex
+oauth-mux codex resume --last
+oauth-mux codex resume <session-id>
+oauth-mux codex exec ...
+```
+
+Raw adapter plumbing such as `oauth-mux codex run -- --no-alt-screen resume
+--last` may continue to exist for tests and diagnostics, but it is not the
+primary UX.
+
+## 1. Incident That Triggered This Spec
+
+The operator attempted to resume an existing Codex session inside a managed
+oauth-mux frame:
+
+```bash
+./zig-out/bin/oauth-mux codex run \
+  --profile codex-max \
+  --json-status-file dist/live-qa/managed-resume-20260506TXXXXXXZ/status.ndjson \
+  -- --no-alt-screen resume --last
+```
+
+The command failed with:
+
+```text
+[ERR] codex run: FileNotFound
+```
+
+Two separate UX defects are visible:
+
+1. `--json-status-file` opens the destination file directly. If the parent
+   directory does not already exist, startup fails before Codex or the session
+   authority bridge is exercised.
+2. `oauth-mux codex run` only forwards harness args after `--`. Unrecognized
+   args before `--` are silently ignored by the adapter parser. Attempts such
+   as `oauth-mux codex run codex resume` do not do what the operator expects.
+
+Both are acceptance failures. They make the correct architecture hard to use
+and turn ordinary resume behavior into command-shape coercion.
+
+## 2. Current Implementation Boundary
+
+Already real on `main`:
+
+- `oauth-mux codex run` creates a temporary `CODEX_HOME` with mux-owned
+  `auth.json` and generated `config.toml`.
+- `sessions/`, `history.jsonl`, `session_index.jsonl`, and
+  `shell_snapshots/` are bridged by reference to canonical Codex session
+  authority by default.
+- `--session-home`, `OMUX_CODEX_SESSION_HOME`, and
+  `--isolated-session-store` exist.
+- Synthetic smokes prove the bridge structure and write-through behavior.
+- Synthetic smokes prove A -> `usage_limit_reached` -> B swap through the
+  adapter/proxy in one stable child PID.
+
+Not real yet:
+
+- Live managed-frame `resume <id>` parity.
+- Live managed-frame `resume --last` parity.
+- Provider-originated live Level 3 account swap in a real interactive
+  `oauth-mux codex` session.
+- Same-thread continuity across account swap.
+- Bare `codex` plus background oauth-mux seamless handoff.
+
+## 3. UX Contract
+
+### 3.1 Primary Commands
+
+The supported user-facing commands SHOULD be:
+
+```bash
+oauth-mux codex [adapter-options] [-- codex-args...]
+oauth-mux codex resume [session-id]
+oauth-mux codex resume --last
+oauth-mux codex resume
+oauth-mux codex exec ...
+```
+
+`oauth-mux codex resume` with no id should delegate to Codex's native session
+chooser inside the managed frame when Codex supports that path.
+
+### 3.2 Adapter Options
+
+Adapter-owned options are consumed by oauth-mux:
+
+- `--profile <name>`
+- `--account <provider:account>`
+- `--session-home <path>`
+- `--isolated-session-store`
+- `--json-status`
+- `--json-status-file <path>`
+- future `--status-dir <path>` if a directory-based artifact API proves
+  friendlier than file paths
+
+Harness-owned args are forwarded exactly, in order, without reinterpretation.
+
+### 3.3 Parser Rules
+
+The parser MUST NOT silently drop unknown args.
+
+Recommended command grammar:
+
+1. Existing account-management subcommands keep their current meaning:
+   `login`, `login-device`, `login-status`, `login-status-all`,
+   `broker-*`, `revalidate-exhausted`, and other diagnostic surfaces.
+2. `run` remains the explicit raw adapter command for tests and scripts.
+3. `resume`, `exec`, and otherwise harness-shaped commands are promoted to
+   adapter mode and forwarded to Codex.
+4. Inside `codex run`, any unknown arg before `--` is a hard error with a
+   suggestion:
+
+   ```text
+   oauth-mux codex run: unknown adapter option "resume".
+   Use `oauth-mux codex resume ...` or `oauth-mux codex run -- resume ...`.
+   ```
+
+5. For top-level `oauth-mux codex`, unknown harness-shaped args are forwarded
+   rather than ignored.
+
+### 3.4 Status Artifact Rules
+
+`--json-status-file <path>` MUST:
+
+- create parent directories if they do not exist;
+- fail with a typed, helpful error when the parent cannot be created;
+- never print token material, credential paths, raw JWTs, full session paths,
+  transcript content, or session ids in normal output;
+- prefer relative/redacted path descriptions in user-facing errors, while
+  debug logs may carry full paths only under an explicit debug mode.
+
+## 4. Refactor Plan
+
+### Phase 0: Spec and Tracker Truthing
+
+- Add this spec.
+- Link it from the session-authority bridge spec and current quarry todo.
+- Keep TIN-979 open until live managed-frame resume succeeds.
+- If needed, split a new implementation ticket for "managed Codex UX
+  command grammar and status artifact hardening".
+
+### Phase 1: No-Spend UX Hardening
+
+Implementation targets:
+
+1. Add a small status-file opener that creates parent directories and returns
+   typed startup errors.
+2. Make `codex run` parser strict: unknown pre-`--` args fail loudly.
+3. Add first-class `oauth-mux codex resume ...` alias that forwards into
+   managed adapter mode.
+4. Add first-class `oauth-mux codex exec ...` alias only when command parity
+   is understood; otherwise fail with a clear "not yet brokered" message.
+5. Keep legacy diagnostic subcommands unambiguous.
+
+No provider calls are required for Phase 1.
+
+### Phase 2: Managed Resume Acceptance
+
+Acceptance targets:
+
+1. `oauth-mux codex resume <existing-id>` sees the same canonical session
+   authority as bare `codex resume <existing-id>`.
+2. `oauth-mux codex resume --last` resolves the same latest session as bare
+   `codex resume --last`.
+3. `oauth-mux codex resume` opens the native chooser or equivalent managed
+   chooser without requiring the user to know a slug.
+4. A new managed session writes to canonical session authority and is visible
+   to bare `codex resume`.
+5. The adapter status stream reports `session_authority:"canonical_bridge"`,
+   `auth_authority:"mux_owned_overlay"`, and `managed_config:"mux_owned_overlay"`.
+
+### Phase 3: Level 3 Live Swap Acceptance
+
+Run only after Phase 2 is green.
+
+Acceptance target:
+
+- A real interactive `oauth-mux codex` session observes provider-originated
+  quota exhaustion on account A and continues on credited account B without
+  restart or prompt.
+
+This remains TIN-951 territory. Phase 2 is not allowed to claim this.
+
+### Phase 4: Public Surface Cleanup
+
+- Document `oauth-mux codex` as the product entrypoint.
+- Move `oauth-mux codex run` into an advanced/testing section.
+- Keep `stay-afloat`, `codex managed`, and restart-shaped command surfaces
+  labeled as diagnostics or Level 1 infrastructure only.
+
+## 5. Regression Guards
+
+### 5.1 Unit Tests
+
+Parser tests:
+
+- `oauth-mux codex run resume --last` fails with an unknown-option diagnostic.
+- `oauth-mux codex run -- resume --last` forwards exactly
+  `["resume", "--last"]`.
+- `oauth-mux codex resume --last` forwards exactly `["resume", "--last"]`
+  through managed adapter mode.
+- `oauth-mux codex resume <id>` forwards exactly `["resume", "<id>"]`.
+- `oauth-mux codex resume` forwards exactly `["resume"]` or enters the
+  managed chooser path.
+- Existing `oauth-mux codex login-device <account>` and diagnostic subcommands
+  still parse to legacy command variants.
+
+Status-file tests:
+
+- Nested relative status-file paths create parents.
+- Absolute status-file paths create parents when allowed.
+- Unwritable parent returns a typed error, not bare `FileNotFound`.
+- Status-file startup failure happens before proxy binding or child spawn.
+
+Session bridge tests:
+
+- Overlay points session-authority entries at canonical authority by reference.
+- `auth.json` and `config.toml` remain mux-owned overlay files.
+- Missing `history.jsonl` or `session_index.jsonl` is created in canonical
+  authority, not copied into an isolated fork.
+
+### 5.2 Property-Based Tests
+
+Add deterministic PBTs under `zig build test`; keep seeds printed on failure.
+
+Recommended properties:
+
+1. **CLI forwarding preservation.**
+   For generated argument vectors containing safe byte strings, when args occur
+   after `--` or after a first-class harness alias, the forwarded argv equals
+   the generated sequence exactly.
+
+2. **No silent parser drops.**
+   For generated unknown pre-`--` args in `codex run`, parsing returns a typed
+   error or help diagnostic; it never produces a runnable adapter command with
+   those args omitted.
+
+3. **Status path preparation.**
+   For generated nested relative path shapes, status-file preparation either
+   creates all parents and the file or returns one typed permission/path error.
+   It never returns bare `FileNotFound`.
+
+4. **Session authority reference integrity.**
+   For generated subsets of Codex session-authority entries, overlay creation
+   preserves reference semantics: writes through the overlay are observable in
+   canonical authority, and no full recursive copy of `sessions/` occurs.
+
+5. **Redaction closure.**
+   For generated secret-like strings placed in auth paths, tokens, JWT
+   fragments, account ids, and session ids, normal output and status frames do
+   not contain those strings.
+
+6. **Swap state-machine invariants.**
+   For generated traces of upstream classes (`ok`, `401`,
+   `usage_limit_reached`, `usage_not_included`, generic `429`, `5xx`), the
+   adapter:
+   - observes quota before swap;
+   - swaps at most once per turn boundary;
+   - never restarts child state;
+   - does not swap on `usage_not_included`;
+   - returns typed no-account-selectable when all candidates are blocked.
+
+7. **Refresh serialization model.**
+   For generated concurrent refresh requests on the same account, the model
+   allows exactly one provider refresh attempt and shares the result with
+   waiters.
+
+### 5.3 E2E and Smoke Tests
+
+Add or extend shell smokes:
+
+- `scripts/smoke-codex-cli-ux.sh`
+  - exercises first-class `oauth-mux codex resume ...` aliases against
+    `scripts/test-stub-codex.py`;
+  - asserts legacy diagnostics still parse;
+  - asserts wrong `codex run resume` form fails helpfully.
+
+- `scripts/smoke-codex-managed-resume.sh`
+  - builds a fake canonical Codex home with session authority;
+  - runs managed adapter with `resume <id>`, `resume --last`, and `resume`;
+  - stub proves it can read canonical session files through the overlay;
+  - status artifact parent directory is intentionally absent before startup.
+
+- Extend `scripts/smoke-codex-concurrent-sessions.sh`
+  - two managed resumes against the same canonical session authority;
+  - distinct proxy ports and distinct overlay configs;
+  - shared session authority remains safe.
+
+- Keep `scripts/smoke-codex-acceptance.sh`
+  - no-spend A -> 429 -> B synthetic swap in one stable child PID.
+
+### 5.4 Cassette Coverage
+
+Use three cassette layers, each with redaction and replay:
+
+1. **CLI/session cassettes.**
+   Captured local stub transcripts for command shapes:
+   `resume <id>`, `resume --last`, `resume`, failed unknown arg, status-file
+   parent missing, isolated session store. These are safe to check in because
+   they use stubs and contain no transcript content.
+
+2. **Codex app-server JSON-RPC cassettes.**
+   Redacted method/event sequences for `initialize`, login, account update,
+   refresh request, and failure surfaces. These protect the IDE-role adapter
+   contract from Codex protocol drift.
+
+3. **Wire proxy HTTP/SSE cassettes.**
+   Redacted `chatgpt.com/backend-api/codex` flows for 200, 401, 429
+   `usage_limit_reached`, `usage_not_included`, compact, memory, and WebSocket
+   upgrade when available. These sit between synthetic mocks and live spend.
+
+Replay requirements:
+
+- Matching by method + path + ordered occurrence.
+- Header allow-list and deny-list assertions.
+- Secret scanner before fixtures can be committed.
+- Miss diagnostics are structural, not raw-body dumps.
+
+### 5.5 Live QA Gates
+
+Live gates are not substitutes for tests; they are final evidence:
+
+1. Managed resume gate:
+   - run `oauth-mux codex resume --last` against a real existing session;
+   - store redacted status artifact;
+   - verify no prompt slug coercion was required.
+
+2. Level 3 gate:
+   - run real `oauth-mux codex`;
+   - observe provider-originated account A quota exhaustion;
+   - verify continuation on account B in the same child process;
+   - emit runtime claim no stronger than actual evidence.
+
+## 6. Advanced Testing and Analysis
+
+The hard part is not just code coverage. The product is a runtime protocol
+system with auth state, route health, process ownership, and provider
+responses. Use higher-leverage testing where it fits.
+
+### 6.1 Model-Based Testing
+
+Build a small pure state-machine model for:
+
+- accounts and availability;
+- active adapter session;
+- turn lifecycle;
+- upstream response classification;
+- credential refresh;
+- account swap;
+- child process lifecycle;
+- status events.
+
+Then generate traces and compare the implementation's emitted events to the
+model. This is the highest-value advanced technique for this repo because the
+product contract is already state-machine shaped.
+
+### 6.2 Bounded Exhaustive Exploration
+
+Before reaching for full symbolic tooling, exhaustively enumerate small cases:
+
+- accounts: 0, 1, 2, 3;
+- events: 200, 401, 429 quota, 429 tier, 5xx;
+- session modes: canonical, isolated, explicit override;
+- command modes: alias, raw `run --`, malformed pre-`--`.
+
+This catches edge cases such as all accounts exhausted, one spare fallback,
+and wrong-route resume without requiring a symbolic executor.
+
+### 6.3 Concolic or Symbolic Execution
+
+Useful in theory, expensive in this Zig codebase today.
+
+Candidate targets if we later invest:
+
+- CLI parser: bounded symbolic argv tokens could prove no unknown arg is
+  silently dropped.
+- HTTP classification parser: symbolic response bodies could prove only
+  `usage_limit_reached` triggers quota swap.
+- path preparation: symbolic path components could expose traversal or
+  parent-creation mistakes.
+
+Non-goal for now: full-process symbolic execution of the adapter/proxy. The
+state space includes filesystem, process spawning, network, and provider
+protocols; model-based and cassette tests will produce better signal sooner.
+
+### 6.4 Differential Testing
+
+For single-account, no-swap flows:
+
+- run bare `codex resume --last` under canonical `CODEX_HOME`;
+- run `oauth-mux codex resume --last` with one selectable route;
+- compare observable session selection behavior, exit status, and non-secret
+  command shape.
+
+The outputs need not be byte-identical because oauth-mux owns status frames,
+but the user-visible semantic result should match.
+
+### 6.5 Metamorphic Testing
+
+Replay the same cassette under transformations that should not change the
+outcome:
+
+- reorder non-semantic headers;
+- vary casing of HTTP header names;
+- rotate account priority while keeping only one selectable account;
+- add irrelevant config fields;
+- vary path nesting for status artifacts.
+
+The expected account decision and claim level should remain stable.
+
+### 6.6 Concurrency and Race Testing
+
+Use deterministic stress smokes, not unbounded sleeps:
+
+- multiple adapters sharing canonical session authority;
+- multiple adapters refreshing the same account;
+- route-health update racing with account selection;
+- status file creation racing with parent directory creation;
+- proxy serving while child exits.
+
+Invariants:
+
+- no account-local `config.toml` clobber;
+- no duplicate refresh attempts for a single refresh token;
+- no child restart presented as recovery;
+- no status/event path leaks.
+
+### 6.7 Mutation Testing
+
+Lightweight manual mutation is worthwhile:
+
+- flip `usage_limit_reached` to generic `429` and expect tests to fail;
+- remove parent-dir creation and expect status-file tests to fail;
+- drop `--` forwarding and expect CLI PBT to fail;
+- print a generated secret string and expect redaction PBT to fail.
+
+This can be scripted later, but even a small mutation checklist will prevent
+false confidence.
+
+## 7. Definition of Done
+
+This refactor is done when:
+
+1. Daily commands work:
+   - `oauth-mux codex resume --last`
+   - `oauth-mux codex resume <id>`
+   - `oauth-mux codex resume`
+2. Raw `codex run` misuse fails helpfully and never silently drops args.
+3. `--json-status-file` creates parents and never fails as bare
+   `FileNotFound`.
+4. Stub e2e proves managed resume parity through canonical session authority.
+5. Live dogfood proves managed resume parity with a real Codex session.
+6. Status output remains redacted.
+7. TIN-979 is not closed until the live dogfood passes.
+8. No doc or claim uses managed resume success as a substitute for Level 3
+   live account-swap success.

--- a/docs/spec/harness-session-authority-bridge-2026-05-05.md
+++ b/docs/spec/harness-session-authority-bridge-2026-05-05.md
@@ -6,6 +6,8 @@ oauth-mux owns muxed auth/config state.
 
 Anchor: `docs/spec/broker-mcp-contract-2026-05-03.md`.
 Codex implementation anchor: `docs/spec/codex-adapter-contract-2026-05-03.md`.
+Managed Codex resume UX/refactor plan:
+`docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md`.
 
 ## 0.0 Current Implementation Checkpoint
 
@@ -20,7 +22,9 @@ The synthetic acceptance smoke proves the managed overlay exposes the canonical
 `sessions/`, `history.jsonl`, `session_index.jsonl`, and `shell_snapshots/`
 entries by reference without printing paths. This is structural evidence only.
 The remaining P1 acceptance is live managed-frame resume dogfood with real
-Codex sessions.
+Codex sessions. The 2026-05-06 managed-resume UX refactor plan records the
+daily-use command contract and regression guards required before this is
+treated as parity with bare Codex.
 
 ## 0. Problem
 

--- a/justfile
+++ b/justfile
@@ -173,7 +173,7 @@ check:
     nix develop --command just check-local
 
 check-local:
-    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh && ./scripts/stay-afloat-wrapper-doc-smoke.sh && ./scripts/smoke-broker.sh && ./scripts/smoke-codex-acceptance.sh && ./scripts/smoke-codex-concurrent-sessions.sh && ./scripts/smoke-codex-tier-insufficient.sh && ./scripts/smoke-codex-all-exhausted.sh && ./scripts/smoke-codex-401-propagation.sh && ./scripts/smoke-codex-cassette-replay.sh'
+    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh && ./scripts/stay-afloat-wrapper-doc-smoke.sh && ./scripts/smoke-broker.sh && ./scripts/smoke-codex-cli-ux.sh && ./scripts/smoke-codex-acceptance.sh && ./scripts/smoke-codex-concurrent-sessions.sh && ./scripts/smoke-codex-tier-insufficient.sh && ./scripts/smoke-codex-all-exhausted.sh && ./scripts/smoke-codex-401-propagation.sh && ./scripts/smoke-codex-cassette-replay.sh'
     @echo "all checks passed"
 
 e2e:
@@ -203,6 +203,13 @@ smoke-broker-local:
     ./scripts/smoke-broker.sh
 
 # ── Codex adapter synthetic smoke (no provider traffic) ──
+
+smoke-codex-cli-ux:
+    nix develop --command just smoke-codex-cli-ux-local
+
+smoke-codex-cli-ux-local:
+    zig build
+    ./scripts/smoke-codex-cli-ux.sh
 
 smoke-codex-acceptance:
     nix develop --command just smoke-codex-acceptance-local

--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# No-spend UX smoke for first-class `oauth-mux codex ...` adapter entrypoints.
+#
+# Covers the daily-use resume shapes that should not require raw
+# `codex run -- ...` coercion:
+#
+#   oauth-mux codex resume --last
+#   oauth-mux codex resume <id>
+#   oauth-mux codex resume
+#   oauth-mux codex run -- resume --last
+#
+# It also pins the malformed raw-run path:
+#
+#   oauth-mux codex run resume --last
+#
+# That path must fail helpfully rather than silently dropping args.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$ROOT/zig-out/bin/oauth-mux"
+
+if [[ ! -x "$BIN" ]]; then
+    echo "smoke-codex-cli-ux: oauth-mux binary not built at $BIN" >&2
+    echo "  run: just build" >&2
+    exit 64
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "smoke-codex-cli-ux: jq required" >&2
+    exit 64
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "smoke-codex-cli-ux: python3 required" >&2
+    exit 64
+fi
+
+TMP="$(mktemp -d -t omux-codex-cli-ux.XXXXXX)"
+CANONICAL_SESSION_HOME="$TMP/canonical-codex"
+
+cleanup() {
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP/account-A" "$CANONICAL_SESSION_HOME/sessions/2026/05/06" "$CANONICAL_SESSION_HOME/shell_snapshots"
+touch "$CANONICAL_SESSION_HOME/history.jsonl" "$CANONICAL_SESSION_HOME/session_index.jsonl"
+printf '%s\n' '{"fixture":"resume"}' >"$CANONICAL_SESSION_HOME/sessions/2026/05/06/session.jsonl"
+
+ID_TOKEN="h.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9wbGFuX3R5cGUiOiJwcm8ifX0.s"
+cat >"$TMP/account-A/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"AT-cli-ux-A","refresh_token":"RT-A","account_id":"acc-A-id"},"auth_mode":"Chatgpt"}
+EOF
+printf '%s\n' 'preexisting = "account-A"' >"$TMP/account-A/config.toml"
+
+cat >"$TMP/oauth-mux.config.json" <<EOF
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "kind": "codex",
+      "accounts": {
+        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "$TMP/account-A/auth.json" } }
+      }
+    }
+  },
+  "profiles": {
+    "codex-max": { "providers": ["codex:max-1#codex-max"] }
+  }
+}
+EOF
+
+assert_grep() {
+    local label=$1 pattern=$2 file=$3
+    if grep -q -E "$pattern" "$file"; then
+        echo "  ✓ $label"
+    else
+        echo "  ✗ $label" >&2
+        echo "    pattern: $pattern" >&2
+        echo "    file: $file" >&2
+        cat "$file" >&2 || true
+        exit 1
+    fi
+}
+
+run_case() {
+    local mode=$1 label=$2 expected_argv=$3
+    shift 3
+    local dir="$TMP/$label"
+    local ndjson="$dir/status/nested/adapter.ndjson"
+    local stderr="$dir/adapter.stderr"
+    local report="$dir/stub.report"
+    local -a cmd
+
+    mkdir -p "$dir"
+    if [[ "$mode" == "top" ]]; then
+        cmd=( "$BIN" codex --profile codex-max --json-status-file "$ndjson" "$@" )
+    else
+        cmd=( "$BIN" codex run --profile codex-max --json-status-file "$ndjson" -- "$@" )
+    fi
+
+    OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_CODEX_SESSION_HOME="$CANONICAL_SESSION_HOME" \
+      OMUX_STUB_CANONICAL_SESSION_HOME="$CANONICAL_SESSION_HOME" \
+      OMUX_STUB_CODEX_TURNS=0 \
+      OMUX_STUB_CODEX_REPORT="$report" \
+      "${cmd[@]}" 2>"$stderr"
+
+    if [[ ! -s "$ndjson" ]]; then
+        echo "  ✗ $label status file was not created at nested path" >&2
+        cat "$stderr" >&2 || true
+        exit 1
+    fi
+    if [[ ! -s "$report" ]]; then
+        echo "  ✗ $label stub report missing" >&2
+        cat "$stderr" >&2 || true
+        exit 1
+    fi
+
+    assert_grep "$label session_started" '"kind":"session_started"' "$ndjson"
+    assert_grep "$label canonical session bridge" '"session_authority":"canonical_bridge"' "$ndjson"
+    assert_grep "$label session_ended" '"kind":"session_ended".*"exit_code":0' "$ndjson"
+
+    if grep -q '"kind":"session_started"' "$stderr"; then
+        echo "  ✗ $label leaked adapter status frames to stderr" >&2
+        cat "$stderr" >&2
+        exit 1
+    fi
+
+    local actual_argv
+    actual_argv="$(jq -c .argv "$report")"
+    if [[ "$actual_argv" == "$expected_argv" ]]; then
+        echo "  ✓ $label forwarded argv $expected_argv"
+    else
+        echo "  ✗ $label argv mismatch: expected $expected_argv actual $actual_argv" >&2
+        cat "$report" >&2
+        exit 1
+    fi
+
+    if [[ "$(jq -r .session_bridge.checked "$report")" == "true" \
+          && "$(jq -r .session_bridge.sessions_samefile "$report")" == "true" \
+          && "$(jq -r .session_bridge.history_samefile "$report")" == "true" \
+          && "$(jq -r .session_bridge.session_index_samefile "$report")" == "true" \
+          && "$(jq -r .session_bridge.shell_snapshots_samefile "$report")" == "true" ]]; then
+        echo "  ✓ $label bridged canonical session authority"
+    else
+        echo "  ✗ $label session bridge failed" >&2
+        cat "$report" >&2
+        exit 1
+    fi
+}
+
+echo "smoke-codex-cli-ux: first-class resume aliases"
+run_case top "resume-last" '["resume","--last"]' resume --last
+run_case top "resume-id" '["resume","managed-good-session"]' resume managed-good-session
+run_case top "resume-chooser" '["resume"]' resume
+run_case raw "raw-run" '["resume","--last"]' resume --last
+
+echo "smoke-codex-cli-ux: malformed raw run fails helpfully"
+BAD_ERR="$TMP/bad-run.stderr"
+BAD_REPORT="$TMP/bad-run.report"
+if OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+     OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+     OMUX_STUB_CODEX_REPORT="$BAD_REPORT" \
+     "$BIN" codex run resume --last 2>"$BAD_ERR"; then
+    echo "  ✗ malformed raw run unexpectedly succeeded" >&2
+    exit 1
+fi
+assert_grep "malformed raw run reports unknown option" 'unknown adapter option "resume"' "$BAD_ERR"
+if [[ -e "$BAD_REPORT" ]]; then
+    echo "  ✗ malformed raw run launched stub unexpectedly" >&2
+    cat "$BAD_REPORT" >&2
+    exit 1
+else
+    echo "  ✓ malformed raw run exits before child spawn"
+fi
+
+echo "smoke-codex-cli-ux: all assertions passed."

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -23,6 +23,8 @@ Env (set by the smoke harness):
   OMUX_STUB_CANONICAL_SESSION_HOME — optional canonical session authority
                             home; when set, the stub verifies the managed
                             CODEX_HOME exposes sessions by reference.
+  The report records argv after the stub binary so CLI forwarding smokes can
+  assert `oauth-mux codex ...` command shape without provider traffic.
 """
 
 from __future__ import annotations
@@ -134,6 +136,7 @@ def main() -> int:
 
     end_pid = os.getpid()
     report = {
+        "argv": sys.argv[1:],
         "start_pid": pid,
         "end_pid": end_pid,
         "pid_stable": pid == end_pid,

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -138,7 +138,10 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     defer if (status_file) |*file| file.close();
     var status_writer = stderr.any();
     if (opts.json_status_file) |path| {
-        status_file = try std.fs.cwd().createFile(path, .{ .mode = 0o600, .truncate = true });
+        status_file = openStatusFile(path) catch |e| {
+            try stderr.print("oauth-mux codex: cannot open --json-status-file: {s}\n", .{@errorName(e)});
+            return e;
+        };
         status_writer = status_file.?.writer().any();
     }
 
@@ -293,6 +296,13 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         .Exited => |c| if (c != 0) std.process.exit(c),
         else => std.process.exit(1),
     }
+}
+
+fn openStatusFile(path: []const u8) !std.fs.File {
+    if (std.fs.path.dirname(path)) |dir| {
+        try std.fs.cwd().makePath(dir);
+    }
+    return try std.fs.cwd().createFile(path, .{ .mode = 0o600, .truncate = true });
 }
 
 fn proxyThreadMain(p: *wire_proxy.Proxy, shutdown: *std.atomic.Value(bool)) void {
@@ -482,6 +492,32 @@ test "expandTilde no-op when no tilde" {
     const a = try expandTilde(std.testing.allocator, "/no/tilde/here");
     defer std.testing.allocator.free(a);
     try std.testing.expectEqualStrings("/no/tilde/here", a);
+}
+
+test "openStatusFile property: nested parents are created" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const cases = [_][]const u8{
+        "status.ndjson",
+        "one/status.ndjson",
+        "one/two/status.ndjson",
+        "one/two/three/status.ndjson",
+    };
+
+    for (cases) |relative| {
+        const status_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, relative });
+        defer std.testing.allocator.free(status_path);
+        const file = try openStatusFile(status_path);
+        try file.writeAll("{\"ok\":true}\n");
+        file.close();
+
+        const bytes = try std.fs.cwd().readFileAlloc(std.testing.allocator, status_path, 1024);
+        defer std.testing.allocator.free(bytes);
+        try std.testing.expectEqualStrings("{\"ok\":true}\n", bytes);
+    }
 }
 
 test "createSessionCodexHomeUnder copies auth and does not clobber source config" {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -53,6 +53,7 @@ pub const Command = union(enum) {
         isolated_session_store: bool = false,
         json_status: bool = false,
         json_status_file: ?[]const u8 = null,
+        invalid_option: ?[]const u8 = null,
         /// Args after `--` forwarded to codex unchanged.
         forward_argv: []const []const u8 = &.{},
     };
@@ -336,7 +337,10 @@ pub fn parse(args: []const []const u8) Command {
         // Broker-mediated session entrypoint. Other `codex ...`
         // subcommands continue through the legacy parser until the
         // adapter path is ready to replace them.
-        if (rest.len > 0 and eql(rest[0], "run")) return parseCodexAdapter(rest[1..]);
+        if (rest.len == 0) return .{ .codex_adapter = .{} };
+        if (eql(rest[0], "help") or eql(rest[0], "--help") or eql(rest[0], "-h")) return .codex_help;
+        if (eql(rest[0], "run")) return parseCodexAdapter(rest[1..], true);
+        if (!isCodexLegacySubcommand(rest[0])) return parseCodexAdapter(rest, false);
         return parseCodex(rest);
     }
     if (eql(cmd, "mcp")) return parseMcp(rest);
@@ -368,7 +372,7 @@ fn parseExec(args: []const []const u8) Command {
     return .{ .exec = parseExecArgs(args) };
 }
 
-fn parseCodexAdapter(args: []const []const u8) Command {
+fn parseCodexAdapter(args: []const []const u8, strict_run: bool) Command {
     var result = Command.CodexAdapterArgs{};
     var i: usize = 0;
     while (i < args.len) : (i += 1) {
@@ -392,9 +396,43 @@ fn parseCodexAdapter(args: []const []const u8) Command {
             i += 1;
             result.json_status_file = args[i];
             result.json_status = true;
+        } else if (strict_run) {
+            result.invalid_option = args[i];
+            result.forward_argv = &.{};
+            break;
+        } else {
+            result.forward_argv = args[i..];
+            break;
         }
     }
     return .{ .codex_adapter = result };
+}
+
+fn isCodexLegacySubcommand(arg: []const u8) bool {
+    return eql(arg, "bootstrap-dirs") or
+        eql(arg, "setup") or
+        eql(arg, "login") or
+        eql(arg, "login-device") or
+        eql(arg, "login-status") or
+        eql(arg, "login-status-all") or
+        eql(arg, "onboard") or
+        eql(arg, "canary") or
+        eql(arg, "live-qa") or
+        eql(arg, "revalidate-exhausted") or
+        eql(arg, "probe-all") or
+        eql(arg, "config-candidate") or
+        eql(arg, "config-merge") or
+        eql(arg, "managed-plan") or
+        eql(arg, "managed") or
+        eql(arg, "broker-plan") or
+        eql(arg, "broker-session-plan") or
+        eql(arg, "broker-session-smoke") or
+        eql(arg, "broker-run") or
+        eql(arg, "broker-fallback-drill") or
+        eql(arg, "broker-smoke") or
+        eql(arg, "broker-refresh-smoke") or
+        eql(arg, "broker-401-smoke") or
+        eql(arg, "broker-quota-smoke");
 }
 
 fn parseMcp(args: []const []const u8) Command {
@@ -1259,8 +1297,12 @@ pub fn printUsage(writer: anytype) !void {
         \\  mcp [--profile <name>] [--capability <name>]
         \\      Run the broker MCP/JSON-RPC server on stdio for harness adapters.
         \\
-        \\  codex run [--profile name] [--account provider:account] [--session-home path] [--isolated-session-store] [--json-status] [--json-status-file path] [-- codex-args...]
+        \\  codex [--profile name] [--account provider:account] [--session-home path] [--isolated-session-store] [--json-status] [--json-status-file path] [-- codex-args...]
         \\      Run a broker-mediated Codex adapter session with a local wire proxy.
+        \\  codex resume [id|--last]
+        \\      Resume Codex inside the broker-mediated adapter frame.
+        \\  codex run [adapter options] -- [codex-args...]
+        \\      Advanced/testing spelling for the broker-mediated Codex adapter.
         \\
         \\  init [--interactive] [--codex-max]
         \\      Generate a starter config file.
@@ -1346,9 +1388,12 @@ pub fn printUsage(writer: anytype) !void {
 
 pub fn printCodexUsage(writer: anytype) !void {
     try writer.writeAll(
-        \\oauth-mux codex — isolated Codex account setup and probes
+        \\oauth-mux codex — broker-mediated Codex sessions, setup, and probes
         \\
         \\Usage:
+        \\  oauth-mux codex [--profile name] [--account provider:account] [--session-home path] [--isolated-session-store] [--json-status] [--json-status-file path] [-- codex-args...]
+        \\  oauth-mux codex resume [id|--last]
+        \\  oauth-mux codex run [adapter options] -- [codex-args...]
         \\  oauth-mux setup codex [--accounts a,b,c] [--device|--status-only] [--live]
         \\  oauth-mux codex setup|onboard [--accounts a,b,c] [--device|--status-only] [--live]
         \\  oauth-mux codex canary [--accounts a,b,c] [--capabilities c1,c2] [--live]
@@ -2244,11 +2289,104 @@ test "parse codex run adapter args" {
             try std.testing.expect(adapter.isolated_session_store);
             try std.testing.expect(adapter.json_status);
             try std.testing.expectEqualStrings("/tmp/omux-status.ndjson", adapter.json_status_file.?);
+            try std.testing.expect(adapter.invalid_option == null);
             try std.testing.expectEqual(@as(usize, 2), adapter.forward_argv.len);
             try std.testing.expectEqualStrings("--model", adapter.forward_argv[0]);
             try std.testing.expectEqualStrings("gpt-5.5", adapter.forward_argv[1]);
         },
         else => return error.Unexpected,
+    }
+}
+
+test "parse codex top-level resume aliases route to adapter" {
+    const resume_last_args = [_][]const u8{ "codex", "--profile", "codex-max", "--json-status-file", "/tmp/omux.ndjson", "resume", "--last" };
+    const resume_last = parse(&resume_last_args);
+    switch (resume_last) {
+        .codex_adapter => |adapter| {
+            try std.testing.expectEqualStrings("codex-max", adapter.profile.?);
+            try std.testing.expectEqualStrings("/tmp/omux.ndjson", adapter.json_status_file.?);
+            try std.testing.expectEqual(@as(usize, 2), adapter.forward_argv.len);
+            try std.testing.expectEqualStrings("resume", adapter.forward_argv[0]);
+            try std.testing.expectEqualStrings("--last", adapter.forward_argv[1]);
+        },
+        else => return error.Unexpected,
+    }
+
+    const resume_id_args = [_][]const u8{ "codex", "resume", "session-123" };
+    const resume_id = parse(&resume_id_args);
+    switch (resume_id) {
+        .codex_adapter => |adapter| {
+            try std.testing.expectEqual(@as(usize, 2), adapter.forward_argv.len);
+            try std.testing.expectEqualStrings("resume", adapter.forward_argv[0]);
+            try std.testing.expectEqualStrings("session-123", adapter.forward_argv[1]);
+        },
+        else => return error.Unexpected,
+    }
+
+    const resume_chooser_args = [_][]const u8{ "codex", "resume" };
+    const resume_chooser = parse(&resume_chooser_args);
+    switch (resume_chooser) {
+        .codex_adapter => |adapter| {
+            try std.testing.expectEqual(@as(usize, 1), adapter.forward_argv.len);
+            try std.testing.expectEqualStrings("resume", adapter.forward_argv[0]);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse codex top-level adapter preserves explicit separator" {
+    const args = [_][]const u8{ "codex", "--profile", "codex-max", "--", "--help" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex_adapter => |adapter| {
+            try std.testing.expectEqualStrings("codex-max", adapter.profile.?);
+            try std.testing.expectEqual(@as(usize, 1), adapter.forward_argv.len);
+            try std.testing.expectEqualStrings("--help", adapter.forward_argv[0]);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse codex run property: args after separator are preserved exactly" {
+    const cases = [_][]const []const u8{
+        &.{ "resume", "--last" },
+        &.{ "resume", "019dea53-49a0-7890-9580-e88decb97af0" },
+        &.{ "--no-alt-screen", "resume", "--last" },
+        &.{ "exec", "--json", "hello" },
+    };
+
+    for (cases) |forward| {
+        var argv: [12][]const u8 = undefined;
+        argv[0] = "codex";
+        argv[1] = "run";
+        argv[2] = "--";
+        for (forward, 0..) |arg, i| argv[3 + i] = arg;
+        const parsed = parse(argv[0 .. 3 + forward.len]);
+        switch (parsed) {
+            .codex_adapter => |adapter| {
+                try std.testing.expectEqual(forward.len, adapter.forward_argv.len);
+                for (forward, 0..) |arg, i| {
+                    try std.testing.expectEqualStrings(arg, adapter.forward_argv[i]);
+                }
+                try std.testing.expect(adapter.invalid_option == null);
+            },
+            else => return error.Unexpected,
+        }
+    }
+}
+
+test "parse codex run property: unknown pre-separator args are never dropped" {
+    const invalid = [_][]const u8{ "resume", "--model", "codex", "--no-alt-screen" };
+    for (invalid) |arg| {
+        const args = [_][]const u8{ "codex", "run", arg, "ignored" };
+        const cmd = parse(&args);
+        switch (cmd) {
+            .codex_adapter => |adapter| {
+                try std.testing.expectEqualStrings(arg, adapter.invalid_option.?);
+                try std.testing.expectEqual(@as(usize, 0), adapter.forward_argv.len);
+            },
+            else => return error.Unexpected,
+        }
     }
 }
 
@@ -2338,13 +2476,13 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'run setup onboard canary live-qa revalidate-exhausted probe-all managed-plan managed broker-plan broker-session-plan broker-session-smoke broker-run broker-fallback-drill broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l profile -s p -d 'Profile name' -r
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l account -d 'Route account id' -r
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l session-home -d 'Canonical Codex session authority home' -r
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l isolated-session-store -d 'Use isolated session authority for this run'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l json-status -d 'Emit redacted adapter status frames'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from run' -l json-status-file -d 'Write redacted adapter status frames to a file' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'resume run setup onboard canary live-qa revalidate-exhausted probe-all managed-plan managed broker-plan broker-session-plan broker-session-smoke broker-run broker-fallback-drill broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex run' -l profile -s p -d 'Profile name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex run' -l account -d 'Route account id' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex run' -l session-home -d 'Canonical Codex session authority home' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex run' -l isolated-session-store -d 'Use isolated session authority for this run'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex run' -l json-status -d 'Emit redacted adapter status frames'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex run' -l json-status-file -d 'Write redacted adapter status frames to a file' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -a 'run loop start stop status events handoffs tick' -d 'Daemon subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l stay-afloat -d 'Host foreground stay-afloat tick loop'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from daemon' -l json -d 'JSON output'

--- a/src/main.zig
+++ b/src/main.zig
@@ -51,6 +51,10 @@ pub fn main() !void {
             // `oauth-mux codex run`: broker-mediated Codex adapter
             // session. Anchor:
             // docs/spec/codex-adapter-contract-2026-05-03.md.
+            if (adapter_args.invalid_option) |arg| {
+                log.err("oauth-mux codex run: unknown adapter option \"{s}\". Use `oauth-mux codex <codex-args...>` or `oauth-mux codex run -- <codex-args...>`.", .{arg});
+                std.process.exit(types.ExitCode.general_error.int());
+            }
             codex_adapter.run(allocator, .{
                 .profile = adapter_args.profile,
                 .account = adapter_args.account,


### PR DESCRIPTION
## What changed

- Promotes `oauth-mux codex resume ...` into the broker-mediated Codex adapter path so daily resume flows do not require raw `codex run -- ...` plumbing.
- Makes `oauth-mux codex run` strict: unknown pre-`--` arguments now fail with a clear diagnostic instead of being silently dropped.
- Creates parent directories for `--json-status-file` before opening the status artifact.
- Adds stub Codex argv reporting plus a no-provider `smoke-codex-cli-ux` regression guard and wires it into `check-local`.
- Adds the managed resume UX refactor spec and links it from the broker/session-authority planning docs.

## Why

The managed Codex frame must preserve canonical Codex session authority and feel like normal Codex usage. Requiring operators to remember raw adapter separators, pre-create status directories, or coerce session slugs is not acceptable for the broker product path.

## Validation

- `just build`
- `just test`
- `./scripts/smoke-codex-cli-ux.sh`
- `./scripts/smoke-codex-acceptance.sh`
- `./scripts/smoke-codex-concurrent-sessions.sh`
- `./scripts/smoke-codex-cassette-replay.sh`
- `nix develop --command just check-local`
- `git diff --check`
- `git diff --cached --check`

Note: plain `just check-local` outside Nix still uses the system Zig on this machine and fails before project tests because `/usr/local/bin/zig` is not Zig 0.14. The Nix-wrapped repo gate passed.

## Boundary

This is Phase 1 no-spend UX hardening plus regression coverage. It does not claim live managed-frame resume parity, provider-originated live account swap, same-thread continuity, or bare `codex` plus background oauth-mux handoff.