### PR TITLE
Record managed Codex auth health

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,4 +102,7 @@ failure, not quota fallback evidence. Status artifacts should also show an
 `auth_writeback` frame; `changed:true,written:true,ok:true` means Codex updated
 managed overlay auth and oauth-mux imported it back to the route's auth source.
 `source_conflict:true` means another writer changed the mux source first, so
-oauth-mux refused to overwrite it.
+oauth-mux refused to overwrite it. When unrecovered 401s occur and no overlay
+auth changed, oauth-mux records account-credential health for the next launch
+and emits `auth_health_observed` with `quota_claim:false`; that does not prove
+the subscription lacks quota.

--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -221,6 +221,9 @@ app-server, the proxy classifies status:
 if status == 401:
     quota/observe(kind=auth_unauthorized, ...)
     return upstream response unchanged
+    # after child exit only: if no same-account recovery and no overlay auth
+    # changed, record account-credential health for next-launch route selection
+    # with quota_claim:false.
 elif status == 429:
     parse body for error.type
     if error.type == "usage_limit_reached":
@@ -418,6 +421,10 @@ oauth-mux evidence. Frame shapes are stable under broker `surface_version:
 // auth authority import from the managed overlay back to the selected
 // mux-owned account source after Codex refreshes tokens inside CODEX_HOME
 { "kind": "auth_writeback", "auth_authority": "mux_owned_overlay", "overlay_auth_present": true, "source_auth_present": true, "changed": true, "written": true, "source_conflict": false, "ok": true, "token_material_printed": false, "path_printed": false }
+
+// unrecovered 401 classification after child exit; this records credential
+// health for the next broker-owned launch, but it is not quota evidence
+{ "kind": "auth_health_observed", "account": "codex:max-1", "auth_unauthorized_turns": 6, "responses_401_turns": 2, "recovered_after_401": false, "recorded": true, "reason": "unrecovered_401_no_writeback", "scope": "account_credential", "quota_claim": false, "token_material_printed": false, "path_printed": false }
 
 // quota observation that did not trigger a swap
 { "kind": "quota_observed", "account": "codex:max-1", "kind_detail": "rate_limited", "retry_after_s": 12 }

--- a/docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md
+++ b/docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md
@@ -612,3 +612,11 @@ Truth boundary:
   mux-owned auth overlays either need durable token writeback/import back to the
   selected account store, or repeated 401/refresh-token-failure evidence must
   mark the route auth-unready and select a fallback account on the next launch.
+
+Follow-up implemented:
+
+- The adapter now records unrecovered managed-session 401s as account-credential
+  health only after the child exits and only when the overlay auth did not
+  change. The status stream emits `auth_health_observed` with
+  `quota_claim:false`, and the next `broker-session-plan` should route around
+  that stale auth source when another healthy route exists.

--- a/docs/spec/codex-wire-evidence-2026-05-03.md
+++ b/docs/spec/codex-wire-evidence-2026-05-03.md
@@ -198,6 +198,11 @@ In the current adapter-owned child + wire-proxy topology:
   overwrite that fresher source.
 - Proxy emits `proxy_observed_401_codex_handles` for telemetry.
 - DOES NOT call `pool.markUnauthorized` (would defeat refresh loop).
+- If the managed session exits after unrecovered 401s and the overlay
+  `auth.json` did not change, the adapter records account-credential health
+  for the next launch and emits `auth_health_observed` with
+  `quota_claim:false`. This is a local auth-source repair signal, not quota
+  evidence and not a live account-substitution proof.
 
 _OPERATOR-CONFIRM_: revoke a refresh_token externally, drive a turn,
 verify (a) codex's AuthManager logs RefreshToken, (b) auth.json mtime

--- a/scripts/smoke-codex-401-propagation.sh
+++ b/scripts/smoke-codex-401-propagation.sh
@@ -24,6 +24,7 @@ PORTFILE="$TMP/upstream.port"
 NDJSON="$TMP/adapter.ndjson"
 ADAPTER_STDERR="$TMP/adapter.stderr"
 STUB_REPORT="$TMP/stub-codex.report"
+STUB_BIN_DIR="$TMP/bin"
 
 cleanup() {
     if [[ -n "${UPSTREAM_PID:-}" ]] && kill -0 "$UPSTREAM_PID" 2>/dev/null; then
@@ -34,13 +35,14 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$TMP/account-A" "$TMP/account-B"
+mkdir -p "$TMP/account-A" "$TMP/account-B" "$STUB_BIN_DIR"
+mkdir -p "$TMP/state"
 ID_TOKEN="h.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9wbGFuX3R5cGUiOiJwcm8iLCJjaGF0Z3B0X2FjY291bnRfaXNfZmVkcmFtcCI6dHJ1ZX19.s"
 cat >"$TMP/account-A/auth.json" <<EOF
-{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"AT-401-A","refresh_token":"RT-A","account_id":"acc-A-id"},"auth_mode":"Chatgpt"}
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"$ID_TOKEN","refresh_token":"RT-A","account_id":"acc-A-id"},"auth_mode":"Chatgpt"}
 EOF
 cat >"$TMP/account-B/auth.json" <<EOF
-{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"AT-401-B","refresh_token":"RT-B","account_id":"acc-B-id"},"auth_mode":"Chatgpt"}
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"$ID_TOKEN","refresh_token":"RT-B","account_id":"acc-B-id"},"auth_mode":"Chatgpt"}
 EOF
 
 cat >"$TMP/oauth-mux.config.json" <<EOF
@@ -50,8 +52,8 @@ cat >"$TMP/oauth-mux.config.json" <<EOF
     "codex": {
       "kind": "codex",
       "accounts": {
-        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "$TMP/account-A/auth.json" } },
-        "max-2": { "priority": 20, "secret": { "backend": "file", "path": "$TMP/account-B/auth.json" } }
+        "max-1": { "priority": 30, "config_dir": "$TMP/account-A", "secret": { "backend": "file", "path": "$TMP/account-A/auth.json" } },
+        "max-2": { "priority": 20, "config_dir": "$TMP/account-B", "secret": { "backend": "file", "path": "$TMP/account-B/auth.json" } }
       }
     }
   },
@@ -60,6 +62,30 @@ cat >"$TMP/oauth-mux.config.json" <<EOF
   }
 }
 EOF
+
+cat >"$TMP/state/health.json" <<'EOF'
+{
+  "version": 2,
+  "accounts": [
+    {
+      "key": "codex:max-2#codex-max",
+      "last_probe_source": "capability_probe",
+      "last_probe_hint_class": "none",
+      "last_probe_decision": "use_this",
+      "liveness": {
+        "state": "live",
+        "availability": "available"
+      }
+    }
+  ]
+}
+EOF
+
+cat >"$STUB_BIN_DIR/codex" <<'EOF'
+#!/usr/bin/env sh
+exit 0
+EOF
+chmod +x "$STUB_BIN_DIR/codex"
 
 OMUX_STUB_PORT=0 \
   OMUX_STUB_PORTFILE="$PORTFILE" \
@@ -76,6 +102,7 @@ UPSTREAM_PORT="$(cat "$PORTFILE" | tr -d '[:space:]')"
 echo "smoke-codex-401-propagation: stub upstream pid=$UPSTREAM_PID port=$UPSTREAM_PORT always_status=401"
 
 OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+  OMUX_STATE_DIR="$TMP/state" \
   OMUX_UPSTREAM_HOST="127.0.0.1:$UPSTREAM_PORT" \
   OMUX_UPSTREAM_SCHEME="http" \
   OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
@@ -117,6 +144,7 @@ assert_grep "session_started" '"kind":"session_started"' "$NDJSON"
 assert_grep "session_started redacts CODEX_HOME path" '"codex_home_path_printed":false' "$NDJSON"
 assert_grep "proxy_turn 401 classified auth_unauthorized" '"kind":"proxy_turn".*"status":401.*"classification":"auth_unauthorized"' "$NDJSON"
 assert_grep "proxy_observed_401_codex_handles diagnostic emitted" '"kind":"proxy_observed_401_codex_handles"' "$NDJSON"
+assert_grep "unrecovered 401 recorded as auth health, not quota" '"kind":"auth_health_observed".*"recorded":true.*"reason":"unrecovered_401_no_writeback".*"quota_claim":false' "$NDJSON"
 
 assert_no_grep "no swap fired" '"kind":"proxy_post_swap_turn"' "$NDJSON"
 assert_no_grep "no same-turn retry fired" '"kind":"proxy_same_turn_retry"' "$NDJSON"
@@ -157,6 +185,25 @@ else
     exit 1
 fi
 
+PLAN_AFTER="$(PATH="$STUB_BIN_DIR:$PATH" OMUX_CONFIG="$TMP/oauth-mux.config.json" OMUX_STATE_DIR="$TMP/state" "$BIN" codex broker-session-plan --profile codex-max --capability codex-max --json)"
+SELECTED_AFTER="$(jq -r '.selected.account' <<<"$PLAN_AFTER")"
+if [[ "$SELECTED_AFTER" == "max-2" ]]; then
+    echo "  ✓ next broker-session-plan avoids unrecovered max-1 auth"
+else
+    echo "  ✗ broker-session-plan selected $SELECTED_AFTER after unrecovered max-1 auth" >&2
+    jq . <<<"$PLAN_AFTER" >&2
+    exit 1
+fi
+
+MAX1_SKIP="$(jq -r '.routes[] | select(.account == "max-1") | .skip_reason' <<<"$PLAN_AFTER")"
+if [[ "$MAX1_SKIP" == "token_revoked" ]]; then
+    echo "  ✓ max-1 marked as reauth/try-next credential health"
+else
+    echo "  ✗ max-1 skip_reason after unrecovered auth was $MAX1_SKIP" >&2
+    jq .routes <<<"$PLAN_AFTER" >&2
+    exit 1
+fi
+
 echo
-echo "smoke-codex-401-propagation: all 13 assertions passed."
+echo "smoke-codex-401-propagation: all 16 assertions passed."
 echo "  full ndjson: $NDJSON"

--- a/scripts/smoke-codex-status-summary.sh
+++ b/scripts/smoke-codex-status-summary.sh
@@ -39,6 +39,7 @@ cat >"$AUTH_FAILED" <<'EOF'
 {"kind":"proxy_turn","account":"codex:max-1","method":"GET","path_kind":"codex_other","status":401,"classification":"auth_unauthorized","body_class":"none","claim_level":"broker_owned","streamed":true,"delivered_to_codex":true}
 {"kind":"proxy_observed_401_codex_handles","account":"codex:max-1"}
 {"kind":"proxy_turn","account":"codex:max-1","method":"POST","path_kind":"responses","status":401,"classification":"auth_unauthorized","body_class":"none","claim_level":"broker_owned","streamed":true,"delivered_to_codex":true}
+{"kind":"auth_health_observed","account":"codex:max-1","auth_unauthorized_turns":2,"responses_401_turns":1,"recovered_after_401":false,"recorded":true,"reason":"unrecovered_401_no_writeback","scope":"account_credential","quota_claim":false,"token_material_printed":false,"path_printed":false}
 {"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":false}
 EOF
 
@@ -84,6 +85,16 @@ if [[ "$(jq -r .auth_unauthorized_turns <<<"$AUTH_FAILED_SUMMARY")" != "2" ]]; t
 fi
 if [[ "$(jq -r .responses_401_turns <<<"$AUTH_FAILED_SUMMARY")" != "1" ]]; then
     echo "auth-failed responses 401 count mismatch" >&2
+    echo "$AUTH_FAILED_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .auth_health_recorded_observed <<<"$AUTH_FAILED_SUMMARY")" != "true" ]]; then
+    echo "auth-failed summary should report recorded credential health" >&2
+    echo "$AUTH_FAILED_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .auth_health_quota_claim_observed <<<"$AUTH_FAILED_SUMMARY")" != "false" ]]; then
+    echo "auth-failed summary must not turn auth health into quota evidence" >&2
     echo "$AUTH_FAILED_SUMMARY" >&2
     exit 1
 fi

--- a/scripts/summarize-codex-status.py
+++ b/scripts/summarize-codex-status.py
@@ -110,6 +110,7 @@ def summarize(path: Path) -> dict[str, Any]:
     session_started = next((e for e in events if e.get("kind") == "session_started"), {})
     session_ended = next((e for e in reversed(events) if e.get("kind") == "session_ended"), {})
     fallback = find_fallback_sequence(events)
+    auth_health_events = [e for e in events if e.get("kind") == "auth_health_observed"]
     auth_unauthorized_turns = [
         e
         for e in proxy_turns
@@ -146,6 +147,9 @@ def summarize(path: Path) -> dict[str, Any]:
         "responses_401_turns": len(responses_401_turns),
         "auth_failure_observed": auth_failure_observed,
         "auth_recovered_observed": auth_recovered_observed,
+        "auth_health_events": len(auth_health_events),
+        "auth_health_recorded_observed": any(e.get("recorded") is True for e in auth_health_events),
+        "auth_health_quota_claim_observed": any(e.get("quota_claim") is True for e in auth_health_events),
         "same_turn_retry_events": sum(1 for e in events if e.get("kind") == "proxy_same_turn_retry"),
         "same_turn_retry_unavailable_events": sum(
             1 for e in events if e.get("kind") == "proxy_same_turn_retry_unavailable"

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -31,6 +31,7 @@ const broker = @import("../../broker/mod.zig");
 const broker_types = @import("../../broker/types.zig");
 const broker_loader = @import("../../broker_loader.zig");
 const config_mod = @import("../../config.zig");
+const health_mod = @import("../../health.zig");
 const shell = @import("../../shell.zig");
 const wire_proxy = @import("wire_proxy.zig");
 
@@ -152,6 +153,11 @@ const AuthWritebackObservation = struct {
     source_conflict: bool = false,
     ok: bool = true,
     error_name: ?[]const u8 = null,
+};
+
+const ManagedAuthHealthObservation = struct {
+    recorded: bool = false,
+    reason: []const u8 = "not_observed",
 };
 
 const SessionAuthorityEntryKind = enum {
@@ -381,9 +387,14 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     if (auth_writeback.source_conflict) {
         try stderr.writeAll("oauth-mux codex: auth writeback conflict; not overwriting newer account auth\n");
     }
+    const auth_failure = proxy.authFailureObservation();
+    const auth_health = recordManagedAuthFailureHealth(allocator, auth_failure, auth_writeback);
 
     if (emit_status) {
         try writeAuthWritebackStatus(status_writer, auth_writeback);
+        if (auth_failure.auth_unauthorized_turns > 0) {
+            try writeManagedAuthHealthStatus(status_writer, auth_failure, auth_health);
+        }
         if (resume_request.requested()) {
             const observation = if (codex_home.authority_home) |authority_home|
                 try observeResumeWriteback(allocator, authority_home, if (resume_snapshot) |*snapshot| snapshot else null, resume_request)
@@ -735,6 +746,61 @@ fn writeAuthWritebackStatus(
         try writer.print(",\"error\":\"{s}\"", .{name});
     }
     try writer.writeAll("}\n");
+}
+
+fn recordManagedAuthFailureHealth(
+    allocator: std.mem.Allocator,
+    observation: wire_proxy.AuthFailureObservation,
+    auth_writeback: AuthWritebackObservation,
+) ManagedAuthHealthObservation {
+    if (!observation.unrecovered()) {
+        return .{ .recorded = false, .reason = "recovered_or_absent" };
+    }
+    if (!auth_writeback.ok) {
+        return .{ .recorded = false, .reason = "auth_writeback_observation_failed" };
+    }
+    if (auth_writeback.changed) {
+        return .{ .recorded = false, .reason = "child_auth_changed" };
+    }
+
+    const account_id = observation.account orelse return .{ .recorded = false, .reason = "missing_account" };
+    const colon = std.mem.indexOfScalar(u8, account_id, ':') orelse return .{ .recorded = false, .reason = "invalid_account_id" };
+    if (colon == 0 or colon + 1 >= account_id.len) return .{ .recorded = false, .reason = "invalid_account_id" };
+
+    const provider = account_id[0..colon];
+    const account = account_id[colon + 1 ..];
+    const key = health_mod.accountKey(provider, account);
+
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+    store.recordHttpStatus(key.slice(), 401, null);
+    store.recordProbeEvidence(key.slice(), .broker_run_live, null, .auth_dead, .try_next_account);
+    store.persist();
+
+    return .{ .recorded = true, .reason = "unrecovered_401_no_writeback" };
+}
+
+fn writeManagedAuthHealthStatus(
+    writer: anytype,
+    observation: wire_proxy.AuthFailureObservation,
+    health: ManagedAuthHealthObservation,
+) !void {
+    try writer.writeAll("{\"kind\":\"auth_health_observed\",\"account\":");
+    if (observation.account) |account| {
+        try std.json.stringify(account, .{}, writer);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.print(
+        ",\"auth_unauthorized_turns\":{d},\"responses_401_turns\":{d},\"recovered_after_401\":{any},\"recorded\":{any},\"reason\":\"{s}\",\"scope\":\"account_credential\",\"quota_claim\":false,\"token_material_printed\":false,\"path_printed\":false}}\n",
+        .{
+            observation.auth_unauthorized_turns,
+            observation.responses_401_turns,
+            observation.recovered_after_401,
+            health.recorded,
+            health.reason,
+        },
+    );
 }
 
 fn copyFileContents(

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -128,6 +128,8 @@ pub const Proxy = struct {
     /// but is deliberately separate from the live claim ladder.
     synthetic_swap_seen: bool = false,
 
+    auth_failure_tracker: AuthFailureTracker = .{},
+
     pub fn bind(
         allocator: std.mem.Allocator,
         pool: *account_pool_mod.AccountPool,
@@ -166,6 +168,10 @@ pub const Proxy = struct {
 
     pub fn syntheticSwapSeen(self: *const Proxy) bool {
         return self.synthetic_swap_seen;
+    }
+
+    pub fn authFailureObservation(self: *const Proxy) AuthFailureObservation {
+        return self.auth_failure_tracker.observation();
     }
 
     /// Accept one connection, handle one HTTP/1.1 transaction, close.
@@ -324,6 +330,7 @@ pub const Proxy = struct {
         status_and_class: StatusAndClassification,
         delivered_to_codex: bool,
     ) void {
+        self.auth_failure_tracker.observe(account_id, req.path, status_and_class.classification);
         self.logEvent("proxy_turn", .{
             .account = account_id,
             .method = req.method,
@@ -418,6 +425,61 @@ pub const Proxy = struct {
         }
         w.writeAll("}\n") catch return;
         self.log_writer.writeAll(buf.items) catch {};
+    }
+};
+
+pub const AuthFailureObservation = struct {
+    account: ?[]const u8 = null,
+    auth_unauthorized_turns: usize = 0,
+    responses_401_turns: usize = 0,
+    recovered_after_401: bool = false,
+
+    pub fn unrecovered(self: AuthFailureObservation) bool {
+        return self.account != null and
+            self.auth_unauthorized_turns > 0 and
+            !self.recovered_after_401;
+    }
+};
+
+const AuthFailureTracker = struct {
+    account: ?[]const u8 = null,
+    auth_unauthorized_turns: usize = 0,
+    responses_401_turns: usize = 0,
+    recovered_after_401: bool = false,
+
+    fn observe(
+        self: *AuthFailureTracker,
+        account_id: []const u8,
+        path: []const u8,
+        classification: Classification,
+    ) void {
+        switch (classification.kind) {
+            .auth_unauthorized => {
+                self.account = account_id;
+                self.auth_unauthorized_turns += 1;
+                self.recovered_after_401 = false;
+                if (std.mem.eql(u8, pathKind(path), "responses")) {
+                    self.responses_401_turns += 1;
+                }
+            },
+            .ok => {
+                if (self.account) |failed_account| {
+                    if (std.mem.eql(u8, failed_account, account_id) and self.auth_unauthorized_turns > 0) {
+                        self.recovered_after_401 = true;
+                    }
+                }
+            },
+            else => {},
+        }
+    }
+
+    fn observation(self: AuthFailureTracker) AuthFailureObservation {
+        return .{
+            .account = self.account,
+            .auth_unauthorized_turns = self.auth_unauthorized_turns,
+            .responses_401_turns = self.responses_401_turns,
+            .recovered_after_401 = self.recovered_after_401,
+        };
     }
 };
 
@@ -1235,4 +1297,55 @@ test "copyForwardingHeaders preserves the load-bearing 8 + drops hop-by-hop" {
     try std.testing.expect(out.find("Content-Length") == null);
     try std.testing.expect(out.find("Transfer-Encoding") == null);
     try std.testing.expect(out.find("Host") == null);
+}
+
+test "AuthFailureTracker reports unrecovered response 401" {
+    var tracker = AuthFailureTracker{};
+    tracker.observe(
+        "codex:max-1",
+        "/backend-api/codex/responses",
+        .{ .kind = .auth_unauthorized },
+    );
+
+    const observation = tracker.observation();
+    try std.testing.expect(observation.unrecovered());
+    try std.testing.expectEqualStrings("codex:max-1", observation.account.?);
+    try std.testing.expectEqual(@as(usize, 1), observation.auth_unauthorized_turns);
+    try std.testing.expectEqual(@as(usize, 1), observation.responses_401_turns);
+}
+
+test "AuthFailureTracker treats same-account ok as recovery" {
+    var tracker = AuthFailureTracker{};
+    tracker.observe(
+        "codex:max-1",
+        "/backend-api/codex/responses",
+        .{ .kind = .auth_unauthorized },
+    );
+    tracker.observe(
+        "codex:max-1",
+        "/backend-api/codex/responses",
+        .{ .kind = .ok },
+    );
+
+    const observation = tracker.observation();
+    try std.testing.expect(!observation.unrecovered());
+    try std.testing.expect(observation.recovered_after_401);
+}
+
+test "AuthFailureTracker does not treat another account ok as recovery" {
+    var tracker = AuthFailureTracker{};
+    tracker.observe(
+        "codex:max-1",
+        "/backend-api/codex/responses",
+        .{ .kind = .auth_unauthorized },
+    );
+    tracker.observe(
+        "codex:max-2",
+        "/backend-api/codex/responses",
+        .{ .kind = .ok },
+    );
+
+    const observation = tracker.observation();
+    try std.testing.expect(observation.unrecovered());
+    try std.testing.expect(!observation.recovered_after_401);
 }


### PR DESCRIPTION
## Summary
- Track unrecovered managed Codex 401s after child exit and record account-credential health for the next broker-owned launch.
- Preserve the in-session 401 boundary: Codex still receives the 401 and gets its native refresh attempt; oauth-mux does not swap on auth failures.
- Extend status summaries, smokes, README, and specs so auth health remains distinct from quota fallback evidence.

## Root Cause
Dogfood-7 showed brokered auth failure on max-1, but local route planning still treated stale positive health as selectable. The prior evidence was also easy to overstate as account or quota unavailability instead of current auth-source failure.

## Validation
- nix develop --command just check-local
- scripts/smoke-codex-401-propagation.sh
- scripts/smoke-codex-status-summary.sh
- python3 scripts/summarize-codex-status.py dist/live-qa/managed-resume-dogfood-7/status.ndjson --require-brokered