### PR TITLE
Harden Codex wire capture review

### DIFF
--- a/docs/spec/codex-wire-evidence-2026-05-03.md
+++ b/docs/spec/codex-wire-evidence-2026-05-03.md
@@ -23,10 +23,15 @@ TIN-950 adds the capture/replay tooling only:
   mitmproxy HTTP capture path.
 - `scripts/codex-wire-addon.py` writes reviewed, redacted per-flow JSON
   from that capture path.
+- `scripts/capture-codex-wire.sh review captures/codex-wire-<TS>`
+  summarizes endpoint/status coverage, extracts 429 quota shapes, and
+  fails on obvious secret-like values before a capture is promoted.
 - `scripts/test-cassette-upstream.py` replays reviewed capture JSON by
   `(method, path)`.
 - `just smoke-codex-cassette-replay` proves the replayer on a tiny
   synthetic cassette without provider traffic.
+- `just smoke-codex-capture-review` pins the offline reviewer: scrubbed
+  quota fixtures pass and obvious bearer-token leaks fail.
 
 The existing in-session smoke (`just smoke-codex-acceptance`) proves the
 adapter/proxy can classify and substitute against synthetic versions of
@@ -44,8 +49,26 @@ confirm the shapes themselves match upstream reality.
 - Capture timestamp range: _OPERATOR-CONFIRM_
 - Capture run directory: `captures/codex-wire-<TS>/`
 - mitmdump version: _OPERATOR-CONFIRM_
+- Capture review summary: _OPERATOR-CONFIRM_ (`capture-codex-wire.sh review`)
 - Replay tooling: `scripts/test-cassette-upstream.py`
 - Synthetic replay smoke: `just smoke-codex-cassette-replay`
+
+## Capture Promotion Checklist
+
+Before any captured flow is committed as a cassette or cited as live
+evidence:
+
+1. Run `scripts/capture-codex-wire.sh review captures/codex-wire-<TS>`
+   against the capture root, not the raw `.flows` file.
+2. Confirm the summary includes the expected path/status mix for the
+   scenario being promoted: normal 200, 401 refresh, 429
+   `usage_limit_reached`, compact, memory, or other Codex endpoint.
+3. Confirm `redaction_failures` and `malformed` are empty.
+4. Manually inspect the fixture-sized JSON selected for promotion.
+   The reviewer catches obvious token/JWT/API-key strings; it is not a
+   formal proof that all account-identifying material is gone.
+5. Commit only scrubbed per-flow JSON. Do not commit
+   `captures/**/flows.binary`.
 
 ## 1. Endpoints Observed
 

--- a/justfile
+++ b/justfile
@@ -173,7 +173,7 @@ check:
     nix develop --command just check-local
 
 check-local:
-    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh && ./scripts/stay-afloat-wrapper-doc-smoke.sh && ./scripts/smoke-broker.sh && ./scripts/smoke-codex-cli-ux.sh && ./scripts/smoke-codex-acceptance.sh && ./scripts/smoke-codex-concurrent-sessions.sh && ./scripts/smoke-codex-child-refresh.sh && ./scripts/smoke-codex-tier-insufficient.sh && ./scripts/smoke-codex-all-exhausted.sh && ./scripts/smoke-codex-401-propagation.sh && ./scripts/smoke-codex-cassette-replay.sh'
+    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh && ./scripts/stay-afloat-wrapper-doc-smoke.sh && ./scripts/smoke-broker.sh && ./scripts/smoke-codex-cli-ux.sh && ./scripts/smoke-codex-acceptance.sh && ./scripts/smoke-codex-concurrent-sessions.sh && ./scripts/smoke-codex-child-refresh.sh && ./scripts/smoke-codex-tier-insufficient.sh && ./scripts/smoke-codex-all-exhausted.sh && ./scripts/smoke-codex-401-propagation.sh && ./scripts/smoke-codex-cassette-replay.sh && ./scripts/smoke-codex-capture-review.sh'
     @echo "all checks passed"
 
 e2e:
@@ -266,6 +266,12 @@ smoke-codex-cassette-replay:
 
 smoke-codex-cassette-replay-local:
     ./scripts/smoke-codex-cassette-replay.sh
+
+smoke-codex-capture-review:
+    nix develop --command just smoke-codex-capture-review-local
+
+smoke-codex-capture-review-local:
+    ./scripts/smoke-codex-capture-review.sh
 
 # ── Config ──
 

--- a/scripts/capture-codex-wire.sh
+++ b/scripts/capture-codex-wire.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Phase 0: capture Codex wire traffic for the broker MCP contract.
+# Capture Codex wire traffic for the broker MCP contract.
 #
 # Anchor: docs/spec/broker-mcp-contract-2026-05-03.md section 5 Phase 0.
-# Goal:   replace assumptions with observed traffic before any Phase 2
-#         wire-proxy code lands.
+# Goal:   replace assumptions with observed traffic and validate the
+#         implemented same-turn quota retry shape against provider reality.
 #
 # Captures HTTP traffic, including any WebSocket upgrade request metadata,
 # to chatgpt.com/backend-api/codex via mitmdump.
@@ -30,6 +30,7 @@ capture-codex-wire.sh - Phase 0 evidence capture for the Codex adapter.
 USAGE
   scripts/capture-codex-wire.sh init             # one-time mitmproxy CA install check
   scripts/capture-codex-wire.sh proxy            # start the HTTP capture proxy in foreground
+  scripts/capture-codex-wire.sh review DIR       # summarize/redaction-check a capture
   scripts/capture-codex-wire.sh help
 
 WORKFLOW
@@ -49,7 +50,9 @@ WORKFLOW
      drive an account to weekly quota exhaustion to capture the 429 +
      usage_limit_reached body.
   4. Stop the proxy with ^C. Find captures under captures/.
-  5. Distill findings into docs/spec/codex-wire-evidence-2026-05-03.md.
+  5. Run:
+       scripts/capture-codex-wire.sh review captures/codex-wire-<TS>
+  6. Distill findings into docs/spec/codex-wire-evidence-2026-05-03.md.
 
 REDACTION
   The mitmproxy addon redacts Authorization, Cookie, and ChatGPT-Account-
@@ -118,9 +121,20 @@ META
     -w "$RUN_DIR/http/flows.binary"
 }
 
+cmd_review() {
+  local dir="${1:-}"
+  if [[ -z "$dir" ]]; then
+    echo "error: review requires a capture directory" >&2
+    exit 64
+  fi
+  require_cmd python3 "install python3"
+  exec python3 "$ROOT/scripts/review-codex-wire-capture.py" "$dir"
+}
+
 case "$cmd" in
   help|-h|--help) usage ;;
   init)           cmd_init ;;
   proxy)          cmd_proxy ;;
+  review)         shift; cmd_review "${1:-}" ;;
   *)              usage; exit 64 ;;
 esac

--- a/scripts/review-codex-wire-capture.py
+++ b/scripts/review-codex-wire-capture.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Review redacted Codex wire captures before fixture promotion.
+
+This is a local/offline safety check for captures produced by
+scripts/capture-codex-wire.sh proxy. It does not inspect raw mitmproxy
+.flows files. It reads only the addon-produced per-flow JSON and reports
+endpoint/status coverage plus obvious redaction failures.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+TOKEN_PATTERNS = [
+    re.compile(r"Bearer\s+(?![A-Za-z0-9_-]{0,8}-<)[A-Za-z0-9._~-]{24,}"),
+    re.compile(r"eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}"),
+    re.compile(r"sk-[A-Za-z0-9_-]{16,}"),
+]
+
+
+def _walk_strings(node: Any):
+    if isinstance(node, str):
+        yield node
+    elif isinstance(node, dict):
+        for v in node.values():
+            yield from _walk_strings(v)
+    elif isinstance(node, list):
+        for v in node:
+            yield from _walk_strings(v)
+
+
+def _path_kind(path: str) -> str:
+    if path == "/backend-api/codex/responses" or path.startswith("/backend-api/codex/responses?"):
+        return "responses"
+    if path == "/backend-api/codex/responses/compact" or path.startswith("/backend-api/codex/responses/compact?"):
+        return "responses_compact"
+    if "/backend-api/codex/memories/trace_summarize" in path:
+        return "memories_trace_summarize"
+    if path.startswith("/backend-api/codex/"):
+        return "codex_other"
+    if "/oauth/token" in path:
+        return "oauth_token"
+    return "other"
+
+
+def _find_http_dir(path: Path) -> Path:
+    if path.is_dir() and (path / "http").is_dir():
+        return path / "http"
+    return path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("capture_dir", help="capture run dir or its http/ subdir")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable summary")
+    args = parser.parse_args()
+
+    http_dir = _find_http_dir(Path(args.capture_dir))
+    if not http_dir.is_dir():
+        print(f"error: not a directory: {http_dir}", file=sys.stderr)
+        return 64
+
+    flows = []
+    redaction_failures: list[str] = []
+    malformed: list[str] = []
+    path_counts: dict[str, int] = {}
+    status_counts: dict[str, int] = {}
+    quota_shapes: list[dict[str, Any]] = []
+
+    for p in sorted(http_dir.glob("*.json")):
+        try:
+            record = json.loads(p.read_text())
+        except Exception as exc:  # noqa: BLE001
+            malformed.append(f"{p.name}: {exc}")
+            continue
+
+        flows.append(record)
+        path = str(record.get("path", ""))
+        kind = _path_kind(path)
+        path_counts[kind] = path_counts.get(kind, 0) + 1
+
+        status = record.get("response", {}).get("status")
+        status_key = str(status)
+        status_counts[status_key] = status_counts.get(status_key, 0) + 1
+
+        response_body = record.get("response", {}).get("body")
+        if status == 429 and isinstance(response_body, dict):
+            err = response_body.get("error")
+            if isinstance(err, dict):
+                quota_shapes.append({
+                    "path_kind": kind,
+                    "error_type": err.get("type"),
+                    "has_resets_at": "resets_at" in err,
+                    "plan_type": err.get("plan_type"),
+                })
+
+        for s in _walk_strings(record):
+            for pat in TOKEN_PATTERNS:
+                if pat.search(s):
+                    redaction_failures.append(f"{p.name}: possible secret-like value matched {pat.pattern}")
+                    break
+
+    summary = {
+        "ok": not malformed and not redaction_failures,
+        "flow_count": len(flows),
+        "path_counts": path_counts,
+        "status_counts": status_counts,
+        "quota_shapes": quota_shapes,
+        "malformed": malformed,
+        "redaction_failures": redaction_failures,
+    }
+
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(f"flows: {summary['flow_count']}")
+        print(f"paths: {json.dumps(path_counts, sort_keys=True)}")
+        print(f"statuses: {json.dumps(status_counts, sort_keys=True)}")
+        if quota_shapes:
+            print(f"quota_shapes: {json.dumps(quota_shapes, sort_keys=True)}")
+        if malformed:
+            print("malformed:")
+            for item in malformed:
+                print(f"  - {item}")
+        if redaction_failures:
+            print("redaction_failures:")
+            for item in redaction_failures:
+                print(f"  - {item}")
+
+    return 0 if summary["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke-codex-capture-review.sh
+++ b/scripts/smoke-codex-capture-review.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Offline smoke for the Codex wire-capture reviewer.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d -t omux-capture-review.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+CAP="$TMP/codex-wire-synth/http"
+mkdir -p "$CAP"
+
+cat >"$CAP/00001-POST-backend-api_codex_responses.json" <<'JSON'
+{
+  "captured_at": 1788000000.0,
+  "host": "chatgpt.com",
+  "scheme": "https",
+  "method": "POST",
+  "path": "/backend-api/codex/responses",
+  "request": {
+    "headers": [
+      ["Authorization", "Bearer abcdef-<0123456789>"],
+      ["ChatGPT-Account-ID", "acct-a-<abcdef0123>"]
+    ],
+    "body": {"model": "gpt-5.5"}
+  },
+  "response": {
+    "status": 429,
+    "reason": "Too Many Requests",
+    "headers": [["content-type", "application/json"]],
+    "body": {
+      "error": {
+        "type": "usage_limit_reached",
+        "plan_type": "pro",
+        "resets_at": 1788000000
+      }
+    }
+  },
+  "timing_ms": 42
+}
+JSON
+
+python3 "$ROOT/scripts/review-codex-wire-capture.py" "$TMP/codex-wire-synth" --json >"$TMP/summary.json"
+
+python3 - "$TMP/summary.json" <<'PY'
+import json
+import sys
+summary = json.load(open(sys.argv[1]))
+assert summary["ok"] is True, summary
+assert summary["flow_count"] == 1, summary
+assert summary["path_counts"]["responses"] == 1, summary
+assert summary["status_counts"]["429"] == 1, summary
+shape = summary["quota_shapes"][0]
+assert shape["error_type"] == "usage_limit_reached", shape
+assert shape["has_resets_at"] is True, shape
+assert shape["plan_type"] == "pro", shape
+PY
+
+cat >"$CAP/00002-POST-secret-leak.json" <<'JSON'
+{
+  "captured_at": 1788000001.0,
+  "host": "chatgpt.com",
+  "scheme": "https",
+  "method": "POST",
+  "path": "/backend-api/codex/responses",
+  "request": {
+    "headers": [
+      ["Authorization", "Bearer live-token-value-that-should-never-be-promoted"]
+    ],
+    "body": {}
+  },
+  "response": {
+    "status": 200,
+    "reason": "OK",
+    "headers": [],
+    "body": {}
+  },
+  "timing_ms": 1
+}
+JSON
+
+if python3 "$ROOT/scripts/review-codex-wire-capture.py" "$TMP/codex-wire-synth" --json >"$TMP/leak-summary.json"; then
+  echo "smoke-codex-capture-review: expected leaked bearer fixture to fail" >&2
+  exit 1
+fi
+
+python3 - "$TMP/leak-summary.json" <<'PY'
+import json
+import sys
+summary = json.load(open(sys.argv[1]))
+assert summary["ok"] is False, summary
+assert summary["redaction_failures"], summary
+PY
+
+printf 'smoke-codex-capture-review: all assertions passed.\n'


### PR DESCRIPTION
## Summary
- add a capture review command for redacted Codex wire captures
- summarize endpoint/status coverage and quota error shapes before fixture promotion
- add an offline smoke that accepts scrubbed quota captures and rejects obvious bearer-token leaks
- document the capture promotion checklist in the wire evidence spec

## Tests
- git diff --check
- ./scripts/capture-codex-wire.sh help
- python3 scripts/review-codex-wire-capture.py --help
- just smoke-codex-capture-review-local
- just smoke-codex-cassette-replay-local (required localhost bind permission)

## Truth boundary
This hardens the evidence/cassette path only. It does not claim live provider-originated same-turn fallback is complete.