### PR TITLE
Fix Codex auth fallback chain summary

### DIFF
--- a/scripts/smoke-codex-status-summary.sh
+++ b/scripts/smoke-codex-status-summary.sh
@@ -18,6 +18,7 @@ BROKERED="$TMP/brokered.ndjson"
 FALLBACK="$TMP/fallback.ndjson"
 AUTH_FAILED="$TMP/auth-failed.ndjson"
 AUTH_FALLBACK="$TMP/auth-fallback.ndjson"
+AUTH_FALLBACK_CHAIN="$TMP/auth-fallback-chain.ndjson"
 INCOMPLETE="$TMP/incomplete.ndjson"
 
 cat >"$BROKERED" <<'EOF'
@@ -52,6 +53,15 @@ cat >"$AUTH_FALLBACK" <<'EOF'
 {"kind":"proxy_turn","account":"codex:max-2","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true,"delivered_to_codex":true}
 {"kind":"auth_health_observed","account":"codex:max-1","auth_unauthorized_turns":1,"responses_401_turns":1,"recovered_after_401":false,"recorded":true,"reason":"unrecovered_401_no_writeback","scope":"account_credential","quota_claim":false,"token_material_printed":false,"path_printed":false}
 {"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":true}
+EOF
+
+cat >"$AUTH_FALLBACK_CHAIN" <<'EOF'
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"proxy_turn","account":"codex:max-1","method":"GET","path_kind":"codex_other","status":401,"classification":"auth_unauthorized","body_class":"json_error","claim_level":"broker_owned","streamed":false,"delivered_to_codex":false}
+{"kind":"proxy_auth_same_turn_retry","from":"codex:max-1","to":"codex:max-2","reason":"auth_unauthorized","dropped":"x-codex-turn-state"}
+{"kind":"proxy_turn","account":"codex:max-2","method":"GET","path_kind":"codex_other","status":401,"classification":"auth_unauthorized","body_class":"json_error","claim_level":"broker_owned","streamed":false,"delivered_to_codex":false}
+{"kind":"proxy_auth_same_turn_retry","from":"codex:max-2","to":"codex:max-3","reason":"auth_unauthorized","dropped":"x-codex-turn-state"}
+{"kind":"proxy_turn","account":"codex:max-3","method":"GET","path_kind":"codex_other","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true,"delivered_to_codex":true}
 EOF
 
 cat >"$INCOMPLETE" <<'EOF'
@@ -131,9 +141,36 @@ if [[ "$(jq -r .auth_fallback_sequence.fallback_account <<<"$AUTH_FALLBACK_SUMMA
     echo "$AUTH_FALLBACK_SUMMARY" >&2
     exit 1
 fi
+if [[ "$(jq -r .auth_fallback_sequence.retry.to <<<"$AUTH_FALLBACK_SUMMARY")" != "codex:max-2" ]]; then
+    echo "auth-fallback terminal retry mismatch" >&2
+    echo "$AUTH_FALLBACK_SUMMARY" >&2
+    exit 1
+fi
 if [[ "$(jq -r .auth_health_quota_claim_observed <<<"$AUTH_FALLBACK_SUMMARY")" != "false" ]]; then
     echo "auth-fallback summary must not claim quota" >&2
     echo "$AUTH_FALLBACK_SUMMARY" >&2
+    exit 1
+fi
+
+AUTH_FALLBACK_CHAIN_SUMMARY="$(python3 "$ROOT/scripts/summarize-codex-status.py" "$AUTH_FALLBACK_CHAIN" --require-brokered)"
+if [[ "$(jq -r .verdict <<<"$AUTH_FALLBACK_CHAIN_SUMMARY")" != "auth_fallback_sequence_observed" ]]; then
+    echo "auth-fallback-chain verdict mismatch" >&2
+    echo "$AUTH_FALLBACK_CHAIN_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .auth_fallback_sequence.fallback_account <<<"$AUTH_FALLBACK_CHAIN_SUMMARY")" != "codex:max-3" ]]; then
+    echo "auth-fallback-chain account mismatch" >&2
+    echo "$AUTH_FALLBACK_CHAIN_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .auth_fallback_sequence.retry.to <<<"$AUTH_FALLBACK_CHAIN_SUMMARY")" != "codex:max-3" ]]; then
+    echo "auth-fallback-chain terminal retry mismatch" >&2
+    echo "$AUTH_FALLBACK_CHAIN_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .auth_fallback_sequence.retry_count <<<"$AUTH_FALLBACK_CHAIN_SUMMARY")" != "2" ]]; then
+    echo "auth-fallback-chain retry count mismatch" >&2
+    echo "$AUTH_FALLBACK_CHAIN_SUMMARY" >&2
     exit 1
 fi
 

--- a/scripts/summarize-codex-status.py
+++ b/scripts/summarize-codex-status.py
@@ -106,9 +106,9 @@ def find_fallback_sequence(events: list[dict[str, Any]]) -> dict[str, Any]:
 
 def find_auth_fallback_sequence(events: list[dict[str, Any]]) -> dict[str, Any]:
     auth_idx: int | None = None
-    retry_idx: int | None = None
     auth_account: str | None = None
-    retry_event: dict[str, Any] | None = None
+    retry_events: list[dict[str, Any]] = []
+    terminal_retry_event: dict[str, Any] | None = None
     fallback_turn: dict[str, Any] | None = None
 
     for idx, event in enumerate(events):
@@ -128,40 +128,46 @@ def find_auth_fallback_sequence(events: list[dict[str, Any]]) -> dict[str, Any]:
             "reason": "no auth_unauthorized proxy_turn",
         }
 
-    for idx in range(auth_idx + 1, len(events)):
-        event = events[idx]
+    for event in events[auth_idx + 1 :]:
         if event.get("kind") == "proxy_auth_same_turn_retry":
-            retry_idx = idx
-            retry_event = event
+            retry_events.append(event)
+            continue
+        if event.get("kind") != "proxy_turn":
+            continue
+        if event.get("status") != 200:
+            continue
+
+        if not retry_events:
+            continue
+        latest_retry = retry_events[-1]
+        if event.get("account") == latest_retry.get("to"):
+            fallback_turn = event
+            terminal_retry_event = latest_retry
             break
 
-    if retry_idx is None:
+    if not retry_events:
         return {
             "observed": False,
             "reason": "auth_unauthorized without proxy_auth_same_turn_retry",
             "auth_account": auth_account,
         }
 
-    for event in events[retry_idx + 1 :]:
-        if event.get("kind") != "proxy_turn":
-            continue
-        if event.get("account") != auth_account and event.get("status") == 200:
-            fallback_turn = event
-            break
-
     if fallback_turn is None:
         return {
             "observed": False,
             "reason": "auth retry without successful fallback-account turn",
             "auth_account": auth_account,
-            "retry": retry_event,
+            "retry": retry_events[-1],
+            "retries": retry_events,
         }
 
     return {
         "observed": True,
         "auth_account": auth_account,
         "fallback_account": fallback_turn.get("account"),
-        "retry": retry_event,
+        "retry": terminal_retry_event,
+        "retries": retry_events,
+        "retry_count": len(retry_events),
         "fallback_status": fallback_turn.get("status"),
         "fallback_path_kind": fallback_turn.get("path_kind"),
     }


### PR DESCRIPTION
## Summary
- report the terminal auth retry that produced the successful fallback turn
- include the full auth retry chain and retry count in the status summarizer
- add a chained-auth-fallback fixture to the status summarizer smoke

## Validation
- scripts/smoke-codex-status-summary.sh
- git diff --check HEAD~1..HEAD