### PR TITLE
[codex] Preserve child auth after managed refresh

### DIFF
--- a/docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md
+++ b/docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md
@@ -476,3 +476,33 @@ This refactor is done when:
 7. TIN-979 is not closed until the live dogfood passes.
 8. No doc or claim uses managed resume success as a substitute for Level 3
    live account-swap success.
+
+## 8. Dogfood Finding: Same-Account 401 Refresh Loop
+
+The first real managed `resume --last` dogfood after PR #194 did not prove
+resume parity. Status evidence showed the adapter started with
+`session_authority:"canonical_bridge"` and selected `codex:max-1`, then the
+wire proxy observed repeated upstream `401` responses.
+
+Root cause:
+
+- Codex can refresh the selected account inside the managed overlay after a
+  `401`.
+- The proxy was still re-signing every upstream request from oauth-mux's
+  materialized route credential.
+- That meant Codex's refreshed child `Authorization` header was ignored, so
+  the next request could keep using the stale materialized access token.
+
+Correct behavior:
+
+- If inbound `ChatGPT-Account-ID` still matches the broker-elected account,
+  preserve the child's inbound `Authorization` header. This lets Codex's
+  native same-account refresh loop work.
+- If oauth-mux elects a different account, substitute the elected account's
+  materialized `Authorization` / `ChatGPT-Account-ID` as before.
+
+Regression guard:
+
+- `scripts/smoke-codex-child-refresh.sh` drives two synthetic same-account
+  turns with different child bearer tokens and asserts that the upstream sees
+  the bearer change without an account swap or a stale 401 loop.

--- a/justfile
+++ b/justfile
@@ -173,7 +173,7 @@ check:
     nix develop --command just check-local
 
 check-local:
-    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh && ./scripts/stay-afloat-wrapper-doc-smoke.sh && ./scripts/smoke-broker.sh && ./scripts/smoke-codex-cli-ux.sh && ./scripts/smoke-codex-acceptance.sh && ./scripts/smoke-codex-concurrent-sessions.sh && ./scripts/smoke-codex-tier-insufficient.sh && ./scripts/smoke-codex-all-exhausted.sh && ./scripts/smoke-codex-401-propagation.sh && ./scripts/smoke-codex-cassette-replay.sh'
+    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh && ./scripts/stay-afloat-wrapper-doc-smoke.sh && ./scripts/smoke-broker.sh && ./scripts/smoke-codex-cli-ux.sh && ./scripts/smoke-codex-acceptance.sh && ./scripts/smoke-codex-concurrent-sessions.sh && ./scripts/smoke-codex-child-refresh.sh && ./scripts/smoke-codex-tier-insufficient.sh && ./scripts/smoke-codex-all-exhausted.sh && ./scripts/smoke-codex-401-propagation.sh && ./scripts/smoke-codex-cassette-replay.sh'
     @echo "all checks passed"
 
 e2e:
@@ -226,6 +226,15 @@ smoke-codex-concurrent-sessions:
 smoke-codex-concurrent-sessions-local:
     zig build
     ./scripts/smoke-codex-concurrent-sessions.sh
+
+# ── Codex adapter same-account refresh smoke (no provider traffic) ──
+
+smoke-codex-child-refresh:
+    nix develop --command just smoke-codex-child-refresh-local
+
+smoke-codex-child-refresh-local:
+    zig build
+    ./scripts/smoke-codex-child-refresh.sh
 
 # ── Codex adapter negative-path smokes (no provider traffic) ──
 

--- a/scripts/smoke-codex-child-refresh.sh
+++ b/scripts/smoke-codex-child-refresh.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Child-refresh smoke: when the managed Codex child refreshes the same
+# elected account after a 401, the proxy must preserve the child's new
+# Authorization header instead of re-signing every request with the stale
+# materialized token from oauth-mux config.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$ROOT/zig-out/bin/oauth-mux"
+
+if [[ ! -x "$BIN" ]]; then
+    echo "smoke-codex-child-refresh: oauth-mux binary not built at $BIN" >&2
+    echo "  run: just build" >&2
+    exit 64
+fi
+
+if ! command -v jq >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then
+    echo "smoke-codex-child-refresh: jq and python3 required" >&2
+    exit 64
+fi
+
+TMP="$(mktemp -d -t omux-child-refresh.XXXXXX)"
+PORTFILE="$TMP/upstream.port"
+UPSTREAM_LOG="$TMP/upstream.log"
+NDJSON="$TMP/adapter.ndjson"
+ADAPTER_STDERR="$TMP/adapter.stderr"
+STUB_REPORT="$TMP/stub-codex.report"
+
+cleanup() {
+    if [[ -n "${UPSTREAM_PID:-}" ]] && kill -0 "$UPSTREAM_PID" 2>/dev/null; then
+        kill "$UPSTREAM_PID" 2>/dev/null || true
+        wait "$UPSTREAM_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP/account-A" "$TMP/account-B"
+ID_TOKEN="h.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9wbGFuX3R5cGUiOiJwcm8iLCJjaGF0Z3B0X2FjY291bnRfaXNfZmVkcmFtcCI6ZmFsc2V9fQ.s"
+cat >"$TMP/account-A/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"MATERIALIZED-STUCK-A","refresh_token":"RT-A","account_id":"acc-A-id"},"auth_mode":"Chatgpt"}
+EOF
+cat >"$TMP/account-B/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"MATERIALIZED-B","refresh_token":"RT-B","account_id":"acc-B-id"},"auth_mode":"Chatgpt"}
+EOF
+
+cat >"$TMP/oauth-mux.config.json" <<EOF
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "kind": "codex",
+      "accounts": {
+        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "$TMP/account-A/auth.json" } },
+        "max-2": { "priority": 20, "secret": { "backend": "file", "path": "$TMP/account-B/auth.json" } }
+      }
+    }
+  },
+  "profiles": {
+    "codex-max": { "providers": ["codex:max-1#codex-max", "codex:max-2#codex-max"] }
+  }
+}
+EOF
+
+OMUX_STUB_PORT=0 \
+  OMUX_STUB_PORTFILE="$PORTFILE" \
+  OMUX_STUB_LOGFILE="$UPSTREAM_LOG" \
+  OMUX_STUB_OK_BEFORE_429=99 \
+  python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$TMP/upstream.stderr" &
+UPSTREAM_PID=$!
+
+for _ in {1..40}; do
+    [[ -s "$PORTFILE" ]] && break
+    sleep 0.05
+done
+[[ -s "$PORTFILE" ]] || { echo "stub upstream did not bind" >&2; exit 1; }
+UPSTREAM_PORT="$(cat "$PORTFILE" | tr -d '[:space:]')"
+echo "smoke-codex-child-refresh: stub upstream pid=$UPSTREAM_PID port=$UPSTREAM_PORT"
+
+OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+  OMUX_UPSTREAM_HOST="127.0.0.1:$UPSTREAM_PORT" \
+  OMUX_UPSTREAM_SCHEME="http" \
+  OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+  OMUX_STUB_CODEX_TURNS=2 \
+  OMUX_STUB_CODEX_CHATGPT_ACCOUNT_ID="acc-A-id" \
+  OMUX_STUB_CODEX_AUTH_TOKENS="CHILD-OLD,CHILD-REFRESHED" \
+  OMUX_STUB_CODEX_REPORT="$STUB_REPORT" \
+  "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$NDJSON" 2>"$ADAPTER_STDERR" || {
+    echo "adapter exited nonzero" >&2
+    cat "$NDJSON" >&2 || true
+    cat "$ADAPTER_STDERR" >&2 || true
+    exit 1
+}
+
+echo "smoke-codex-child-refresh: assertions"
+
+assert_grep() {
+    local label=$1 pattern=$2 file=$3
+    if grep -q -E "$pattern" "$file"; then
+        echo "  ✓ $label"
+    else
+        echo "  ✗ $label" >&2
+        echo "    pattern: $pattern" >&2
+        cat "$file" >&2
+        return 1
+    fi
+}
+
+assert_no_grep() {
+    local label=$1 pattern=$2 file=$3
+    if grep -q -E "$pattern" "$file"; then
+        echo "  ✗ $label (unexpected match for: $pattern)" >&2
+        cat "$file" >&2
+        return 1
+    else
+        echo "  ✓ $label"
+    fi
+}
+
+assert_grep "session_started" '"kind":"session_started"' "$NDJSON"
+assert_grep "same-account child auth was preserved" '"kind":"proxy_preserved_child_auth".*"reason":"same_account_child_refresh"' "$NDJSON"
+assert_grep "turns stayed 200 ok" '"kind":"proxy_turn".*"status":200.*"classification":"ok"' "$NDJSON"
+TURN_COUNT=$(grep -c '"kind":"proxy_turn"' "$NDJSON" | tr -d ' ')
+if [[ "$TURN_COUNT" -eq 2 ]]; then
+    echo "  ✓ proxy recorded both turns"
+else
+    echo "  ✗ proxy recorded $TURN_COUNT turns (expected 2)" >&2
+    cat "$NDJSON" >&2
+    exit 1
+fi
+assert_no_grep "no account swap fired" '"kind":"proxy_post_swap_turn"' "$NDJSON"
+assert_no_grep "no stale 401 loop" '"status":401' "$NDJSON"
+assert_grep "session ended broker-owned" '"kind":"session_ended".*"final_claim_level":"broker_owned"' "$NDJSON"
+
+if grep -q '"kind":"session_started"' "$ADAPTER_STDERR"; then
+    echo "  ✗ adapter status frames leaked to stderr despite --json-status-file" >&2
+    exit 1
+else
+    echo "  ✓ --json-status-file keeps adapter status frames out of stderr"
+fi
+
+REQ_COUNT=$(jq -s 'length' "$UPSTREAM_LOG")
+if [[ "$REQ_COUNT" -eq 2 ]]; then
+    echo "  ✓ upstream saw both child turns"
+else
+    echo "  ✗ upstream saw $REQ_COUNT requests (expected 2)" >&2
+    cat "$UPSTREAM_LOG" >&2
+    exit 1
+fi
+
+DISTINCT_AUTH=$(jq -r .auth_prefix "$UPSTREAM_LOG" | sort -u | wc -l | tr -d ' ')
+if [[ "$DISTINCT_AUTH" -eq 2 ]]; then
+    echo "  ✓ upstream saw refreshed child bearer change"
+else
+    echo "  ✗ upstream did not see refreshed child bearer; proxy likely reused stale materialized token" >&2
+    jq -r .auth_prefix "$UPSTREAM_LOG" >&2
+    exit 1
+fi
+
+DISTINCT_ACCOUNTS=$(jq -r .account_id "$UPSTREAM_LOG" | sort -u | wc -l | tr -d ' ')
+if [[ "$DISTINCT_ACCOUNTS" -eq 1 ]] && [[ "$(jq -r '.[0].account_id' <(jq -s '.' "$UPSTREAM_LOG"))" == "acc-A-id" ]]; then
+    echo "  ✓ same elected account stayed selected"
+else
+    echo "  ✗ account changed unexpectedly" >&2
+    jq -r .account_id "$UPSTREAM_LOG" >&2
+    exit 1
+fi
+
+GOT_200=$(jq -r '.turns | map(select(.status == 200)) | length' "$STUB_REPORT")
+if [[ "$GOT_200" -eq 2 ]]; then
+    echo "  ✓ stub-codex saw two 200 turns"
+else
+    echo "  ✗ stub-codex saw $GOT_200 200 turns (expected 2)" >&2
+    jq .turns "$STUB_REPORT" >&2
+    exit 1
+fi
+
+echo
+echo "smoke-codex-child-refresh: all 12 assertions passed."
+echo "  full ndjson: $NDJSON"
+echo "  stub upstream log: $UPSTREAM_LOG"

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -23,6 +23,11 @@ Env (set by the smoke harness):
   OMUX_STUB_CANONICAL_SESSION_HOME — optional canonical session authority
                             home; when set, the stub verifies the managed
                             CODEX_HOME exposes sessions by reference.
+  OMUX_STUB_CODEX_CHATGPT_ACCOUNT_ID — optional ChatGPT-Account-ID header
+                            to send on every proxy request.
+  OMUX_STUB_CODEX_AUTH_TOKENS — optional comma-separated bearer tokens to
+                            send through Authorization, one per turn. The
+                            last token is reused when turns exceed entries.
   The report records argv after the stub binary so CLI forwarding smokes can
   assert `oauth-mux codex ...` command shape without provider traffic.
 """
@@ -47,7 +52,17 @@ def _read_proxy_url(codex_home: Path) -> str:
     return m.group(1)
 
 
-def _post(proxy_url: str, body: bytes) -> tuple[int, str]:
+def _auth_token_for_turn(turn: int) -> str | None:
+    raw = os.environ.get("OMUX_STUB_CODEX_AUTH_TOKENS", "")
+    if not raw:
+        return None
+    tokens = [part for part in raw.split(",") if part]
+    if not tokens:
+        return None
+    return tokens[min(turn, len(tokens) - 1)]
+
+
+def _post(proxy_url: str, body: bytes, turn: int) -> tuple[int, str]:
     # base_url is like http://127.0.0.1:NNNN/backend-api/codex
     # We want to POST to that prefix + /responses.
     m = re.match(r"http://([^/]+)(/.*)$", proxy_url)
@@ -56,18 +71,25 @@ def _post(proxy_url: str, body: bytes) -> tuple[int, str]:
         sys.exit(2)
     netloc, prefix = m.group(1), m.group(2)
     conn = http.client.HTTPConnection(netloc, timeout=15)
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": "stub-codex/0",
+        "x-codex-turn-state": "stub-turn-state-v1",
+        "x-codex-installation-id": "stub-install-1",
+        "OpenAI-Beta": "responses_websockets=2026-02-06",
+    }
+    account_id = os.environ.get("OMUX_STUB_CODEX_CHATGPT_ACCOUNT_ID")
+    auth_token = _auth_token_for_turn(turn)
+    if account_id:
+        headers["ChatGPT-Account-ID"] = account_id
+    if auth_token:
+        headers["Authorization"] = f"Bearer {auth_token}"
     try:
         conn.request(
             "POST",
             prefix + "/responses",
             body=body,
-            headers={
-                "Content-Type": "application/json",
-                "User-Agent": "stub-codex/0",
-                "x-codex-turn-state": "stub-turn-state-v1",
-                "x-codex-installation-id": "stub-install-1",
-                "OpenAI-Beta": "responses_websockets=2026-02-06",
-            },
+            headers=headers,
         )
         resp = conn.getresponse()
         return resp.status, resp.read().decode("utf-8", errors="replace")
@@ -129,6 +151,7 @@ def main() -> int:
         status, body = _post(
             proxy_url,
             json.dumps({"input": f"stub turn {i}"}).encode("utf-8"),
+            i,
         )
         turn_results.append({"turn": i, "status": status, "body_head": body[:120]})
         print(f"stub-codex: turn {i} -> {status}", file=sys.stderr, flush=True)

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -16,7 +16,11 @@
 //!   1. Read the inbound request from codex.
 //!   2. Substitute the three account-bound headers (Authorization,
 //!      ChatGPT-Account-ID, X-OpenAI-Fedramp) with the broker's
-//!      currently-elected account's values.
+//!      currently-elected account's values, except when Codex has
+//!      refreshed the same elected account inside the managed overlay.
+//!      In that same-account case, preserve the child's refreshed
+//!      Authorization so the proxy does not pin Codex to a stale
+//!      materialized access token.
 //!   3. Forward all other headers UNCHANGED — including the eight
 //!      load-bearing ones from §4.2 (User-Agent, originator,
 //!      x-codex-installation-id, x-codex-turn-state,
@@ -212,13 +216,15 @@ pub const Proxy = struct {
         // ── 3. Build outbound request with substituted headers ──
         var out_headers = HeaderList.init(a);
         try copyForwardingHeaders(&req.headers, &out_headers);
-        try out_headers.set("Authorization", try std.fmt.allocPrint(a, "Bearer {s}", .{tokens.access_token}));
-        try out_headers.set("ChatGPT-Account-ID", tokens.account_id);
-        if (tokens.fedramp) {
-            try out_headers.set("X-OpenAI-Fedramp", "true");
-        }
+        const preserved_child_auth = try setOutboundAuthHeaders(a, &req.headers, &out_headers, tokens);
         const host_for_header = upstreamHost(a);
         try out_headers.set("Host", host_for_header);
+        if (preserved_child_auth) {
+            self.logEvent("proxy_preserved_child_auth", .{
+                .account = elected.id,
+                .reason = "same_account_child_refresh",
+            });
+        }
 
         // Detect account change since the previous request. If this is
         // a post-swap turn, drop x-codex-turn-state — the token is the
@@ -299,10 +305,12 @@ pub const Proxy = struct {
                 //      auth.json on disk.
                 //   3. Codex retries the original request.
                 //
-                // The proxy's NEXT materialize call re-reads
-                // auth.json and picks up the fresh access_token —
-                // so the retried request succeeds without oauth-mux
-                // doing any refresh work itself.
+                // The proxy preserves the child's refreshed
+                // Authorization header on the NEXT request when the
+                // inbound ChatGPT-Account-ID still matches the
+                // broker-elected account. That lets Codex's native
+                // refresh loop succeed without requiring oauth-mux
+                // to implement refresh-token rotation in this path.
                 //
                 // Marking the account dead here would defeat that
                 // recovery loop by removing the account from the
@@ -503,6 +511,46 @@ fn copyForwardingHeaders(in: *const HeaderList, out: *HeaderList) !void {
         }
         try out.append(h.name, h.value);
     }
+}
+
+fn setOutboundAuthHeaders(
+    a: std.mem.Allocator,
+    inbound: *const HeaderList,
+    out: *HeaderList,
+    tokens: broker_types.ChatgptAuthTokens,
+) !bool {
+    if (shouldPreserveChildAuth(
+        inbound.find("ChatGPT-Account-ID"),
+        inbound.find("Authorization"),
+        tokens.account_id,
+    )) {
+        try out.set("Authorization", inbound.find("Authorization").?);
+        try out.set("ChatGPT-Account-ID", inbound.find("ChatGPT-Account-ID").?);
+        if (inbound.find("X-OpenAI-Fedramp")) |fedramp| {
+            try out.set("X-OpenAI-Fedramp", fedramp);
+        } else if (tokens.fedramp) {
+            try out.set("X-OpenAI-Fedramp", "true");
+        }
+        return true;
+    }
+
+    try out.set("Authorization", try std.fmt.allocPrint(a, "Bearer {s}", .{tokens.access_token}));
+    try out.set("ChatGPT-Account-ID", tokens.account_id);
+    if (tokens.fedramp) {
+        try out.set("X-OpenAI-Fedramp", "true");
+    }
+    return false;
+}
+
+fn shouldPreserveChildAuth(
+    inbound_account_id: ?[]const u8,
+    inbound_authorization: ?[]const u8,
+    elected_account_id: []const u8,
+) bool {
+    const account_id = inbound_account_id orelse return false;
+    const authorization = inbound_authorization orelse return false;
+    if (authorization.len == 0) return false;
+    return std.mem.eql(u8, account_id, elected_account_id);
 }
 
 // ── Forwarding + streaming (uses std.http.Client for TLS) ────────────
@@ -718,6 +766,48 @@ test "classify 200 OK -> .ok" {
 test "classify 401 -> auth_unauthorized" {
     const c = classify(std.testing.allocator, 401, "{}");
     try std.testing.expectEqual(broker_types.QuotaKind.auth_unauthorized, c.kind);
+}
+
+test "shouldPreserveChildAuth preserves refreshed bearer for same elected account only" {
+    try std.testing.expect(shouldPreserveChildAuth("acct-1", "Bearer refreshed", "acct-1"));
+    try std.testing.expect(!shouldPreserveChildAuth("acct-1", "Bearer refreshed", "acct-2"));
+    try std.testing.expect(!shouldPreserveChildAuth("acct-1", null, "acct-1"));
+    try std.testing.expect(!shouldPreserveChildAuth(null, "Bearer refreshed", "acct-1"));
+    try std.testing.expect(!shouldPreserveChildAuth("acct-1", "", "acct-1"));
+}
+
+test "setOutboundAuthHeaders preserves child auth for same account and substitutes on swap" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var inbound = HeaderList.init(a);
+    try inbound.append("Authorization", "Bearer child-refreshed");
+    try inbound.append("ChatGPT-Account-ID", "acct-1");
+    try inbound.append("X-OpenAI-Fedramp", "false");
+
+    var same_out = HeaderList.init(a);
+    const same_tokens = broker_types.ChatgptAuthTokens{
+        .access_token = "materialized-stale",
+        .account_id = "acct-1",
+        .fedramp = true,
+    };
+    const preserved = try setOutboundAuthHeaders(a, &inbound, &same_out, same_tokens);
+    try std.testing.expect(preserved);
+    try std.testing.expectEqualStrings("Bearer child-refreshed", same_out.find("Authorization").?);
+    try std.testing.expectEqualStrings("acct-1", same_out.find("ChatGPT-Account-ID").?);
+    try std.testing.expectEqualStrings("false", same_out.find("X-OpenAI-Fedramp").?);
+
+    var swap_out = HeaderList.init(a);
+    const swap_tokens = broker_types.ChatgptAuthTokens{
+        .access_token = "materialized-next",
+        .account_id = "acct-2",
+        .fedramp = false,
+    };
+    const swapped = try setOutboundAuthHeaders(a, &inbound, &swap_out, swap_tokens);
+    try std.testing.expect(!swapped);
+    try std.testing.expectEqualStrings("Bearer materialized-next", swap_out.find("Authorization").?);
+    try std.testing.expectEqualStrings("acct-2", swap_out.find("ChatGPT-Account-ID").?);
 }
 
 test "classify 503 -> provider_5xx" {


### PR DESCRIPTION
## What changed

- Preserves the managed Codex child's inbound `Authorization` header when its `ChatGPT-Account-ID` still matches the broker-elected account.
- Continues substituting broker-materialized headers when oauth-mux elects a different account.
- Adds `smoke-codex-child-refresh`, a no-provider regression where the child sends two same-account bearer values and the upstream must observe the bearer change without account rotation.
- Documents the failed managed-resume dogfood root cause in the managed resume spec.

## Why

The first real managed `resume --last` dogfood after PR #194 did not prove resume parity. The status artifact showed `session_authority:"canonical_bridge"`, followed by repeated upstream `401` responses on `codex:max-1`.

Root cause: Codex can refresh the selected account in the managed overlay, but the proxy was re-signing every request from oauth-mux's materialized route credential. That pinned the child to a stale access token and defeated Codex's native same-account refresh loop.

## Validation

- `just test`
- `./scripts/smoke-codex-child-refresh.sh`
- `./scripts/smoke-codex-401-propagation.sh`
- `./scripts/smoke-codex-acceptance.sh`
- `nix develop --command just check-local`
- `git diff --check`
- `git diff --cached --check`

## Boundary

This fixes the same-account 401 refresh loop observed during managed resume dogfood. It still does not claim live managed resume parity until the real resume is retried, and it does not claim Level 3 live quota account swap or bare `codex` plus background oauth-mux handoff.