### PR TITLE
Truth brokered auth failure status

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,6 @@ python3 scripts/summarize-codex-status.py dist/live-qa/<run>/status.ndjson --req
 but did not observe account exhaustion or substitution. The Level 3/4 evidence
 shape requires a `quota_exhausted` proxy turn, a retry/swap event, and a
 successful turn on a distinct fallback account.
+`verdict:"brokered_auth_failed"` means the managed frame started, but upstream
+returned unrecovered `401 auth_unauthorized` responses. That is an auth-health
+failure, not quota fallback evidence.

--- a/docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md
+++ b/docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md
@@ -567,3 +567,48 @@ Remaining Level 3 evidence still required:
   distinct fallback account.
 - Do not treat this brokered-resume success as proof of live account-swap
   success until an actual `proxy_turn` / swap sequence shows it.
+
+## 11. Dogfood Finding: Managed Overlay Auth Can Go Stale Across Restarts
+
+The first dogfood restart after refreshing the oauth-mux executable used:
+
+```bash
+./zig-out/bin/oauth-mux codex --profile codex-max \
+  --json-status-file dist/live-qa/managed-resume-dogfood-6/status.ndjson \
+  resume 019dea53-49a0-7890-9580-e88decb97af0
+```
+
+Evidence:
+
+- The adapter did start a broker-owned managed frame:
+  `session_started`, `auth_authority:"mux_owned_overlay"`,
+  `session_authority:"canonical_bridge"`.
+- The explicit resume target was found before launch and writeback was observed.
+- Every proxied upstream request returned `401 auth_unauthorized`, including
+  the main `POST /backend-api/codex/responses` turns.
+- Codex surfaced the provider refresh-token failure:
+  "Your access token could not be refreshed because your refresh token was
+  already used. Please log out and sign in again."
+- `broker-session-plan`, `doctor runtime`, and `codex login-status-all` still
+  reported `codex:max-1` as locally ready/available because the source
+  `auth.json` remained structurally parseable and the stored route liveness was
+  stale-positive.
+
+Interpretation:
+
+- PR #195's same-account child-auth preservation fixed stale access-token
+  re-signing within one managed session.
+- It did not prove durable refresh-token writeback from the mux-owned
+  `CODEX_HOME` auth overlay back to the route authority used for the next
+  managed launch.
+- A successful long-running managed session can therefore consume/rotate a
+  refresh token inside its overlay, while the next managed launch starts from
+  an older route auth tuple and falls into unrecovered 401.
+
+Truth boundary:
+
+- This is not quota exhaustion and not live account-substitution evidence.
+- This is a P0/P1 auth-authority gap for long-running dogfood reliability:
+  mux-owned auth overlays either need durable token writeback/import back to the
+  selected account store, or repeated 401/refresh-token-failure evidence must
+  mark the route auth-unready and select a fallback account on the next launch.

--- a/scripts/smoke-codex-status-summary.sh
+++ b/scripts/smoke-codex-status-summary.sh
@@ -16,6 +16,7 @@ trap 'rm -rf "$TMP"' EXIT
 
 BROKERED="$TMP/brokered.ndjson"
 FALLBACK="$TMP/fallback.ndjson"
+AUTH_FAILED="$TMP/auth-failed.ndjson"
 
 cat >"$BROKERED" <<'EOF'
 {"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
@@ -30,6 +31,15 @@ cat >"$FALLBACK" <<'EOF'
 {"kind":"proxy_same_turn_retry","from":"codex:max-1","to":"codex:max-2","reason":"quota_exhausted","dropped":"x-codex-turn-state"}
 {"kind":"proxy_turn","account":"codex:max-2","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true}
 {"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":true}
+EOF
+
+cat >"$AUTH_FAILED" <<'EOF'
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"proxy_observed_401_codex_handles","account":"codex:max-1"}
+{"kind":"proxy_turn","account":"codex:max-1","method":"GET","path_kind":"codex_other","status":401,"classification":"auth_unauthorized","body_class":"none","claim_level":"broker_owned","streamed":true,"delivered_to_codex":true}
+{"kind":"proxy_observed_401_codex_handles","account":"codex:max-1"}
+{"kind":"proxy_turn","account":"codex:max-1","method":"POST","path_kind":"responses","status":401,"classification":"auth_unauthorized","body_class":"none","claim_level":"broker_owned","streamed":true,"delivered_to_codex":true}
+{"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":false}
 EOF
 
 BROKERED_SUMMARY="$(python3 "$ROOT/scripts/summarize-codex-status.py" "$BROKERED" --require-brokered)"
@@ -58,6 +68,23 @@ fi
 if [[ "$(jq -r .provider_originated_live_fallback_claim <<<"$FALLBACK_SUMMARY")" != "false" ]]; then
     echo "summarizer must not claim provider-originated live fallback from NDJSON shape alone" >&2
     echo "$FALLBACK_SUMMARY" >&2
+    exit 1
+fi
+
+AUTH_FAILED_SUMMARY="$(python3 "$ROOT/scripts/summarize-codex-status.py" "$AUTH_FAILED" --require-brokered)"
+if [[ "$(jq -r .verdict <<<"$AUTH_FAILED_SUMMARY")" != "brokered_auth_failed" ]]; then
+    echo "auth-failed verdict mismatch" >&2
+    echo "$AUTH_FAILED_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .auth_unauthorized_turns <<<"$AUTH_FAILED_SUMMARY")" != "2" ]]; then
+    echo "auth-failed 401 count mismatch" >&2
+    echo "$AUTH_FAILED_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .responses_401_turns <<<"$AUTH_FAILED_SUMMARY")" != "1" ]]; then
+    echo "auth-failed responses 401 count mismatch" >&2
+    echo "$AUTH_FAILED_SUMMARY" >&2
     exit 1
 fi
 

--- a/scripts/summarize-codex-status.py
+++ b/scripts/summarize-codex-status.py
@@ -110,12 +110,26 @@ def summarize(path: Path) -> dict[str, Any]:
     session_started = next((e for e in events if e.get("kind") == "session_started"), {})
     session_ended = next((e for e in reversed(events) if e.get("kind") == "session_ended"), {})
     fallback = find_fallback_sequence(events)
+    auth_unauthorized_turns = [
+        e
+        for e in proxy_turns
+        if e.get("status") == 401 or e.get("classification") == "auth_unauthorized"
+    ]
+    ok_turns = [e for e in proxy_turns if e.get("status") == 200]
+    responses_401_turns = [
+        e
+        for e in auth_unauthorized_turns
+        if e.get("path_kind") == "responses"
+    ]
 
     brokered_session = (
         session_started.get("claim_level") == "broker_owned"
         or session_started.get("claim_level") == "broker_owned_app_server"
         or session_ended.get("final_claim_level") == "broker_owned"
     )
+    auth_failure_observed = bool(auth_unauthorized_turns)
+    auth_failed_without_recovery = auth_failure_observed and not ok_turns
+    auth_recovered_observed = auth_failure_observed and bool(ok_turns)
 
     return {
         "path": str(path),
@@ -128,6 +142,10 @@ def summarize(path: Path) -> dict[str, Any]:
         "proxy_turns_by_status": event_key_count(proxy_turns, "status"),
         "proxy_turns_by_path_kind": event_key_count(proxy_turns, "path_kind"),
         "proxy_turns_by_body_class": event_key_count(proxy_turns, "body_class"),
+        "auth_unauthorized_turns": len(auth_unauthorized_turns),
+        "responses_401_turns": len(responses_401_turns),
+        "auth_failure_observed": auth_failure_observed,
+        "auth_recovered_observed": auth_recovered_observed,
         "same_turn_retry_events": sum(1 for e in events if e.get("kind") == "proxy_same_turn_retry"),
         "same_turn_retry_unavailable_events": sum(
             1 for e in events if e.get("kind") == "proxy_same_turn_retry_unavailable"
@@ -140,6 +158,10 @@ def summarize(path: Path) -> dict[str, Any]:
         "verdict": (
             "fallback_sequence_observed"
             if fallback.get("observed")
+            else "brokered_auth_failed"
+            if brokered_session and auth_failed_without_recovery
+            else "brokered_auth_recovered"
+            if brokered_session and auth_recovered_observed
             else "brokered_without_fallback"
             if brokered_session and proxy_turns
             else "insufficient_evidence"


### PR DESCRIPTION
## Summary

- classify all-401 managed Codex status artifacts as brokered_auth_failed instead of brokered_without_fallback
- add auth 401 counters to the Codex status summarizer
- record dogfood-6 as an auth-authority/writeback gap, not quota fallback evidence

## Reality check

Dogfood-6 did start a broker-owned managed frame, but every upstream request on codex:max-1 returned 401 auth_unauthorized. Planning still selected max-1 because stored liveness and structural auth checks were stale-positive. This PR keeps that failure mode visible.

## Validation

- just check-local
- python3 scripts/summarize-codex-status.py dist/live-qa/managed-resume-dogfood-6/status.ndjson --require-brokered
- python3 scripts/summarize-codex-status.py dist/live-qa/managed-resume-dogfood-5/status.ndjson --require-brokered