### PR TITLE
Add Codex dogfood status monitor helper

### DIFF
--- a/scripts/monitor-codex-status.sh
+++ b/scripts/monitor-codex-status.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+status_file="${1:-dist/live-qa/managed-resume-dogfood-9/status.ndjson}"
+interval_seconds="${2:-60}"
+out_dir="${3:-$(dirname "$status_file")}"
+
+mkdir -p "$out_dir"
+
+monitor_log="$out_dir/monitor.log"
+event_log="$out_dir/quota-terminal-events.log"
+
+event_pattern='"status":(429|503)|quota_exhausted|usage_limit_reached|proxy_same_turn_retry|proxy_upstream_failed|session_ended|session_aborted|auth_writeback|auth_health_observed|resume_writeback'
+
+while true; do
+	printf '\n== %s ==\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$monitor_log"
+	python3 scripts/summarize-codex-status.py "$status_file" --require-brokered >>"$monitor_log" 2>&1
+
+	event_tmp="$(mktemp "${TMPDIR:-/tmp}/oauth-mux-codex-events.XXXXXX")"
+	if rg -n "$event_pattern" "$status_file" >"$event_tmp" 2>/dev/null; then
+		printf '\n== %s ==\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$event_log"
+		cat "$event_tmp" >>"$event_log"
+		tail -n 80 "$status_file" >>"$event_log"
+	fi
+	rm -f "$event_tmp"
+
+	sleep "$interval_seconds"
+done


### PR DESCRIPTION
Adds a small shell helper for recurring dogfood artifact monitoring.\n\nThe helper snapshots scripts/summarize-codex-status.py at a chosen interval and writes a separate event log when quota, retry, terminal, or writeback frames appear. This keeps long-running managed dogfood runs observable without manually re-running the summarizer.\n\nValidation:\n- bash -n scripts/monitor-codex-status.sh\n\nCurrent dogfood-9 state while setting this up:\n- auth_fallback_sequence_observed\n- 215 brokered proxy turns\n- current traffic on codex:max-4\n- no quota/terminal events recorded yet