### PR TITLE
Truth brokered dogfood status evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Real on `main`:
 - Brokered Codex resume has been dogfooded successfully through the proxy:
   `resume <session-id>` reached `POST /backend-api/codex/responses` with
   `status:200`.
+- Current dogfood status evidence includes hundreds of brokered
+  `POST /responses` 200s through `codex:max-1`; it does not yet include a real
+  provider-originated `429 usage_limit_reached` or fallback-account turn.
 - Synthetic smokes prove account A can hit `429 usage_limit_reached`, be
   marked exhausted, and account B can handle the same request in the same child
   process before Codex receives the 429.

--- a/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
+++ b/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
@@ -24,10 +24,11 @@ prepared fallback, and synthetic smokes are evidence or diagnostics only.
 ## Current Live State
 
 Observed on 2026-05-05 around 15:37 EDT, then updated after the first
-brokered-resume dogfood on 2026-05-06:
+brokered-resume dogfood on 2026-05-06 and a follow-up no-spend check on
+2026-05-06:
 
-- Repository: clean on `main`, one local commit ahead of `origin/main` at
-  `954d673` (`Whoohoo brokered Codex resume`) during this checkpoint.
+- Repository: clean on `main`, synced with `origin/main` at `8a111bf`
+  (`Add GitHub tracker comment fallback`) during this checkpoint.
 - Selected live `codex-max` route: `max-1`.
 - Spend-gated exhausted-route revalidation after the reset window found
   `max-1`, `max-2`, and `max-3` available again; `max-4` was already
@@ -52,6 +53,10 @@ The brokered-resume dogfood proved a separate prerequisite:
 - Live `POST /backend-api/codex/responses` turns returned `status:200` through
   the oauth-mux proxy after the request-framing and same-account child-refresh
   fixes.
+- `dist/live-qa/managed-resume-dogfood-5/status.ndjson` contains 352
+  brokered proxy turns through `codex:max-1`: 347 `POST /responses` 200s and
+  5 `GET codex_other` 200s. It contains no provider-originated 429, no
+  `proxy_same_turn_retry`, and no fallback-account turn.
 
 That is meaningful UX/architecture progress. It is not account-exhaustion
 success and must not be described as stay-afloat completion.


### PR DESCRIPTION
## Summary
- record the current clean/synced main checkpoint
- clarify that dogfood-5 proves many brokered Codex 200s through max-1, not fallback
- update README current-state language so brokered-session success is not confused with provider-originated quota fallback

## Evidence
- dist/live-qa/managed-resume-dogfood-5/status.ndjson has 352 brokered proxy turns through codex:max-1
- 347 POST /responses 200s, 5 GET codex_other 200s
- no provider-originated 429, no proxy_same_turn_retry, no fallback-account turn

## Tests
- git diff --check
- just build
- smoke-github-tracker-comment
- no-spend broker-session-plan: max-1 selected, max-2/max-3/max-4 selectable fallbacks

## Boundary
Docs/truthing only. This does not claim live provider-originated fallback is complete.