### PR TITLE
Harden Codex auth fallback evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The evidence ladder is:
   invariants.
 - Shell e2e/smoke tests for broker MCP, Codex CLI UX, Codex synthetic swap,
   concurrent sessions, same-account child refresh, tier-insufficient handling,
-  all-accounts-exhausted handling, 401 propagation, and cassette replay.
+  all-accounts-exhausted handling, 401 auth fallback, and cassette replay.
 - Cassette replay infrastructure for scrubbed Codex wire captures.
 - Live QA only after local and cassette layers are green, with explicit spend
   consent and redacted status artifacts.
@@ -106,3 +106,7 @@ oauth-mux refused to overwrite it. When unrecovered 401s occur and no overlay
 auth changed, oauth-mux records account-credential health for the next launch
 and emits `auth_health_observed` with `quota_claim:false`; that does not prove
 the subscription lacks quota.
+`verdict:"auth_fallback_sequence_observed"` means the selected account produced
+`401 auth_unauthorized`, oauth-mux retried the same buffered request against a
+different account before Codex saw the 401, and the fallback account returned
+200. That is a managed auth-continuity proof, not quota exhaustion evidence.

--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -405,7 +405,7 @@ oauth-mux evidence. Frame shapes are stable under broker `surface_version:
 
 ```jsonc
 // adapter startup
-{ "kind": "session_started", "session_id": "...", "selected_account": "codex:max-1", "claim_level": "broker_owned", "wire_proxy_addr": "127.0.0.1:54321" }
+{ "kind": "session_started", "adapter": "codex", "adapter_version": "0.1.6", "managed_frame_id": "omux-codex-...", "selected_account": "codex:max-1", "proxy_port": 54321, "claim_level": "broker_owned", "status_file_present": true }
 
 // target shape for a successful invisible quota handoff; current synthetic
 // tests emit proxy_same_turn_retry while runtime claim stays broker_owned
@@ -422,8 +422,14 @@ oauth-mux evidence. Frame shapes are stable under broker `surface_version:
 // mux-owned account source after Codex refreshes tokens inside CODEX_HOME
 { "kind": "auth_writeback", "auth_authority": "mux_owned_overlay", "overlay_auth_present": true, "source_auth_present": true, "changed": true, "written": true, "source_conflict": false, "ok": true, "token_material_printed": false, "path_printed": false }
 
+// selected-account 401 hidden from Codex by same-turn auth fallback. This is
+// auth continuity, not quota exhaustion.
+{ "kind": "proxy_turn", "account": "codex:max-1", "method": "POST", "path_kind": "responses", "status": 401, "classification": "auth_unauthorized", "delivered_to_codex": false }
+{ "kind": "proxy_auth_same_turn_retry", "from": "codex:max-1", "to": "codex:max-2", "reason": "auth_unauthorized", "dropped": "x-codex-turn-state" }
+{ "kind": "proxy_turn", "account": "codex:max-2", "method": "POST", "path_kind": "responses", "status": 200, "classification": "ok", "delivered_to_codex": true }
+
 // unrecovered 401 classification after child exit; this records credential
-// health for the next broker-owned launch, but it is not quota evidence
+// health for the next broker-owned launch, but it is not quota evidence.
 { "kind": "auth_health_observed", "account": "codex:max-1", "auth_unauthorized_turns": 6, "responses_401_turns": 2, "recovered_after_401": false, "recorded": true, "reason": "unrecovered_401_no_writeback", "scope": "account_credential", "quota_claim": false, "token_material_printed": false, "path_printed": false }
 
 // quota observation that did not trigger a swap
@@ -431,6 +437,10 @@ oauth-mux evidence. Frame shapes are stable under broker `surface_version:
 
 // teardown before live quota-handoff proof remains broker_owned
 { "kind": "session_ended", "session_id": "...", "turns": 14, "swaps": 0, "final_claim_level": "broker_owned" }
+
+// if the managed frame aborts before normal teardown, it must still emit a
+// terminal status frame when the parent can run cleanup
+{ "kind": "session_aborted", "adapter": "codex", "reason": "child_wait_error", "exit_code": -1, "final_claim_level": "broker_owned", "synthetic_swap_observed": false, "wait_error": "..." }
 ```
 
 These frames are the only structured surface the adapter publishes. The

--- a/docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md
+++ b/docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md
@@ -620,3 +620,9 @@ Follow-up implemented:
   change. The status stream emits `auth_health_observed` with
   `quota_claim:false`, and the next `broker-session-plan` should route around
   that stale auth source when another healthy route exists.
+- The proxy now buffers selected-account 401s and, when a different account is
+  selectable, retries the same request against that fallback before Codex sees
+  the 401. Status evidence is `proxy_auth_same_turn_retry` plus a fallback
+  `proxy_turn` with `status:200`; the summarizer reports
+  `verdict:"auth_fallback_sequence_observed"`. This remains separate from live
+  quota fallback evidence.

--- a/docs/spec/codex-wire-evidence-2026-05-03.md
+++ b/docs/spec/codex-wire-evidence-2026-05-03.md
@@ -180,13 +180,21 @@ fixture shape.
   L136 + `exec/src/lib.rs` L1580–1588).
 
 In the current adapter-owned child + wire-proxy topology:
-- The proxy propagates the 401 to codex unchanged (streamed response).
-- Codex's RefreshToken path runs entirely inside codex; oauth-mux
-  doesn't see it.
+- The proxy buffers 401 responses so it can make an evidence-preserving
+  auth decision before Codex sees the failure.
+- If another account is selectable, the proxy marks the failed account
+  unauthorized in the in-process pool, drops `x-codex-turn-state`, and retries
+  the same request against the fallback account. It emits
+  `proxy_auth_same_turn_retry`. This is auth-continuity evidence, not quota
+  exhaustion evidence.
+- If no fallback account is selectable, the proxy returns the buffered 401 to
+  codex unchanged and emits `proxy_observed_401_codex_handles`.
+- Codex's RefreshToken path can still run entirely inside codex on the no-
+  fallback path.
 - During the same managed session, the proxy preserves Codex's refreshed
   same-account `Authorization` header instead of re-signing with stale
   oauth-mux materialized auth. This keeps Codex's native retry path
-  authoritative for 401 recovery.
+  authoritative when Codex receives and recovers from a 401 itself.
 - At child exit, the adapter compares the managed overlay `auth.json`
   with the selected account's mux-owned auth source. If Codex refreshed
   tokens inside the overlay, oauth-mux imports that changed file back
@@ -196,8 +204,9 @@ In the current adapter-owned child + wire-proxy topology:
   if another managed session changed the source after this overlay was
   created, oauth-mux reports `source_conflict:true` and does not
   overwrite that fresher source.
-- Proxy emits `proxy_observed_401_codex_handles` for telemetry.
-- DOES NOT call `pool.markUnauthorized` (would defeat refresh loop).
+- `pool.markUnauthorized` is called only after fallback credentials have
+  materialized for a replacement account. Without a selectable fallback, the
+  proxy leaves the failed account to Codex's native refresh loop.
 - If the managed session exits after unrecovered 401s and the overlay
   `auth.json` did not change, the adapter records account-credential health
   for the next launch and emits `auth_health_observed` with

--- a/scripts/smoke-codex-401-propagation.sh
+++ b/scripts/smoke-codex-401-propagation.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# 401 propagation smoke: upstream 401 is auth refresh territory owned by
-# Codex. The proxy must classify it, emit the diagnostic event, and
-# propagate the 401 unchanged without rotating accounts.
+# 401 auth fallback smoke: the selected account returns 401 while a fallback
+# account is healthy. The proxy must classify the selected account as auth
+# unhealthy, retry the same request against the fallback before Codex sees the
+# 401, and persist account-credential health without claiming quota.
 
 set -euo pipefail
 
@@ -89,7 +90,8 @@ chmod +x "$STUB_BIN_DIR/codex"
 
 OMUX_STUB_PORT=0 \
   OMUX_STUB_PORTFILE="$PORTFILE" \
-  OMUX_STUB_ALWAYS_STATUS=401 \
+  OMUX_STUB_OK_BEFORE_429=99 \
+  OMUX_STUB_ACCOUNT_STATUS_JSON='{"acc-A-id":401}' \
   python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$TMP/upstream.stderr" &
 UPSTREAM_PID=$!
 
@@ -99,7 +101,7 @@ for _ in {1..40}; do
 done
 [[ -s "$PORTFILE" ]] || { echo "stub upstream did not bind" >&2; exit 1; }
 UPSTREAM_PORT="$(cat "$PORTFILE" | tr -d '[:space:]')"
-echo "smoke-codex-401-propagation: stub upstream pid=$UPSTREAM_PID port=$UPSTREAM_PORT always_status=401"
+echo "smoke-codex-401-propagation: stub upstream pid=$UPSTREAM_PID port=$UPSTREAM_PORT max-1=401 max-2=200"
 
 OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_STATE_DIR="$TMP/state" \
@@ -142,12 +144,13 @@ assert_no_grep() {
 
 assert_grep "session_started" '"kind":"session_started"' "$NDJSON"
 assert_grep "session_started redacts CODEX_HOME path" '"codex_home_path_printed":false' "$NDJSON"
-assert_grep "proxy_turn 401 classified auth_unauthorized" '"kind":"proxy_turn".*"status":401.*"classification":"auth_unauthorized"' "$NDJSON"
-assert_grep "proxy_observed_401_codex_handles diagnostic emitted" '"kind":"proxy_observed_401_codex_handles"' "$NDJSON"
+assert_grep "proxy_turn 401 classified auth_unauthorized" '"kind":"proxy_turn".*"account":"codex:max-1".*"status":401.*"classification":"auth_unauthorized".*"delivered_to_codex":false' "$NDJSON"
+assert_grep "proxy_auth_same_turn_retry fired" '"kind":"proxy_auth_same_turn_retry".*"from":"codex:max-1".*"to":"codex:max-2".*"reason":"auth_unauthorized"' "$NDJSON"
+assert_grep "fallback account returned 200" '"kind":"proxy_turn".*"account":"codex:max-2".*"status":200.*"classification":"ok"' "$NDJSON"
 assert_grep "unrecovered 401 recorded as auth health, not quota" '"kind":"auth_health_observed".*"recorded":true.*"reason":"unrecovered_401_no_writeback".*"quota_claim":false' "$NDJSON"
 
-assert_no_grep "no swap fired" '"kind":"proxy_post_swap_turn"' "$NDJSON"
-assert_no_grep "no same-turn retry fired" '"kind":"proxy_same_turn_retry"' "$NDJSON"
+assert_no_grep "401 was not handed to Codex" '"kind":"proxy_observed_401_codex_handles"' "$NDJSON"
+assert_no_grep "quota retry did not fire" '"kind":"proxy_same_turn_retry"' "$NDJSON"
 assert_no_grep "no quota_exhausted misclassification" '"classification":"quota_exhausted"' "$NDJSON"
 assert_no_grep "claim_level not promoted" '"claim_level":"next_turn_seamless"' "$NDJSON"
 assert_grep "session_ended final_claim_level remains broker_owned" '"kind":"session_ended".*"final_claim_level":"broker_owned"' "$NDJSON"
@@ -160,26 +163,26 @@ else
 fi
 
 DISTINCT_ACCT=$(grep -oE '"account":"codex:max-[12]"' "$NDJSON" | sort -u | wc -l | tr -d ' ')
-if [[ "$DISTINCT_ACCT" -eq 1 ]]; then
-    echo "  ✓ exactly one account elected throughout"
+if [[ "$DISTINCT_ACCT" -eq 2 ]]; then
+    echo "  ✓ auth fallback used both accounts"
 else
-    echo "  ✗ 401 caused account rotation across $DISTINCT_ACCT accounts" >&2
+    echo "  ✗ expected auth fallback across two accounts; saw distinct=$DISTINCT_ACCT" >&2
     grep -oE '"account":"codex:max-[12]"' "$NDJSON" | sort -u >&2
     exit 1
 fi
 
-GOT_401=$(jq -r '.turns | map(select(.status == 401)) | length' "$STUB_REPORT")
-if [[ "$GOT_401" -eq 4 ]]; then
-    echo "  ✓ stub-codex saw all 4 turns return 401"
+GOT_200=$(jq -r '.turns | map(select(.status == 200)) | length' "$STUB_REPORT")
+if [[ "$GOT_200" -eq 4 ]]; then
+    echo "  ✓ stub-codex saw all 4 turns return 200"
 else
-    echo "  ✗ stub-codex saw $GOT_401 401s (expected 4)" >&2
+    echo "  ✗ stub-codex saw $GOT_200 200s (expected 4)" >&2
     jq .turns "$STUB_REPORT" >&2
     exit 1
 fi
 
 PID_STABLE=$(jq -r .pid_stable "$STUB_REPORT")
 if [[ "$PID_STABLE" == "true" ]]; then
-    echo "  ✓ stub-codex PID stable through 401 storm"
+    echo "  ✓ stub-codex PID stable through auth fallback"
 else
     echo "  ✗ PID changed across 401s" >&2
     exit 1
@@ -205,5 +208,5 @@ else
 fi
 
 echo
-echo "smoke-codex-401-propagation: all 16 assertions passed."
+echo "smoke-codex-401-propagation: all assertions passed."
 echo "  full ndjson: $NDJSON"

--- a/scripts/smoke-codex-acceptance.sh
+++ b/scripts/smoke-codex-acceptance.sh
@@ -163,7 +163,10 @@ echo "smoke-codex-acceptance: assertions"
 
 assert_grep "session_started"           '"kind":"session_started"'           "$NDJSON"
 assert_grep "session_started has proxy_port" '"proxy_port":[0-9]+'           "$NDJSON"
+assert_grep "session_started has managed_frame_id" '"managed_frame_id":"omux-codex-' "$NDJSON"
+assert_grep "session_started has adapter version" '"adapter_version":"[0-9]+\.[0-9]+\.[0-9]+"' "$NDJSON"
 assert_grep "session_started redacts CODEX_HOME path" '"codex_home_path_printed":false' "$NDJSON"
+assert_grep "session_started records status file" '"status_file_present":true' "$NDJSON"
 assert_grep "session_started reports canonical session bridge" '"session_authority":"canonical_bridge"' "$NDJSON"
 assert_grep "session_started redacts session paths" '"session_paths_printed":false' "$NDJSON"
 assert_grep "proxy_turn 200 ok"         '"kind":"proxy_turn".*"status":200.*"classification":"ok"' "$NDJSON"
@@ -192,6 +195,15 @@ fi
 
 if [[ ! -s "$STUB_REPORT" ]]; then
     echo "  ✗ stub-codex report missing" >&2
+    exit 1
+fi
+if [[ "$(jq -r .managed_frame_id_present "$STUB_REPORT")" == "true" \
+      && "$(jq -r .claim_level "$STUB_REPORT")" == "broker_owned" \
+      && "$(jq -r .status_file_present "$STUB_REPORT")" == "true" ]]; then
+    echo "  ✓ child received managed-frame env markers"
+else
+    echo "  ✗ child managed-frame env marker report failed" >&2
+    cat "$STUB_REPORT" >&2
     exit 1
 fi
 if [[ "$(jq -r .session_bridge.checked "$STUB_REPORT")" == "true" \

--- a/scripts/smoke-codex-status-summary.sh
+++ b/scripts/smoke-codex-status-summary.sh
@@ -17,6 +17,8 @@ trap 'rm -rf "$TMP"' EXIT
 BROKERED="$TMP/brokered.ndjson"
 FALLBACK="$TMP/fallback.ndjson"
 AUTH_FAILED="$TMP/auth-failed.ndjson"
+AUTH_FALLBACK="$TMP/auth-fallback.ndjson"
+INCOMPLETE="$TMP/incomplete.ndjson"
 
 cat >"$BROKERED" <<'EOF'
 {"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
@@ -43,6 +45,20 @@ cat >"$AUTH_FAILED" <<'EOF'
 {"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":false}
 EOF
 
+cat >"$AUTH_FALLBACK" <<'EOF'
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"proxy_turn","account":"codex:max-1","method":"POST","path_kind":"responses","status":401,"classification":"auth_unauthorized","body_class":"json_error","claim_level":"broker_owned","streamed":false,"delivered_to_codex":false}
+{"kind":"proxy_auth_same_turn_retry","from":"codex:max-1","to":"codex:max-2","reason":"auth_unauthorized","dropped":"x-codex-turn-state"}
+{"kind":"proxy_turn","account":"codex:max-2","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true,"delivered_to_codex":true}
+{"kind":"auth_health_observed","account":"codex:max-1","auth_unauthorized_turns":1,"responses_401_turns":1,"recovered_after_401":false,"recorded":true,"reason":"unrecovered_401_no_writeback","scope":"account_credential","quota_claim":false,"token_material_printed":false,"path_printed":false}
+{"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":true}
+EOF
+
+cat >"$INCOMPLETE" <<'EOF'
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"proxy_turn","account":"codex:max-1","method":"POST","path_kind":"responses","status":401,"classification":"auth_unauthorized","body_class":"empty","claim_level":"broker_owned","streamed":true,"delivered_to_codex":true}
+EOF
+
 BROKERED_SUMMARY="$(python3 "$ROOT/scripts/summarize-codex-status.py" "$BROKERED" --require-brokered)"
 if [[ "$(jq -r .verdict <<<"$BROKERED_SUMMARY")" != "brokered_without_fallback" ]]; then
     echo "brokered verdict mismatch" >&2
@@ -51,6 +67,11 @@ if [[ "$(jq -r .verdict <<<"$BROKERED_SUMMARY")" != "brokered_without_fallback" 
 fi
 if [[ "$(jq -r .fallback_sequence.observed <<<"$BROKERED_SUMMARY")" != "false" ]]; then
     echo "brokered-only artifact should not claim fallback" >&2
+    echo "$BROKERED_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .terminal_event_observed <<<"$BROKERED_SUMMARY")" != "true" ]]; then
+    echo "brokered-only artifact should have terminal evidence" >&2
     echo "$BROKERED_SUMMARY" >&2
     exit 1
 fi
@@ -96,6 +117,35 @@ fi
 if [[ "$(jq -r .auth_health_quota_claim_observed <<<"$AUTH_FAILED_SUMMARY")" != "false" ]]; then
     echo "auth-failed summary must not turn auth health into quota evidence" >&2
     echo "$AUTH_FAILED_SUMMARY" >&2
+    exit 1
+fi
+
+AUTH_FALLBACK_SUMMARY="$(python3 "$ROOT/scripts/summarize-codex-status.py" "$AUTH_FALLBACK" --require-brokered)"
+if [[ "$(jq -r .verdict <<<"$AUTH_FALLBACK_SUMMARY")" != "auth_fallback_sequence_observed" ]]; then
+    echo "auth-fallback verdict mismatch" >&2
+    echo "$AUTH_FALLBACK_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .auth_fallback_sequence.fallback_account <<<"$AUTH_FALLBACK_SUMMARY")" != "codex:max-2" ]]; then
+    echo "auth-fallback account mismatch" >&2
+    echo "$AUTH_FALLBACK_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .auth_health_quota_claim_observed <<<"$AUTH_FALLBACK_SUMMARY")" != "false" ]]; then
+    echo "auth-fallback summary must not claim quota" >&2
+    echo "$AUTH_FALLBACK_SUMMARY" >&2
+    exit 1
+fi
+
+INCOMPLETE_SUMMARY="$(python3 "$ROOT/scripts/summarize-codex-status.py" "$INCOMPLETE" --require-brokered)"
+if [[ "$(jq -r .verdict <<<"$INCOMPLETE_SUMMARY")" != "brokered_incomplete_auth_failed" ]]; then
+    echo "incomplete verdict mismatch" >&2
+    echo "$INCOMPLETE_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .health_recording_expected_but_missing <<<"$INCOMPLETE_SUMMARY")" != "true" ]]; then
+    echo "incomplete summary should flag missing health recording" >&2
+    echo "$INCOMPLETE_SUMMARY" >&2
     exit 1
 fi
 

--- a/scripts/summarize-codex-status.py
+++ b/scripts/summarize-codex-status.py
@@ -104,12 +104,77 @@ def find_fallback_sequence(events: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def find_auth_fallback_sequence(events: list[dict[str, Any]]) -> dict[str, Any]:
+    auth_idx: int | None = None
+    retry_idx: int | None = None
+    auth_account: str | None = None
+    retry_event: dict[str, Any] | None = None
+    fallback_turn: dict[str, Any] | None = None
+
+    for idx, event in enumerate(events):
+        if event.get("kind") != "proxy_turn":
+            continue
+        if (
+            event.get("status") == 401
+            and event.get("classification") == "auth_unauthorized"
+        ):
+            auth_idx = idx
+            auth_account = event.get("account")
+            break
+
+    if auth_idx is None:
+        return {
+            "observed": False,
+            "reason": "no auth_unauthorized proxy_turn",
+        }
+
+    for idx in range(auth_idx + 1, len(events)):
+        event = events[idx]
+        if event.get("kind") == "proxy_auth_same_turn_retry":
+            retry_idx = idx
+            retry_event = event
+            break
+
+    if retry_idx is None:
+        return {
+            "observed": False,
+            "reason": "auth_unauthorized without proxy_auth_same_turn_retry",
+            "auth_account": auth_account,
+        }
+
+    for event in events[retry_idx + 1 :]:
+        if event.get("kind") != "proxy_turn":
+            continue
+        if event.get("account") != auth_account and event.get("status") == 200:
+            fallback_turn = event
+            break
+
+    if fallback_turn is None:
+        return {
+            "observed": False,
+            "reason": "auth retry without successful fallback-account turn",
+            "auth_account": auth_account,
+            "retry": retry_event,
+        }
+
+    return {
+        "observed": True,
+        "auth_account": auth_account,
+        "fallback_account": fallback_turn.get("account"),
+        "retry": retry_event,
+        "fallback_status": fallback_turn.get("status"),
+        "fallback_path_kind": fallback_turn.get("path_kind"),
+    }
+
+
 def summarize(path: Path) -> dict[str, Any]:
     events = load_events(path)
     proxy_turns = [e for e in events if e.get("kind") == "proxy_turn"]
     session_started = next((e for e in events if e.get("kind") == "session_started"), {})
     session_ended = next((e for e in reversed(events) if e.get("kind") == "session_ended"), {})
+    session_aborted = next((e for e in reversed(events) if e.get("kind") == "session_aborted"), {})
     fallback = find_fallback_sequence(events)
+    auth_fallback = find_auth_fallback_sequence(events)
     auth_health_events = [e for e in events if e.get("kind") == "auth_health_observed"]
     auth_unauthorized_turns = [
         e
@@ -131,6 +196,34 @@ def summarize(path: Path) -> dict[str, Any]:
     auth_failure_observed = bool(auth_unauthorized_turns)
     auth_failed_without_recovery = auth_failure_observed and not ok_turns
     auth_recovered_observed = auth_failure_observed and bool(ok_turns)
+    terminal_event_observed = bool(session_ended or session_aborted)
+    health_recording_expected_but_missing = (
+        auth_failure_observed
+        and not auth_health_events
+        and not terminal_event_observed
+    )
+
+    if fallback.get("observed"):
+        verdict = "fallback_sequence_observed"
+        next_action = "inspect_live_quota_fallback"
+    elif auth_fallback.get("observed"):
+        verdict = "auth_fallback_sequence_observed"
+        next_action = "continue_managed_dogfood"
+    elif brokered_session and auth_failure_observed and not terminal_event_observed:
+        verdict = "brokered_incomplete_auth_failed"
+        next_action = "inspect_incomplete_run"
+    elif brokered_session and auth_failed_without_recovery:
+        verdict = "brokered_auth_failed"
+        next_action = "reauth_account"
+    elif brokered_session and auth_recovered_observed:
+        verdict = "brokered_auth_recovered"
+        next_action = "continue_managed_dogfood"
+    elif brokered_session and proxy_turns:
+        verdict = "brokered_without_fallback"
+        next_action = "wait_for_quota_event"
+    else:
+        verdict = "insufficient_evidence"
+        next_action = "retry_managed"
 
     return {
         "path": str(path),
@@ -150,26 +243,23 @@ def summarize(path: Path) -> dict[str, Any]:
         "auth_health_events": len(auth_health_events),
         "auth_health_recorded_observed": any(e.get("recorded") is True for e in auth_health_events),
         "auth_health_quota_claim_observed": any(e.get("quota_claim") is True for e in auth_health_events),
+        "terminal_event_observed": terminal_event_observed,
+        "session_aborted_observed": bool(session_aborted),
+        "health_recording_expected_but_missing": health_recording_expected_but_missing,
         "same_turn_retry_events": sum(1 for e in events if e.get("kind") == "proxy_same_turn_retry"),
+        "auth_same_turn_retry_events": sum(1 for e in events if e.get("kind") == "proxy_auth_same_turn_retry"),
+        "auth_retry_unavailable_events": sum(1 for e in events if e.get("kind") == "proxy_auth_retry_unavailable"),
         "same_turn_retry_unavailable_events": sum(
             1 for e in events if e.get("kind") == "proxy_same_turn_retry_unavailable"
         ),
         "post_swap_turn_events": sum(1 for e in events if e.get("kind") == "proxy_post_swap_turn"),
         "fallback_sequence": fallback,
+        "auth_fallback_sequence": auth_fallback,
         "synthetic_swap_observed": bool(session_ended.get("synthetic_swap_observed")),
         "level4_shape_observed": bool(fallback.get("observed")),
         "provider_originated_live_fallback_claim": False,
-        "verdict": (
-            "fallback_sequence_observed"
-            if fallback.get("observed")
-            else "brokered_auth_failed"
-            if brokered_session and auth_failed_without_recovery
-            else "brokered_auth_recovered"
-            if brokered_session and auth_recovered_observed
-            else "brokered_without_fallback"
-            if brokered_session and proxy_turns
-            else "insufficient_evidence"
-        ),
+        "verdict": verdict,
+        "next_action": next_action,
     }
 
 

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -36,6 +36,7 @@ Env (set by the smoke harness):
                             CODEX_HOME before sending turns. Used to emulate
                             Codex persisting refreshed ChatGPT tokens in the
                             managed overlay.
+  OMUX_STUB_CODEX_TURN_DELAY_MS — optional delay between turns (default 50).
   The report records argv after the stub binary so CLI forwarding smokes can
   assert `oauth-mux codex ...` command shape without provider traffic.
 """
@@ -169,6 +170,7 @@ def main() -> int:
 
     report_path = Path(os.environ.get("OMUX_STUB_CODEX_REPORT", "/tmp/omux-stub-codex.report"))
     turns = int(os.environ.get("OMUX_STUB_CODEX_TURNS", "5"))
+    turn_delay_ms = int(os.environ.get("OMUX_STUB_CODEX_TURN_DELAY_MS", "50"))
 
     codex_home = Path(os.environ["CODEX_HOME"])
     proxy_url = _read_proxy_url(codex_home)
@@ -192,7 +194,7 @@ def main() -> int:
         )
         turn_results.append({"turn": i, "status": status, "body_head": body[:120]})
         print(f"stub-codex: turn {i} -> {status}", file=sys.stderr, flush=True)
-        time.sleep(0.05)
+        time.sleep(turn_delay_ms / 1000)
 
     end_pid = os.getpid()
     report = {
@@ -204,6 +206,9 @@ def main() -> int:
         "turns": turn_results,
         "codex_home_path_printed": False,
         "active_account_at_start": os.environ.get("OMUX_ACTIVE_ACCOUNT"),
+        "managed_frame_id_present": bool(os.environ.get("OMUX_MANAGED_FRAME_ID")),
+        "claim_level": os.environ.get("OMUX_CLAIM_LEVEL"),
+        "status_file_present": bool(os.environ.get("OMUX_STATUS_FILE")),
         "session_bridge": session_bridge,
         "session_append": session_append,
         "auth_rewrite": auth_rewrite,

--- a/scripts/test-stub-upstream.py
+++ b/scripts/test-stub-upstream.py
@@ -72,6 +72,15 @@ ERROR_TYPE = os.environ.get("OMUX_STUB_429_TYPE", "usage_limit_reached")
 # verify proxy classification + behavior end-to-end.
 ALWAYS_STATUS = os.environ.get("OMUX_STUB_ALWAYS_STATUS", "")
 
+# OMUX_STUB_ACCOUNT_STATUS_JSON maps ChatGPT-Account-ID values to forced
+# status codes, e.g. {"acc-A-id":401}. Accounts not listed follow the normal
+# OK_BEFORE_429 flow. This lets smokes model a dead active account with a
+# healthy fallback account.
+try:
+    ACCOUNT_STATUS = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_STATUS_JSON", "{}"))
+except json.JSONDecodeError:
+    ACCOUNT_STATUS = {}
+
 
 # Per-account request counter. Reset only on process restart.
 ACCOUNT_REQ_COUNT: dict[str, int] = {}
@@ -125,6 +134,15 @@ class StubHandler(http.server.BaseHTTPRequestHandler):
         return _hash10(a) if a else "<missing>"
 
     def _classify_for_account(self) -> tuple[int, dict]:
+        acct = self._account_id()
+        if acct in ACCOUNT_STATUS:
+            try:
+                code = int(ACCOUNT_STATUS[acct])
+            except (TypeError, ValueError):
+                code = 500
+            ACCOUNT_REQ_COUNT[acct] = ACCOUNT_REQ_COUNT.get(acct, 0) + 1
+            return code, {"detail": f"forced status {code} for account"}
+
         # OMUX_STUB_ALWAYS_STATUS short-circuits everything: return
         # this exact status with a minimal JSON body. Counters still
         # advance so per-account log records remain unique.
@@ -133,10 +151,9 @@ class StubHandler(http.server.BaseHTTPRequestHandler):
                 code = int(ALWAYS_STATUS)
             except ValueError:
                 code = 500
-            ACCOUNT_REQ_COUNT[self._account_id()] = ACCOUNT_REQ_COUNT.get(self._account_id(), 0) + 1
+            ACCOUNT_REQ_COUNT[acct] = ACCOUNT_REQ_COUNT.get(acct, 0) + 1
             return code, {"detail": f"forced status {code}"}
 
-        acct = self._account_id()
         n = ACCOUNT_REQ_COUNT.get(acct, 0)
         ACCOUNT_REQ_COUNT[acct] = n + 1
         if n < OK_BEFORE_429:

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -30,6 +30,7 @@ const std = @import("std");
 const broker = @import("../../broker/mod.zig");
 const broker_types = @import("../../broker/types.zig");
 const broker_loader = @import("../../broker_loader.zig");
+const cli = @import("../../cli.zig");
 const config_mod = @import("../../config.zig");
 const health_mod = @import("../../health.zig");
 const shell = @import("../../shell.zig");
@@ -160,6 +161,13 @@ const ManagedAuthHealthObservation = struct {
     reason: []const u8 = "not_observed",
 };
 
+const FinalSessionStatus = struct {
+    aborted: bool = false,
+    reason: []const u8 = "child_exit",
+    term: ?std.process.Child.Term = null,
+    wait_error: ?[]const u8 = null,
+};
+
 const SessionAuthorityEntryKind = enum {
     directory,
     file,
@@ -283,6 +291,8 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     defer proxy.deinit();
     proxy.profile = opts.profile;
     const proxy_port = proxy.port();
+    const managed_frame_id = try std.fmt.allocPrint(allocator, "omux-codex-{d}-{d}", .{ std.time.milliTimestamp(), proxy_port });
+    defer allocator.free(managed_frame_id);
 
     // 5. Create a per-session CODEX_HOME overlay containing copied
     // auth material, generated proxy config, and canonical session
@@ -310,8 +320,8 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
 
     if (emit_status) {
         try status_writer.print(
-            "{{\"kind\":\"session_started\",\"adapter\":\"codex\",\"selected_account\":\"{s}\",\"codex_home_path_printed\":false,\"proxy_port\":{d},\"claim_level\":\"broker_owned\",\"auth_authority\":\"mux_owned_overlay\",\"managed_config\":\"mux_owned_overlay\",\"session_authority\":\"{s}\",\"session_paths_printed\":false}}\n",
-            .{ elected.id, proxy_port, codex_home.session_authority.toString() },
+            "{{\"kind\":\"session_started\",\"adapter\":\"codex\",\"adapter_version\":\"{s}\",\"managed_frame_id\":\"{s}\",\"selected_account\":\"{s}\",\"codex_home_path_printed\":false,\"proxy_port\":{d},\"claim_level\":\"broker_owned\",\"auth_authority\":\"mux_owned_overlay\",\"managed_config\":\"mux_owned_overlay\",\"session_authority\":\"{s}\",\"session_paths_printed\":false,\"status_file_present\":{any}}}\n",
+            .{ cli.version, managed_frame_id, elected.id, proxy_port, codex_home.session_authority.toString(), opts.json_status_file != null },
         );
         if (resume_request.requested()) {
             try writeResumePreflightStatus(
@@ -339,6 +349,9 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     defer env_map.deinit();
     try env_map.put("CODEX_HOME", codex_home.path);
     try env_map.put("OMUX_ACTIVE_PROVIDER", "codex");
+    try env_map.put("OMUX_MANAGED_FRAME_ID", managed_frame_id);
+    try env_map.put("OMUX_CLAIM_LEVEL", "broker_owned");
+    if (opts.json_status_file) |path| try env_map.put("OMUX_STATUS_FILE", path);
     const account_only = elected.id[std.mem.indexOfScalar(u8, elected.id, ':').? + 1 ..];
     try env_map.put("OMUX_ACTIVE_ACCOUNT", account_only);
     if (opts.profile) |p| try env_map.put("OMUX_ACTIVE_PROFILE", p);
@@ -368,7 +381,20 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     const term = child.wait() catch |e| {
         try stderr.print("oauth-mux codex: child wait: {s}\n", .{@errorName(e)});
         shutdown.store(true, .release);
+        tickleProxy(proxy_port);
         proxy_thread.join();
+        try finalizeManagedSession(
+            allocator,
+            stderr,
+            status_writer,
+            emit_status,
+            &proxy,
+            &codex_home,
+            source_auth_path,
+            resume_request,
+            if (resume_snapshot) |*snapshot| snapshot else null,
+            .{ .aborted = true, .reason = "child_wait_error", .wait_error = @errorName(e) },
+        );
         return e;
     };
 
@@ -377,40 +403,18 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     tickleProxy(proxy_port);
     proxy_thread.join();
 
-    const auth_writeback = observeAuthWriteback(allocator, codex_home.path, source_auth_path, codex_home.auth_initial_hash) catch |e| failed: {
-        try stderr.print("oauth-mux codex: auth writeback failed: {s}\n", .{@errorName(e)});
-        break :failed AuthWritebackObservation{
-            .ok = false,
-            .error_name = @errorName(e),
-        };
-    };
-    if (auth_writeback.source_conflict) {
-        try stderr.writeAll("oauth-mux codex: auth writeback conflict; not overwriting newer account auth\n");
-    }
-    const auth_failure = proxy.authFailureObservation();
-    const auth_health = recordManagedAuthFailureHealth(allocator, auth_failure, auth_writeback);
-
-    if (emit_status) {
-        try writeAuthWritebackStatus(status_writer, auth_writeback);
-        if (auth_failure.auth_unauthorized_turns > 0) {
-            try writeManagedAuthHealthStatus(status_writer, auth_failure, auth_health);
-        }
-        if (resume_request.requested()) {
-            const observation = if (codex_home.authority_home) |authority_home|
-                try observeResumeWriteback(allocator, authority_home, if (resume_snapshot) |*snapshot| snapshot else null, resume_request)
-            else
-                ResumeObservation{};
-            try writeResumeWritebackStatus(status_writer, resume_request, codex_home.session_authority, observation);
-        }
-        const exit_code: i32 = switch (term) {
-            .Exited => |c| c,
-            else => -1,
-        };
-        try status_writer.print(
-            "{{\"kind\":\"session_ended\",\"adapter\":\"codex\",\"exit_code\":{d},\"final_claim_level\":\"{s}\",\"synthetic_swap_observed\":{any}}}\n",
-            .{ exit_code, proxy.peakClaimLevel().toString(), proxy.syntheticSwapSeen() },
-        );
-    }
+    try finalizeManagedSession(
+        allocator,
+        stderr,
+        status_writer,
+        emit_status,
+        &proxy,
+        &codex_home,
+        source_auth_path,
+        resume_request,
+        if (resume_snapshot) |*snapshot| snapshot else null,
+        .{ .term = term },
+    );
 
     // Propagate exit code.
     switch (term) {
@@ -424,6 +428,67 @@ fn openStatusFile(path: []const u8) !std.fs.File {
         try std.fs.cwd().makePath(dir);
     }
     return try std.fs.cwd().createFile(path, .{ .mode = 0o600, .truncate = true });
+}
+
+fn finalizeManagedSession(
+    allocator: std.mem.Allocator,
+    stderr: anytype,
+    status_writer: anytype,
+    emit_status: bool,
+    proxy: *wire_proxy.Proxy,
+    codex_home: *const SessionCodexHome,
+    source_auth_path: []const u8,
+    resume_request: ResumeRequest,
+    resume_snapshot: ?*RolloutSnapshot,
+    final_status: FinalSessionStatus,
+) !void {
+    const auth_writeback = observeAuthWriteback(allocator, codex_home.path, source_auth_path, codex_home.auth_initial_hash) catch |e| failed: {
+        try stderr.print("oauth-mux codex: auth writeback failed: {s}\n", .{@errorName(e)});
+        break :failed AuthWritebackObservation{
+            .ok = false,
+            .error_name = @errorName(e),
+        };
+    };
+    if (auth_writeback.source_conflict) {
+        try stderr.writeAll("oauth-mux codex: auth writeback conflict; not overwriting newer account auth\n");
+    }
+    const auth_failure = proxy.authFailureObservation();
+    const auth_health = recordManagedAuthFailureHealth(allocator, auth_failure, auth_writeback);
+
+    if (!emit_status) return;
+
+    try writeAuthWritebackStatus(status_writer, auth_writeback);
+    if (auth_failure.auth_unauthorized_turns > 0) {
+        try writeManagedAuthHealthStatus(status_writer, auth_failure, auth_health);
+    }
+    if (resume_request.requested()) {
+        const observation = if (codex_home.authority_home) |authority_home|
+            try observeResumeWriteback(allocator, authority_home, resume_snapshot, resume_request)
+        else
+            ResumeObservation{};
+        try writeResumeWritebackStatus(status_writer, resume_request, codex_home.session_authority, observation);
+    }
+
+    const exit_code: i32 = if (final_status.term) |term| switch (term) {
+        .Exited => |c| c,
+        else => -1,
+    } else -1;
+
+    if (final_status.aborted) {
+        try status_writer.print(
+            "{{\"kind\":\"session_aborted\",\"adapter\":\"codex\",\"reason\":\"{s}\",\"exit_code\":{d},\"final_claim_level\":\"{s}\",\"synthetic_swap_observed\":{any}",
+            .{ final_status.reason, exit_code, proxy.peakClaimLevel().toString(), proxy.syntheticSwapSeen() },
+        );
+        if (final_status.wait_error) |err| {
+            try status_writer.print(",\"wait_error\":\"{s}\"", .{err});
+        }
+        try status_writer.writeAll("}\n");
+    } else {
+        try status_writer.print(
+            "{{\"kind\":\"session_ended\",\"adapter\":\"codex\",\"exit_code\":{d},\"final_claim_level\":\"{s}\",\"synthetic_swap_observed\":{any}}}\n",
+            .{ exit_code, proxy.peakClaimLevel().toString(), proxy.syntheticSwapSeen() },
+        );
+    }
 }
 
 fn proxyThreadMain(p: *wire_proxy.Proxy, shutdown: *std.atomic.Value(bool)) void {

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -33,17 +33,20 @@
 //!      fallback immediately, drop the sticky turn-state header, and retry
 //!      the same request before writing the response to codex. If no fallback
 //!      is selectable, return the buffered failure.
+//!      On auth_unauthorized, try the same fallback shape before Codex sees
+//!      the 401. If fallback is unavailable, return the buffered 401 so Codex
+//!      can still run its native refresh loop.
 //!   7. Stream the final response body verbatim back to codex (SSE works
 //!      because chunked-transfer is forwarded byte-for-byte).
 //!
 //! Phase 2 scope (honestly labelled limitations):
 //!   - Synchronous, single-connection-at-a-time (codex sends one
 //!     request per turn). No request pipelining.
-//!   - **Streaming for 200/3xx/401/5xx; buffered for 429.** SSE turns
+//!   - **Streaming for 200/3xx/5xx; buffered for 401/429.** SSE turns
 //!     stream byte-for-byte from upstream to codex via Connection:close
-//!     framing — the TUI animation moves in real time. 429 responses
-//!     are small JSON and need the body for classification, so they
-//!     stay buffered (with a 64 KiB cap). Phase 2.1 added this.
+//!     framing — the TUI animation moves in real time. 401 and 429 responses
+//!     are small and need a retry decision before any bytes reach Codex, so
+//!     they stay buffered (with a 64 KiB cap).
 //!   - No WebSocket upgrade support; if codex requests a WS upgrade
 //!     we propagate the upstream's response (which on `chatgpt.com`
 //!     is HTTP 426 / falls back to chunked). Phase 2.2 adds WS.
@@ -314,6 +317,65 @@ pub const Proxy = struct {
             final_account = fallback.id;
         }
 
+        if (status_and_class.classification.kind == .auth_unauthorized) auth_retry: {
+            const auth_failed_account = final_account;
+            const fallback = self.pool.elect(self.profile, null, &.{auth_failed_account}) catch |err| {
+                self.logEvent("proxy_auth_retry_unavailable", .{
+                    .from = auth_failed_account,
+                    .err = @errorName(err),
+                });
+                self.logEvent("proxy_observed_401_codex_handles", .{
+                    .account = auth_failed_account,
+                });
+                break :auth_retry;
+            };
+
+            var fallback_tokens = self.materializer.materialize_chatgpt(
+                self.materializer.ctx,
+                a,
+                fallback.id,
+            ) catch |err| {
+                self.logEvent("proxy_auth_materialize_failed", .{
+                    .from = auth_failed_account,
+                    .to = fallback.id,
+                    .err = @errorName(err),
+                });
+                self.logEvent("proxy_observed_401_codex_handles", .{
+                    .account = auth_failed_account,
+                });
+                break :auth_retry;
+            };
+            _ = &fallback_tokens;
+
+            self.pool.markUnauthorized(auth_failed_account) catch |err| {
+                self.logEvent("proxy_auth_mark_unauthorized_failed", .{
+                    .account = auth_failed_account,
+                    .err = @errorName(err),
+                });
+            };
+
+            var retry_headers = HeaderList.init(a);
+            _ = try buildOutboundHeaders(a, &req, &retry_headers, fallback_tokens, true);
+            self.logEvent("proxy_auth_same_turn_retry", .{
+                .from = auth_failed_account,
+                .to = fallback.id,
+                .reason = "auth_unauthorized",
+                .dropped = "x-codex-turn-state",
+            });
+            self.synthetic_swap_seen = true;
+
+            status_and_class = forwardAndStream(a, req, retry_headers, writer) catch |err| {
+                self.logEvent("proxy_upstream_failed", .{ .account = fallback.id, .err = @errorName(err) });
+                try writeStatus(writer, 502, "Upstream Error");
+                return;
+            };
+            self.applyClassification(fallback.id, status_and_class.classification) catch |err| {
+                self.logEvent("proxy_apply_classification_failed", .{ .err = @errorName(err) });
+            };
+            self.logProxyTurn(fallback.id, req, status_and_class, status_and_class.buffered_response == null);
+            final_account = fallback.id;
+        }
+
         if (status_and_class.buffered_response) |buffered| {
             try writeBufferedStoredResponse(writer, buffered);
         }
@@ -360,41 +422,7 @@ pub const Proxy = struct {
                 const until = c.resets_at orelse (now_unix + 60);
                 try self.pool.markRateLimited(account_id, until);
             },
-            .auth_unauthorized => {
-                // DO NOT mark the account dead on a first 401.
-                //
-                // In the adapter-owned child topology, the 401 is
-                // propagated to codex (writeStreamedResponse forwards
-                // the upstream status verbatim). Codex's AuthManager
-                // then runs UnauthorizedRecovery::Reload →
-                // UnauthorizedRecovery::RefreshToken which:
-                //   1. POSTs to https://auth.openai.com/oauth/token
-                //      with the account's refresh_token to mint a
-                //      fresh access_token.
-                //   2. persist_tokens writes the new tokens back to
-                //      auth.json on disk.
-                //   3. Codex retries the original request.
-                //
-                // The proxy preserves the child's refreshed
-                // Authorization header on the NEXT request when the
-                // inbound ChatGPT-Account-ID still matches the
-                // broker-elected account. That lets Codex's native
-                // refresh loop succeed without requiring oauth-mux
-                // to implement refresh-token rotation in this path.
-                //
-                // Marking the account dead here would defeat that
-                // recovery loop by removing the account from the
-                // pool before codex got a chance to refresh.
-                //
-                // True credential death (revoked refresh token,
-                // account deleted) surfaces inside codex via
-                // classify_refresh_token_failure → the user sees
-                // the standard codex re-login prompt; oauth-mux
-                // doesn't need to second-guess that.
-                self.logEvent("proxy_observed_401_codex_handles", .{
-                    .account = account_id,
-                });
-            },
+            .auth_unauthorized => {},
             .tier_insufficient, .provider_5xx => {
                 // Recorded for telemetry only; no pool mutation.
             },
@@ -730,10 +758,11 @@ const StatusAndClassification = struct {
 /// Forward the inbound request to chatgpt.com and write the response
 /// directly to the client writer.
 ///
-/// 429 responses are buffered (small JSON, need body to classify
-/// usage_limit_reached vs usage_not_included).
+/// 401 and 429 responses are buffered so the proxy can decide whether to
+/// retry against a fallback account before any bytes reach Codex. 429 also
+/// needs the body to classify usage_limit_reached vs usage_not_included.
 ///
-/// All other responses (200 streaming SSE, 401, 5xx) are streamed
+/// All other responses (200 streaming SSE, 5xx) are streamed
 /// byte-for-byte from upstream's reader to the client. Connection-close
 /// framing is used so we don't have to re-chunk std.http.Client's
 /// already-decoded body bytes.
@@ -779,9 +808,9 @@ fn forwardAndStream(
 
     const status_u16: u16 = @intFromEnum(http_req.response.status);
 
-    // 429 is the only path that needs the body for classification.
-    // Every other status classifies on the status code alone.
-    if (status_u16 == 429) {
+    // 401 and 429 are retry decision points, so they must be buffered before
+    // anything is written to Codex.
+    if (status_u16 == 401 or status_u16 == 429) {
         // Cap at 64 KiB — chatgpt.com's 429 JSON bodies are small.
         const body = try http_req.reader().readAllAlloc(a, 64 * 1024);
         const classification = classify(a, status_u16, body);


### PR DESCRIPTION
## Summary
- buffer Codex 401 responses and retry the same request against a healthy fallback account before Codex sees the auth failure
- finalize managed-session evidence more reliably, including managed-frame IDs, status-file markers, auth health, and aborted-session frames
- extend status summaries, stubs, smokes, README, and specs to separate auth-continuity fallback from quota fallback

## Validation
- git diff --check
- just check