### PR TITLE
Add Codex dogfood status summarizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,14 @@ Next P0: capture and run live evidence for provider-originated
 `429 usage_limit_reached` inside a managed session. Until that proves the same
 no-visible-429 sequence against real `chatgpt.com`, live quota-burn dogfood is
 telemetry, not product acceptance.
+
+Summarize a dogfood status artifact without overclaiming:
+
+```bash
+python3 scripts/summarize-codex-status.py dist/live-qa/<run>/status.ndjson --require-brokered
+```
+
+`verdict:"brokered_without_fallback"` means the session went through oauth-mux
+but did not observe account exhaustion or substitution. The Level 3/4 evidence
+shape requires a `quota_exhausted` proxy turn, a retry/swap event, and a
+successful turn on a distinct fallback account.

--- a/justfile
+++ b/justfile
@@ -173,7 +173,7 @@ check:
     nix develop --command just check-local
 
 check-local:
-    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh && ./scripts/stay-afloat-wrapper-doc-smoke.sh && ./scripts/smoke-broker.sh && ./scripts/smoke-codex-cli-ux.sh && ./scripts/smoke-codex-acceptance.sh && ./scripts/smoke-codex-concurrent-sessions.sh && ./scripts/smoke-codex-child-refresh.sh && ./scripts/smoke-codex-tier-insufficient.sh && ./scripts/smoke-codex-all-exhausted.sh && ./scripts/smoke-codex-401-propagation.sh && ./scripts/smoke-codex-cassette-replay.sh && ./scripts/smoke-codex-capture-review.sh && ./scripts/smoke-github-tracker-comment.sh'
+    sh -c 'zig build test && zig build && for cfg in examples/*.config.json; do OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate; done && ./scripts/e2e-local.sh && ./scripts/first-run-e2e.sh && ./scripts/stay-afloat-wrapper-doc-smoke.sh && ./scripts/smoke-broker.sh && ./scripts/smoke-codex-cli-ux.sh && ./scripts/smoke-codex-acceptance.sh && ./scripts/smoke-codex-concurrent-sessions.sh && ./scripts/smoke-codex-child-refresh.sh && ./scripts/smoke-codex-tier-insufficient.sh && ./scripts/smoke-codex-all-exhausted.sh && ./scripts/smoke-codex-401-propagation.sh && ./scripts/smoke-codex-cassette-replay.sh && ./scripts/smoke-codex-capture-review.sh && ./scripts/smoke-codex-status-summary.sh && ./scripts/smoke-github-tracker-comment.sh'
     @echo "all checks passed"
 
 e2e:
@@ -272,6 +272,9 @@ smoke-codex-capture-review:
 
 smoke-codex-capture-review-local:
     ./scripts/smoke-codex-capture-review.sh
+
+smoke-codex-status-summary:
+    ./scripts/smoke-codex-status-summary.sh
 
 smoke-github-tracker-comment:
     ./scripts/smoke-github-tracker-comment.sh

--- a/scripts/smoke-codex-status-summary.sh
+++ b/scripts/smoke-codex-status-summary.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Smoke-test the Codex status summarizer against brokered-only and fallback
+# shaped NDJSON artifacts.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if ! command -v jq >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then
+    echo "smoke-codex-status-summary: jq and python3 required" >&2
+    exit 64
+fi
+
+TMP="$(mktemp -d -t omux-status-summary.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+BROKERED="$TMP/brokered.ndjson"
+FALLBACK="$TMP/fallback.ndjson"
+
+cat >"$BROKERED" <<'EOF'
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"proxy_turn","account":"codex:max-1","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true}
+{"kind":"proxy_turn","account":"codex:max-1","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true}
+{"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":false}
+EOF
+
+cat >"$FALLBACK" <<'EOF'
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"proxy_turn","account":"codex:max-1","method":"POST","path_kind":"responses","status":429,"classification":"quota_exhausted","body_class":"usage_limit_reached","delivered_to_codex":false}
+{"kind":"proxy_same_turn_retry","from":"codex:max-1","to":"codex:max-2","reason":"quota_exhausted","dropped":"x-codex-turn-state"}
+{"kind":"proxy_turn","account":"codex:max-2","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true}
+{"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":true}
+EOF
+
+BROKERED_SUMMARY="$(python3 "$ROOT/scripts/summarize-codex-status.py" "$BROKERED" --require-brokered)"
+if [[ "$(jq -r .verdict <<<"$BROKERED_SUMMARY")" != "brokered_without_fallback" ]]; then
+    echo "brokered verdict mismatch" >&2
+    echo "$BROKERED_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .fallback_sequence.observed <<<"$BROKERED_SUMMARY")" != "false" ]]; then
+    echo "brokered-only artifact should not claim fallback" >&2
+    echo "$BROKERED_SUMMARY" >&2
+    exit 1
+fi
+
+FALLBACK_SUMMARY="$(python3 "$ROOT/scripts/summarize-codex-status.py" "$FALLBACK" --require-brokered --require-fallback-sequence)"
+if [[ "$(jq -r .verdict <<<"$FALLBACK_SUMMARY")" != "fallback_sequence_observed" ]]; then
+    echo "fallback verdict mismatch" >&2
+    echo "$FALLBACK_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .fallback_sequence.fallback_account <<<"$FALLBACK_SUMMARY")" != "codex:max-2" ]]; then
+    echo "fallback account mismatch" >&2
+    echo "$FALLBACK_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .provider_originated_live_fallback_claim <<<"$FALLBACK_SUMMARY")" != "false" ]]; then
+    echo "summarizer must not claim provider-originated live fallback from NDJSON shape alone" >&2
+    echo "$FALLBACK_SUMMARY" >&2
+    exit 1
+fi
+
+echo "smoke-codex-status-summary: all assertions passed."

--- a/scripts/summarize-codex-status.py
+++ b/scripts/summarize-codex-status.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Summarize oauth-mux Codex adapter NDJSON status evidence.
+
+This intentionally distinguishes brokered-session evidence from account-swap
+evidence. A status file with many 200s through the proxy is useful, but it is
+not live fallback proof unless a quota event and fallback account turn appear
+in order.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+def load_events(path: Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as f:
+        for lineno, line in enumerate(f, 1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                value = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise SystemExit(f"{path}:{lineno}: invalid JSON: {exc}") from exc
+            if isinstance(value, dict):
+                events.append(value)
+    return events
+
+
+def event_key_count(events: list[dict[str, Any]], key: str) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for event in events:
+        value = event.get(key)
+        if value is not None:
+            counts[str(value)] += 1
+    return dict(sorted(counts.items()))
+
+
+def find_fallback_sequence(events: list[dict[str, Any]]) -> dict[str, Any]:
+    quota_idx: int | None = None
+    retry_idx: int | None = None
+    quota_account: str | None = None
+    retry_event: dict[str, Any] | None = None
+    fallback_turn: dict[str, Any] | None = None
+
+    for idx, event in enumerate(events):
+        if event.get("kind") != "proxy_turn":
+            continue
+        if (
+            event.get("status") == 429
+            and event.get("classification") == "quota_exhausted"
+        ):
+            quota_idx = idx
+            quota_account = event.get("account")
+            break
+
+    if quota_idx is None:
+        return {
+            "observed": False,
+            "reason": "no quota_exhausted proxy_turn",
+        }
+
+    for idx in range(quota_idx + 1, len(events)):
+        event = events[idx]
+        if event.get("kind") == "proxy_same_turn_retry":
+            retry_idx = idx
+            retry_event = event
+            break
+
+    if retry_idx is None:
+        return {
+            "observed": False,
+            "reason": "quota_exhausted without proxy_same_turn_retry",
+            "quota_account": quota_account,
+        }
+
+    for event in events[retry_idx + 1 :]:
+        if event.get("kind") != "proxy_turn":
+            continue
+        if event.get("account") != quota_account and event.get("status") == 200:
+            fallback_turn = event
+            break
+
+    if fallback_turn is None:
+        return {
+            "observed": False,
+            "reason": "same-turn retry without successful fallback-account turn",
+            "quota_account": quota_account,
+            "retry": retry_event,
+        }
+
+    return {
+        "observed": True,
+        "quota_account": quota_account,
+        "fallback_account": fallback_turn.get("account"),
+        "retry": retry_event,
+        "fallback_status": fallback_turn.get("status"),
+        "fallback_path_kind": fallback_turn.get("path_kind"),
+    }
+
+
+def summarize(path: Path) -> dict[str, Any]:
+    events = load_events(path)
+    proxy_turns = [e for e in events if e.get("kind") == "proxy_turn"]
+    session_started = next((e for e in events if e.get("kind") == "session_started"), {})
+    session_ended = next((e for e in reversed(events) if e.get("kind") == "session_ended"), {})
+    fallback = find_fallback_sequence(events)
+
+    brokered_session = (
+        session_started.get("claim_level") == "broker_owned"
+        or session_started.get("claim_level") == "broker_owned_app_server"
+        or session_ended.get("final_claim_level") == "broker_owned"
+    )
+
+    return {
+        "path": str(path),
+        "events": len(events),
+        "brokered_session_observed": brokered_session,
+        "selected_account": session_started.get("selected_account"),
+        "session_authority": session_started.get("session_authority"),
+        "proxy_turns": len(proxy_turns),
+        "proxy_turns_by_account": event_key_count(proxy_turns, "account"),
+        "proxy_turns_by_status": event_key_count(proxy_turns, "status"),
+        "proxy_turns_by_path_kind": event_key_count(proxy_turns, "path_kind"),
+        "proxy_turns_by_body_class": event_key_count(proxy_turns, "body_class"),
+        "same_turn_retry_events": sum(1 for e in events if e.get("kind") == "proxy_same_turn_retry"),
+        "same_turn_retry_unavailable_events": sum(
+            1 for e in events if e.get("kind") == "proxy_same_turn_retry_unavailable"
+        ),
+        "post_swap_turn_events": sum(1 for e in events if e.get("kind") == "proxy_post_swap_turn"),
+        "fallback_sequence": fallback,
+        "synthetic_swap_observed": bool(session_ended.get("synthetic_swap_observed")),
+        "level4_shape_observed": bool(fallback.get("observed")),
+        "provider_originated_live_fallback_claim": False,
+        "verdict": (
+            "fallback_sequence_observed"
+            if fallback.get("observed")
+            else "brokered_without_fallback"
+            if brokered_session and proxy_turns
+            else "insufficient_evidence"
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("status_file", type=Path)
+    parser.add_argument("--require-brokered", action="store_true")
+    parser.add_argument("--require-fallback-sequence", action="store_true")
+    args = parser.parse_args()
+
+    summary = summarize(args.status_file)
+    print(json.dumps(summary, sort_keys=True))
+
+    if args.require_brokered and not summary["brokered_session_observed"]:
+        return 1
+    if args.require_fallback_sequence and not summary["fallback_sequence"]["observed"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add a Codex adapter NDJSON status summarizer for dogfood artifacts.
- Distinguish brokered-session evidence from fallback-sequence evidence.
- Wire a summarizer smoke into check-local and document the canonical command in README.

## Truth boundary

The current live dogfood artifact summarizes as brokered traffic through oauth-mux, not provider-originated fallback proof. The summarizer keeps provider_originated_live_fallback_claim false and requires an observed quota turn plus retry/swap plus fallback-account 200 before reporting a fallback sequence.

## Validation

- just check-local
- python3 scripts/summarize-codex-status.py dist/live-qa/managed-resume-dogfood-5/status.ndjson --require-brokered

Latest dogfood summary at PR creation: brokered_without_fallback, 462 proxy turns, all on codex:max-1, all 200, no quota event, no swap.