### PR TITLE
Add GitHub tracker comment fallback

### DIFF
--- a/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
+++ b/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
@@ -317,6 +317,9 @@ These need review before public promotion:
   write-capable scopes, while the Apps connector identity is independent and
   can read identity but fails issue-comment writes. Treat connector writes as
   a GitHub App permission/installation problem until proven otherwise.
+- GitHub #198 tracks the permission fix. Until the connector can write issue
+  comments, use `scripts/github-tracker-comment.sh` as the local `gh` fallback;
+  it dry-runs auth/body checks and refuses obvious unredacted token shapes.
 - Remaining acceptance gate: provider-originated `usage_limit_reached` inside a
   real managed `oauth-mux codex` session, with redacted status evidence showing
   the same no-visible-429 retry sequence and a stable child process.

--- a/docs/tracker-hygiene.md
+++ b/docs/tracker-hygiene.md
@@ -1,0 +1,36 @@
+# Tracker Hygiene
+
+Use the GitHub/Linear connectors for tracker reads and writes when their
+installation has the required permissions. If the GitHub Apps connector returns
+`403 Resource not accessible by integration` for an issue or PR comment, use the
+local `gh` fallback instead of dropping the tracker update.
+
+```bash
+scripts/github-tracker-comment.sh ISSUE path/to/body.md
+```
+
+For stdin:
+
+```bash
+printf '%s\n' 'tracker update body' | scripts/github-tracker-comment.sh ISSUE -
+```
+
+The script refuses empty bodies and obvious bearer/JWT/API-key/PAT-shaped
+strings before posting. That guard is not a substitute for manually reviewing
+redacted live evidence, status artifacts, and cassette snippets before putting
+them in a public tracker.
+
+If `GH_TOKEN` or `GITHUB_TOKEN` points at a stale token but local keyring auth is
+valid, force `gh` to use the keyring:
+
+```bash
+scripts/github-tracker-comment.sh --ignore-env-token ISSUE path/to/body.md
+```
+
+Dry-run the auth and body checks without posting:
+
+```bash
+scripts/github-tracker-comment.sh --dry-run ISSUE path/to/body.md
+```
+
+Tracked limitation: GitHub #198.

--- a/justfile
+++ b/justfile
@@ -173,7 +173,7 @@ check:
     nix develop --command just check-local
 
 check-local:
-    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh && ./scripts/stay-afloat-wrapper-doc-smoke.sh && ./scripts/smoke-broker.sh && ./scripts/smoke-codex-cli-ux.sh && ./scripts/smoke-codex-acceptance.sh && ./scripts/smoke-codex-concurrent-sessions.sh && ./scripts/smoke-codex-child-refresh.sh && ./scripts/smoke-codex-tier-insufficient.sh && ./scripts/smoke-codex-all-exhausted.sh && ./scripts/smoke-codex-401-propagation.sh && ./scripts/smoke-codex-cassette-replay.sh && ./scripts/smoke-codex-capture-review.sh'
+    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh && ./scripts/stay-afloat-wrapper-doc-smoke.sh && ./scripts/smoke-broker.sh && ./scripts/smoke-codex-cli-ux.sh && ./scripts/smoke-codex-acceptance.sh && ./scripts/smoke-codex-concurrent-sessions.sh && ./scripts/smoke-codex-child-refresh.sh && ./scripts/smoke-codex-tier-insufficient.sh && ./scripts/smoke-codex-all-exhausted.sh && ./scripts/smoke-codex-401-propagation.sh && ./scripts/smoke-codex-cassette-replay.sh && ./scripts/smoke-codex-capture-review.sh && ./scripts/smoke-github-tracker-comment.sh'
     @echo "all checks passed"
 
 e2e:
@@ -272,6 +272,12 @@ smoke-codex-capture-review:
 
 smoke-codex-capture-review-local:
     ./scripts/smoke-codex-capture-review.sh
+
+smoke-github-tracker-comment:
+    ./scripts/smoke-github-tracker-comment.sh
+
+github-tracker-comment ISSUE BODY_FILE:
+    ./scripts/github-tracker-comment.sh {{ISSUE}} {{BODY_FILE}}
 
 # ── Config ──
 

--- a/scripts/github-tracker-comment.sh
+++ b/scripts/github-tracker-comment.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Post a GitHub tracker comment through local gh when the Apps connector is
+# read-only or missing issue-comment permission.
+
+set -euo pipefail
+
+repo="${OMUX_GITHUB_REPO:-Jesssullivan/oauth-mux}"
+dry_run=false
+ignore_env_token=false
+
+usage() {
+  cat <<'OMUX_GH_COMMENT_USAGE'
+github-tracker-comment.sh - guarded local-gh fallback for tracker comments
+
+USAGE
+  scripts/github-tracker-comment.sh [--repo OWNER/REPO] [--dry-run] [--ignore-env-token] ISSUE BODY_FILE
+  scripts/github-tracker-comment.sh [--repo OWNER/REPO] [--dry-run] ISSUE -
+
+OPTIONS
+  --repo OWNER/REPO      GitHub repository. Defaults to OMUX_GITHUB_REPO or Jesssullivan/oauth-mux.
+  --dry-run              Validate the body and auth surface without posting.
+  --ignore-env-token     Unset GH_TOKEN/GITHUB_TOKEN so gh falls back to keyring auth.
+
+SAFETY
+  The body is scanned for obvious bearer/JWT/API-key/PAT-shaped secrets before
+  posting. This is a high-signal guard, not a proof of full redaction.
+OMUX_GH_COMMENT_USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="${2:-}"
+      if [[ -z "$repo" ]]; then
+        echo "error: --repo requires OWNER/REPO" >&2
+        exit 64
+      fi
+      shift 2
+      ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    --ignore-env-token)
+      ignore_env_token=true
+      shift
+      ;;
+    -h|--help|help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "error: unknown option: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ $# -ne 2 ]]; then
+  usage >&2
+  exit 64
+fi
+
+issue="$1"
+body_arg="$2"
+
+if ! [[ "$issue" =~ ^[0-9]+$ ]]; then
+  echo "error: ISSUE must be a numeric issue or PR number" >&2
+  exit 64
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh is required for tracker comment fallback" >&2
+  exit 64
+fi
+
+tmp_body=""
+cleanup() {
+  if [[ -n "$tmp_body" ]]; then
+    rm -f "$tmp_body"
+  fi
+}
+trap cleanup EXIT
+
+if [[ "$body_arg" == "-" ]]; then
+  tmp_body="$(mktemp -t omux-gh-comment.XXXXXX)"
+  cat >"$tmp_body"
+  body_file="$tmp_body"
+else
+  body_file="$body_arg"
+fi
+
+if [[ ! -f "$body_file" ]]; then
+  echo "error: body file does not exist: $body_file" >&2
+  exit 66
+fi
+
+if [[ ! -s "$body_file" ]]; then
+  echo "error: body file is empty" >&2
+  exit 65
+fi
+
+if grep -Eiq \
+  '(Bearer[[:space:]]+[A-Za-z0-9._~+/=-]{20,}|eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}|sk-[A-Za-z0-9_-]{16,}|gh[pousr]_[A-Za-z0-9_]{20,})' \
+  "$body_file"; then
+  echo "error: body contains a possible unredacted secret; refusing to post" >&2
+  exit 65
+fi
+
+if [[ "$ignore_env_token" == true ]]; then
+  unset GH_TOKEN GITHUB_TOKEN
+fi
+
+if [[ "$dry_run" == true ]]; then
+  gh auth status --hostname github.com >/dev/null
+  printf 'github-tracker-comment: dry-run ok repo=%s issue=%s body_file=%s\n' "$repo" "$issue" "$body_file"
+  exit 0
+fi
+
+gh issue comment "$issue" --repo "$repo" --body-file "$body_file"

--- a/scripts/smoke-github-tracker-comment.sh
+++ b/scripts/smoke-github-tracker-comment.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Offline smoke for the guarded GitHub tracker-comment fallback.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d -t omux-gh-comment-smoke.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+safe="$TMP/safe.md"
+leak="$TMP/leak.md"
+
+printf 'Safe tracker update with redacted status evidence.\n' >"$safe"
+printf 'Authorization: Bearer live-token-value-that-should-not-post\n' >"$leak"
+
+PATH="$TMP:$PATH"
+cat >"$TMP/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
+  exit 0
+fi
+if [[ "${1:-}" == "issue" && "${2:-}" == "comment" ]]; then
+  echo "smoke gh should not be asked to post during --dry-run" >&2
+  exit 9
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 9
+SH
+chmod +x "$TMP/gh"
+
+"$ROOT/scripts/github-tracker-comment.sh" --dry-run --repo Jesssullivan/oauth-mux 198 "$safe" >"$TMP/out.txt"
+grep -q 'dry-run ok repo=Jesssullivan/oauth-mux issue=198' "$TMP/out.txt"
+
+"$ROOT/scripts/github-tracker-comment.sh" --help >"$TMP/help.txt"
+grep -q 'USAGE' "$TMP/help.txt"
+grep -q -- '--ignore-env-token' "$TMP/help.txt"
+
+if "$ROOT/scripts/github-tracker-comment.sh" --dry-run 198 "$leak" >"$TMP/leak.out" 2>"$TMP/leak.err"; then
+  echo "smoke-github-tracker-comment: expected secret-like body to fail" >&2
+  exit 1
+fi
+grep -q 'possible unredacted secret' "$TMP/leak.err"
+
+printf 'smoke-github-tracker-comment: all assertions passed.\n'


### PR DESCRIPTION
## Summary
- add a guarded local-gh fallback for tracker comments when the Apps connector lacks issue-comment permission
- add a dry-run/offline smoke that validates safe bodies, help output, and secret-like body refusal
- document tracker hygiene and link the connector permission tracker

## Dogfood
- posted to #198 with scripts/github-tracker-comment.sh: https://github.com/Jesssullivan/oauth-mux/issues/198#issuecomment-4389756883

## Tests
- git diff --check
- ./scripts/github-tracker-comment.sh --help
- ./scripts/smoke-github-tracker-comment.sh
- just smoke-github-tracker-comment
- ./scripts/github-tracker-comment.sh --dry-run 198 <safe-body>

## Boundary
This does not fix the GitHub Apps connector permission itself. It gives us a reliable local fallback until #198 is resolved.