### PR TITLE
Persist Codex overlay auth refreshes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Real on `main`:
   process before Codex receives the 429.
 - Same-account Codex child refresh is preserved so oauth-mux does not pin Codex
   to stale materialized access tokens after a native refresh.
+- Managed Codex overlay auth is imported back to the selected mux-owned account
+  source after child exit, so a refreshed `auth.json` is not lost between
+  managed frames.
 
 Not proven yet:
 
@@ -95,4 +98,8 @@ shape requires a `quota_exhausted` proxy turn, a retry/swap event, and a
 successful turn on a distinct fallback account.
 `verdict:"brokered_auth_failed"` means the managed frame started, but upstream
 returned unrecovered `401 auth_unauthorized` responses. That is an auth-health
-failure, not quota fallback evidence.
+failure, not quota fallback evidence. Status artifacts should also show an
+`auth_writeback` frame; `changed:true,written:true,ok:true` means Codex updated
+managed overlay auth and oauth-mux imported it back to the route's auth source.
+`source_conflict:true` means another writer changed the mux source first, so
+oauth-mux refused to overwrite it.

--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -415,6 +415,10 @@ oauth-mux evidence. Frame shapes are stable under broker `surface_version:
 { "kind": "resume_preflight", "mode": "last", "session_authority": "canonical_bridge", "rollouts_before": 42, "session_id_printed": false, "path_printed": false }
 { "kind": "resume_writeback", "mode": "last", "session_authority": "canonical_bridge", "changed_existing": 1, "created": 0, "session_id_printed": false, "path_printed": false }
 
+// auth authority import from the managed overlay back to the selected
+// mux-owned account source after Codex refreshes tokens inside CODEX_HOME
+{ "kind": "auth_writeback", "auth_authority": "mux_owned_overlay", "overlay_auth_present": true, "source_auth_present": true, "changed": true, "written": true, "source_conflict": false, "ok": true, "token_material_printed": false, "path_printed": false }
+
 // quota observation that did not trigger a swap
 { "kind": "quota_observed", "account": "codex:max-1", "kind_detail": "rate_limited", "retry_after_s": 12 }
 

--- a/docs/spec/codex-wire-evidence-2026-05-03.md
+++ b/docs/spec/codex-wire-evidence-2026-05-03.md
@@ -183,15 +183,28 @@ In the current adapter-owned child + wire-proxy topology:
 - The proxy propagates the 401 to codex unchanged (streamed response).
 - Codex's RefreshToken path runs entirely inside codex; oauth-mux
   doesn't see it.
-- Proxy's NEXT materialize call re-reads `auth.json` from disk and
-  picks up the refreshed token (no proxy-side state needed).
+- During the same managed session, the proxy preserves Codex's refreshed
+  same-account `Authorization` header instead of re-signing with stale
+  oauth-mux materialized auth. This keeps Codex's native retry path
+  authoritative for 401 recovery.
+- At child exit, the adapter compares the managed overlay `auth.json`
+  with the selected account's mux-owned auth source. If Codex refreshed
+  tokens inside the overlay, oauth-mux imports that changed file back
+  into the selected account source and emits a redacted `auth_writeback`
+  status frame. This prevents the next managed frame from reusing an
+  already-consumed refresh token. The import is compare-and-swap shaped:
+  if another managed session changed the source after this overlay was
+  created, oauth-mux reports `source_conflict:true` and does not
+  overwrite that fresher source.
 - Proxy emits `proxy_observed_401_codex_handles` for telemetry.
 - DOES NOT call `pool.markUnauthorized` (would defeat refresh loop).
 
 _OPERATOR-CONFIRM_: revoke a refresh_token externally, drive a turn,
 verify (a) codex's AuthManager logs RefreshToken, (b) auth.json mtime
-advances after the refresh, (c) the next turn through the proxy uses
-the new access_token.
+advances inside the managed overlay after the refresh, (c) the same
+managed session's retry uses the child refreshed bearer, and (d) the
+post-exit `auth_writeback` frame reports `changed:true` and
+`written:true` without printing path or token material.
 
 ## 5. 429 + `usage_limit_reached` — Frame Sequence
 

--- a/docs/spec/harness-session-authority-bridge-2026-05-05.md
+++ b/docs/spec/harness-session-authority-bridge-2026-05-05.md
@@ -26,6 +26,15 @@ Codex sessions. The 2026-05-06 managed-resume UX refactor plan records the
 daily-use command contract and regression guards required before this is
 treated as parity with bare Codex.
 
+The 2026-05-06 dogfood-6 auth failure exposed the auth-side counterpart:
+Codex can refresh tokens inside the managed overlay, and the adapter must
+import changed overlay `auth.json` back into the selected mux-owned account
+source before the next managed frame. Current code emits a redacted
+`auth_writeback` frame for that import. This writeback is scoped to the
+oauth-mux account source, not canonical `~/.codex/auth.json`. The import
+does not overwrite a source auth file that changed independently after the
+overlay was created; that conflict is surfaced as `source_conflict:true`.
+
 ## 0. Problem
 
 `oauth-mux codex run` currently creates a temporary `CODEX_HOME` overlay so
@@ -78,7 +87,10 @@ copy into an adapter overlay, but it must not mutate the user's canonical auth
 store unless the user is explicitly enrolling or reauthing that account.
 
 For Codex today: `auth.json` and likely `installation_id` are auth-authority
-inputs for the managed overlay.
+inputs for the managed overlay. If Codex mutates overlay `auth.json` during
+its native 401 refresh path, oauth-mux writes the changed file back to the
+selected account source so route auth does not go stale between managed
+frames.
 
 ### 2.2 Managed Config Overlay
 

--- a/scripts/smoke-codex-child-refresh.sh
+++ b/scripts/smoke-codex-child-refresh.sh
@@ -62,6 +62,7 @@ cat >"$TMP/oauth-mux.config.json" <<EOF
   }
 }
 EOF
+REFRESHED_AUTH="{\"OPENAI_API_KEY\":null,\"tokens\":{\"id_token\":\"$ID_TOKEN\",\"access_token\":\"CHILD-REFRESHED\",\"refresh_token\":\"RT-A-REFRESHED\",\"account_id\":\"acc-A-id\"},\"auth_mode\":\"Chatgpt\"}"
 
 OMUX_STUB_PORT=0 \
   OMUX_STUB_PORTFILE="$PORTFILE" \
@@ -85,6 +86,7 @@ OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_STUB_CODEX_TURNS=2 \
   OMUX_STUB_CODEX_CHATGPT_ACCOUNT_ID="acc-A-id" \
   OMUX_STUB_CODEX_AUTH_TOKENS="CHILD-OLD,CHILD-REFRESHED" \
+  OMUX_STUB_REWRITE_AUTH_JSON="$REFRESHED_AUTH" \
   OMUX_STUB_CODEX_REPORT="$STUB_REPORT" \
   "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$NDJSON" 2>"$ADAPTER_STDERR" || {
     echo "adapter exited nonzero" >&2
@@ -120,6 +122,7 @@ assert_no_grep() {
 
 assert_grep "session_started" '"kind":"session_started"' "$NDJSON"
 assert_grep "same-account child auth was preserved" '"kind":"proxy_preserved_child_auth".*"reason":"same_account_child_refresh"' "$NDJSON"
+assert_grep "overlay auth refresh was imported" '"kind":"auth_writeback".*"changed":true.*"written":true.*"ok":true' "$NDJSON"
 assert_grep "turns stayed 200 ok" '"kind":"proxy_turn".*"status":200.*"classification":"ok"' "$NDJSON"
 TURN_COUNT=$(grep -c '"kind":"proxy_turn"' "$NDJSON" | tr -d ' ')
 if [[ "$TURN_COUNT" -eq 2 ]]; then
@@ -158,6 +161,16 @@ else
     exit 1
 fi
 
+SOURCE_ACCESS_TOKEN=$(jq -r '.tokens.access_token' "$TMP/account-A/auth.json")
+SOURCE_REFRESH_TOKEN=$(jq -r '.tokens.refresh_token' "$TMP/account-A/auth.json")
+if [[ "$SOURCE_ACCESS_TOKEN" == "CHILD-REFRESHED" && "$SOURCE_REFRESH_TOKEN" == "RT-A-REFRESHED" ]]; then
+    echo "  ✓ refreshed overlay auth was written back to mux source"
+else
+    echo "  ✗ mux source auth was not refreshed from overlay" >&2
+    jq '{access_token:.tokens.access_token, refresh_token:.tokens.refresh_token}' "$TMP/account-A/auth.json" >&2
+    exit 1
+fi
+
 DISTINCT_ACCOUNTS=$(jq -r .account_id "$UPSTREAM_LOG" | sort -u | wc -l | tr -d ' ')
 if [[ "$DISTINCT_ACCOUNTS" -eq 1 ]] && [[ "$(jq -r '.[0].account_id' <(jq -s '.' "$UPSTREAM_LOG"))" == "acc-A-id" ]]; then
     echo "  ✓ same elected account stayed selected"
@@ -176,7 +189,15 @@ else
     exit 1
 fi
 
+if [[ "$(jq -r '.auth_rewrite.checked' "$STUB_REPORT")" == "true" ]]; then
+    echo "  ✓ stub emulated Codex overlay auth persistence"
+else
+    echo "  ✗ stub did not rewrite overlay auth" >&2
+    jq .auth_rewrite "$STUB_REPORT" >&2
+    exit 1
+fi
+
 echo
-echo "smoke-codex-child-refresh: all 12 assertions passed."
+echo "smoke-codex-child-refresh: all 15 assertions passed."
 echo "  full ndjson: $NDJSON"
 echo "  stub upstream log: $UPSTREAM_LOG"

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -32,6 +32,10 @@ Env (set by the smoke harness):
                             a redacted marker to. Used by resume smokes to
                             prove the managed session authority receives
                             child writes.
+  OMUX_STUB_REWRITE_AUTH_JSON — optional auth.json contents to write inside
+                            CODEX_HOME before sending turns. Used to emulate
+                            Codex persisting refreshed ChatGPT tokens in the
+                            managed overlay.
   The report records argv after the stub binary so CLI forwarding smokes can
   assert `oauth-mux codex ...` command shape without provider traffic.
 """
@@ -145,6 +149,19 @@ def _append_session_marker(codex_home: Path) -> dict:
     }
 
 
+def _rewrite_auth_json(codex_home: Path) -> dict:
+    contents = os.environ.get("OMUX_STUB_REWRITE_AUTH_JSON")
+    if contents is None:
+        return {"checked": False}
+    (codex_home / "auth.json").write_text(contents, encoding="utf-8")
+    return {
+        "checked": True,
+        "written": True,
+        "token_material_printed": False,
+        "path_printed": False,
+    }
+
+
 def main() -> int:
     pid = os.getpid()
     pidfile = Path(os.environ.get("OMUX_STUB_CODEX_PIDFILE", "/tmp/omux-stub-codex.pid"))
@@ -157,6 +174,7 @@ def main() -> int:
     proxy_url = _read_proxy_url(codex_home)
     session_bridge = _session_bridge_report(codex_home)
     session_append = _append_session_marker(codex_home)
+    auth_rewrite = _rewrite_auth_json(codex_home)
 
     started_at = time.time()
     print(
@@ -188,6 +206,7 @@ def main() -> int:
         "active_account_at_start": os.environ.get("OMUX_ACTIVE_ACCOUNT"),
         "session_bridge": session_bridge,
         "session_append": session_append,
+        "auth_rewrite": auth_rewrite,
     }
     report_path.write_text(json.dumps(report, indent=2))
     print(f"stub-codex: pid_stable={report['pid_stable']} turns={turns}", file=sys.stderr, flush=True)

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -77,6 +77,7 @@ const SessionCodexHome = struct {
     path: []u8,
     session_authority: SessionAuthorityMode,
     authority_home: ?[]u8 = null,
+    auth_initial_hash: [32]u8,
 
     fn deinit(self: SessionCodexHome, allocator: std.mem.Allocator) void {
         std.fs.cwd().deleteTree(self.path) catch {};
@@ -141,6 +142,16 @@ const ResumeObservation = struct {
     created: usize = 0,
     explicit_target_found_before: ?bool = null,
     explicit_target_changed: ?bool = null,
+};
+
+const AuthWritebackObservation = struct {
+    overlay_auth_present: bool = false,
+    source_auth_present: bool = false,
+    changed: bool = false,
+    written: bool = false,
+    source_conflict: bool = false,
+    ok: bool = true,
+    error_name: ?[]const u8 = null,
 };
 
 const SessionAuthorityEntryKind = enum {
@@ -360,7 +371,19 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     tickleProxy(proxy_port);
     proxy_thread.join();
 
+    const auth_writeback = observeAuthWriteback(allocator, codex_home.path, source_auth_path, codex_home.auth_initial_hash) catch |e| failed: {
+        try stderr.print("oauth-mux codex: auth writeback failed: {s}\n", .{@errorName(e)});
+        break :failed AuthWritebackObservation{
+            .ok = false,
+            .error_name = @errorName(e),
+        };
+    };
+    if (auth_writeback.source_conflict) {
+        try stderr.writeAll("oauth-mux codex: auth writeback conflict; not overwriting newer account auth\n");
+    }
+
     if (emit_status) {
+        try writeAuthWritebackStatus(status_writer, auth_writeback);
         if (resume_request.requested()) {
             const observation = if (codex_home.authority_home) |authority_home|
                 try observeResumeWriteback(allocator, authority_home, if (resume_snapshot) |*snapshot| snapshot else null, resume_request)
@@ -448,6 +471,7 @@ fn createSessionCodexHomeUnder(
     const auth_dst = try std.fs.path.join(allocator, &.{ session_home, "auth.json" });
     defer allocator.free(auth_dst);
     try copyFileContents(allocator, source_auth_path, auth_dst);
+    const auth_initial_hash = try hashFileContents(allocator, auth_dst);
 
     if (std.fs.path.dirname(source_auth_path)) |source_dir| {
         const install_src = try std.fs.path.join(allocator, &.{ source_dir, "installation_id" });
@@ -470,6 +494,7 @@ fn createSessionCodexHomeUnder(
         .path = session_home,
         .session_authority = session_authority,
         .authority_home = if (session_authority_home) |home| try allocator.dupe(u8, home) else null,
+        .auth_initial_hash = auth_initial_hash,
     };
 }
 
@@ -691,6 +716,27 @@ fn writeResumeWritebackStatus(
     try writer.writeAll(",\"session_id_printed\":false,\"path_printed\":false}\n");
 }
 
+fn writeAuthWritebackStatus(
+    writer: anytype,
+    observation: AuthWritebackObservation,
+) !void {
+    try writer.print(
+        "{{\"kind\":\"auth_writeback\",\"auth_authority\":\"mux_owned_overlay\",\"overlay_auth_present\":{any},\"source_auth_present\":{any},\"changed\":{any},\"written\":{any},\"source_conflict\":{any},\"ok\":{any},\"token_material_printed\":false,\"path_printed\":false",
+        .{
+            observation.overlay_auth_present,
+            observation.source_auth_present,
+            observation.changed,
+            observation.written,
+            observation.source_conflict,
+            observation.ok,
+        },
+    );
+    if (observation.error_name) |name| {
+        try writer.print(",\"error\":\"{s}\"", .{name});
+    }
+    try writer.writeAll("}\n");
+}
+
 fn copyFileContents(
     allocator: std.mem.Allocator,
     source_path: []const u8,
@@ -701,6 +747,110 @@ fn copyFileContents(
     const f = try std.fs.cwd().createFile(dest_path, .{ .mode = 0o600, .truncate = true });
     defer f.close();
     try f.writeAll(bytes);
+}
+
+fn observeAuthWriteback(
+    allocator: std.mem.Allocator,
+    session_home: []const u8,
+    source_auth_path: []const u8,
+    initial_auth_hash: [32]u8,
+) !AuthWritebackObservation {
+    var observation = AuthWritebackObservation{};
+
+    const overlay_auth_path = try std.fs.path.join(allocator, &.{ session_home, "auth.json" });
+    defer allocator.free(overlay_auth_path);
+
+    const overlay_bytes = std.fs.cwd().readFileAlloc(allocator, overlay_auth_path, 2 * 1024 * 1024) catch |e| switch (e) {
+        error.FileNotFound => return observation,
+        else => return e,
+    };
+    defer allocator.free(overlay_bytes);
+    observation.overlay_auth_present = true;
+
+    const overlay_hash = hashBytes(overlay_bytes);
+    observation.changed = !std.mem.eql(u8, overlay_hash[0..], initial_auth_hash[0..]);
+
+    var source_bytes: ?[]u8 = null;
+    defer if (source_bytes) |bytes| allocator.free(bytes);
+    source_bytes = std.fs.cwd().readFileAlloc(allocator, source_auth_path, 2 * 1024 * 1024) catch |e| switch (e) {
+        error.FileNotFound => null,
+        else => return e,
+    };
+    observation.source_auth_present = source_bytes != null;
+
+    if (!observation.changed) return observation;
+
+    if (source_bytes) |bytes| {
+        if (std.mem.eql(u8, overlay_bytes, bytes)) {
+            return observation;
+        }
+        const source_hash = hashBytes(bytes);
+        if (!std.mem.eql(u8, source_hash[0..], initial_auth_hash[0..])) {
+            observation.source_conflict = true;
+            observation.ok = false;
+            return observation;
+        }
+    }
+
+    if (observation.changed) {
+        try writeFileReplaceBytes(allocator, source_auth_path, overlay_bytes);
+        observation.written = true;
+    }
+
+    return observation;
+}
+
+fn hashFileContents(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+) ![32]u8 {
+    const bytes = try std.fs.cwd().readFileAlloc(allocator, path, 2 * 1024 * 1024);
+    defer allocator.free(bytes);
+    return hashBytes(bytes);
+}
+
+fn hashBytes(bytes: []const u8) [32]u8 {
+    var digest: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
+    return digest;
+}
+
+fn writeFileReplaceBytes(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    bytes: []const u8,
+) !void {
+    if (std.fs.path.dirname(path)) |dir| {
+        try std.fs.cwd().makePath(dir);
+    }
+
+    const tmp_path = try std.fmt.allocPrint(allocator, "{s}.tmp-{x}", .{ path, std.crypto.random.int(u64) });
+    defer allocator.free(tmp_path);
+
+    const is_absolute = std.fs.path.isAbsolute(path);
+    const file = if (is_absolute)
+        try std.fs.createFileAbsolute(tmp_path, .{ .exclusive = true, .mode = 0o600 })
+    else
+        try std.fs.cwd().createFile(tmp_path, .{ .exclusive = true, .mode = 0o600 });
+    errdefer {
+        if (is_absolute) {
+            std.fs.deleteFileAbsolute(tmp_path) catch {};
+        } else {
+            std.fs.cwd().deleteFile(tmp_path) catch {};
+        }
+    }
+
+    {
+        defer file.close();
+        try file.writeAll(bytes);
+        try file.sync();
+    }
+
+    if (is_absolute) {
+        try std.fs.renameAbsolute(tmp_path, path);
+    } else {
+        try std.fs.cwd().rename(tmp_path, path);
+    }
 }
 
 fn writeManagedConfigToml(
@@ -883,6 +1033,121 @@ test "createSessionCodexHomeUnder copies auth and does not clobber source config
     const original_config = try std.fs.cwd().readFileAlloc(std.testing.allocator, source_config, 1024);
     defer std.testing.allocator.free(original_config);
     try std.testing.expectEqualStrings("preexisting = true\n", original_config);
+}
+
+test "observeAuthWriteback imports changed overlay auth into mux source" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("account");
+    {
+        const auth = try tmp.dir.createFile("account/auth.json", .{ .mode = 0o600 });
+        defer auth.close();
+        try auth.writeAll("{\"tokens\":{\"access_token\":\"old\",\"refresh_token\":\"old-rt\"}}\n");
+    }
+
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const auth_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "account", "auth.json" });
+    defer std.testing.allocator.free(auth_path);
+
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null);
+    defer codex_home.deinit(std.testing.allocator);
+
+    const overlay_auth = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "auth.json" });
+    defer std.testing.allocator.free(overlay_auth);
+    {
+        const auth = try std.fs.cwd().createFile(overlay_auth, .{ .mode = 0o600, .truncate = true });
+        defer auth.close();
+        try auth.writeAll("{\"tokens\":{\"access_token\":\"new\",\"refresh_token\":\"new-rt\"}}\n");
+    }
+
+    const observation = try observeAuthWriteback(std.testing.allocator, codex_home.path, auth_path, codex_home.auth_initial_hash);
+    try std.testing.expect(observation.overlay_auth_present);
+    try std.testing.expect(observation.source_auth_present);
+    try std.testing.expect(observation.changed);
+    try std.testing.expect(observation.written);
+    try std.testing.expect(!observation.source_conflict);
+    try std.testing.expect(observation.ok);
+    try std.testing.expect(observation.error_name == null);
+
+    const source_auth = try std.fs.cwd().readFileAlloc(std.testing.allocator, auth_path, 1024);
+    defer std.testing.allocator.free(source_auth);
+    try std.testing.expectEqualStrings("{\"tokens\":{\"access_token\":\"new\",\"refresh_token\":\"new-rt\"}}\n", source_auth);
+}
+
+test "observeAuthWriteback leaves unchanged overlay auth alone" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("account");
+    {
+        const auth = try tmp.dir.createFile("account/auth.json", .{ .mode = 0o600 });
+        defer auth.close();
+        try auth.writeAll("{\"tokens\":{\"access_token\":\"same\"}}\n");
+    }
+
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const auth_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "account", "auth.json" });
+    defer std.testing.allocator.free(auth_path);
+
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null);
+    defer codex_home.deinit(std.testing.allocator);
+
+    const observation = try observeAuthWriteback(std.testing.allocator, codex_home.path, auth_path, codex_home.auth_initial_hash);
+    try std.testing.expect(observation.overlay_auth_present);
+    try std.testing.expect(observation.source_auth_present);
+    try std.testing.expect(!observation.changed);
+    try std.testing.expect(!observation.written);
+    try std.testing.expect(!observation.source_conflict);
+    try std.testing.expect(observation.ok);
+    try std.testing.expect(observation.error_name == null);
+}
+
+test "observeAuthWriteback refuses to overwrite independently changed mux source" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("account");
+    {
+        const auth = try tmp.dir.createFile("account/auth.json", .{ .mode = 0o600 });
+        defer auth.close();
+        try auth.writeAll("{\"tokens\":{\"access_token\":\"old\",\"refresh_token\":\"old-rt\"}}\n");
+    }
+
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const auth_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "account", "auth.json" });
+    defer std.testing.allocator.free(auth_path);
+
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null);
+    defer codex_home.deinit(std.testing.allocator);
+
+    const overlay_auth = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "auth.json" });
+    defer std.testing.allocator.free(overlay_auth);
+    {
+        const auth = try std.fs.cwd().createFile(overlay_auth, .{ .mode = 0o600, .truncate = true });
+        defer auth.close();
+        try auth.writeAll("{\"tokens\":{\"access_token\":\"overlay-new\",\"refresh_token\":\"overlay-rt\"}}\n");
+    }
+    {
+        const auth = try std.fs.cwd().createFile(auth_path, .{ .mode = 0o600, .truncate = true });
+        defer auth.close();
+        try auth.writeAll("{\"tokens\":{\"access_token\":\"source-new\",\"refresh_token\":\"source-rt\"}}\n");
+    }
+
+    const observation = try observeAuthWriteback(std.testing.allocator, codex_home.path, auth_path, codex_home.auth_initial_hash);
+    try std.testing.expect(observation.overlay_auth_present);
+    try std.testing.expect(observation.source_auth_present);
+    try std.testing.expect(observation.changed);
+    try std.testing.expect(!observation.written);
+    try std.testing.expect(observation.source_conflict);
+    try std.testing.expect(!observation.ok);
+
+    const source_auth = try std.fs.cwd().readFileAlloc(std.testing.allocator, auth_path, 1024);
+    defer std.testing.allocator.free(source_auth);
+    try std.testing.expectEqualStrings("{\"tokens\":{\"access_token\":\"source-new\",\"refresh_token\":\"source-rt\"}}\n", source_auth);
 }
 
 test "createSessionCodexHomeUnder bridges canonical session authority without copying" {


### PR DESCRIPTION
## Summary
- import changed managed Codex overlay auth.json back to the selected mux-owned account source after child exit
- make auth import compare-and-swap shaped so concurrent source changes report source_conflict instead of being overwritten
- extend child-refresh smoke/stub and truth docs for auth_writeback evidence

## Tests
- zig build test
- just build
- scripts/smoke-codex-child-refresh.sh
- scripts/smoke-codex-401-propagation.sh
- just check-local