### PR TITLE
[codex] Refresh README lifecycle truth narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,103 @@
 # oauth-mux
 
-`oauth-mux` is an OAuth/account broker for developer harnesses. The product
-target is:
+`oauth-mux` is OAuth/account multiplexing for professional AI harnesses and
+autonomous agents.
+
+Developers and agents now operate across personal, work, team, subscription,
+API-key, and service identities. Most CLIs still expose a brittle single-account
+path: one local auth store, one active subscription, one opaque 401/429 failure
+surface. `oauth-mux` puts a broker in front of that path so a harness session can
+stay usable when auth, quota, tier, or local runtime state changes.
+
+The product bar is intentionally narrow and hard:
 
 > The user runs `oauth-mux <harness>` such as `oauth-mux codex`. The harness
 > behaves like the real one. The active subscription account exhausts quota.
 > Another credited account is substituted in place. The harness process is not
 > restarted. The user is not prompted.
 
-Restart, supervised relaunch, route-warming, and `prepared_fallback` are not
-product success. They are diagnostics or lower-level infrastructure.
+Restart, supervised relaunch, route warming, and `prepared_fallback` are
+diagnostic infrastructure. They are not product success.
 
-## Use It Now
+## Current Truth
 
-Functional today:
+Source and local dogfood are `0.1.7` candidate. Public npm, GitHub Release, and
+Homebrew install lanes still publish `0.1.6`.
 
-- Managed Codex sessions through `oauth-mux codex` and
-  `oauth-mux codex resume ...`.
-- Native Codex resume chooser and canonical session history inside the managed
-  frame.
-- Codex behavior config passthrough for user settings such as `[features]`,
-  legacy `experimental_*`, MCP servers, approval/sandbox policy, profiles, and
-  model defaults.
-- Live managed Codex quota handoff across enrolled routes, with redacted
-  installed-runtime proof.
-- Agent-safe JSON diagnostics for accounts, runtime state, route selection, and
-  Codex status artifacts.
+What works today:
 
-Still scoped or pending:
+- Managed Codex launch and resume through `oauth-mux codex` and
+  `oauth-mux codex resume`.
+- Native Codex chooser/session authority bridge, including canonical
+  `state_5.sqlite*` when present.
+- Root-partitioned Codex config passthrough for user settings such as
+  `[features]`, legacy `experimental_*`, MCP servers, approval/sandbox policy,
+  profiles, model defaults, and non-managed provider definitions.
+- Lazy account refresh at credential materialization or explicit repair time;
+  managed launch reports `pre_spawn_network_refresh:false`.
+- Live managed Codex quota handoff for installed `oauth-mux codex resume`, with
+  the strongest preserved proof in
+  `docs/evidence/codex-engineered-quota-handoff-20260509/`.
+- Redacted JSON diagnostics for agents and operators.
 
-- Same-thread provider semantics across account boundaries.
+Still research or open:
+
+- Same-thread provider semantic continuity across account boundaries.
 - Mid-turn streaming recovery.
-- Unmanaged bare-`codex` hot-swap from a background daemon.
-- Non-Codex harness stay-afloat claims.
+- Unmanaged bare-`codex` daemon hot-swap.
+- Non-Codex provider stay-afloat proof.
+- Long-window soak and negative permutation cassette coverage.
 
-Install:
+## Lifecycle
+
+```mermaid
+flowchart LR
+    install["Install"] --> init["init"]
+    init --> enroll["Enroll accounts"]
+    enroll --> diagnose["Local diagnostics"]
+    diagnose --> route["Route selection"]
+    route --> launch["Managed harness launch"]
+    launch --> signal["Provider signal observed"]
+    signal --> decision["Broker decision"]
+    decision --> materialize["Fallback materialization"]
+    materialize --> status["Redacted status artifact"]
+    status --> repair["Repair / revalidate loop"]
+    repair --> diagnose
+```
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Mux as oauth-mux
+    participant Codex
+    participant Proxy
+    participant Provider
+
+    User->>Mux: oauth-mux codex resume
+    Mux->>Mux: select route
+    Mux->>Mux: build auth/config overlay
+    Mux->>Mux: bridge canonical session authority
+    Mux->>Codex: spawn managed Codex
+    Codex->>Proxy: responses request
+    Proxy->>Provider: selected account request
+    Provider-->>Proxy: 200 / 401 / 429 usage_limit_reached / tier or rate error
+    Proxy->>Mux: classify signal
+    Mux-->>Proxy: retry fallback when eligible
+    Proxy-->>Codex: successful response or typed terminal result
+    Mux->>Mux: write redacted evidence
+```
+
+Route-state labels are stable public vocabulary:
+`available`, `quota_exhausted`, `rate_limited`, `tier_insufficient`,
+`auth_permanently_failed`, `credential_unavailable`, `revalidation_needed`, and
+`not_afloat`.
+
+See `docs/lifecycle.md` for the deeper lifecycle, agent control-plane, and claim
+ladder diagrams.
+
+## Install
+
+Public install lanes currently resolve to `0.1.6`:
 
 ```bash
 npm install -g oauth-mux
@@ -42,65 +105,62 @@ npm install -g oauth-mux
 brew install jesssullivan/omux/oauth-mux
 ```
 
-First Codex path:
+Local `0.1.7` candidate dogfood should keep provenance explicit:
+
+```bash
+just build
+mkdir -p ~/.local/bin
+rm -f ~/.local/bin/oauth-mux
+cp ./zig-out/bin/oauth-mux ~/.local/bin/oauth-mux
+shasum -a 256 ./zig-out/bin/oauth-mux ~/.local/bin/oauth-mux
+which -a oauth-mux
+oauth-mux version
+```
+
+On macOS, remove the old Mach-O before copying the dogfood binary. Overwriting in
+place can leave stale taskgated/code-signing state on the old vnode and produce
+an immediate `SIGKILL` / status `137`.
+
+## Usage
+
+Human first run:
 
 ```bash
 oauth-mux init --codex-max
 oauth-mux doctor
-oauth-mux accounts list --provider codex --json
-oauth-mux route explain --profile codex-max --capability codex-max --json
+oauth-mux route explain --profile codex-max --capability codex-max
 oauth-mux codex resume
 ```
 
-If a route needs upstream auth, use the labeled handoff from `route explain`,
-for example:
+If a route needs upstream auth, run the labeled handoff reported by
+`route explain`, for example:
 
 ```bash
 oauth-mux codex login-device max-3
 ```
 
-Agent-safe diagnostics:
+Agent-safe inspection:
 
 ```bash
 oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 oauth-mux accounts list --provider codex --json
 oauth-mux route explain --profile codex-max --capability codex-max --json
+oauth-mux repair-plan --profile codex-max --capability codex-max --json
 oauth-mux codex status-latest --json
 ```
 
-These commands do not spend provider calls. Live probes and revalidation stay
-behind explicit confirmation.
+Those commands do not spend provider calls. Live probes, revalidation, and
+provider-spend paths stay behind explicit confirmation.
 
-## Current Codex State
+## UX / DX / AX Contract
 
-`oauth-mux codex` is the current reference adapter. It runs Codex in a managed
-frame with mux-owned auth/config, a proxy provider, and a canonical Codex
-session-authority bridge. Installed-runtime evidence proves managed Codex quota
-handoff; synthetic smokes cover the surrounding auth, tier, all-exhausted,
-chooser, config-passthrough, child-refresh, concurrent-session, and cassette
-paths.
+UX:
 
-Current account-state and handoff truth lives in `docs/qa-handoff-matrix.md`.
-The reviewed proof bundles are
-`docs/evidence/codex-managed-quota-handoff-20260508/` and
-`docs/evidence/codex-engineered-quota-handoff-20260509/`.
+- The managed harness should feel native.
+- There is no hidden daemon dependency for the current Codex path.
+- Handoffs are labeled and user-mediated when upstream login is required.
 
-## Where To Go Next
-
-- `docs/README.md`: docs map.
-- `docs/adoption.md`: first-run UX and agent-safe command paths.
-- `docs/qa-handoff-matrix.md`: route states, handoff claims, account labels,
-  and current Codex truth.
-- `docs/release-install-lanes.md`: install, package, CI/CD, and dogfood lanes.
-- `docs/spec/future-adapter-roadmap-2026-05-10.md`: future adapter proof gates.
-
-The product anchor is
-`docs/spec/broker-mcp-contract-2026-05-03.md`. The Codex adapter contract is
-`docs/spec/codex-adapter-contract-2026-05-03.md`.
-
-## Testing Ladder
-
-Use `just` as the entrypoint.
+DX:
 
 ```bash
 just build
@@ -108,110 +168,28 @@ just test
 just check-local
 ```
 
-The evidence ladder is:
+Use `just release-proof <version>` before any registry mutation. Direct
+`zig build` is fine for iteration, but `just` is the operator entrypoint.
 
-- Unit tests and deterministic PBT-style tests in Zig for parsers, route state,
-  classification, session ids, credential handles, header copying, and overlay
-  invariants.
-- Shell e2e/smoke tests for broker MCP, Codex CLI UX, Codex synthetic swap,
-  concurrent sessions, same-account child refresh, tier-insufficient handling,
-  all-accounts-exhausted handling, 401 auth fallback, and cassette replay.
-- Cassette replay infrastructure for scrubbed Codex wire captures.
-- Live QA only after local and cassette layers are green, with explicit spend
-  consent and redacted status artifacts.
+AX:
 
-The canonical handoff/account-state matrix is `docs/qa-handoff-matrix.md`.
-Release and installer lane truth is `docs/release-install-lanes.md`.
+- JSON surfaces are redacted and account-label based.
+- Agents do not need token files or raw provider stores to choose a next action.
+- oauth-mux does not silently perform provider-spend actions.
+- Diagnostic output should include exact next-action commands.
 
-Next P0: harden the engineered live handoff into deterministic regression
-coverage and keep collecting evidence for same-thread provider semantics across
-account boundaries. The 2026-05-08 installed-runtime artifact closes managed
-load/resume quota handoff; the 2026-05-09 artifact closes the engineered
-managed quota handoff shape; dogfood-9 remains failure evidence and
-route-health input, not product acceptance.
+## Proof
 
-Summarize a dogfood status artifact without overclaiming:
+Keep the claim ladder tied to evidence:
 
-```bash
-oauth-mux codex status-latest --json
-oauth-mux codex status-latest --status-file dist/live-qa/<run>/status.ndjson --json
-python3 scripts/summarize-codex-status.py dist/live-qa/<run>/status.ndjson --require-brokered
-```
+- `docs/qa-handoff-matrix.md`: route states, handoff patterns, and current Codex
+  truth.
+- `docs/release-install-lanes.md`: public package lanes versus local dogfood
+  lanes.
+- `docs/lifecycle.md`: application lifecycle, managed Codex flow, agent-safe
+  control plane, and claim levels.
+- `docs/evidence/codex-engineered-quota-handoff-20260509/`: current headline
+  managed Codex quota-handoff proof.
 
-`oauth-mux codex status-latest` is the installed-binary operator surface. The
-Python summarizer remains the repo regression oracle and should agree on
-success/failure verdicts for tracked evidence.
-Both summaries include `launch_timing.child_spawn_elapsed_ms` when the status
-artifact contains startup phase events; these timings are diagnostics for
-fast visible TUI, not product success evidence.
-If Codex terminates by signal, managed status now records a typed
-`session_aborted` terminal event with `term_kind`, `term_code`, and
-`signal_name` such as `SIGKILL`; use that artifact evidence instead of relying
-only on shell text like "terminated by signal".
-
-Managed config status is intentionally class-based. `session_started` reports
-`config_passthrough`, `user_config_present`, `config_overridden_keys`, and
-`config_paths_printed:false`. Unsafe forwarded Codex config overrides emit
-`config_passthrough_check` with counts and booleans such as
-`model_provider_override:true`; raw paths, tokens, session ids, and user config
-values are not printed.
-
-Run managed Codex dogfood only through an installed `oauth-mux` executable on
-PATH, after installing the current build into the operator environment:
-
-```bash
-oauth-mux codex resume <session-id>
-```
-
-For local dogfood, keep the provenance explicit:
-
-```bash
-which -a oauth-mux
-scripts/project-version.sh
-oauth-mux version
-shasum -a 256 ./zig-out/bin/oauth-mux
-shasum -a 256 "$(command -v oauth-mux)"
-```
-
-The worktree build and the installed PATH binary should match when testing
-unreleased behavior. A Homebrew binary may legitimately lag the worktree until
-the rendered formula from `dist/out/v<version>/homebrew/oauth-mux.rb` is
-promoted to the public `jesssullivan/omux` tap.
-
-Managed Codex runs write redacted status evidence by default under the
-oauth-mux state directory (`$XDG_STATE_HOME/oauth-mux/codex/status/` on Linux,
-`~/Library/Application Support/oauth-mux/codex/status/` on macOS, or
-`$OMUX_STATE_DIR/codex/status/` when set). Passing `--json-status-file` is still
-available for an explicit artifact path, but it is not required for the installed
-dogfood command.
-
-Repo-local `./zig-out/bin/oauth-mux`, extra dogfood wrapper scripts, and
-arg-clad launch helpers are not acceptance evidence for live quota stay-afloat.
-
-`verdict:"brokered_without_fallback"` means the session went through oauth-mux
-but did not observe account exhaustion or substitution. The Level 3/4 evidence
-shape requires a `quota_exhausted` proxy turn, a retry/swap event, and a
-successful turn on a distinct fallback account.
-`verdict:"brokered_auth_failed"` means the managed frame started, but upstream
-returned unrecovered `401 auth_unauthorized` responses. That is an auth-health
-failure, not quota fallback evidence. Status artifacts should also show an
-`auth_writeback` frame; `changed:true,written:true,ok:true` means Codex updated
-managed overlay auth and oauth-mux imported it back to the route's auth source.
-`source_conflict:true` means another writer changed the mux source first, so
-oauth-mux refused to overwrite it. When unrecovered 401s occur and no overlay
-auth changed, oauth-mux records account-credential health for the next launch
-and emits `auth_health_observed` with `quota_claim:false`; that does not prove
-the subscription lacks quota.
-`verdict:"auth_fallback_sequence_observed"` means the selected account produced
-`401 auth_unauthorized`, oauth-mux retried the same buffered request against a
-different account before Codex saw the 401, and the fallback account returned
-200. That is a managed auth-continuity proof, not quota exhaustion evidence.
-In the dogfood-9 artifact, that selected account was `codex:max-1` and the
-successful live wire traffic moved to `codex:max-4`.
-`verdict:"successful_live_quota_handoff"` means a provider-originated
-`usage_limit_reached` quota event was observed, oauth-mux retried the same
-request on a distinct fallback account before delivering the 429 to Codex, and
-the fallback account returned 200.
-`verdict:"quota_handoff_failed"` means a live quota event was observed, but
-oauth-mux exhausted the eligible candidate set and could not complete a
-substitution. That is the expected dogfood-9 verdict.
+The product anchor is `docs/spec/broker-mcp-contract-2026-05-03.md`. The Codex
+adapter contract is `docs/spec/codex-adapter-contract-2026-05-03.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@ Start here when you need the right document without reading every spec.
 
 - `../README.md`: install commands, current supported path, and no-spend
   diagnostics.
+- `lifecycle.md`: application lifecycle, managed Codex flow, agent-safe control
+  plane, route states, and claim ladder diagrams.
 - `adoption.md`: first-run UX, install surfaces, agent-safe commands, and
   non-Tinyland deployment notes.
 - `onboarding.md`: full onboarding command reference.

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,0 +1,177 @@
+# oauth-mux Lifecycle
+
+Updated: 2026-05-10
+
+This page expands the lifecycle and claim diagrams kept short in the README. It
+is subordinate to `docs/spec/broker-mcp-contract-2026-05-03.md` and
+`docs/spec/codex-adapter-contract-2026-05-03.md`.
+
+## Application Lifecycle
+
+```mermaid
+flowchart LR
+    install["Install oauth-mux"] --> init["Initialize profile"]
+    init --> enroll["Enroll or label accounts"]
+    enroll --> diagnostics["Local diagnostics"]
+    diagnostics --> route["Route selection"]
+    route --> launch["Managed harness launch"]
+    launch --> observe["Provider signal observed"]
+    observe --> decide["Broker decision"]
+    decide --> fallback["Fallback / materialization"]
+    fallback --> artifact["Redacted status artifact"]
+    artifact --> repair["Repair / revalidate loop"]
+    repair --> diagnostics
+
+    diagnostics --> noSpend["No-spend JSON surfaces"]
+    repair --> userHandoff["User-mediated login / reauth"]
+    repair --> liveProbe["Spend-confirmed live probe"]
+```
+
+The lifecycle separates no-spend inspection from provider-spend operations.
+Agents can inspect route and runtime state without reading token files or
+triggering provider calls. Login, reauth, and live probes remain explicit human
+or operator actions.
+
+## Managed Codex Session Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Mux as oauth-mux
+    participant Overlay as Managed overlay
+    participant Codex
+    participant Proxy
+    participant Provider
+    participant Status as Status artifact
+
+    User->>Mux: oauth-mux codex resume
+    Mux->>Mux: select route
+    Mux->>Overlay: write mux-owned auth/config
+    Mux->>Overlay: bridge canonical session authority
+    Mux->>Codex: spawn managed Codex
+    Codex->>Proxy: responses request
+    Proxy->>Provider: request with selected account
+    Provider-->>Proxy: 200
+    Proxy-->>Codex: forward success
+    Codex->>Proxy: next responses request
+    Proxy->>Provider: request with selected account
+    Provider-->>Proxy: 401 or 429 usage_limit_reached or tier/rate error
+    Proxy->>Mux: classify signal
+    Mux->>Mux: mark route state
+    Mux-->>Proxy: fallback route when eligible
+    Proxy->>Provider: retry buffered request
+    Provider-->>Proxy: 200 or typed terminal result
+    Proxy-->>Codex: deliver recovered response or terminal result
+    Mux->>Status: append redacted evidence
+```
+
+The current live-proven Codex claim is managed quota handoff for installed
+`oauth-mux codex resume`. The proof requires a provider-originated
+`usage_limit_reached` response, route marking, a same-turn retry on a distinct
+fallback account, and fallback `200` before Codex sees the 429.
+
+## Agent-Safe Control Plane
+
+```mermaid
+flowchart TB
+    human["Human or agent"] --> inspect["No-spend JSON command"]
+    inspect --> broker["Broker reports route states"]
+    broker --> action["Exact safe next action"]
+
+    action --> use["Use available route"]
+    action --> wait["Wait for reset / retry window"]
+    action --> reauth["User-mediated login or reauth"]
+    action --> repair["Repair local runtime or store"]
+    action --> confirm["Spend-confirmed probe / revalidation"]
+
+    reauth --> broker
+    repair --> broker
+    confirm --> broker
+```
+
+No-spend commands:
+
+```bash
+oauth-mux doctor runtime --profile codex-max --capability codex-max --json
+oauth-mux accounts list --provider codex --json
+oauth-mux route explain --profile codex-max --capability codex-max --json
+oauth-mux repair-plan --profile codex-max --capability codex-max --json
+oauth-mux codex status-latest --json
+```
+
+Spend-confirmed commands and upstream login commands are separate by design.
+Agents should present those commands to the user or operator; they should not
+infer token paths, copy provider stores, or run live probes without explicit
+authorization.
+
+## Route States
+
+Use these labels exactly in docs, JSON summaries, and operator-facing text:
+
+| State | Meaning | Safe next action |
+| --- | --- | --- |
+| `available` | Route has enough fresh evidence to select. | Use route or keep as fallback. |
+| `quota_exhausted` | Provider reported subscription quota exhaustion. | Wait for reset or run confirmed revalidation after reset/plan change. |
+| `rate_limited` | Provider throttled route but not subscription-exhausted. | Wait/retry according to policy. |
+| `tier_insufficient` | Account cannot use requested capability. | Try another route; do not call it quota. |
+| `auth_permanently_failed` | Upstream auth is invalid/stale. | Run labeled provider-owned login handoff. |
+| `credential_unavailable` | Local materialization failed. | Repair local store/runtime; do not spend provider calls first. |
+| `revalidation_needed` | Stored reset window expired; evidence is stale. | Run spend-confirmed revalidation. |
+| `not_afloat` | No selectable route for the profile/capability. | Reauth, wait, revalidate, or enroll another route. |
+
+## Truth Ladder
+
+```mermaid
+flowchart LR
+    prepared["prepared_fallback\nDiagnostic only"] --> broker["broker_owned\nManaged broker frame"]
+    broker --> nextTurn["next_turn_seamless\nLive-proven for managed Codex quota handoff"]
+    nextTurn --> midTurn["mid_turn_streaming\nOpen"]
+    nextTurn --> thread["cross_session_thread_continuity\nOpen"]
+    nextTurn --> daemon["unmanaged_daemon_handoff\nOpen"]
+
+    classDef proven fill:#dcfce7,stroke:#15803d,color:#14532d
+    classDef diagnostic fill:#fef9c3,stroke:#a16207,color:#713f12
+    classDef open fill:#f1f5f9,stroke:#64748b,color:#334155
+
+    class prepared diagnostic
+    class broker,nextTurn proven
+    class midTurn,thread,daemon open
+```
+
+Claim interpretation:
+
+- `prepared_fallback` means oauth-mux knows a candidate fallback exists. It does
+  not prove a harness turn survived account exhaustion.
+- `broker_owned` means the harness ran through oauth-mux-owned auth/config and
+  status instrumentation.
+- `next_turn_seamless` means oauth-mux observed an eligible provider failure,
+  retried through a distinct fallback account, and kept the harness process
+  alive without prompting the user.
+- `mid_turn_streaming`, `cross_session_thread_continuity`, and unmanaged daemon
+  handoff remain open claims.
+
+## Status Verdicts
+
+Status summaries are evidence classifiers, not marketing copy.
+
+| Verdict | Interpretation |
+| --- | --- |
+| `brokered_without_fallback` | The session went through oauth-mux, but no account exhaustion or substitution was observed. |
+| `brokered_auth_failed` | The managed frame started, but upstream returned unrecovered `401 auth_unauthorized`. This is auth health failure, not quota evidence. |
+| `auth_fallback_sequence_observed` | A selected route returned 401, oauth-mux retried the buffered request on a different account before Codex saw the 401, and the fallback returned 200. |
+| `successful_live_quota_handoff` | A provider-originated `usage_limit_reached` quota event was observed, oauth-mux retried the request on a distinct fallback account before delivering the 429 to Codex, and fallback returned 200. |
+| `quota_handoff_failed` | A live quota event was observed, but oauth-mux exhausted eligible candidates and could not complete substitution. |
+
+If Codex terminates by signal, managed status records a typed `session_aborted`
+terminal event with `term_kind`, `term_code`, and `signal_name`. Use the artifact
+fields instead of shell text alone.
+
+## Evidence Links
+
+- `docs/qa-handoff-matrix.md`: current route-state and handoff matrix.
+- `docs/release-install-lanes.md`: public install lanes and local dogfood
+  provenance.
+- `docs/evidence/codex-engineered-quota-handoff-20260509/`: strongest preserved
+  managed Codex quota-handoff proof.
+- `docs/evidence/codex-managed-quota-handoff-20260508/`: earlier managed
+  load/resume quota-handoff proof.


### PR DESCRIPTION
## Summary
- Reframe README around OAuth/account multiplexing for professional AI harnesses and autonomous agents.
- Encode current version truth: source/local dogfood is 0.1.7 candidate; public npm/GitHub/Homebrew remain 0.1.6.
- Add docs/lifecycle.md with Mermaid lifecycle, managed Codex flow, agent-safe control plane, route states, claim ladder, and status verdict glossary.

## Validation
- git diff --check
- nix develop --command zig build test
- scripts/smoke-codex-cli-ux.sh
- scripts/smoke-codex-status-summary.sh
- nix develop --command just check-local

## Notes
- Same-thread provider continuity, mid-turn streaming recovery, unmanaged daemon hot-swap, universal provider support, and non-Codex stay-afloat remain explicitly unclaimed.