### PR TITLE
Truth dogfood-9 auth fallback evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,12 @@ Real on `main`:
 - Brokered Codex resume has been dogfooded successfully through the proxy:
   `resume <session-id>` reached `POST /backend-api/codex/responses` with
   `status:200`.
-- Current dogfood status evidence includes hundreds of brokered
-  `POST /responses` 200s through `codex:max-1`; it does not yet include a real
-  provider-originated `429 usage_limit_reached` or fallback-account turn.
+- Current dogfood status evidence includes a managed auth-continuity handoff:
+  dogfood-9 launched with `codex:max-1`, observed selected-account
+  `401 auth_unauthorized`, retried the buffered request across `max-2` and
+  `max-3`, and continued with successful `POST /responses` traffic through
+  `codex:max-4`. It does not yet include a real provider-originated
+  `429 usage_limit_reached` or quota fallback turn.
 - Synthetic smokes prove account A can hit `429 usage_limit_reached`, be
   marked exhausted, and account B can handle the same request in the same child
   process before Codex receives the 429.
@@ -110,3 +113,5 @@ the subscription lacks quota.
 `401 auth_unauthorized`, oauth-mux retried the same buffered request against a
 different account before Codex saw the 401, and the fallback account returned
 200. That is a managed auth-continuity proof, not quota exhaustion evidence.
+In the dogfood-9 artifact, that selected account was `codex:max-1` and the
+successful live wire traffic moved to `codex:max-4`.

--- a/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
+++ b/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
@@ -23,12 +23,11 @@ prepared fallback, and synthetic smokes are evidence or diagnostics only.
 
 ## Current Live State
 
-Observed on 2026-05-05 around 15:37 EDT, then updated after the first
-brokered-resume dogfood on 2026-05-06 and a follow-up no-spend check on
-2026-05-06:
+Observed on 2026-05-05 around 15:37 EDT, then updated after brokered-resume
+dogfood on 2026-05-06 and dogfood-9 auth-continuity evidence on 2026-05-07:
 
-- Repository: clean on `main`, synced with `origin/main` at `8a111bf`
-  (`Add GitHub tracker comment fallback`) during this checkpoint.
+- Repository: clean on `main`, synced with `origin/main` at `9cdf5a3`
+  (`Add Codex dogfood status monitor helper (#209)`) during this checkpoint.
 - Selected live `codex-max` route: `max-1`.
 - Spend-gated exhausted-route revalidation after the reset window found
   `max-1`, `max-2`, and `max-3` available again; `max-4` was already
@@ -53,13 +52,16 @@ The brokered-resume dogfood proved a separate prerequisite:
 - Live `POST /backend-api/codex/responses` turns returned `status:200` through
   the oauth-mux proxy after the request-framing and same-account child-refresh
   fixes.
-- `dist/live-qa/managed-resume-dogfood-5/status.ndjson` contains 352
-  brokered proxy turns through `codex:max-1`: 347 `POST /responses` 200s and
-  5 `GET codex_other` 200s. It contains no provider-originated 429, no
-  `proxy_same_turn_retry`, and no fallback-account turn.
+- `dist/live-qa/managed-resume-dogfood-5/status.ndjson` proved brokered
+  resume and ordinary selected-route 200s.
+- `dist/live-qa/managed-resume-dogfood-9/status.ndjson` proved live managed
+  auth-continuity fallback: launched on `codex:max-1`, observed selected-route
+  `401 auth_unauthorized`, retried through `max-2` and `max-3`, and continued
+  successful live traffic through `codex:max-4`.
 
-That is meaningful UX/architecture progress. It is not account-exhaustion
-success and must not be described as stay-afloat completion.
+That is meaningful UX/architecture progress and a real auth failure
+stay-afloat event. It is not quota-exhaustion success and must not be described
+as Level 3 quota handoff completion.
 
 ## Mainline Reality
 
@@ -75,6 +77,9 @@ Already merged on main:
   one stable child PID.
 - Brokered Codex resume through canonical session authority; the managed frame
   can now resume a real existing Codex session and proxy normal provider turns.
+- Brokered auth-continuity dogfood: selected-route 401s can be hidden from
+  Codex by same-turn retry across fallback accounts, with subsequent useful
+  traffic on `codex:max-4`.
 - Same-account child auth refresh preservation; oauth-mux no longer overwrites
   a Codex-refreshed bearer for the same account with stale materialized route
   credentials.
@@ -89,6 +94,8 @@ Already merged on main:
 Not yet proven:
 
 - Live provider-originated Level 3 account swap.
+- Live provider-originated quota fallback. Dogfood-9 is auth fallback, not
+  quota fallback.
 - Live invisible same-turn recovery where a fallback account handles the user
   turn before Codex sees `usage_limit_reached`.
 - Same-thread continuity across account swap.
@@ -286,6 +293,8 @@ These need review before public promotion:
 6. Start the Claude adapter only after the Codex Level 3 proof is recorded
    or explicitly parked.
 7. Re-run `just check-local` after each code/test slice.
+8. Keep dogfood-9 monitoring active while it remains useful, but interpret it
+   as burning `codex:max-4` after auth fallback, not `codex:max-1`.
 
 ## Hygiene Pass Notes
 

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -17,13 +17,15 @@ deb/rpm assets, and a public Jess-owned Homebrew tap. The remaining adoption
 risks are no longer general release mechanics. They are specific product
 boundaries that need separate tracking.
 
-Supersession note, 2026-05-03: the Codex proof ladder now includes
+Supersession note, 2026-05-07: the Codex proof ladder now includes
 broker-owned session planning, no-spend local broker smokes, spend-gated
 broker-run live turns, bounded broker-run session loops, exhausted-route
-revalidation, and controlled fallback drills. The current paid `codex-max`
-cohort is four routes: `max-1` selected, `max-4` spare fallback, and
-`max-2`/`max-3` quota-exhausted for `codex-max`. Provider-originated
-in-session quota fallback remains tracked by GitHub `#131` / Linear `TIN-916`.
+revalidation, controlled fallback drills, managed resume, and a live
+dogfood-9 auth-continuity fallback. After the 2026-05-05 spend-gated
+revalidation, no-spend planning recorded four selectable `codex-max` routes.
+Dogfood-9 then launched on `max-1`, observed auth failures, and continued
+useful live traffic on `max-4`. Provider-originated in-session quota fallback
+remains tracked by GitHub `#131` / Linear `TIN-916`.
 
 ## Public Issue Map
 
@@ -32,7 +34,7 @@ in-session quota fallback remains tracked by GitHub `#131` / Linear `TIN-916`.
 | Homebrew distribution | `#66` | `TIN-858`, related to `TIN-737` | Public Jess-owned tap exists and clean local install QA passes; Tinyland tap remains private/staged. Live website copy was rechecked on 2026-05-03 and now uses the public `jesssullivan/omux` tap. |
 | Stay-afloat daemon | `#67` | `TIN-738`, `TIN-859`, `TIN-860`, `TIN-866`, `TIN-867`, `TIN-897`, `TIN-898`, `TIN-940` | Foreground/agent-safe stay-afloat is shipped; production background daemon is not. Socket daemon is explicitly non-product plumbing. The active claim matrix lives in `docs/daemon-boundary.md`; managed Codex launch/resume and broker-owned app-server sessions are scoped proof surfaces. Supervised child capture is diagnostic only, not a product claim level. |
 | Provider expansion | `#68` | `TIN-736`, `TIN-861`, `TIN-862`, `TIN-863`, `TIN-876`, `TIN-877`, `TIN-878`, `TIN-879` | Codex route selection and broker-owned sessions are live-proven for scoped commands; true seamless active-session handoff is not. Non-Codex proof is capability-level or still needs operator proof. |
-| Paid multi-account proof | `#67`, `#68` | `TIN-892`, `TIN-893`, `TIN-894`, `TIN-895`, `TIN-896` | Codex has a current four-route paid cohort: `max-1` selected, `max-4` spare fallback, and `max-2`/`max-3` quota-exhausted for `codex-max`. Claude, Figma, and long-window soak evidence remain separate gates. |
+| Paid multi-account proof | `#67`, `#68` | `TIN-892`, `TIN-893`, `TIN-894`, `TIN-895`, `TIN-896` | Codex has a four-route paid cohort. After 2026-05-05 revalidation, all four `codex-max` routes were recorded selectable; dogfood-9 later proved managed auth-continuity fallback from selected `max-1` to live traffic on `max-4`. Claude, Figma, quota handoff, and long-window soak evidence remain separate gates. |
 
 ## Homebrew Boundary
 
@@ -82,10 +84,10 @@ Current truth:
   auth, and silent mutation.
 - Codex fallback is proven across several scopes: historical 2026-05-01
   route-state evidence moved from exhausted `max-1#codex-max` to available
-  `max-2#codex-max`; the current 2026-05-03 four-route cohort selects
-  `max-1#codex-max`, keeps `max-4#codex-max` as spare fallback, and records
-  `max-2#codex-max` plus `max-3#codex-max` as provider quota-exhausted for
-  `codex-max`.
+  `max-2#codex-max`; 2026-05-05 spend-gated revalidation restored all four
+  `codex-max` routes as selectable; dogfood-9 proved managed auth-continuity
+  fallback from selected `max-1` to successful live traffic on `max-4`.
+  Provider-originated quota fallback remains unproven.
 - The 2026-05-01 sandbox recheck remains useful historical evidence: inside
   the Codex sandbox, all configured Codex account stores reported
   `unwritable_store`; outside that sandbox, the stores were runtime-ready and

--- a/docs/spec/test-and-coverage-review-2026-05-05.md
+++ b/docs/spec/test-and-coverage-review-2026-05-05.md
@@ -7,10 +7,11 @@ Codex adapter contract: `docs/spec/codex-adapter-contract-2026-05-03.md`.
 
 This review replaces the stale quarry-branch assessment from
 `/Users/jess/git/oauth-mux-broker`. It describes current `main` through
-`954d673` (`Whoohoo brokered Codex resume`), after route-health truthing,
-Codex quarry smokes, expired-quota revalidation state, restart-claim demotion,
-managed resume UX work, request-framing fixes, and same-account child-refresh
-preservation.
+`9cdf5a3` (`Add Codex dogfood status monitor helper (#209)`), after
+route-health truthing, Codex quarry smokes, expired-quota revalidation state,
+restart-claim demotion, managed resume UX work, request-framing fixes,
+same-account child-refresh preservation, auth fallback chain summarization,
+managed auth-health recording, and the dogfood-9 live auth-continuity event.
 
 ## Product Bar
 
@@ -91,6 +92,24 @@ That unblocks fallback capacity for TIN-951 / GitHub #177. It does not
 prove Level 3, because no provider-originated quota event was observed
 inside a live `oauth-mux codex` session during that check.
 
+## Dogfood-9 Auth Continuity
+
+`dist/live-qa/managed-resume-dogfood-9/status.ndjson` is the strongest current
+live managed-session artifact, but it is an auth-continuity artifact, not a
+quota artifact.
+
+The run launched with `selected_account:"codex:max-1"` and
+`session_authority:"canonical_bridge"`. The selected account returned
+`401 auth_unauthorized`, oauth-mux retried the same buffered request through
+`codex:max-2` and `codex:max-3`, and `codex:max-4` returned `200`. Subsequent
+useful live `POST /responses` traffic continued through `codex:max-4`.
+
+The summarizer verdict is `auth_fallback_sequence_observed`. That means
+managed same-turn auth failure stay-afloat worked in a real dogfood session.
+It does not close TIN-916 / GitHub #131 or TIN-951 / GitHub #177, because the
+artifact has no `429`, no `usage_limit_reached`, no `quota_exhausted`, and no
+quota swap/retry event.
+
 ## What Current Main Proves
 
 - The broker MCP core can select accounts, materialize Codex credential
@@ -99,6 +118,9 @@ inside a live `oauth-mux codex` session during that check.
   without restarting its child process.
 - The managed Codex frame can resume a real existing canonical Codex session
   and proxy normal live `responses` turns successfully.
+- The managed Codex proxy can keep a real session afloat across selected-route
+  auth failure by retrying the buffered request on a fallback account before
+  Codex sees the 401.
 - The proxy can preserve a same-account Codex-refreshed bearer instead of
   forcing stale oauth-mux materialized credentials.
 - Route-health state now distinguishes expired reset windows as
@@ -113,6 +135,8 @@ inside a live `oauth-mux codex` session during that check.
 ## What Current Main Does Not Prove
 
 - Live provider-originated Level 3 account swap.
+- Live provider-originated quota fallback. Dogfood-9 proves auth fallback, not
+  quota fallback.
 - Live invisible same-turn recovery where Codex never sees a visible
   `usage_limit_reached` failure when a fallback account is selectable.
 - Same-thread continuity across account swap.


### PR DESCRIPTION
## Summary
- record dogfood-9 as live managed auth-continuity fallback from selected max-1 to useful traffic on max-4
- keep provider-originated quota fallback explicitly unproven for #131 / #177
- refresh README, test/coverage review, quarry todo, and product gap map stale route wording

## Validation
- git diff --check
- bash -n scripts/monitor-codex-status.sh
- python3 scripts/summarize-codex-status.py dist/live-qa/managed-resume-dogfood-9/status.ndjson --require-brokered