### PR TITLE
Retry Codex quota turns before surfacing 429

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,10 @@ delete and re-anchor on the broker contract.
 4. `docs/spec/harness-session-authority-bridge-2026-05-05.md` — auth/config
    overlays must not hide or fork harness session authority
 5. `justfile` — operator entrypoint for all build/test/release tasks
-6. `flake.nix` — Nix devShell and package definitions
-7. `build.zig` / `build.zig.zon` — Zig build system
-8. `src/` — implementation
+6. `README.md` — public-facing current-state summary; subordinate to specs
+7. `flake.nix` — Nix devShell and package definitions
+8. `build.zig` / `build.zig.zon` — Zig build system
+9. `src/` — implementation
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Real on `main`:
   `resume <session-id>` reached `POST /backend-api/codex/responses` with
   `status:200`.
 - Synthetic smokes prove account A can hit `429 usage_limit_reached`, be
-  marked exhausted, and account B can handle the next request in the same child
-  process.
+  marked exhausted, and account B can handle the same request in the same child
+  process before Codex receives the 429.
 - Same-account Codex child refresh is preserved so oauth-mux does not pin Codex
   to stale materialized access tokens after a native refresh.
 
@@ -31,16 +31,17 @@ Not proven yet:
 
 - Live provider-originated account exhaustion inside a managed `oauth-mux codex`
   session.
-- Invisible same-turn recovery where Codex never sees the quota failure.
+- Live invisible same-turn recovery where Codex never sees the quota failure.
 - Same-thread continuity across account swap.
 - Bare `codex` plus a separate background oauth-mux daemon seamlessly handing
   off accounts.
 - Claude, Cursor, Pi, or other harness adapters.
 
-The current Codex proxy implementation is still a next-request fallback path:
+The current Codex proxy implementation now has a synthetic same-turn retry path:
 it classifies `429 usage_limit_reached`, marks the active account exhausted,
-and the next request elects another account. That is useful progress, but it is
-not the full seamless product bar if the failed turn is visible to the user.
+elects a fallback account, drops `x-codex-turn-state`, and retries the same
+request before writing the response to Codex. That is still not a live product
+claim until real provider-originated quota exhaustion proves the same sequence.
 
 ## Truth Sources
 
@@ -74,7 +75,7 @@ The evidence ladder is:
 - Live QA only after local and cassette layers are green, with explicit spend
   consent and redacted status artifacts.
 
-Next P0: implement and test a stronger `429 usage_limit_reached` handoff path
-where, if a fallback account is selectable, oauth-mux retries or recovers the
-same user turn before Codex receives a visible quota failure. Until that exists
-and is proven, live quota-burn dogfood is telemetry, not product acceptance.
+Next P0: capture and run live evidence for provider-originated
+`429 usage_limit_reached` inside a managed session. Until that proves the same
+no-visible-429 sequence against real `chatgpt.com`, live quota-burn dogfood is
+telemetry, not product acceptance.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# oauth-mux
+
+`oauth-mux` is an OAuth/account broker for developer harnesses. The product
+target is:
+
+> The user runs `oauth-mux <harness>` such as `oauth-mux codex`. The harness
+> behaves like the real one. The active subscription account exhausts quota.
+> Another credited account is substituted in place. The harness process is not
+> restarted. The user is not prompted.
+
+Restart, supervised relaunch, route-warming, and `prepared_fallback` are not
+product success. They are diagnostics or lower-level infrastructure.
+
+## Current Codex State
+
+Real on `main`:
+
+- Broker MCP/account selection core exists.
+- `oauth-mux codex` runs Codex in a managed frame with mux-owned auth/config
+  and a canonical Codex session-authority bridge.
+- Brokered Codex resume has been dogfooded successfully through the proxy:
+  `resume <session-id>` reached `POST /backend-api/codex/responses` with
+  `status:200`.
+- Synthetic smokes prove account A can hit `429 usage_limit_reached`, be
+  marked exhausted, and account B can handle the next request in the same child
+  process.
+- Same-account Codex child refresh is preserved so oauth-mux does not pin Codex
+  to stale materialized access tokens after a native refresh.
+
+Not proven yet:
+
+- Live provider-originated account exhaustion inside a managed `oauth-mux codex`
+  session.
+- Invisible same-turn recovery where Codex never sees the quota failure.
+- Same-thread continuity across account swap.
+- Bare `codex` plus a separate background oauth-mux daemon seamlessly handing
+  off accounts.
+- Claude, Cursor, Pi, or other harness adapters.
+
+The current Codex proxy implementation is still a next-request fallback path:
+it classifies `429 usage_limit_reached`, marks the active account exhausted,
+and the next request elects another account. That is useful progress, but it is
+not the full seamless product bar if the failed turn is visible to the user.
+
+## Truth Sources
+
+- `AGENTS.md`
+- `docs/spec/broker-mcp-contract-2026-05-03.md`
+- `docs/spec/codex-adapter-contract-2026-05-03.md`
+- `docs/spec/harness-session-authority-bridge-2026-05-05.md`
+- `docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md`
+- `docs/spec/test-and-coverage-review-2026-05-05.md`
+- `docs/spec/broker-worktree-quarry-todo-2026-05-05.md`
+
+## Testing Ladder
+
+Use `just` as the entrypoint.
+
+```bash
+just build
+just test
+just check-local
+```
+
+The evidence ladder is:
+
+- Unit tests and deterministic PBT-style tests in Zig for parsers, route state,
+  classification, session ids, credential handles, header copying, and overlay
+  invariants.
+- Shell e2e/smoke tests for broker MCP, Codex CLI UX, Codex synthetic swap,
+  concurrent sessions, same-account child refresh, tier-insufficient handling,
+  all-accounts-exhausted handling, 401 propagation, and cassette replay.
+- Cassette replay infrastructure for scrubbed Codex wire captures.
+- Live QA only after local and cassette layers are green, with explicit spend
+  consent and redacted status artifacts.
+
+Next P0: implement and test a stronger `429 usage_limit_reached` handoff path
+where, if a fallback account is selectable, oauth-mux retries or recovers the
+same user turn before Codex receives a visible quota failure. Until that exists
+and is proven, live quota-burn dogfood is telemetry, not product acceptance.

--- a/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
+++ b/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
@@ -301,10 +301,12 @@ These need review before public promotion:
   selected `codex:max-1`; selectable fallbacks `max-2`, `max-3`, and `max-4`;
   `selectable_broker_routes:4`, `selectable_fallback_routes:3`,
   `spare_fallback_ready:true`, `single_route_at_risk:false`.
-- GitHub issue comment writes for #131, #176, and #177 were attempted from the
-  connector but failed with `403 Resource not accessible by integration`.
-  The issue-ready update is therefore recorded here until it can be posted by
-  a credential with issue-comment permission.
+- GitHub MCP connector issue-comment writes for #131, #176, and #177 failed
+  with `403 Resource not accessible by integration`; the connector needs
+  issue-comment permission before it can be trusted for tracker writes.
+- Local `gh` posting succeeded after ignoring a stale `GH_TOKEN` environment
+  variable and using the valid keyring/CLI auth. Comments posted:
+  #131 `4384946494`, #177 `4384947088`, #176 `4384947627`.
 - Remaining acceptance gate: provider-originated `usage_limit_reached` inside a
   real managed `oauth-mux codex` session, with redacted status evidence showing
   the same no-visible-429 retry sequence and a stable child process.

--- a/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
+++ b/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
@@ -65,8 +65,9 @@ Already merged on main:
 - Per-session `CODEX_HOME` overlay; account-local `config.toml` is not
   clobbered by adapter sessions.
 - Synthetic Codex acceptance smoke: account A succeeds, then returns
-  `usage_limit_reached`, then account B handles a post-swap turn in one
-  stable child PID.
+  `usage_limit_reached`; oauth-mux buffers that 429, marks A exhausted,
+  retries the same request with B, and the stub Codex child sees only 200s in
+  one stable child PID.
 - Brokered Codex resume through canonical session authority; the managed frame
   can now resume a real existing Codex session and proxy normal provider turns.
 - Same-account child auth refresh preservation; oauth-mux no longer overwrites
@@ -83,8 +84,8 @@ Already merged on main:
 Not yet proven:
 
 - Live provider-originated Level 3 account swap.
-- Invisible same-turn recovery where a fallback account handles the user turn
-  before Codex sees `usage_limit_reached`.
+- Live invisible same-turn recovery where a fallback account handles the user
+  turn before Codex sees `usage_limit_reached`.
 - Same-thread continuity across account swap.
 - Mid-turn recovery.
 - Bare `codex` plus a separate background oauth-mux daemon seamlessly
@@ -232,16 +233,12 @@ These need review before public promotion:
      and quota exhaustion when available.
 
 3. 429 recovery mode
-   - Main currently proves synthetic between-turn A-to-B behavior.
-   - The current proxy returns the `429 usage_limit_reached` to Codex, marks
-     account A exhausted, and only elects account B on the next request.
-   - That is below the strict product bar if the failed turn is visible.
-   - P0 implementation target: buffer/classify 429, mark A exhausted, elect B,
-     and either retry the same request upstream with B or synthesize a recovery
-     path before Codex receives the quota failure.
-   - Do not claim seamless stay-afloat until a synthetic smoke proves no 429
-     reaches the Codex child when B succeeds, and live evidence later confirms
-     provider behavior.
+   - Main now proves synthetic same-turn A-to-B retry behavior.
+   - The proxy buffers `429 usage_limit_reached`, marks account A exhausted,
+     elects B, drops `x-codex-turn-state`, retries the same request, and only
+     writes B's response to Codex when B succeeds.
+   - Do not claim live seamless stay-afloat until provider-originated evidence
+     confirms the same no-visible-429 sequence against real `chatgpt.com`.
 
 4. Daemon-attached broker mode
    - In-process broker is good enough for current adapter smokes.
@@ -273,25 +270,17 @@ These need review before public promotion:
 ## Local Todo Order
 
 1. Keep main clean and preserve all four selectable `codex-max` routes.
-2. Implement the same-turn 429 handoff attempt before treating quota-burn
-   dogfood as acceptance:
-   - synthetic `A -> 429 usage_limit_reached -> immediate B -> 200`;
-   - assert no 429 is delivered to the stub Codex child when B succeeds;
-   - assert one stable child PID and redacted `account_swap` /
-     `proxy_same_turn_retry` status frames;
-   - negative guards for `usage_not_included`, generic 429, 401 propagation,
-     and all-accounts-exhausted.
-3. Capture real Codex wire cassettes for TIN-950 / GitHub #176:
+2. Capture real Codex wire cassettes for TIN-950 / GitHub #176:
    normal 200 flow first, then 401 and 429 only when safely available.
-4. Run live Level 3 acceptance for TIN-951 only when the operator is ready to
+3. Run live Level 3 acceptance for TIN-951 only when the operator is ready to
    spend and there is a realistic way to observe provider-originated quota
    exhaustion in an active `oauth-mux codex` session.
-5. Keep demoting route-warming/restart surfaces from product language.
-6. Keep extending the test ladder: Zig unit/PBT, shell e2e, cassette replay,
+4. Keep demoting route-warming/restart surfaces from product language.
+5. Keep extending the test ladder: Zig unit/PBT, shell e2e, cassette replay,
    live redacted artifacts, and hosted CI.
-7. Start the Claude adapter only after the Codex Level 3 proof is recorded
+6. Start the Claude adapter only after the Codex Level 3 proof is recorded
    or explicitly parked.
-8. Re-run `just check-local` after each code/test slice.
+7. Re-run `just check-local` after each code/test slice.
 
 ## Hygiene Pass Notes
 

--- a/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
+++ b/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
@@ -23,9 +23,11 @@ prepared fallback, and synthetic smokes are evidence or diagnostics only.
 
 ## Current Live State
 
-Observed on 2026-05-05 around 15:37 EDT:
+Observed on 2026-05-05 around 15:37 EDT, then updated after the first
+brokered-resume dogfood on 2026-05-06:
 
-- Repository: clean on `main...origin/main` at `59c2f69`.
+- Repository: clean on `main`, one local commit ahead of `origin/main` at
+  `954d673` (`Whoohoo brokered Codex resume`) during this checkpoint.
 - Selected live `codex-max` route: `max-1`.
 - Spend-gated exhausted-route revalidation after the reset window found
   `max-1`, `max-2`, and `max-3` available again; `max-4` was already
@@ -41,6 +43,19 @@ Level 3 acceptance: no provider-originated `usage_limit_reached` event
 has occurred inside a live `oauth-mux codex` session during this
 checkpoint.
 
+The brokered-resume dogfood proved a separate prerequisite:
+
+- `oauth-mux codex --profile codex-max resume <session-id>` re-entered a
+  canonical Codex session through the managed frame.
+- Status evidence reported `session_authority:"canonical_bridge"`,
+  `auth_authority:"mux_owned_overlay"`, and `managed_config:"mux_owned_overlay"`.
+- Live `POST /backend-api/codex/responses` turns returned `status:200` through
+  the oauth-mux proxy after the request-framing and same-account child-refresh
+  fixes.
+
+That is meaningful UX/architecture progress. It is not account-exhaustion
+success and must not be described as stay-afloat completion.
+
 ## Mainline Reality
 
 Already merged on main:
@@ -52,6 +67,11 @@ Already merged on main:
 - Synthetic Codex acceptance smoke: account A succeeds, then returns
   `usage_limit_reached`, then account B handles a post-swap turn in one
   stable child PID.
+- Brokered Codex resume through canonical session authority; the managed frame
+  can now resume a real existing Codex session and proxy normal provider turns.
+- Same-account child auth refresh preservation; oauth-mux no longer overwrites
+  a Codex-refreshed bearer for the same account with stale materialized route
+  credentials.
 - Cassette capture/replay tooling; real operator capture data is still
   pending.
 - `--json-status-file` artifact path, so oauth-mux status frames do not
@@ -63,17 +83,16 @@ Already merged on main:
 Not yet proven:
 
 - Live provider-originated Level 3 account swap.
+- Invisible same-turn recovery where a fallback account handles the user turn
+  before Codex sees `usage_limit_reached`.
 - Same-thread continuity across account swap.
 - Mid-turn recovery.
 - Bare `codex` plus a separate background oauth-mux daemon seamlessly
   handing off account state.
-- Managed-frame resume parity. The adapter-owned temporary `CODEX_HOME`
-  now bridges canonical Codex session authority by reference, but live
-  `resume <id>` / `resume --last` dogfood is still pending before this is
-  treated as parity with bare Codex. The 2026-05-06 UX refactor spec adds
-  the missing command contract: first-class `oauth-mux codex resume ...`,
-  strict `codex run` parsing, status-file parent creation, and PBT/e2e/
-  cassette guards.
+- Managed-frame resume parity beyond explicit-id resume. The adapter-owned
+  temporary `CODEX_HOME` now bridges canonical Codex session authority by
+  reference, and explicit live `resume <id>` dogfood succeeded. `resume --last`
+  and chooser parity remain useful UX checks.
 
 ## Quarry Worktree
 
@@ -214,9 +233,15 @@ These need review before public promotion:
 
 3. 429 recovery mode
    - Main currently proves synthetic between-turn A-to-B behavior.
-   - Still need real evidence for whether same conversation thread survives
-     account swap.
-   - Do not claim mid-turn or same-thread recovery until captured.
+   - The current proxy returns the `429 usage_limit_reached` to Codex, marks
+     account A exhausted, and only elects account B on the next request.
+   - That is below the strict product bar if the failed turn is visible.
+   - P0 implementation target: buffer/classify 429, mark A exhausted, elect B,
+     and either retry the same request upstream with B or synthesize a recovery
+     path before Codex receives the quota failure.
+   - Do not claim seamless stay-afloat until a synthetic smoke proves no 429
+     reaches the Codex child when B succeeds, and live evidence later confirms
+     provider behavior.
 
 4. Daemon-attached broker mode
    - In-process broker is good enough for current adapter smokes.
@@ -230,9 +255,9 @@ These need review before public promotion:
    - Full-store copies are rejected; the current adapter uses a
      bridge/reference model per
      `docs/spec/harness-session-authority-bridge-2026-05-05.md`.
-   - Remaining acceptance: daily-use managed resume UX and live
-     managed-frame resume dogfood per
-     `docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md`.
+   - Explicit live managed-frame resume now works. Continue daily-use checks
+     for `resume --last`, native chooser behavior, and redacted writeback
+     evidence per `docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md`.
 
 6. Bare `codex` path
    - The aspirational background daemon plus bare `codex` remains harder
@@ -248,18 +273,25 @@ These need review before public promotion:
 ## Local Todo Order
 
 1. Keep main clean and preserve all four selectable `codex-max` routes.
-2. Run live Level 3 acceptance for TIN-951 only when the operator is
-   ready to spend and there is a realistic way to observe
-   provider-originated quota exhaustion in an active `oauth-mux codex`
-   session.
+2. Implement the same-turn 429 handoff attempt before treating quota-burn
+   dogfood as acceptance:
+   - synthetic `A -> 429 usage_limit_reached -> immediate B -> 200`;
+   - assert no 429 is delivered to the stub Codex child when B succeeds;
+   - assert one stable child PID and redacted `account_swap` /
+     `proxy_same_turn_retry` status frames;
+   - negative guards for `usage_not_included`, generic 429, 401 propagation,
+     and all-accounts-exhausted.
 3. Capture real Codex wire cassettes for TIN-950 / GitHub #176:
    normal 200 flow first, then 401 and 429 only when safely available.
-4. Run live managed-frame resume dogfood before promoting managed-frame
-   resume as parity with bare Codex.
+4. Run live Level 3 acceptance for TIN-951 only when the operator is ready to
+   spend and there is a realistic way to observe provider-originated quota
+   exhaustion in an active `oauth-mux codex` session.
 5. Keep demoting route-warming/restart surfaces from product language.
-6. Start the Claude adapter only after the Codex Level 3 proof is recorded
+6. Keep extending the test ladder: Zig unit/PBT, shell e2e, cassette replay,
+   live redacted artifacts, and hosted CI.
+7. Start the Claude adapter only after the Codex Level 3 proof is recorded
    or explicitly parked.
-7. Re-run `just check-local` after each code/test slice.
+8. Re-run `just check-local` after each code/test slice.
 
 ## Hygiene Pass Notes
 

--- a/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
+++ b/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
@@ -284,6 +284,31 @@ These need review before public promotion:
 
 ## Hygiene Pass Notes
 
+2026-05-06:
+
+- PR/local commit `5161b23` changed the Codex proxy from next-request-only
+  quota recovery to synthetic same-turn retry:
+  `A -> 429 usage_limit_reached -> mark A exhausted -> elect B -> drop
+  x-codex-turn-state -> retry same request -> B 200`.
+- `scripts/smoke-codex-acceptance.sh` now asserts the stub Codex child sees
+  only 200s when a fallback account succeeds; the original quota 429 is logged
+  as `delivered_to_codex:false`.
+- Negative-path guards now assert no same-turn retry on
+  `usage_not_included` or 401, and all-accounts-exhausted reports
+  `proxy_same_turn_retry_unavailable` plus a clean no-account-selectable path.
+- Full `just check-local` passed after the proxy and smoke updates.
+- No-spend live route readiness, run with normal local filesystem access:
+  selected `codex:max-1`; selectable fallbacks `max-2`, `max-3`, and `max-4`;
+  `selectable_broker_routes:4`, `selectable_fallback_routes:3`,
+  `spare_fallback_ready:true`, `single_route_at_risk:false`.
+- GitHub issue comment writes for #131, #176, and #177 were attempted from the
+  connector but failed with `403 Resource not accessible by integration`.
+  The issue-ready update is therefore recorded here until it can be posted by
+  a credential with issue-comment permission.
+- Remaining acceptance gate: provider-originated `usage_limit_reached` inside a
+  real managed `oauth-mux codex` session, with redacted status evidence showing
+  the same no-visible-429 retry sequence and a stable child process.
+
 2026-05-05:
 
 - Added the tier-insufficient, all-exhausted, and 401-propagation Codex

--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -45,12 +45,12 @@ canonical session authority, mux-owned auth/config, and live
 `POST /backend-api/codex/responses` turns returning `status:200`. This proves
 the managed frame and normal proxy path, not account-exhaustion success.
 
-The current 429 implementation remains next-request recovery: the proxy returns
-`429 usage_limit_reached` to Codex, marks the active account exhausted, and the
-next request elects a different account. That is below the strict product bar if
-the failed turn is visible. The next implementation target is a same-turn
-handoff attempt that retries or recovers before Codex receives the quota
-failure when a fallback account is selectable.
+The current 429 implementation now has a synthetic same-turn retry path: the
+proxy buffers `429 usage_limit_reached`, marks the active account exhausted,
+elects a fallback, drops `x-codex-turn-state`, and retries the same request
+before writing a response to Codex. The smoke proves Codex sees only the
+fallback `200` in that synthetic case. Live provider-originated quota evidence
+is still required before promoting the runtime claim.
 
 That smoke is structural evidence only. It uses local stubs and fake
 fixture tokens, makes no provider calls, and keeps the adapter output at
@@ -404,8 +404,8 @@ oauth-mux evidence. Frame shapes are stable under broker `surface_version:
 // adapter startup
 { "kind": "session_started", "session_id": "...", "selected_account": "codex:max-1", "claim_level": "broker_owned", "wire_proxy_addr": "127.0.0.1:54321" }
 
-// target shape for a successful invisible quota handoff; not emitted by the
-// current next-request-only 429 path
+// target shape for a successful invisible quota handoff; current synthetic
+// tests emit proxy_same_turn_retry while runtime claim stays broker_owned
 { "kind": "account_swap", "from": "codex:max-1", "to": "codex:max-3", "reason": "quota_exhausted", "via": "wire_proxy_429_retry", "claim_level": "next_turn_seamless" }
 
 // every refresh

--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -39,6 +39,19 @@ and `shell_snapshots/` are bridged by reference to canonical Codex session
 authority by default. `docs/spec/harness-session-authority-bridge-2026-05-05.md`
 tracks the remaining live resume acceptance.
 
+Implementation update, 2026-05-06: explicit live brokered resume now works
+through the managed frame and proxy. The status artifact for that dogfood showed
+canonical session authority, mux-owned auth/config, and live
+`POST /backend-api/codex/responses` turns returning `status:200`. This proves
+the managed frame and normal proxy path, not account-exhaustion success.
+
+The current 429 implementation remains next-request recovery: the proxy returns
+`429 usage_limit_reached` to Codex, marks the active account exhausted, and the
+next request elects a different account. That is below the strict product bar if
+the failed turn is visible. The next implementation target is a same-turn
+handoff attempt that retries or recovers before Codex receives the quota
+failure when a fallback account is selectable.
+
 That smoke is structural evidence only. It uses local stubs and fake
 fixture tokens, makes no provider calls, and keeps the adapter output at
 `claim_level:"broker_owned"` while reporting
@@ -391,8 +404,9 @@ oauth-mux evidence. Frame shapes are stable under broker `surface_version:
 // adapter startup
 { "kind": "session_started", "session_id": "...", "selected_account": "codex:max-1", "claim_level": "broker_owned", "wire_proxy_addr": "127.0.0.1:54321" }
 
-// every account swap
-{ "kind": "account_swap", "from": "codex:max-1", "to": "codex:max-3", "reason": "quota_exhausted", "via": "wire_proxy_429_synth_401", "claim_level": "next_turn_seamless" }
+// target shape for a successful invisible quota handoff; not emitted by the
+// current next-request-only 429 path
+{ "kind": "account_swap", "from": "codex:max-1", "to": "codex:max-3", "reason": "quota_exhausted", "via": "wire_proxy_429_retry", "claim_level": "next_turn_seamless" }
 
 // every refresh
 { "kind": "credential_refresh", "account": "codex:max-1", "trigger": "proactive_exp", "outcome": "ok" }
@@ -404,8 +418,8 @@ oauth-mux evidence. Frame shapes are stable under broker `surface_version:
 // quota observation that did not trigger a swap
 { "kind": "quota_observed", "account": "codex:max-1", "kind_detail": "rate_limited", "retry_after_s": 12 }
 
-// teardown
-{ "kind": "session_ended", "session_id": "...", "turns": 14, "swaps": 2, "final_claim_level": "next_turn_seamless" }
+// teardown before live quota-handoff proof remains broker_owned
+{ "kind": "session_ended", "session_id": "...", "turns": 14, "swaps": 0, "final_claim_level": "broker_owned" }
 ```
 
 These frames are the only structured surface the adapter publishes. The
@@ -463,10 +477,12 @@ suite for §3 behavior.
 
 - Real interactive `oauth-mux codex` session, two enrolled accounts,
   account A near quota, account B credited. User runs prompts until
-  account A exhausts. Verify: account B continues the session,
-  `claim_level: next_turn_seamless` emitted, `oauth-mux codex` did not
-  prompt the user, the `codex` child process did not restart (verified
-  by `ppid` stability across the swap). This is the metric.
+  account A exhausts. Verify: account B continues the session without a visible
+  quota-failed turn when a fallback account is selectable,
+  `claim_level: next_turn_seamless` is emitted only after that evidence,
+  `oauth-mux codex` did not prompt the user, and the `codex` child process did
+  not restart (verified by `ppid` stability across the swap). This is the
+  metric.
 
 ### 11.5 ToS-honest paid-cohort soak (Phase 3)
 
@@ -518,7 +534,8 @@ The adapter is acceptable when:
    from bare `codex` modulo §5 TUI degradation.
 2. `oauth-mux codex` runs a multi-account session and on observed
    live-account exhaustion swaps to a credited account in the same
-   `codex app-server` child, emitting `claim_level: next_turn_seamless`.
+   `codex app-server` child before Codex receives a visible quota-failed turn,
+   emitting `claim_level: next_turn_seamless` only after that evidence.
 3. The wire-layer proxy correctly classifies every entry of §3's matrix
    against captured fixtures.
 4. The adapter never prints token material, refresh-token bytes, full

--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -397,6 +397,10 @@ oauth-mux evidence. Frame shapes are stable under broker `surface_version:
 // every refresh
 { "kind": "credential_refresh", "account": "codex:max-1", "trigger": "proactive_exp", "outcome": "ok" }
 
+// resume authority preflight and writeback evidence
+{ "kind": "resume_preflight", "mode": "last", "session_authority": "canonical_bridge", "rollouts_before": 42, "session_id_printed": false, "path_printed": false }
+{ "kind": "resume_writeback", "mode": "last", "session_authority": "canonical_bridge", "changed_existing": 1, "created": 0, "session_id_printed": false, "path_printed": false }
+
 // quota observation that did not trigger a swap
 { "kind": "quota_observed", "account": "codex:max-1", "kind_detail": "rate_limited", "retry_after_s": 12 }
 

--- a/docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md
+++ b/docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md
@@ -506,3 +506,64 @@ Regression guard:
 - `scripts/smoke-codex-child-refresh.sh` drives two synthetic same-account
   turns with different child bearer tokens and asserts that the upstream sees
   the bearer change without an account swap or a stale 401 loop.
+
+## 9. Dogfood Finding: Splash Screen Is Not Resume Evidence
+
+The second real managed `resume --last` dogfood after the same-account refresh
+fix completed a provider turn through the proxy, but the Codex TUI still
+looked like a fresh startup screen. That is not enough evidence either way:
+Codex can resume a rollout without replaying enough transcript in the visible
+startup pane to make the operator confident.
+
+Correct evidence:
+
+- Before launching the child, oauth-mux snapshots the bridged Codex session
+  authority.
+- After the child exits, oauth-mux reports whether an existing rollout was
+  changed, whether a fresh rollout was created, and whether an explicit resume
+  target changed.
+- The status frame continues to redact session ids and paths.
+
+Regression guard:
+
+- `scripts/smoke-codex-cli-ux.sh` now requires managed resume aliases to emit
+  `resume_preflight` and `resume_writeback` frames, and the stub child appends
+  through the bridged session authority so the adapter proves writeback
+  observation instead of relying on terminal appearance.
+
+## 10. Dogfood Finding: Brokered Resume Works, Cloudflare 400 Was Framing
+
+The first successful brokered resume proof used:
+
+```bash
+./zig-out/bin/oauth-mux codex --profile codex-max \
+  --json-status-file dist/live-qa/managed-resume-dogfood-5/status.ndjson \
+  resume 019dea53-49a0-7890-9580-e88decb97af0
+```
+
+Evidence:
+
+- The process environment reported `OMUX_ACTIVE_PROVIDER=codex`,
+  `OMUX_ACTIVE_ACCOUNT=max-1`, and `OMUX_ACTIVE_PROFILE=codex-max`.
+- The managed `CODEX_HOME` overlay was active.
+- `resume_preflight` found the explicit canonical rollout before launch.
+- `proxy_turn` frames showed the main
+  `POST /backend-api/codex/responses` path as `status:200`,
+  `classification:"ok"`, and `body_class:"none"`.
+
+The prior `dogfood-4` run had already proven that explicit resume writeback
+worked, but the main `responses` POST returned Cloudflare `400 Bad Request`.
+The likely root cause was proxy request framing: oauth-mux forwarded inbound
+`Content-Length` and set `Host` as extra headers while `std.http.Client` was
+also responsible for those fields. The proxy now drops inbound `Host`,
+`Content-Length`, and `Transfer-Encoding` and lets `std.http.Client` own
+request framing.
+
+Remaining Level 3 evidence still required:
+
+- Observe a real provider-originated `429 usage_limit_reached` for the active
+  account inside this managed session.
+- Confirm oauth-mux records the quota event and the next turn selects a
+  distinct fallback account.
+- Do not treat this brokered-resume success as proof of live account-swap
+  success until an actual `proxy_turn` / swap sequence shows it.

--- a/docs/spec/codex-wire-evidence-2026-05-03.md
+++ b/docs/spec/codex-wire-evidence-2026-05-03.md
@@ -96,8 +96,8 @@ x-openai-internal-codex-residency: us   # conditional
 ```
 
 `x-codex-turn-state` is the load-bearing one. The wire proxy DROPS
-this header on the post-swap turn (per `wire_proxy.zig`) — every
-other header in this set is forwarded verbatim.
+this header on same-turn retry and post-swap turns (per `wire_proxy.zig`) —
+every other header in this set is forwarded verbatim.
 
 NOT sent (do not forge):
 - `Sec-Fetch-Site` / `Sec-Fetch-Mode` (browser-only)
@@ -204,9 +204,12 @@ The wire proxy:
 - Buffers the response body (small JSON).
 - Classifies as `quota_exhausted` with `resets_at` parsed from body.
 - Calls `pool.markQuotaExhausted(account_id, resets_at)`.
-- Returns the 429 to codex unchanged.
-- On NEXT request from codex, elects a different account.
-- Drops `x-codex-turn-state` on the post-swap turn.
+- If a fallback account is selectable, elects it immediately, drops
+  `x-codex-turn-state`, retries the same request, and returns the fallback
+  response to codex. The original 429 is logged as
+  `delivered_to_codex:false`.
+- If no fallback account is selectable, returns the buffered failure and logs
+  `proxy_same_turn_retry_unavailable`.
 
 _OPERATOR-CONFIRM_: drive an account to weekly quota; capture the
 exact body bytes; verify field names + casing match.

--- a/docs/spec/test-and-coverage-review-2026-05-05.md
+++ b/docs/spec/test-and-coverage-review-2026-05-05.md
@@ -56,20 +56,21 @@ The shell smoke suite covers these adapter stories:
 - `smoke-broker`: 22 assertions. Broker MCP method composition:
   handshake, account listing, selection, materialization, quota
   observation, swap, and status.
-- `smoke-codex-acceptance`: 18 assertions. Synthetic Codex A-to-B
-  swap: account A succeeds, then returns `usage_limit_reached`, then
-  account B handles the next turn in one stable child PID.
+- `smoke-codex-acceptance`: 20 assertions. Synthetic Codex A-to-B
+  swap: account A succeeds, then returns `usage_limit_reached`; oauth-mux
+  buffers that 429, marks A exhausted, retries the same request with B, and
+  the stub Codex child sees only 200s in one stable child PID.
 - `smoke-codex-concurrent-sessions`: 16 assertions. Per-session
   `CODEX_HOME` overlays prevent the old account-local `config.toml`
   clobber race.
 - `smoke-codex-child-refresh`: 12 assertions. Codex child-refresh for the
   same account is preserved by the proxy, preventing stale materialized-token
   loops after a native Codex refresh.
-- `smoke-codex-tier-insufficient`: 10 assertions.
+- `smoke-codex-tier-insufficient`: 11 assertions.
   `usage_not_included` is classified as `tier_insufficient`; no swap.
-- `smoke-codex-all-exhausted`: 10 assertions. All accounts exhausted
-  returns a clean no-account-selectable failure.
-- `smoke-codex-401-propagation`: 12 assertions. Upstream 401 is left
+- `smoke-codex-all-exhausted`: 12 assertions. All accounts exhausted returns
+  a clean no-account-selectable failure after same-turn retry is unavailable.
+- `smoke-codex-401-propagation`: 13 assertions. Upstream 401 is left
   for Codex's own refresh path; oauth-mux does not prematurely kill the
   route.
 - `smoke-codex-cassette-replay`: 12 assertions. Captured-flow JSON can
@@ -112,7 +113,7 @@ inside a live `oauth-mux codex` session during that check.
 ## What Current Main Does Not Prove
 
 - Live provider-originated Level 3 account swap.
-- Invisible same-turn recovery where Codex never sees a visible
+- Live invisible same-turn recovery where Codex never sees a visible
   `usage_limit_reached` failure when a fallback account is selectable.
 - Same-thread continuity across account swap.
 - Mid-turn recovery.
@@ -132,11 +133,11 @@ inside a live `oauth-mux codex` session during that check.
    must not be labeled as Level 3.
 3. **The Codex path depends on wire interposition.** Codex's 401 path
    can refresh; quota is a 429 and must be observed at the wire layer.
-4. **The current 429 implementation is next-request recovery, not invisible
-   same-turn recovery.** It marks account A exhausted after returning the 429
-   and elects account B on the next request. The next P0 must harden this so a
-   selectable fallback can handle the same user turn before Codex receives a
-   visible quota failure.
+4. **The current 429 implementation has synthetic same-turn retry, not live
+   provider proof.** It buffers a quota 429, marks account A exhausted, elects
+   account B, drops `x-codex-turn-state`, and retries the same request before
+   writing to Codex. The remaining risk is whether real `chatgpt.com` quota
+   events and thread state behave like the synthetic model.
 5. **The current child/proxy topology is the user-facing near path.**
    `oauth-mux codex` owns the mediation point. Bare `codex` with a
    background daemon remains a harder future sidecar problem.
@@ -145,14 +146,14 @@ inside a live `oauth-mux codex` session during that check.
 
 ## Next Gates
 
-1. Implement and test stronger same-turn 429 handoff semantics:
-   - synthetic `A -> 429 usage_limit_reached -> immediate B -> 200`;
-   - assert the stub Codex child does not receive a 429 when B succeeds;
+1. Capture real Codex wire cassettes and live evidence for the same-turn 429
+   path:
+   - provider-originated `A -> 429 usage_limit_reached -> immediate B -> 200`;
+   - assert the live Codex process does not receive a visible 429 when B
+     succeeds;
    - assert one stable child PID, redacted status frames, and no restart
-     language;
-   - negative guards for `usage_not_included`, generic 429, 401 propagation,
-     and all-accounts-exhausted.
-2. Extend the deterministic test ladder around that work:
+     language.
+2. Keep extending the deterministic test ladder around that work:
    - Zig unit/PBT for response classification and swap state-machine
      invariants;
    - shell e2e for proxy behavior and CLI/session authority;

--- a/docs/spec/test-and-coverage-review-2026-05-05.md
+++ b/docs/spec/test-and-coverage-review-2026-05-05.md
@@ -6,9 +6,11 @@ Anchor: `docs/spec/broker-mcp-contract-2026-05-03.md`.
 Codex adapter contract: `docs/spec/codex-adapter-contract-2026-05-03.md`.
 
 This review replaces the stale quarry-branch assessment from
-`/Users/jess/git/oauth-mux-broker`. It describes current `main` at
-`59c2f69`, after the route-health truthing, Codex quarry smokes,
-expired-quota revalidation state, and restart-claim demotion work.
+`/Users/jess/git/oauth-mux-broker`. It describes current `main` through
+`954d673` (`Whoohoo brokered Codex resume`), after route-health truthing,
+Codex quarry smokes, expired-quota revalidation state, restart-claim demotion,
+managed resume UX work, request-framing fixes, and same-account child-refresh
+preservation.
 
 ## Product Bar
 
@@ -33,13 +35,17 @@ flags, and synthetic smokes are not success.
 - `scripts/smoke-broker.sh`.
 - `scripts/smoke-codex-acceptance.sh`.
 - `scripts/smoke-codex-concurrent-sessions.sh`.
+- `scripts/smoke-codex-child-refresh.sh`.
 - `scripts/smoke-codex-tier-insufficient.sh`.
 - `scripts/smoke-codex-all-exhausted.sh`.
 - `scripts/smoke-codex-401-propagation.sh`.
 - `scripts/smoke-codex-cassette-replay.sh`.
 
-Validation status for this review: `just check-local` passed on
-2026-05-05 after the doc update.
+Validation status for the current resume/proxy slice: focused local gates have
+passed (`zig build test`, `zig build`, `smoke-codex-cli-ux`,
+`smoke-codex-acceptance`, and `smoke-codex-child-refresh`). A full
+`just check-local` should be rerun before merge/release claims when this review
+changes implementation.
 
 Repo-wide Zig test inventory is broad (`rg '^test "' src` finds 306
 in-file tests). The broker/Codex-adapter subset is materially covered
@@ -50,12 +56,15 @@ The shell smoke suite covers these adapter stories:
 - `smoke-broker`: 22 assertions. Broker MCP method composition:
   handshake, account listing, selection, materialization, quota
   observation, swap, and status.
-- `smoke-codex-acceptance`: 15 assertions. Synthetic Codex A-to-B
+- `smoke-codex-acceptance`: 18 assertions. Synthetic Codex A-to-B
   swap: account A succeeds, then returns `usage_limit_reached`, then
   account B handles the next turn in one stable child PID.
 - `smoke-codex-concurrent-sessions`: 16 assertions. Per-session
   `CODEX_HOME` overlays prevent the old account-local `config.toml`
   clobber race.
+- `smoke-codex-child-refresh`: 12 assertions. Codex child-refresh for the
+  same account is preserved by the proxy, preventing stale materialized-token
+  loops after a native Codex refresh.
 - `smoke-codex-tier-insufficient`: 10 assertions.
   `usage_not_included` is classified as `tier_insufficient`; no swap.
 - `smoke-codex-all-exhausted`: 10 assertions. All accounts exhausted
@@ -87,6 +96,10 @@ inside a live `oauth-mux codex` session during that check.
   tuples, observe quota, swap accounts, and report status in-process.
 - The Codex adapter/proxy skeleton can run synthetic in-session flows
   without restarting its child process.
+- The managed Codex frame can resume a real existing canonical Codex session
+  and proxy normal live `responses` turns successfully.
+- The proxy can preserve a same-account Codex-refreshed bearer instead of
+  forcing stale oauth-mux materialized credentials.
 - Route-health state now distinguishes expired reset windows as
   `revalidation_needed` until explicit provider revalidation refreshes
   truth.
@@ -99,6 +112,8 @@ inside a live `oauth-mux codex` session during that check.
 ## What Current Main Does Not Prove
 
 - Live provider-originated Level 3 account swap.
+- Invisible same-turn recovery where Codex never sees a visible
+  `usage_limit_reached` failure when a fallback account is selectable.
 - Same-thread continuity across account swap.
 - Mid-turn recovery.
 - Bare `codex` plus a separate background oauth-mux daemon seamlessly
@@ -117,26 +132,44 @@ inside a live `oauth-mux codex` session during that check.
    must not be labeled as Level 3.
 3. **The Codex path depends on wire interposition.** Codex's 401 path
    can refresh; quota is a 429 and must be observed at the wire layer.
-4. **The current child/proxy topology is the user-facing near path.**
+4. **The current 429 implementation is next-request recovery, not invisible
+   same-turn recovery.** It marks account A exhausted after returning the 429
+   and elects account B on the next request. The next P0 must harden this so a
+   selectable fallback can handle the same user turn before Codex receives a
+   visible quota failure.
+5. **The current child/proxy topology is the user-facing near path.**
    `oauth-mux codex` owns the mediation point. Bare `codex` with a
    background daemon remains a harder future sidecar problem.
-5. **Restart diagnostics should keep shrinking.** They are useful for
+6. **Restart diagnostics should keep shrinking.** They are useful for
    incident capture, not for product claims.
 
 ## Next Gates
 
-1. Run the live TIN-951 acceptance only when the operator is ready to
+1. Implement and test stronger same-turn 429 handoff semantics:
+   - synthetic `A -> 429 usage_limit_reached -> immediate B -> 200`;
+   - assert the stub Codex child does not receive a 429 when B succeeds;
+   - assert one stable child PID, redacted status frames, and no restart
+     language;
+   - negative guards for `usage_not_included`, generic 429, 401 propagation,
+     and all-accounts-exhausted.
+2. Extend the deterministic test ladder around that work:
+   - Zig unit/PBT for response classification and swap state-machine
+     invariants;
+   - shell e2e for proxy behavior and CLI/session authority;
+   - cassette replay for real wire-shape drift;
+   - hosted CI before public claims.
+3. Run the live TIN-951 acceptance only when the operator is ready to
    spend and has a credible way to observe provider-originated quota
    exhaustion in an active `oauth-mux codex` session.
-2. Run TIN-950 / GitHub #176 capture for at least one normal 200 turn.
+4. Run TIN-950 / GitHub #176 capture for at least one normal 200 turn.
    Capture 401 and 429 only when safely available. Commit only reviewed,
    scrubbed, fixture-sized JSON.
-3. Keep quarry work as quarry. The stale branch still has useful policy
+5. Keep quarry work as quarry. The stale branch still has useful policy
    and review ideas, but main already supersedes much of its source diff.
-4. Keep `docs/policy/tos-posture-2026-05-05.md` current before public
+6. Keep `docs/policy/tos-posture-2026-05-05.md` current before public
    promotion. Do not market account rotation as unlimited usage or quota
    evasion.
-5. Start the Claude adapter only after Codex Level 3 is recorded or the
+7. Start the Claude adapter only after Codex Level 3 is recorded or the
    Codex blocker is explicitly parked.
 
 ## Definition of Done for This Review

--- a/scripts/smoke-codex-401-propagation.sh
+++ b/scripts/smoke-codex-401-propagation.sh
@@ -119,6 +119,7 @@ assert_grep "proxy_turn 401 classified auth_unauthorized" '"kind":"proxy_turn".*
 assert_grep "proxy_observed_401_codex_handles diagnostic emitted" '"kind":"proxy_observed_401_codex_handles"' "$NDJSON"
 
 assert_no_grep "no swap fired" '"kind":"proxy_post_swap_turn"' "$NDJSON"
+assert_no_grep "no same-turn retry fired" '"kind":"proxy_same_turn_retry"' "$NDJSON"
 assert_no_grep "no quota_exhausted misclassification" '"classification":"quota_exhausted"' "$NDJSON"
 assert_no_grep "claim_level not promoted" '"claim_level":"next_turn_seamless"' "$NDJSON"
 assert_grep "session_ended final_claim_level remains broker_owned" '"kind":"session_ended".*"final_claim_level":"broker_owned"' "$NDJSON"
@@ -157,5 +158,5 @@ else
 fi
 
 echo
-echo "smoke-codex-401-propagation: all 12 assertions passed."
+echo "smoke-codex-401-propagation: all 13 assertions passed."
 echo "  full ndjson: $NDJSON"

--- a/scripts/smoke-codex-acceptance.sh
+++ b/scripts/smoke-codex-acceptance.sh
@@ -20,8 +20,8 @@
 # Asserts the full NDJSON sequence in the status file:
 #   session_started        (account A elected)
 #   proxy_turn 200 ok      (account A, multiple times)
-#   proxy_turn 429 quota_exhausted (account A)
-#   proxy_post_swap_turn   (A -> B, dropped x-codex-turn-state)
+#   proxy_turn 429 quota_exhausted (account A, not delivered to Codex)
+#   proxy_same_turn_retry  (A -> B, dropped x-codex-turn-state)
 #   proxy_turn 200 ok      (account B, claim_level broker_owned)
 #   session_ended          (final_claim_level broker_owned, synthetic_swap_observed true,
 #                           exit_code 0)
@@ -132,7 +132,7 @@ OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
   OMUX_CODEX_SESSION_HOME="$CANONICAL_SESSION_HOME" \
   OMUX_STUB_CANONICAL_SESSION_HOME="$CANONICAL_SESSION_HOME" \
-  OMUX_STUB_CODEX_TURNS=5 \
+  OMUX_STUB_CODEX_TURNS=3 \
   OMUX_STUB_CODEX_PIDFILE="$STUB_PIDFILE" \
   OMUX_STUB_CODEX_REPORT="$STUB_REPORT" \
   "$BIN" codex run --profile codex-max --json-status-file "$NDJSON" 2>"$ADAPTER_STDERR" || {
@@ -168,8 +168,9 @@ assert_grep "session_started reports canonical session bridge" '"session_authori
 assert_grep "session_started redacts session paths" '"session_paths_printed":false' "$NDJSON"
 assert_grep "proxy_turn 200 ok"         '"kind":"proxy_turn".*"status":200.*"classification":"ok"' "$NDJSON"
 assert_grep "proxy_turn 429 quota_exhausted" '"kind":"proxy_turn".*"status":429.*"classification":"quota_exhausted"' "$NDJSON"
-assert_grep "proxy_post_swap_turn fired" '"kind":"proxy_post_swap_turn"'     "$NDJSON"
-assert_grep "post-swap dropped x-codex-turn-state" '"dropped":"x-codex-turn-state"' "$NDJSON"
+assert_grep "quota 429 was not delivered to Codex" '"kind":"proxy_turn".*"status":429.*"delivered_to_codex":false' "$NDJSON"
+assert_grep "proxy_same_turn_retry fired" '"kind":"proxy_same_turn_retry"' "$NDJSON"
+assert_grep "same-turn retry dropped x-codex-turn-state" '"dropped":"x-codex-turn-state"' "$NDJSON"
 assert_grep "claim_level remains broker_owned" '"claim_level":"broker_owned"' "$NDJSON"
 assert_grep "session_ended final_claim_level broker_owned" '"kind":"session_ended".*"final_claim_level":"broker_owned"' "$NDJSON"
 assert_grep "session_ended records synthetic swap" '"kind":"session_ended".*"synthetic_swap_observed":true' "$NDJSON"
@@ -216,6 +217,14 @@ else
     exit 1
 fi
 
+if jq -e 'all(.turns[]; .status == 200)' "$STUB_REPORT" >/dev/null; then
+    echo "  ✓ stub-codex saw only 200 turns; quota 429 stayed inside proxy"
+else
+    echo "  ✗ stub-codex saw a non-200 turn" >&2
+    cat "$STUB_REPORT" >&2
+    exit 1
+fi
+
 UPSTREAM_ACCT_COUNT=$(jq -r .account_id "$UPLOG" 2>/dev/null | sort -u | wc -l | tr -d ' ' || echo 0)
 if [[ "$UPSTREAM_ACCT_COUNT" -ge 2 ]]; then
     echo "  ✓ stub upstream saw 2+ distinct ChatGPT-Account-IDs (proxy substituted both)"
@@ -233,7 +242,7 @@ else
 fi
 
 echo
-echo "smoke-codex-acceptance: all 18 assertions passed."
+echo "smoke-codex-acceptance: all 20 assertions passed."
 echo "  full ndjson: $NDJSON"
 echo "  stub upstream log: $UPLOG"
 echo "  stub codex report: $STUB_REPORT"

--- a/scripts/smoke-codex-all-exhausted.sh
+++ b/scripts/smoke-codex-all-exhausted.sh
@@ -109,7 +109,9 @@ assert_grep "account A had at least one 200 ok" '"kind":"proxy_turn".*"account":
 assert_grep "account B had at least one 200 ok" '"kind":"proxy_turn".*"account":"codex:max-2".*"status":200.*"classification":"ok"' "$NDJSON"
 assert_grep "account A returned 429 quota_exhausted" '"kind":"proxy_turn".*"account":"codex:max-1".*"status":429.*"classification":"quota_exhausted"' "$NDJSON"
 assert_grep "account B returned 429 quota_exhausted" '"kind":"proxy_turn".*"account":"codex:max-2".*"status":429.*"classification":"quota_exhausted"' "$NDJSON"
-assert_grep "proxy_post_swap_turn fired" '"kind":"proxy_post_swap_turn"' "$NDJSON"
+assert_grep "proxy_same_turn_retry fired" '"kind":"proxy_same_turn_retry"' "$NDJSON"
+assert_grep "fallback quota 429 was not delivered before no-account failure" '"kind":"proxy_turn".*"account":"codex:max-2".*"status":429.*"delivered_to_codex":false' "$NDJSON"
+assert_grep "same-turn retry unavailable after all accounts exhausted" '"kind":"proxy_same_turn_retry_unavailable"' "$NDJSON"
 assert_grep "proxy_no_account_selectable event fired" '"kind":"proxy_no_account_selectable"' "$NDJSON"
 
 if grep -q '"kind":"session_started"' "$ADAPTER_STDERR"; then
@@ -139,5 +141,5 @@ fi
 assert_grep "session_ended final_claim_level broker_owned" '"kind":"session_ended".*"final_claim_level":"broker_owned"' "$NDJSON"
 
 echo
-echo "smoke-codex-all-exhausted: all 10 assertions passed."
+echo "smoke-codex-all-exhausted: all 12 assertions passed."
 echo "  full ndjson: $NDJSON"

--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -46,7 +46,8 @@ trap cleanup EXIT
 
 mkdir -p "$TMP/account-A" "$CANONICAL_SESSION_HOME/sessions/2026/05/06" "$CANONICAL_SESSION_HOME/shell_snapshots"
 touch "$CANONICAL_SESSION_HOME/history.jsonl" "$CANONICAL_SESSION_HOME/session_index.jsonl"
-printf '%s\n' '{"fixture":"resume"}' >"$CANONICAL_SESSION_HOME/sessions/2026/05/06/session.jsonl"
+printf '%s\n' '{"fixture":"resume"}' >"$CANONICAL_SESSION_HOME/sessions/2026/05/06/rollout-managed-good-session.jsonl"
+printf '%s\n' '{"bridge":"preexisting"}' >"$CANONICAL_SESSION_HOME/sessions/omux-session-bridge-smoke.jsonl"
 
 ID_TOKEN="h.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9wbGFuX3R5cGUiOiJwcm8ifX0.s"
 cat >"$TMP/account-A/auth.json" <<EOF
@@ -104,6 +105,7 @@ run_case() {
       OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
       OMUX_CODEX_SESSION_HOME="$CANONICAL_SESSION_HOME" \
       OMUX_STUB_CANONICAL_SESSION_HOME="$CANONICAL_SESSION_HOME" \
+      OMUX_STUB_APPEND_SESSION="sessions/2026/05/06/rollout-managed-good-session.jsonl" \
       OMUX_STUB_CODEX_TURNS=0 \
       OMUX_STUB_CODEX_REPORT="$report" \
       "${cmd[@]}" 2>"$stderr"
@@ -121,6 +123,9 @@ run_case() {
 
     assert_grep "$label session_started" '"kind":"session_started"' "$ndjson"
     assert_grep "$label canonical session bridge" '"session_authority":"canonical_bridge"' "$ndjson"
+    assert_grep "$label resume preflight" '"kind":"resume_preflight"' "$ndjson"
+    assert_grep "$label resume writeback" '"kind":"resume_writeback".*"changed_existing":[1-9]' "$ndjson"
+    assert_grep "$label resume status redacts paths" '"kind":"resume_writeback".*"session_id_printed":false,"path_printed":false' "$ndjson"
     assert_grep "$label session_ended" '"kind":"session_ended".*"exit_code":0' "$ndjson"
 
     if grep -q '"kind":"session_started"' "$stderr"; then
@@ -147,6 +152,15 @@ run_case() {
         echo "  ✓ $label bridged canonical session authority"
     else
         echo "  ✗ $label session bridge failed" >&2
+        cat "$report" >&2
+        exit 1
+    fi
+
+    if [[ "$(jq -r .session_append.checked "$report")" == "true" \
+          && "$(jq -r .session_append.path_printed "$report")" == "false" ]]; then
+        echo "  ✓ $label appended through bridged session authority"
+    else
+        echo "  ✗ $label session append evidence failed" >&2
         cat "$report" >&2
         exit 1
     fi

--- a/scripts/smoke-codex-tier-insufficient.sh
+++ b/scripts/smoke-codex-tier-insufficient.sh
@@ -122,6 +122,7 @@ assert_grep "proxy_turn 200 ok at least once" '"kind":"proxy_turn".*"status":200
 assert_grep "proxy_turn 429 classified tier_insufficient" '"kind":"proxy_turn".*"status":429.*"classification":"tier_insufficient"' "$NDJSON"
 
 assert_no_grep "no swap fired" '"kind":"proxy_post_swap_turn"' "$NDJSON"
+assert_no_grep "no same-turn retry fired" '"kind":"proxy_same_turn_retry"' "$NDJSON"
 assert_no_grep "no quota_exhausted misclassification" '"classification":"quota_exhausted"' "$NDJSON"
 assert_no_grep "claim_level not promoted" '"claim_level":"next_turn_seamless"' "$NDJSON"
 assert_grep "session_ended final_claim_level remains broker_owned" '"kind":"session_ended".*"final_claim_level":"broker_owned"' "$NDJSON"
@@ -152,5 +153,5 @@ else
 fi
 
 echo
-echo "smoke-codex-tier-insufficient: all 10 assertions passed."
+echo "smoke-codex-tier-insufficient: all 11 assertions passed."
 echo "  full ndjson: $NDJSON"

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -28,6 +28,10 @@ Env (set by the smoke harness):
   OMUX_STUB_CODEX_AUTH_TOKENS — optional comma-separated bearer tokens to
                             send through Authorization, one per turn. The
                             last token is reused when turns exceed entries.
+  OMUX_STUB_APPEND_SESSION — optional path relative to CODEX_HOME to append
+                            a redacted marker to. Used by resume smokes to
+                            prove the managed session authority receives
+                            child writes.
   The report records argv after the stub binary so CLI forwarding smokes can
   assert `oauth-mux codex ...` command shape without provider traffic.
 """
@@ -127,6 +131,20 @@ def _session_bridge_report(codex_home: Path) -> dict:
     }
 
 
+def _append_session_marker(codex_home: Path) -> dict:
+    rel = os.environ.get("OMUX_STUB_APPEND_SESSION")
+    if not rel:
+        return {"checked": False}
+    target = codex_home / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps({"stub_resume_write": True, "argv_len": len(sys.argv) - 1}) + "\n")
+    return {
+        "checked": True,
+        "path_printed": False,
+    }
+
+
 def main() -> int:
     pid = os.getpid()
     pidfile = Path(os.environ.get("OMUX_STUB_CODEX_PIDFILE", "/tmp/omux-stub-codex.pid"))
@@ -138,6 +156,7 @@ def main() -> int:
     codex_home = Path(os.environ["CODEX_HOME"])
     proxy_url = _read_proxy_url(codex_home)
     session_bridge = _session_bridge_report(codex_home)
+    session_append = _append_session_marker(codex_home)
 
     started_at = time.time()
     print(
@@ -168,6 +187,7 @@ def main() -> int:
         "codex_home_path_printed": False,
         "active_account_at_start": os.environ.get("OMUX_ACTIVE_ACCOUNT"),
         "session_bridge": session_bridge,
+        "session_append": session_append,
     }
     report_path.write_text(json.dumps(report, indent=2))
     print(f"stub-codex: pid_stable={report['pid_stable']} turns={turns}", file=sys.stderr, flush=True)

--- a/scripts/test-stub-upstream.py
+++ b/scripts/test-stub-upstream.py
@@ -33,11 +33,9 @@ This is enough for the proxy to:
   1. classify 200 as ok for the elected account
   2. classify 429+usage_limit_reached as quota_exhausted
   3. mark that account in the pool
-  4. on next request, elect a different account (the broker's
-     account/swap semantics)
-  5. proxy_post_swap_turn fires (proxy notices account change,
-     drops x-codex-turn-state)
-  6. that next request lands on the new account at the stub
+  4. elect a different account immediately when one is selectable
+  5. proxy_same_turn_retry fires and drops x-codex-turn-state
+  6. the retried request lands on the new account at the stub
   7. stub sees the new account_id, returns 200 (per-account counter)
 
 The harness asserts the NDJSON status frames on stderr from

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -76,6 +76,71 @@ const SessionAuthorityMode = enum {
 const SessionCodexHome = struct {
     path: []u8,
     session_authority: SessionAuthorityMode,
+    authority_home: ?[]u8 = null,
+
+    fn deinit(self: SessionCodexHome, allocator: std.mem.Allocator) void {
+        std.fs.cwd().deleteTree(self.path) catch {};
+        allocator.free(self.path);
+        if (self.authority_home) |home| allocator.free(home);
+    }
+};
+
+const ResumeMode = enum {
+    none,
+    chooser,
+    last,
+    explicit,
+
+    fn toString(self: ResumeMode) []const u8 {
+        return switch (self) {
+            .none => "none",
+            .chooser => "chooser",
+            .last => "last",
+            .explicit => "explicit",
+        };
+    }
+};
+
+const ResumeRequest = struct {
+    mode: ResumeMode = .none,
+    explicit_id: ?[]const u8 = null,
+
+    fn requested(self: ResumeRequest) bool {
+        return self.mode != .none;
+    }
+};
+
+const RolloutEntry = struct {
+    size: u64,
+    mtime: i128,
+};
+
+const RolloutSnapshot = struct {
+    allocator: std.mem.Allocator,
+    entries: std.StringHashMapUnmanaged(RolloutEntry) = .{},
+
+    fn init(allocator: std.mem.Allocator) RolloutSnapshot {
+        return .{ .allocator = allocator };
+    }
+
+    fn deinit(self: *RolloutSnapshot) void {
+        var it = self.entries.keyIterator();
+        while (it.next()) |key| self.allocator.free(key.*);
+        self.entries.deinit(self.allocator);
+    }
+
+    fn count(self: *const RolloutSnapshot) usize {
+        return self.entries.count();
+    }
+};
+
+const ResumeObservation = struct {
+    rollouts_before: usize = 0,
+    rollouts_after: usize = 0,
+    changed_existing: usize = 0,
+    created: usize = 0,
+    explicit_target_found_before: ?bool = null,
+    explicit_target_changed: ?bool = null,
 };
 
 const SessionAuthorityEntryKind = enum {
@@ -215,9 +280,15 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         opts.session_home,
         opts.isolated_session_store,
     );
-    defer {
-        std.fs.cwd().deleteTree(codex_home.path) catch {};
-        allocator.free(codex_home.path);
+    defer codex_home.deinit(allocator);
+
+    const resume_request = detectResumeRequest(opts.forward_argv);
+    var resume_snapshot: ?RolloutSnapshot = null;
+    defer if (resume_snapshot) |*snapshot| snapshot.deinit();
+    if (resume_request.requested()) {
+        if (codex_home.authority_home) |authority_home| {
+            resume_snapshot = try snapshotRollouts(allocator, authority_home);
+        }
     }
 
     if (emit_status) {
@@ -225,6 +296,15 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
             "{{\"kind\":\"session_started\",\"adapter\":\"codex\",\"selected_account\":\"{s}\",\"codex_home_path_printed\":false,\"proxy_port\":{d},\"claim_level\":\"broker_owned\",\"auth_authority\":\"mux_owned_overlay\",\"managed_config\":\"mux_owned_overlay\",\"session_authority\":\"{s}\",\"session_paths_printed\":false}}\n",
             .{ elected.id, proxy_port, codex_home.session_authority.toString() },
         );
+        if (resume_request.requested()) {
+            try writeResumePreflightStatus(
+                status_writer,
+                resume_request,
+                codex_home.session_authority,
+                if (resume_snapshot) |*snapshot| snapshot.count() else 0,
+                if (resume_snapshot) |*snapshot| findExplicitResumeTarget(snapshot, resume_request.explicit_id) != null else null,
+            );
+        }
     }
 
     // 6. Build argv: `codex` plus any forwarded user args.
@@ -281,6 +361,13 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     proxy_thread.join();
 
     if (emit_status) {
+        if (resume_request.requested()) {
+            const observation = if (codex_home.authority_home) |authority_home|
+                try observeResumeWriteback(allocator, authority_home, if (resume_snapshot) |*snapshot| snapshot else null, resume_request)
+            else
+                ResumeObservation{};
+            try writeResumeWritebackStatus(status_writer, resume_request, codex_home.session_authority, observation);
+        }
         const exit_code: i32 = switch (term) {
             .Exited => |c| c,
             else => -1,
@@ -382,6 +469,7 @@ fn createSessionCodexHomeUnder(
     return .{
         .path = session_home,
         .session_authority = session_authority,
+        .authority_home = if (session_authority_home) |home| try allocator.dupe(u8, home) else null,
     };
 }
 
@@ -439,6 +527,168 @@ fn ensureFileExists(path: []const u8) !void {
         else => return e,
     };
     file.close();
+}
+
+fn detectResumeRequest(argv: []const []const u8) ResumeRequest {
+    var i: usize = 0;
+    while (i < argv.len) : (i += 1) {
+        if (!std.mem.eql(u8, argv[i], "resume")) continue;
+        if (i + 1 >= argv.len) return .{ .mode = .chooser };
+        const next = argv[i + 1];
+        if (std.mem.eql(u8, next, "--last") or std.mem.eql(u8, next, "-l")) {
+            return .{ .mode = .last };
+        }
+        if (std.mem.startsWith(u8, next, "-")) {
+            return .{ .mode = .chooser };
+        }
+        return .{ .mode = .explicit, .explicit_id = next };
+    }
+    return .{};
+}
+
+fn snapshotRollouts(allocator: std.mem.Allocator, authority_home: []const u8) !RolloutSnapshot {
+    var snapshot = RolloutSnapshot.init(allocator);
+    errdefer snapshot.deinit();
+    const sessions_dir = try std.fs.path.join(allocator, &.{ authority_home, "sessions" });
+    defer allocator.free(sessions_dir);
+    try snapshotRolloutsUnder(allocator, sessions_dir, &snapshot);
+    return snapshot;
+}
+
+fn snapshotRolloutsUnder(
+    allocator: std.mem.Allocator,
+    dir_path: []const u8,
+    snapshot: *RolloutSnapshot,
+) !void {
+    var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch |e| switch (e) {
+        error.FileNotFound => return,
+        else => return e,
+    };
+    defer dir.close();
+
+    var it = dir.iterate();
+    while (try it.next()) |entry| {
+        const path = try std.fs.path.join(allocator, &.{ dir_path, entry.name });
+        defer allocator.free(path);
+        switch (entry.kind) {
+            .directory => try snapshotRolloutsUnder(allocator, path, snapshot),
+            .file, .sym_link => {
+                if (!std.mem.endsWith(u8, entry.name, ".jsonl")) continue;
+                const stat = std.fs.cwd().statFile(path) catch continue;
+                const owned_path = try allocator.dupe(u8, path);
+                errdefer allocator.free(owned_path);
+                try snapshot.entries.put(allocator, owned_path, .{
+                    .size = stat.size,
+                    .mtime = stat.mtime,
+                });
+            },
+            else => {},
+        }
+    }
+}
+
+fn findExplicitResumeTarget(snapshot: *const RolloutSnapshot, explicit_id: ?[]const u8) ?[]const u8 {
+    const id = explicit_id orelse return null;
+    var it = snapshot.entries.keyIterator();
+    while (it.next()) |path| {
+        if (std.mem.indexOf(u8, path.*, id) != null) return path.*;
+    }
+    return null;
+}
+
+fn observeResumeWriteback(
+    allocator: std.mem.Allocator,
+    authority_home: []const u8,
+    before: ?*const RolloutSnapshot,
+    request: ResumeRequest,
+) !ResumeObservation {
+    var after = try snapshotRollouts(allocator, authority_home);
+    defer after.deinit();
+
+    var observation = ResumeObservation{
+        .rollouts_before = if (before) |snapshot| snapshot.count() else 0,
+        .rollouts_after = after.count(),
+        .explicit_target_found_before = if (request.explicit_id != null and before != null)
+            findExplicitResumeTarget(before.?, request.explicit_id) != null
+        else
+            null,
+        .explicit_target_changed = if (request.explicit_id != null) false else null,
+    };
+
+    var it = after.entries.iterator();
+    while (it.next()) |after_entry| {
+        if (before) |snapshot| {
+            if (snapshot.entries.get(after_entry.key_ptr.*)) |before_entry| {
+                const changed = before_entry.size != after_entry.value_ptr.size or
+                    before_entry.mtime != after_entry.value_ptr.mtime;
+                if (changed) {
+                    observation.changed_existing += 1;
+                    if (request.explicit_id) |id| {
+                        if (std.mem.indexOf(u8, after_entry.key_ptr.*, id) != null) {
+                            observation.explicit_target_changed = true;
+                        }
+                    }
+                }
+            } else {
+                observation.created += 1;
+            }
+        } else {
+            observation.created += 1;
+        }
+    }
+
+    return observation;
+}
+
+fn writeOptionalBool(writer: anytype, value: ?bool) !void {
+    if (value) |v| {
+        try writer.writeAll(if (v) "true" else "false");
+    } else {
+        try writer.writeAll("null");
+    }
+}
+
+fn writeResumePreflightStatus(
+    writer: anytype,
+    request: ResumeRequest,
+    authority: SessionAuthorityMode,
+    rollouts_before: usize,
+    explicit_target_found_before: ?bool,
+) !void {
+    try writer.print(
+        "{{\"kind\":\"resume_preflight\",\"mode\":\"{s}\",\"session_authority\":\"{s}\",\"rollouts_before\":{d},\"explicit_id_provided\":{s},\"explicit_target_found_before\":",
+        .{
+            request.mode.toString(),
+            authority.toString(),
+            rollouts_before,
+            if (request.explicit_id != null) "true" else "false",
+        },
+    );
+    try writeOptionalBool(writer, explicit_target_found_before);
+    try writer.writeAll(",\"session_id_printed\":false,\"path_printed\":false}\n");
+}
+
+fn writeResumeWritebackStatus(
+    writer: anytype,
+    request: ResumeRequest,
+    authority: SessionAuthorityMode,
+    observation: ResumeObservation,
+) !void {
+    try writer.print(
+        "{{\"kind\":\"resume_writeback\",\"mode\":\"{s}\",\"session_authority\":\"{s}\",\"rollouts_before\":{d},\"rollouts_after\":{d},\"changed_existing\":{d},\"created\":{d},\"explicit_target_found_before\":",
+        .{
+            request.mode.toString(),
+            authority.toString(),
+            observation.rollouts_before,
+            observation.rollouts_after,
+            observation.changed_existing,
+            observation.created,
+        },
+    );
+    try writeOptionalBool(writer, observation.explicit_target_found_before);
+    try writer.writeAll(",\"explicit_target_changed\":");
+    try writeOptionalBool(writer, observation.explicit_target_changed);
+    try writer.writeAll(",\"session_id_printed\":false,\"path_printed\":false}\n");
 }
 
 fn copyFileContents(
@@ -520,6 +770,63 @@ test "openStatusFile property: nested parents are created" {
     }
 }
 
+test "detectResumeRequest classifies forwarded Codex resume shapes" {
+    const none = detectResumeRequest(&.{ "--model", "gpt-5.5" });
+    try std.testing.expectEqual(ResumeMode.none, none.mode);
+
+    const chooser = detectResumeRequest(&.{"resume"});
+    try std.testing.expectEqual(ResumeMode.chooser, chooser.mode);
+
+    const last = detectResumeRequest(&.{ "--no-alt-screen", "resume", "--last" });
+    try std.testing.expectEqual(ResumeMode.last, last.mode);
+
+    const short_last = detectResumeRequest(&.{ "resume", "-l" });
+    try std.testing.expectEqual(ResumeMode.last, short_last.mode);
+
+    const explicit = detectResumeRequest(&.{ "resume", "019dea53-49a0-7890-9580-e88decb97af0" });
+    try std.testing.expectEqual(ResumeMode.explicit, explicit.mode);
+    try std.testing.expectEqualStrings("019dea53-49a0-7890-9580-e88decb97af0", explicit.explicit_id.?);
+}
+
+test "resume writeback observation reports existing rollout changes without printing paths" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("canonical/sessions/2026/05/06");
+    {
+        const rollout = try tmp.dir.createFile("canonical/sessions/2026/05/06/rollout-managed-good-session.jsonl", .{ .mode = 0o600 });
+        defer rollout.close();
+        try rollout.writeAll("{\"fixture\":true}\n");
+    }
+
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
+    defer std.testing.allocator.free(canonical_path);
+    const rollout_path = try std.fs.path.join(std.testing.allocator, &.{ canonical_path, "sessions", "2026", "05", "06", "rollout-managed-good-session.jsonl" });
+    defer std.testing.allocator.free(rollout_path);
+
+    var before = try snapshotRollouts(std.testing.allocator, canonical_path);
+    defer before.deinit();
+    try std.testing.expectEqual(@as(usize, 1), before.count());
+
+    {
+        const rollout = try std.fs.cwd().openFile(rollout_path, .{ .mode = .write_only });
+        defer rollout.close();
+        try rollout.seekFromEnd(0);
+        try rollout.writeAll("{\"managed\":true}\n");
+    }
+
+    const request = ResumeRequest{ .mode = .explicit, .explicit_id = "managed-good-session" };
+    const observation = try observeResumeWriteback(std.testing.allocator, canonical_path, &before, request);
+    try std.testing.expectEqual(@as(usize, 1), observation.rollouts_before);
+    try std.testing.expectEqual(@as(usize, 1), observation.rollouts_after);
+    try std.testing.expectEqual(@as(usize, 1), observation.changed_existing);
+    try std.testing.expectEqual(@as(usize, 0), observation.created);
+    try std.testing.expectEqual(true, observation.explicit_target_found_before.?);
+    try std.testing.expectEqual(true, observation.explicit_target_changed.?);
+}
+
 test "createSessionCodexHomeUnder copies auth and does not clobber source config" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -547,10 +854,7 @@ test "createSessionCodexHomeUnder copies auth and does not clobber source config
     defer std.testing.allocator.free(auth_path);
 
     const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null);
-    defer {
-        std.fs.cwd().deleteTree(codex_home.path) catch {};
-        std.testing.allocator.free(codex_home.path);
-    }
+    defer codex_home.deinit(std.testing.allocator);
     try std.testing.expectEqual(SessionAuthorityMode.isolated, codex_home.session_authority);
 
     const session_auth = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "auth.json" });
@@ -607,10 +911,7 @@ test "createSessionCodexHomeUnder bridges canonical session authority without co
     defer std.testing.allocator.free(canonical_path);
 
     const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, canonical_path);
-    defer {
-        std.fs.cwd().deleteTree(codex_home.path) catch {};
-        std.testing.allocator.free(codex_home.path);
-    }
+    defer codex_home.deinit(std.testing.allocator);
     try std.testing.expectEqual(SessionAuthorityMode.canonical_bridge, codex_home.session_authority);
 
     var link_buf: [std.fs.max_path_bytes]u8 = undefined;

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -217,8 +217,6 @@ pub const Proxy = struct {
         var out_headers = HeaderList.init(a);
         try copyForwardingHeaders(&req.headers, &out_headers);
         const preserved_child_auth = try setOutboundAuthHeaders(a, &req.headers, &out_headers, tokens);
-        const host_for_header = upstreamHost(a);
-        try out_headers.set("Host", host_for_header);
         if (preserved_child_auth) {
             self.logEvent("proxy_preserved_child_auth", .{
                 .account = elected.id,
@@ -263,8 +261,11 @@ pub const Proxy = struct {
         };
         self.logEvent("proxy_turn", .{
             .account = elected.id,
+            .method = req.method,
+            .path_kind = pathKind(req.path),
             .status = status_and_class.status,
             .classification = @tagName(status_and_class.classification.kind),
+            .body_class = status_and_class.body_class orelse "none",
             .claim_level = self.peak_claim.toString(),
             .streamed = status_and_class.streamed,
         });
@@ -494,16 +495,28 @@ fn readChunked(a: std.mem.Allocator, reader: anytype) ![]u8 {
     return try out.toOwnedSlice(a);
 }
 
-/// Forward selected headers from inbound to outbound; drop hop-by-hop
-/// headers and the three we substitute. Per RFC 7230 §6.1, hop-by-hop
-/// headers MUST NOT be forwarded by intermediaries.
+/// Forward selected headers from inbound to outbound. Drop hop-by-hop
+/// headers, the three account-bound headers we substitute, and wire
+/// framing headers owned by std.http.Client (Host, Content-Length,
+/// Transfer-Encoding). Per RFC 7230 §6.1, hop-by-hop headers MUST NOT
+/// be forwarded by intermediaries.
 fn copyForwardingHeaders(in: *const HeaderList, out: *HeaderList) !void {
     const skip_substituted = [_][]const u8{
-        "authorization",       "chatgpt-account-id", "x-openai-fedramp",
+        "authorization",
+        "chatgpt-account-id",
+        "x-openai-fedramp",
+        // std.http.Client owns request framing:
+        "host",
+        "content-length",
         // hop-by-hop:
-        "connection",          "keep-alive",         "proxy-authenticate",
-        "proxy-authorization", "te",                 "trailers",
-        "transfer-encoding",   "upgrade",            "host",
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
     };
     outer: for (in.items.items) |h| {
         for (skip_substituted) |s| {
@@ -558,6 +571,9 @@ fn shouldPreserveChildAuth(
 const StatusAndClassification = struct {
     status: u16,
     classification: Classification,
+    /// Redacted body classification for non-2xx diagnostic evidence.
+    /// Never contains raw response bytes.
+    body_class: ?[]const u8 = null,
     /// True if the body was streamed verbatim to the client (no buffer);
     /// false if it was buffered for classification (429 path) or never
     /// arrived (early failure).
@@ -624,12 +640,53 @@ fn forwardAndStream(
         defer a.free(body);
         const classification = classify(a, status_u16, body);
         try writeBufferedResponse(client_writer, http_req.response, body);
-        return .{ .status = status_u16, .classification = classification, .streamed = false };
+        return .{
+            .status = status_u16,
+            .classification = classification,
+            .body_class = classification.body_class orelse classifyHttpErrorBody(body),
+            .streamed = false,
+        };
+    }
+
+    if (status_u16 >= 400 and status_u16 < 500 and status_u16 != 401) {
+        const body = try http_req.reader().readAllAlloc(a, 64 * 1024);
+        defer a.free(body);
+        const classification = classify(a, status_u16, body);
+        try writeBufferedResponse(client_writer, http_req.response, body);
+        return .{
+            .status = status_u16,
+            .classification = classification,
+            .body_class = classifyHttpErrorBody(body),
+            .streamed = false,
+        };
     }
 
     const classification = classify(a, status_u16, &.{});
     try writeStreamedResponse(client_writer, http_req.response, http_req.reader());
     return .{ .status = status_u16, .classification = classification, .streamed = true };
+}
+
+fn pathKind(path: []const u8) []const u8 {
+    if (std.mem.eql(u8, path, "/backend-api/codex/responses")) return "responses";
+    if (std.mem.startsWith(u8, path, "/backend-api/codex/responses?")) return "responses";
+    if (std.mem.eql(u8, path, "/backend-api/codex/responses/compact")) return "responses_compact";
+    if (std.mem.startsWith(u8, path, "/backend-api/codex/responses/compact?")) return "responses_compact";
+    if (std.mem.indexOf(u8, path, "/backend-api/codex/memories/trace_summarize") != null) return "memories_trace_summarize";
+    if (std.mem.indexOf(u8, path, "responses_websockets") != null) return "responses_websocket";
+    if (std.mem.startsWith(u8, path, "/backend-api/codex/")) return "codex_other";
+    return "unknown";
+}
+
+fn classifyHttpErrorBody(body: []const u8) []const u8 {
+    if (body.len == 0) return "empty";
+    if (std.mem.indexOf(u8, body, "cloudflare") != null) {
+        if (std.mem.indexOf(u8, body, "400 Bad Request") != null) return "cloudflare_bad_request";
+        if (std.mem.indexOf(u8, body, "403 Forbidden") != null) return "cloudflare_forbidden";
+        return "cloudflare_html";
+    }
+    if (std.mem.indexOf(u8, body, "\"error\"") != null) return "json_error";
+    if (std.mem.indexOf(u8, body, "<html") != null or std.mem.indexOf(u8, body, "<!DOCTYPE html") != null) return "html_error";
+    return "other";
 }
 
 fn parseMethod(s: []const u8) std.http.Method {
@@ -766,6 +823,28 @@ test "classify 200 OK -> .ok" {
 test "classify 401 -> auth_unauthorized" {
     const c = classify(std.testing.allocator, 401, "{}");
     try std.testing.expectEqual(broker_types.QuotaKind.auth_unauthorized, c.kind);
+}
+
+test "pathKind redacts Codex endpoint paths into stable classes" {
+    try std.testing.expectEqualStrings("responses", pathKind("/backend-api/codex/responses"));
+    try std.testing.expectEqualStrings("responses", pathKind("/backend-api/codex/responses?after=1"));
+    try std.testing.expectEqualStrings("responses_compact", pathKind("/backend-api/codex/responses/compact"));
+    try std.testing.expectEqualStrings("responses_compact", pathKind("/backend-api/codex/responses/compact?after=1"));
+    try std.testing.expectEqualStrings("memories_trace_summarize", pathKind("/backend-api/codex/memories/trace_summarize"));
+    try std.testing.expectEqualStrings("codex_other", pathKind("/backend-api/codex/unknown/shape"));
+    try std.testing.expectEqualStrings("unknown", pathKind("/not-codex"));
+}
+
+test "classifyHttpErrorBody identifies Cloudflare 400 without exposing body" {
+    const body =
+        \\<html>
+        \\<head><title>400 Bad Request</title></head>
+        \\<body><center><h1>400 Bad Request</h1></center><hr><center>cloudflare</center></body>
+        \\</html>
+    ;
+    try std.testing.expectEqualStrings("cloudflare_bad_request", classifyHttpErrorBody(body));
+    try std.testing.expectEqualStrings("json_error", classifyHttpErrorBody("{\"error\":{\"type\":\"x\"}}"));
+    try std.testing.expectEqualStrings("empty", classifyHttpErrorBody(""));
 }
 
 test "shouldPreserveChildAuth preserves refreshed bearer for same elected account only" {
@@ -931,10 +1010,11 @@ test "copyForwardingHeaders property: 50 random header sets preserve load-bearin
     // x-codex-installation-id, x-codex-turn-state, x-codex-turn-metadata,
     // OpenAI-Beta, traceparent, tracestate) MUST always survive
     // copyForwardingHeaders. The three substituted (Authorization,
-    // ChatGPT-Account-ID, X-OpenAI-Fedramp) and the hop-by-hop set
-    // MUST always be dropped. Catches the regression where someone
-    // adds a new "drop" rule that accidentally matches a load-bearing
-    // header by case-insensitive prefix.
+    // ChatGPT-Account-ID, X-OpenAI-Fedramp), proxy-owned framing
+    // headers, and the hop-by-hop set MUST always be dropped. Catches
+    // the regression where someone adds a new "drop" rule that
+    // accidentally matches a load-bearing header by case-insensitive
+    // prefix.
     var prng = std.Random.DefaultPrng.init(0xBEEF1234);
     const r = prng.random();
 
@@ -953,6 +1033,7 @@ test "copyForwardingHeaders property: 50 random header sets preserve load-bearin
         "ChatGPT-Account-ID",
         "X-OpenAI-Fedramp",
         "Connection",
+        "Content-Length",
         "Transfer-Encoding",
         "Host",
         "Keep-Alive",
@@ -967,7 +1048,7 @@ test "copyForwardingHeaders property: 50 random header sets preserve load-bearin
 
         // Always include all 8 load-bearing.
         for (load_bearing) |h| try in.append(h, "x");
-        // Always include all 8 must-drop.
+        // Always include all must-drop headers.
         for (must_drop) |h| try in.append(h, "y");
         // Add 0..3 noise headers.
         const noise_count = r.uintLessThan(usize, noise.len + 1);
@@ -1012,6 +1093,7 @@ test "copyForwardingHeaders preserves the load-bearing 8 + drops hop-by-hop" {
     try in.append("ChatGPT-Account-ID", "leaked");
     try in.append("X-OpenAI-Fedramp", "true");
     try in.append("Connection", "keep-alive");
+    try in.append("Content-Length", "123");
     try in.append("Transfer-Encoding", "chunked");
     try in.append("Host", "example");
 
@@ -1036,6 +1118,7 @@ test "copyForwardingHeaders preserves the load-bearing 8 + drops hop-by-hop" {
 
     // hop-by-hop are dropped
     try std.testing.expect(out.find("Connection") == null);
+    try std.testing.expect(out.find("Content-Length") == null);
     try std.testing.expect(out.find("Transfer-Encoding") == null);
     try std.testing.expect(out.find("Host") == null);
 }

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -29,10 +29,11 @@
 //!   5. Classify the response (200 / 401 / 429+usage_limit_reached /
 //!      429+usage_not_included / other-429 / 5xx).
 //!   6. Report quota/observe to the broker pool. On
-//!      quota_exhausted, mark the current account exhausted —
-//!      the NEXT request from codex will go to a fresh account
-//!      (synthetic between-turn swap evidence in this slice).
-//!   7. Stream the response body verbatim back to codex (SSE works
+//!      quota_exhausted, mark the current account exhausted, elect a
+//!      fallback immediately, drop the sticky turn-state header, and retry
+//!      the same request before writing the response to codex. If no fallback
+//!      is selectable, return the buffered failure.
+//!   7. Stream the final response body verbatim back to codex (SSE works
 //!      because chunked-transfer is forwarded byte-for-byte).
 //!
 //! Phase 2 scope (honestly labelled limitations):
@@ -46,12 +47,12 @@
 //!   - No WebSocket upgrade support; if codex requests a WS upgrade
 //!     we propagate the upstream's response (which on `chatgpt.com`
 //!     is HTTP 426 / falls back to chunked). Phase 2.2 adds WS.
-//!   - Path (a) silent in-flight swap is intentionally NOT done
-//!     (likely blocked by per-sub server-side thread state — see
-//!     codex-adapter-contract §3 reality-check decision). Between-turn
-//!     swap with x-codex-turn-state dropped on the post-swap turn
-//!     IS done; in synthetic tests this demonstrates the structural
-//!     next-turn swap path without making a live provider claim.
+//!   - Same-turn retry is attempted for buffered 429 `usage_limit_reached`
+//!     responses before any bytes are written to codex. The retry drops
+//!     `x-codex-turn-state` because that token is likely tied to the previous
+//!     account's server-side state. Synthetic tests prove the structure; live
+//!     provider-originated quota proof is still required before promoting the
+//!     runtime claim level.
 
 const std = @import("std");
 const broker_types = @import("../../broker/types.zig");
@@ -215,8 +216,7 @@ pub const Proxy = struct {
 
         // ── 3. Build outbound request with substituted headers ──
         var out_headers = HeaderList.init(a);
-        try copyForwardingHeaders(&req.headers, &out_headers);
-        const preserved_child_auth = try setOutboundAuthHeaders(a, &req.headers, &out_headers, tokens);
+        const preserved_child_auth = try buildOutboundHeaders(a, &req, &out_headers, tokens, false);
         if (preserved_child_auth) {
             self.logEvent("proxy_preserved_child_auth", .{
                 .account = elected.id,
@@ -249,7 +249,7 @@ pub const Proxy = struct {
         // fixed. We don't transform the body.
 
         // ── 4. Forward to upstream + stream/buffer response ────
-        const status_and_class = forwardAndStream(a, req, out_headers, writer) catch |err| {
+        var status_and_class = forwardAndStream(a, req, out_headers, writer) catch |err| {
             self.logEvent("proxy_upstream_failed", .{ .account = elected.id, .err = @errorName(err) });
             try writeStatus(writer, 502, "Upstream Error");
             return;
@@ -259,8 +259,73 @@ pub const Proxy = struct {
         self.applyClassification(elected.id, status_and_class.classification) catch |err| {
             self.logEvent("proxy_apply_classification_failed", .{ .err = @errorName(err) });
         };
+        self.logProxyTurn(elected.id, req, status_and_class, status_and_class.buffered_response == null);
+
+        var final_account = elected.id;
+
+        if (status_and_class.classification.kind == .quota_exhausted) same_turn_retry: {
+            const fallback = self.pool.elect(self.profile, null, &.{elected.id}) catch |err| {
+                self.logEvent("proxy_same_turn_retry_unavailable", .{
+                    .from = elected.id,
+                    .err = @errorName(err),
+                });
+                break :same_turn_retry;
+            };
+
+            var fallback_tokens = self.materializer.materialize_chatgpt(
+                self.materializer.ctx,
+                a,
+                fallback.id,
+            ) catch |err| {
+                self.logEvent("proxy_same_turn_materialize_failed", .{
+                    .from = elected.id,
+                    .to = fallback.id,
+                    .err = @errorName(err),
+                });
+                break :same_turn_retry;
+            };
+            _ = &fallback_tokens;
+
+            var retry_headers = HeaderList.init(a);
+            _ = try buildOutboundHeaders(a, &req, &retry_headers, fallback_tokens, true);
+            self.logEvent("proxy_same_turn_retry", .{
+                .from = elected.id,
+                .to = fallback.id,
+                .reason = "quota_exhausted",
+                .dropped = "x-codex-turn-state",
+            });
+            self.synthetic_swap_seen = true;
+
+            status_and_class = forwardAndStream(a, req, retry_headers, writer) catch |err| {
+                self.logEvent("proxy_upstream_failed", .{ .account = fallback.id, .err = @errorName(err) });
+                try writeStatus(writer, 502, "Upstream Error");
+                return;
+            };
+            self.applyClassification(fallback.id, status_and_class.classification) catch |err| {
+                self.logEvent("proxy_apply_classification_failed", .{ .err = @errorName(err) });
+            };
+            self.logProxyTurn(fallback.id, req, status_and_class, status_and_class.buffered_response == null);
+            final_account = fallback.id;
+        }
+
+        if (status_and_class.buffered_response) |buffered| {
+            try writeBufferedStoredResponse(writer, buffered);
+        }
+
+        // Track previous_account for next-request swap detection.
+        if (self.previous_account) |old| self.allocator.free(old);
+        self.previous_account = self.allocator.dupe(u8, final_account) catch null;
+    }
+
+    fn logProxyTurn(
+        self: *Proxy,
+        account_id: []const u8,
+        req: Request,
+        status_and_class: StatusAndClassification,
+        delivered_to_codex: bool,
+    ) void {
         self.logEvent("proxy_turn", .{
-            .account = elected.id,
+            .account = account_id,
             .method = req.method,
             .path_kind = pathKind(req.path),
             .status = status_and_class.status,
@@ -268,11 +333,8 @@ pub const Proxy = struct {
             .body_class = status_and_class.body_class orelse "none",
             .claim_level = self.peak_claim.toString(),
             .streamed = status_and_class.streamed,
+            .delivered_to_codex = delivered_to_codex,
         });
-
-        // Track previous_account for next-request swap detection.
-        if (self.previous_account) |old| self.allocator.free(old);
-        self.previous_account = self.allocator.dupe(u8, elected.id) catch null;
     }
 
     fn applyClassification(
@@ -566,7 +628,26 @@ fn shouldPreserveChildAuth(
     return std.mem.eql(u8, account_id, elected_account_id);
 }
 
+fn buildOutboundHeaders(
+    a: std.mem.Allocator,
+    req: *const Request,
+    out: *HeaderList,
+    tokens: broker_types.ChatgptAuthTokens,
+    drop_turn_state: bool,
+) !bool {
+    try copyForwardingHeaders(&req.headers, out);
+    const preserved_child_auth = try setOutboundAuthHeaders(a, &req.headers, out, tokens);
+    if (drop_turn_state) out.remove("x-codex-turn-state");
+    return preserved_child_auth;
+}
+
 // ── Forwarding + streaming (uses std.http.Client for TLS) ────────────
+
+const BufferedResponse = struct {
+    status: u16,
+    headers: HeaderList,
+    body: []const u8,
+};
 
 const StatusAndClassification = struct {
     status: u16,
@@ -578,6 +659,10 @@ const StatusAndClassification = struct {
     /// false if it was buffered for classification (429 path) or never
     /// arrived (early failure).
     streamed: bool,
+    /// Present when the response was buffered and has not yet been written to
+    /// Codex. The caller may retry first, then write this only if recovery is
+    /// unavailable or the retry also fails with a buffered response.
+    buffered_response: ?BufferedResponse = null,
 };
 
 /// Forward the inbound request to chatgpt.com and write the response
@@ -637,27 +722,33 @@ fn forwardAndStream(
     if (status_u16 == 429) {
         // Cap at 64 KiB — chatgpt.com's 429 JSON bodies are small.
         const body = try http_req.reader().readAllAlloc(a, 64 * 1024);
-        defer a.free(body);
         const classification = classify(a, status_u16, body);
-        try writeBufferedResponse(client_writer, http_req.response, body);
         return .{
             .status = status_u16,
             .classification = classification,
             .body_class = classification.body_class orelse classifyHttpErrorBody(body),
             .streamed = false,
+            .buffered_response = .{
+                .status = status_u16,
+                .headers = try captureResponseHeaders(a, http_req.response),
+                .body = body,
+            },
         };
     }
 
     if (status_u16 >= 400 and status_u16 < 500 and status_u16 != 401) {
         const body = try http_req.reader().readAllAlloc(a, 64 * 1024);
-        defer a.free(body);
         const classification = classify(a, status_u16, body);
-        try writeBufferedResponse(client_writer, http_req.response, body);
         return .{
             .status = status_u16,
             .classification = classification,
             .body_class = classifyHttpErrorBody(body),
             .streamed = false,
+            .buffered_response = .{
+                .status = status_u16,
+                .headers = try captureResponseHeaders(a, http_req.response),
+                .body = body,
+            },
         };
     }
 
@@ -776,6 +867,19 @@ fn writeForwardingResponseHeaders(writer: anytype, response: std.http.Client.Res
     }
 }
 
+fn captureResponseHeaders(a: std.mem.Allocator, response: std.http.Client.Response) !HeaderList {
+    var headers = HeaderList.init(a);
+    var hi = response.iterateHeaders();
+    while (hi.next()) |h| {
+        if (asciiEqlIgnoreCase(h.name, "connection")) continue;
+        if (asciiEqlIgnoreCase(h.name, "transfer-encoding")) continue;
+        if (asciiEqlIgnoreCase(h.name, "keep-alive")) continue;
+        if (asciiEqlIgnoreCase(h.name, "content-length")) continue;
+        try headers.append(try a.dupe(u8, h.name), try a.dupe(u8, h.value));
+    }
+    return headers;
+}
+
 /// 429 path: write status + headers + Content-Length + buffered body.
 fn writeBufferedResponse(
     writer: anytype,
@@ -787,6 +891,16 @@ fn writeBufferedResponse(
     try writer.print("Content-Length: {d}\r\n", .{body.len});
     try writer.writeAll("Connection: close\r\n\r\n");
     try writer.writeAll(body);
+}
+
+fn writeBufferedStoredResponse(writer: anytype, response: BufferedResponse) !void {
+    try writer.print("HTTP/1.1 {d} \r\n", .{response.status});
+    for (response.headers.items.items) |h| {
+        try writer.print("{s}: {s}\r\n", .{ h.name, h.value });
+    }
+    try writer.print("Content-Length: {d}\r\n", .{response.body.len});
+    try writer.writeAll("Connection: close\r\n\r\n");
+    try writer.writeAll(response.body);
 }
 
 /// Streaming path: write status + headers (no Content-Length, no


### PR DESCRIPTION
## Summary

- adds a root README and refreshes truth/todo docs around brokered Codex resume vs quota handoff
- changes the Codex wire proxy to buffer `429 usage_limit_reached`, mark the active account exhausted, elect a fallback, drop `x-codex-turn-state`, and retry the same request before writing to Codex
- updates Codex smokes so synthetic A -> 429 -> immediate B -> 200 keeps the stub Codex child on 200s, while 401/tier/all-exhausted negative paths stay guarded
- records route readiness and tracker-comment fallback after MCP GitHub issue comments hit a permission wall

## Validation

- `just check-local`

## Remaining truth gate

This is still synthetic/local evidence. Live Level 3 remains open until a provider-originated `usage_limit_reached` in managed `oauth-mux codex` shows the same no-visible-429 handoff with a stable child process.