### PR TITLE
Codex experimental defaults

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .oauth_mux,
-    .version = "0.1.6",
+    .version = "0.1.7",
     .fingerprint = 0x21c445132f61984e,
     .minimum_zig_version = "0.14.0",
     .paths = .{

--- a/dist/npm/package.json
+++ b/dist/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth-mux",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "OAuth fallback muxing for AI harness subscriptions",
   "license": "MIT",
   "repository": "Jesssullivan/oauth-mux",
@@ -16,11 +16,11 @@
     "postinstall": "node install.js"
   },
   "optionalDependencies": {
-    "oauth-mux-darwin-arm64": "0.1.6",
-    "oauth-mux-darwin-x64": "0.1.6",
-    "oauth-mux-linux-arm64": "0.1.6",
-    "oauth-mux-linux-x64": "0.1.6",
-    "oauth-mux-windows-arm64": "0.1.6",
-    "oauth-mux-windows-x64": "0.1.6"
+    "oauth-mux-darwin-arm64": "0.1.7",
+    "oauth-mux-darwin-x64": "0.1.7",
+    "oauth-mux-linux-arm64": "0.1.7",
+    "oauth-mux-linux-x64": "0.1.7",
+    "oauth-mux-windows-arm64": "0.1.7",
+    "oauth-mux-windows-x64": "0.1.7"
   }
 }

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -152,7 +152,9 @@ session authority is bridged by reference to the canonical Codex home unless
 `--isolated-session-store` is set. `oauth-mux codex resume` with no id keeps
 native Codex chooser ownership; oauth-mux only checks before spawn that the
 managed overlay exposes the same required session-authority entries so the
-chooser does not open empty.
+chooser does not open empty. When canonical Codex has `state_5.sqlite*`, those
+files are bridged by reference and `state_5.sqlite` is treated as chooser
+authority; older homes use the legacy session/history/index/snapshot set.
 
 Codex behavior config is preserved by default. The managed overlay reads the
 canonical config authority from `OMUX_CODEX_CONFIG_HOME`, then parent
@@ -162,7 +164,14 @@ defaults, and custom non-managed providers. oauth-mux strips the selected
 `model_provider` and stale `[model_providers.oauth_mux_openai]` entries before
 appending its proxy provider. Forwarded Codex `--config` / `-c` assignments
 that try to override mux-owned provider keys fail before child spawn with a
-redacted `config_passthrough_check` status event.
+redacted `config_passthrough_check` status event. The generated config uses
+`config_layout:"root_partitioned"` so managed root keys cannot land inside a
+trailing user table.
+When a Codex experimental feature key is absent, the managed overlay defaults
+`terminal_resize_reflow`, `memories`, `external_migration`, `goals`, and
+`prevent_idle_sleep` on for the child config only. Explicit canonical values,
+including `false`, are preserved, and the canonical `config.toml` is not
+mutated.
 
 `doctor runtime`, `route explain`, `route select`, `stay-afloat next`,
 `stay-afloat --once`, and bounded `stay-afloat --loop` are no-spend surfaces

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -15,7 +15,7 @@ The lane contract and current operator rules live in
 | --- | --- | --- | --- | --- | --- |
 | npm global install | 0.1.6 | macOS arm64 | public npm registry | Pass | Public registry reports `oauth-mux@0.1.6` plus all six platform packages. |
 | npm one-shot | 0.1.6 | macOS arm64 | public npm registry | Pass | `npx -y oauth-mux@0.1.6 version` returns `oauth-mux 0.1.6`. |
-| user-local dogfood install | 0.1.6 | macOS arm64 | current worktree copied to `~/.local/bin` | Pass | `./zig-out/bin/oauth-mux` and `~/.local/bin/oauth-mux` hashes match after ad-hoc re-sign; use this lane for unreleased installed-command dogfood. |
+| user-local dogfood install | 0.1.7 candidate | macOS arm64 | current worktree copied to `~/.local/bin` | Pass | Remove the old installed file before copying; `./zig-out/bin/oauth-mux` and `~/.local/bin/oauth-mux` hashes match. Use this lane for unreleased installed-command dogfood. |
 | Nix package | 0.1.6 | macOS arm64 remote builder | `nix build .#` | Pass | `result -> /nix/store/a7izjlmdm21x37glihb9aa34xaa1rfia-oauth-mux-0.1.6`; `./result/bin/oauth-mux version` returns `0.1.6`. |
 | GitHub release tarball | 0.1.6 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Release workflow `25195318899` published all tarballs, packages, checksums, formula, and installer. |
 | `curl | sh` installer | 0.1.6 | macOS arm64 and `../lab` | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass | Default installer repo is canonical; no `REPO=...` override needed. |

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -210,7 +210,9 @@ The managed frame preserves native Codex session authority by reference while
 oauth-mux owns auth and the proxy provider override. Resume chooser mode stays
 native: oauth-mux checks the required session-authority entries before child
 spawn and fails with a redacted diagnostic rather than opening an empty
-chooser.
+chooser. Newer Codex `state_5.sqlite*` chooser state is bridged by reference
+when present; older homes fall back to `sessions/`, `history.jsonl`,
+`session_index.jsonl`, and `shell_snapshots/`.
 
 The managed overlay also preserves normal Codex behavior config from the
 canonical config authority (`OMUX_CODEX_CONFIG_HOME`, then parent
@@ -218,7 +220,14 @@ canonical config authority (`OMUX_CODEX_CONFIG_HOME`, then parent
 servers, approval/sandbox policy, profiles, model defaults, and custom
 non-managed provider definitions survive. oauth-mux strips only mux-owned
 provider selection conflicts and rejects forwarded `--config` / `-c` provider
-overrides before launching Codex.
+overrides before launching Codex. The generated TOML is root-partitioned, so a
+canonical config ending inside a table such as `[tui.model_availability_nux]`
+cannot capture the managed `model_provider` override.
+Missing Codex experimental feature defaults are enabled only in the managed
+child config: `terminal_resize_reflow`, `memories`, `external_migration`,
+`goals`, and `prevent_idle_sleep`. Existing canonical values, including
+explicit `false`, win, and oauth-mux does not rewrite the canonical
+`config.toml`.
 
 Managed Codex live quota handoff is proven for installed
 `oauth-mux codex resume` status artifacts. The 2026-05-09 engineered evidence

--- a/docs/qa-handoff-matrix.md
+++ b/docs/qa-handoff-matrix.md
@@ -48,8 +48,8 @@ capability, such as `codex:max-3#codex-max`.
 
 | Pattern | Entry | Evidence required | Current status |
 | --- | --- | --- | --- |
-| Managed resume chooser | `oauth-mux codex resume` | `resume_authority_check`, native chooser argv, no recursive session copy | covered by CLI smoke |
-| Managed explicit resume | `oauth-mux codex resume <id>` | canonical session bridge, redacted status, runtime identity | live-proven path |
+| Managed resume chooser | `oauth-mux codex resume` | `resume_authority_check`, native chooser argv, `resume_authority_state_db_bridged` when `state_5.sqlite*` exists, no recursive pre-spawn rollout scan | covered by CLI smoke |
+| Managed explicit resume | `oauth-mux codex resume <id>` | canonical session bridge, `resume_lookup_source`, redacted status, runtime identity | live-proven path |
 | Managed last resume | `oauth-mux codex resume --last` | canonical session bridge, writeback check | covered by CLI smoke |
 | Labeled reauth | `oauth-mux codex login-device <account>` | action says `user_handoff`, route label named, no raw identity | live operator flow |
 | Auth fallback | selected route 401, fallback 200 | `proxy_auth_same_turn_retry`, `auth_health_observed quota_claim:false` | live and smoke evidence |

--- a/docs/release-install-lanes.md
+++ b/docs/release-install-lanes.md
@@ -54,8 +54,9 @@ Before dogfooding unreleased behavior:
 
 ```bash
 just build
+mkdir -p ~/.local/bin
+rm -f ~/.local/bin/oauth-mux
 cp ./zig-out/bin/oauth-mux ~/.local/bin/oauth-mux
-codesign --force --sign - ~/.local/bin/oauth-mux  # macOS ad-hoc local install
 shasum -a 256 ./zig-out/bin/oauth-mux ~/.local/bin/oauth-mux
 which -a oauth-mux
 oauth-mux version
@@ -69,9 +70,14 @@ Expected:
 - Homebrew may report the same source version while still being a different
   binary hash; treat it as the package lane.
 
-On macOS, a copied ad-hoc binary can fail immediately with no output if the
-signature/provenance state is inconsistent. Re-signing the copied binary with
-`codesign --force --sign -` is the local dogfood repair.
+On macOS, do not overwrite an existing Mach-O in place for this lane. A direct
+`cp` over `~/.local/bin/oauth-mux` can leave stale taskgated/code-signing state
+on the old vnode; the symptom is immediate `SIGKILL` / shell status `137` with
+a DiagnosticReports entry saying `Taskgated Invalid Signature`. Remove the old
+file first, then copy the new build so the installed file has a fresh vnode and
+the hash still matches the worktree binary. Re-signing the installed copy is a
+separate repair fallback, but it changes the hash and no longer proves byte
+identity with `./zig-out/bin/oauth-mux`.
 
 ## UX, DX, AX Gates
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -141,7 +141,7 @@ at the staged artifact directory instead of GitHub Releases.
 After the GitHub Release exists, run the hosted system-package install proof:
 
 ```bash
-gh workflow run system-package-install-qa.yml -f version=0.1.6
+gh workflow run system-package-install-qa.yml -f version=<version>
 ```
 
 This workflow downloads the published `.deb` and `.rpm` release assets, verifies
@@ -151,7 +151,7 @@ Linux containers on `ubuntu-latest`, and runs `/usr/bin/oauth-mux version`.
 For local reproduction on a healthy Docker-compatible host:
 
 ```bash
-just system-package-qa 0.1.6
+just system-package-qa <version>
 ```
 
 This is stricter than the registry `system` dry-run lane. The dry-run lane

--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -97,6 +97,37 @@ fail before child spawn with a redacted `config_passthrough_check` status
 event. Track remaining edge-layer work in
 <https://github.com/Jesssullivan/oauth-mux/issues/211>.
 
+Implementation update, 2026-05-10: the managed config writer now partitions
+canonical config into root lines and table sections. `model_provider =
+"oauth_mux_openai"` is emitted only at TOML root, stale
+`[model_providers.oauth_mux_openai*]` sections are stripped, preserved user
+tables remain below the root override, and the generated provider table is
+appended after preserved user tables. The regression fixture is a canonical
+config ending in `[tui.model_availability_nux]` with `"gpt-5.5" = 2`.
+`session_started` reports `config_layout:"root_partitioned"`.
+
+Implementation update, 2026-05-10: the session-authority bridge now also
+symlinks `state_5.sqlite`, `state_5.sqlite-wal`, and `state_5.sqlite-shm` when
+canonical Codex has them. `state_5.sqlite` is treated as native chooser
+authority when present; older Codex homes still fall back to the legacy
+`sessions/`, `shell_snapshots/`, `history.jsonl`, and `session_index.jsonl`
+authority set. Redacted status reports `resume_authority_state_db_bridged` and
+`resume_lookup_source`.
+
+Implementation update, 2026-05-10: managed launch no longer runs broad
+`repairRefreshableCodexAuthFailures()` before child spawn. Network refresh is
+deferred to actual credential materialization for the selected/fallback route,
+or to explicit repair/revalidate commands. Status reports
+`pre_spawn_network_refresh:false`; `child_spawn_elapsed_ms` remains the startup
+UX timing to watch.
+
+Implementation update, 2026-05-11: the managed config writer now enables
+missing Codex experimental feature defaults for the child overlay:
+`terminal_resize_reflow`, `memories`, `external_migration`, `goals`, and
+`prevent_idle_sleep`. Existing canonical values, including explicit `false`,
+are preserved, the canonical `config.toml` is not mutated, and
+`session_started` reports `experimental_feature_defaults_injected`.
+
 ## 0. Scope
 
 This adapter exists to deliver the `oauth-mux codex` user entrypoint and

--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -128,6 +128,14 @@ missing Codex experimental feature defaults for the child overlay:
 are preserved, the canonical `config.toml` is not mutated, and
 `session_started` reports `experimental_feature_defaults_injected`.
 
+Implementation update, 2026-05-13: the overlay writer now guards the Codex
+0.130 MCP schema drift that rejects remote-only fields on stdio launchers.
+When a preserved `[mcp_servers.*]` table contains `command`, the managed
+overlay removes unsupported `url` and `bearer_token_env_var` lines from that
+overlay only. HTTP MCP tables without `command` keep those fields. The
+canonical config remains untouched, and `session_started` reports the redacted
+`mcp_stdio_unsupported_fields_removed` count.
+
 ## 0. Scope
 
 This adapter exists to deliver the `oauth-mux codex` user entrypoint and

--- a/docs/spec/codex-productionization-todo-2026-05-09.md
+++ b/docs/spec/codex-productionization-todo-2026-05-09.md
@@ -84,6 +84,10 @@ Not proven:
 - [x] Add the trailing-table config regression for
   `[tui.model_availability_nux]` with `"gpt-5.5" = 2`; status now reports
   `config_layout:"root_partitioned"`.
+- [x] Guard Codex 0.130 MCP schema drift in the managed overlay: stdio MCP
+  tables with `command` drop unsupported `url` and `bearer_token_env_var`
+  lines in the overlay only, while HTTP MCP tables preserve those fields.
+  Status reports `mcp_stdio_unsupported_fields_removed`.
 - [x] Remove launch-time broad `repairRefreshableCodexAuthFailures()` from the
   pre-spawn path. Status reports `pre_spawn_network_refresh:false`; refresh
   remains lazy during credential materialization or explicit repair/revalidate

--- a/docs/spec/codex-productionization-todo-2026-05-09.md
+++ b/docs/spec/codex-productionization-todo-2026-05-09.md
@@ -19,6 +19,13 @@ Proven:
 - The preserved proof bundles are
   `docs/evidence/codex-managed-quota-handoff-20260508/` and
   `docs/evidence/codex-engineered-quota-handoff-20260509/`.
+- 2026-05-10 local verification fixed the installed `0.1.6` runtime
+  regressions in the managed launch path: generated `config.toml` is
+  root-partitioned so trailing user tables such as
+  `[tui.model_availability_nux]` cannot swallow the managed
+  `model_provider`; `state_5.sqlite*` is bridged by reference when present for
+  native chooser parity; and broad pre-spawn Codex auth repair has been removed
+  from launch.
 
 Not proven:
 
@@ -52,6 +59,10 @@ Not proven:
   `/experimental` / `[features]`, MCP, hooks/rules, approval/sandbox, profiles,
   model defaults, and other user behavior settings must pass through while
   oauth-mux overrides only the proxy provider keys.
+- [x] Default missing Codex experimental feature keys in the managed child
+  config (`terminal_resize_reflow`, `memories`, `external_migration`, `goals`,
+  and `prevent_idle_sleep`) while preserving explicit canonical values,
+  including `false`.
 
 ## P0 Proof Work
 
@@ -60,12 +71,23 @@ Not proven:
 - [x] Add a managed-resume chooser regression: canonical authority is checked
   before child spawn, missing authority fails with a redacted diagnostic, and
   chooser mode avoids recursive rollout snapshotting before launch.
+- [x] Bridge newer Codex `state_5.sqlite*` chooser authority by reference when
+  canonical Codex has it. Treat `state_5.sqlite` as chooser authority when
+  present and fall back to legacy `sessions` / `history.jsonl` /
+  `session_index.jsonl` / `shell_snapshots` authority for older Codex homes.
 - [x] Add a managed config passthrough regression with a canonical
   `config.toml` fixture containing representative `[features]`,
   `experimental_*`, MCP, approval/sandbox, profile, custom provider, and model
   defaults. Include profile-scoped provider stripping and pre-spawn rejection
   for forwarded Codex `--config` / `-c` attempts to override mux-owned provider
   keys.
+- [x] Add the trailing-table config regression for
+  `[tui.model_availability_nux]` with `"gpt-5.5" = 2`; status now reports
+  `config_layout:"root_partitioned"`.
+- [x] Remove launch-time broad `repairRefreshableCodexAuthFailures()` from the
+  pre-spawn path. Status reports `pre_spawn_network_refresh:false`; refresh
+  remains lazy during credential materialization or explicit repair/revalidate
+  commands.
 - [x] Capture the engineered in-session exhaustion proof:
   account A starts available, emits successful `200` turns, reaches
   provider-originated `usage_limit_reached`, then account B returns `200` in the
@@ -107,6 +129,16 @@ Not proven:
   redacts sensitive fields.
 - [ ] Add cassette replay for the redacted real `usage_limit_reached` shape from
   the 2026-05-08 proof when a publishable cassette is available.
+
+## P0 Startup And Resume UX
+
+- [x] Explicit `oauth-mux codex resume <id>` no longer recursively snapshots all
+  rollouts before spawn. It resolves targeted evidence from `state_5.sqlite*`,
+  then `session_index.jsonl`, then a bounded filename lookup, and reports
+  `resume_lookup_source` in redacted status.
+- [x] Bare `oauth-mux codex resume` reports authority readiness without scanning
+  rollouts before child spawn. The `child_spawn_elapsed_ms` launch timing
+  remains the primary startup UX metric.
 
 ## P1 Documentation And Website
 

--- a/docs/spec/harness-session-authority-bridge-2026-05-05.md
+++ b/docs/spec/harness-session-authority-bridge-2026-05-05.md
@@ -29,6 +29,12 @@ proven managed resume/load through the proxy, including live quota handoff
 evidence tracked in
 `docs/spec/codex-live-quota-handoff-evidence-2026-05-08.md`.
 
+Implementation update, 2026-05-10: newer Codex chooser state can live in
+`state_5.sqlite*`. The managed overlay now bridges `state_5.sqlite`,
+`state_5.sqlite-wal`, and `state_5.sqlite-shm` by reference when canonical
+Codex has them. `state_5.sqlite` is accepted as chooser authority when
+present; older Codex homes still use the legacy file set above.
+
 The 2026-05-06 dogfood-6 auth failure exposed the auth-side counterpart:
 Codex can refresh tokens inside the managed overlay, and the adapter must
 import changed overlay `auth.json` back into the selected mux-owned account
@@ -142,10 +148,13 @@ For Codex today, candidate session-authority files are:
 - `~/.codex/session_index.jsonl`
 - `~/.codex/history.jsonl`
 - `~/.codex/shell_snapshots/`
+- `~/.codex/state_5.sqlite*` when present, for newer native chooser state
 
 The current required set is pinned by fixture smoke coverage and pre-spawn
-chooser authority checks. Add new entries only with evidence that native Codex
-requires them for chooser/resume parity.
+chooser authority checks. `state_5.sqlite` is sufficient chooser authority
+when present; otherwise the legacy entries above remain the fallback authority
+set. Add new entries only with evidence that native Codex requires them for
+chooser/resume parity.
 
 ### 2.4 Cache, Log, and Runtime State
 
@@ -161,8 +170,9 @@ normal operation. Keep this state local to the managed overlay or to an
 oauth-mux-owned runtime directory. If a harness needs a cache bridge, it must
 be explicit and documented separately from session authority.
 
-For Codex, `logs_*.sqlite`, `state_*.sqlite`, and model caches are not part of
-the initial bridge acceptance.
+For Codex, `state_5.sqlite*` is now a narrowly scoped session-authority bridge
+for native chooser parity. Other `logs_*.sqlite`, `state_*.sqlite`, and model
+caches are not bridged by default.
 
 ### 2.5 oauth-mux Evidence Store
 
@@ -227,6 +237,9 @@ For Codex on Unix-like systems, a candidate overlay is:
   session_index.jsonl -> ~/.codex/session_index.jsonl
   history.jsonl -> ~/.codex/history.jsonl
   shell_snapshots -> ~/.codex/shell_snapshots
+  state_5.sqlite -> ~/.codex/state_5.sqlite       # when canonical has it
+  state_5.sqlite-wal -> ~/.codex/state_5.sqlite-wal
+  state_5.sqlite-shm -> ~/.codex/state_5.sqlite-shm
 ```
 
 This keeps `resume <id>` and `resume --last` pointed at the canonical session

--- a/docs/tracker-updates/2026-05-10/README.md
+++ b/docs/tracker-updates/2026-05-10/README.md
@@ -1,0 +1,41 @@
+# Tracker Updates - 2026-05-10
+
+Local verification after the Codex resume/config/startup regression fix:
+
+- `TIN-979`: managed session authority now bridges newer Codex
+  `state_5.sqlite*` chooser state by reference when present, while keeping
+  `auth.json` and generated `config.toml` mux-owned in the temporary overlay.
+- `TIN-1079`: managed startup no longer runs broad pre-spawn Codex auth repair;
+  explicit resume preflight uses targeted `state_5.sqlite*` /
+  `session_index.jsonl` / filename evidence, and chooser mode reports authority
+  readiness without scanning rollouts before spawn.
+- Config regression: canonical config ending in `[tui.model_availability_nux]`
+  with `"gpt-5.5" = 2` now survives, with
+  `config_layout:"root_partitioned"` status.
+- Config schema guard: migrated Codex 0.130-incompatible stdio MCP tables are
+  made valid in the managed overlay by removing remote-only `url` and
+  `bearer_token_env_var` fields from stdio tables only. HTTP MCP tables keep
+  those fields. Status reports `mcp_stdio_unsupported_fields_removed`.
+- Local install regression: macOS can kill a user-local dogfood binary with
+  `SIGKILL` / `Taskgated Invalid Signature` when `cp` overwrites an existing
+  Mach-O in place. The install lane now removes `~/.local/bin/oauth-mux`
+  before copying so the fresh file has a fresh vnode and hash identity with the
+  worktree binary is preserved.
+
+Validation:
+
+- `zig build test`
+- `just build`
+- `scripts/smoke-codex-cli-ux.sh`
+- `scripts/smoke-codex-provider-degraded.sh`
+- `scripts/smoke-codex-status-summary.sh`
+- `nix develop --command just check-local`
+
+Release hygiene:
+
+- Source version advanced to `0.1.7` for the patch release candidate.
+- QA helper defaults now follow `scripts/project-version.sh` instead of
+  preserving the last published `0.1.6` literal.
+- The hosted system-package install workflow still defaults to the last
+  published release until `v0.1.7` assets exist, because it installs public
+  release artifacts on PRs.

--- a/justfile
+++ b/justfile
@@ -125,10 +125,10 @@ release-handoff VERSION=release_version:
 registry-dry-run VERSION=release_version:
     nix develop --command ./scripts/registry-dry-run.sh {{VERSION}}
 
-system-package-qa VERSION="0.1.6":
+system-package-qa VERSION=release_version:
     ./scripts/system-package-install-qa.sh {{VERSION}}
 
-homebrew-qa VERSION="0.1.6":
+homebrew-qa VERSION=release_version:
     ./scripts/homebrew-install-qa.sh {{VERSION}}
 
 npm-deprecate-plan VERSION="0.1.1":

--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -65,7 +65,13 @@ memories = true
 multi_agent = true
 
 [mcp_servers.design]
+url = "https://figma.invalid/mcp"
+bearer_token_env_var = "FIGMA_ACCESS_TOKEN"
 command = "figma-mcp"
+
+[mcp_servers.linear]
+url = "https://mcp.linear.app/mcp"
+bearer_token_env_var = "LINEAR_API_KEY"
 
 [profiles.work]
 model = "gpt-5.5"
@@ -180,6 +186,7 @@ run_case() {
     assert_grep "$label config passthrough status" '"config_passthrough":true,"user_config_present":true' "$ndjson"
     assert_grep "$label config layout" '"config_layout":"root_partitioned"' "$ndjson"
     assert_grep "$label experimental defaults injected" '"experimental_feature_defaults_injected":4' "$ndjson"
+    assert_grep "$label mcp stdio schema guard" '"mcp_stdio_unsupported_fields_removed":2' "$ndjson"
     assert_grep "$label no pre-spawn network refresh" '"pre_spawn_network_refresh":false' "$ndjson"
     assert_grep "$label child spawn timing" '"kind":"launch_timing".*"phase":"child_spawn"' "$ndjson"
     assert_grep "$label resume preflight" '"kind":"resume_preflight"' "$ndjson"
@@ -252,6 +259,8 @@ run_case() {
           && "$(jq -r .config.user_tui_model_availability_nux "$report")" == "true" \
           && "$(jq -r .config.config_layout_root_partitioned "$report")" == "true" \
           && "$(jq -r .config.user_mcp_server "$report")" == "true" \
+          && "$(jq -r .config.stdio_mcp_remote_fields_absent "$report")" == "true" \
+          && "$(jq -r .config.http_mcp_remote_fields_preserved "$report")" == "true" \
           && "$(jq -r .config.user_approval_policy "$report")" == "true" \
           && "$(jq -r .config.user_sandbox_mode "$report")" == "true" \
           && "$(jq -r .config.profile_model_provider_absent "$report")" == "true" \

--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -49,6 +49,9 @@ mkdir -p "$TMP/account-A" "$TMP/claude-personal" "$STATE_DIR" "$CANONICAL_SESSIO
 touch "$CANONICAL_SESSION_HOME/history.jsonl" "$CANONICAL_SESSION_HOME/session_index.jsonl"
 printf '%s\n' '{"fixture":"resume"}' >"$CANONICAL_SESSION_HOME/sessions/2026/05/06/rollout-managed-good-session.jsonl"
 printf '%s\n' '{"bridge":"preexisting"}' >"$CANONICAL_SESSION_HOME/sessions/omux-session-bridge-smoke.jsonl"
+printf '%s\n' 'managed-good-session' >"$CANONICAL_SESSION_HOME/state_5.sqlite"
+printf '%s\n' 'managed-good-session-wal' >"$CANONICAL_SESSION_HOME/state_5.sqlite-wal"
+printf '%s\n' 'managed-good-session-shm' >"$CANONICAL_SESSION_HOME/state_5.sqlite-shm"
 cat >"$CANONICAL_SESSION_HOME/config.toml" <<'EOF'
 model = "gpt-5.5"
 model_provider = "user_provider"
@@ -76,6 +79,9 @@ base_url = "https://example.invalid/api"
 [model_providers.oauth_mux_openai]
 name = "stale mux"
 base_url = "https://stale.invalid"
+
+[tui.model_availability_nux]
+"gpt-5.5" = 2
 EOF
 
 ID_TOKEN="h.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9wbGFuX3R5cGUiOiJwcm8ifX0.s"
@@ -172,14 +178,23 @@ run_case() {
     assert_grep "$label session_started" '"kind":"session_started"' "$ndjson"
     assert_grep "$label canonical session bridge" '"session_authority":"canonical_bridge"' "$ndjson"
     assert_grep "$label config passthrough status" '"config_passthrough":true,"user_config_present":true' "$ndjson"
+    assert_grep "$label config layout" '"config_layout":"root_partitioned"' "$ndjson"
+    assert_grep "$label experimental defaults injected" '"experimental_feature_defaults_injected":4' "$ndjson"
+    assert_grep "$label no pre-spawn network refresh" '"pre_spawn_network_refresh":false' "$ndjson"
     assert_grep "$label child spawn timing" '"kind":"launch_timing".*"phase":"child_spawn"' "$ndjson"
     assert_grep "$label resume preflight" '"kind":"resume_preflight"' "$ndjson"
     if [[ "$label" == "resume-chooser" ]]; then
         assert_grep "$label resume authority check" '"kind":"resume_authority_check".*"ok":true' "$ndjson"
+        assert_grep "$label state db authority" '"kind":"resume_authority_check".*"resume_authority_state_db_bridged":true' "$ndjson"
         assert_grep "$label no chooser rollout scan before spawn" '"kind":"resume_preflight".*"mode":"chooser".*"rollouts_before":0' "$ndjson"
+        assert_grep "$label chooser lookup not scanned" '"kind":"resume_preflight".*"mode":"chooser".*"resume_lookup_source":"not_scanned"' "$ndjson"
         assert_grep "$label resume writeback" '"kind":"resume_writeback".*"mode":"chooser"' "$ndjson"
-    else
+    elif [[ "$label" == "resume-id" ]]; then
+        assert_grep "$label explicit state-db lookup" '"kind":"resume_preflight".*"mode":"explicit".*"resume_lookup_source":"state_db"' "$ndjson"
         assert_grep "$label resume writeback" '"kind":"resume_writeback".*"changed_existing":[1-9]' "$ndjson"
+    else
+        assert_grep "$label lookup not scanned" '"kind":"resume_preflight".*"resume_lookup_source":"not_scanned"' "$ndjson"
+        assert_grep "$label resume writeback" '"kind":"resume_writeback"' "$ndjson"
     fi
     assert_grep "$label resume status redacts paths" '"kind":"resume_writeback".*"session_id_printed":false,"path_printed":false' "$ndjson"
     assert_grep "$label session_ended" '"kind":"session_ended".*"exit_code":0' "$ndjson"
@@ -204,7 +219,10 @@ run_case() {
           && "$(jq -r .session_bridge.sessions_samefile "$report")" == "true" \
           && "$(jq -r .session_bridge.history_samefile "$report")" == "true" \
           && "$(jq -r .session_bridge.session_index_samefile "$report")" == "true" \
-          && "$(jq -r .session_bridge.shell_snapshots_samefile "$report")" == "true" ]]; then
+          && "$(jq -r .session_bridge.shell_snapshots_samefile "$report")" == "true" \
+          && "$(jq -r .session_bridge.state_db_samefile "$report")" == "true" \
+          && "$(jq -r .session_bridge.state_db_wal_samefile "$report")" == "true" \
+          && "$(jq -r .session_bridge.state_db_shm_samefile "$report")" == "true" ]]; then
         echo "  ✓ $label bridged canonical session authority"
     else
         echo "  ✗ $label session bridge failed" >&2
@@ -226,7 +244,13 @@ run_case() {
           && "$(jq -r .config.user_feature_apps "$report")" == "true" \
           && "$(jq -r .config.user_feature_memories "$report")" == "true" \
           && "$(jq -r .config.user_feature_multi_agent "$report")" == "true" \
+          && "$(jq -r .config.managed_feature_terminal_resize_reflow "$report")" == "true" \
+          && "$(jq -r .config.managed_feature_external_migration "$report")" == "true" \
+          && "$(jq -r .config.managed_feature_goals "$report")" == "true" \
+          && "$(jq -r .config.managed_feature_prevent_idle_sleep "$report")" == "true" \
           && "$(jq -r .config.user_experimental_legacy "$report")" == "true" \
+          && "$(jq -r .config.user_tui_model_availability_nux "$report")" == "true" \
+          && "$(jq -r .config.config_layout_root_partitioned "$report")" == "true" \
           && "$(jq -r .config.user_mcp_server "$report")" == "true" \
           && "$(jq -r .config.user_approval_policy "$report")" == "true" \
           && "$(jq -r .config.user_sandbox_mode "$report")" == "true" \

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -67,10 +67,21 @@ def _config_report(codex_home: Path) -> dict:
         "checked": True,
         "proxy_provider_selected": 'model_provider = "oauth_mux_openai"' in cfg,
         "proxy_provider_present": "[model_providers.oauth_mux_openai]" in cfg,
+        "config_layout_root_partitioned": cfg.find('model_provider = "oauth_mux_openai"') < cfg.find("[tui.model_availability_nux]")
+        if "[tui.model_availability_nux]" in cfg
+        else True,
         "user_feature_apps": "apps = true" in cfg,
         "user_feature_memories": "memories = true" in cfg,
         "user_feature_multi_agent": "multi_agent = true" in cfg,
+        "managed_feature_terminal_resize_reflow": "terminal_resize_reflow = true" in cfg
+        or "features.terminal_resize_reflow = true" in cfg,
+        "managed_feature_external_migration": "external_migration = true" in cfg
+        or "features.external_migration = true" in cfg,
+        "managed_feature_goals": "goals = true" in cfg or "features.goals = true" in cfg,
+        "managed_feature_prevent_idle_sleep": "prevent_idle_sleep = true" in cfg
+        or "features.prevent_idle_sleep = true" in cfg,
         "user_experimental_legacy": "experimental_legacy_flag = true" in cfg,
+        "user_tui_model_availability_nux": "[tui.model_availability_nux]" in cfg and '"gpt-5.5" = 2' in cfg,
         "user_mcp_server": "[mcp_servers.design]" in cfg,
         "user_approval_policy": 'approval_policy = "on-request"' in cfg,
         "user_sandbox_mode": 'sandbox_mode = "workspace-write"' in cfg,
@@ -139,6 +150,12 @@ def _session_bridge_report(codex_home: Path) -> dict:
     index_canonical = canonical / "session_index.jsonl"
     snapshots_overlay = codex_home / "shell_snapshots"
     snapshots_canonical = canonical / "shell_snapshots"
+    state_overlay = codex_home / "state_5.sqlite"
+    state_canonical = canonical / "state_5.sqlite"
+    wal_overlay = codex_home / "state_5.sqlite-wal"
+    wal_canonical = canonical / "state_5.sqlite-wal"
+    shm_overlay = codex_home / "state_5.sqlite-shm"
+    shm_canonical = canonical / "state_5.sqlite-shm"
 
     marker = sessions_overlay / "omux-session-bridge-smoke.jsonl"
     marker.write_text('{"bridge":"ok"}\n')
@@ -149,6 +166,9 @@ def _session_bridge_report(codex_home: Path) -> dict:
         "history_samefile": os.path.samefile(history_overlay, history_canonical),
         "session_index_samefile": os.path.samefile(index_overlay, index_canonical),
         "shell_snapshots_samefile": os.path.samefile(snapshots_overlay, snapshots_canonical),
+        "state_db_samefile": state_canonical.exists() and os.path.samefile(state_overlay, state_canonical),
+        "state_db_wal_samefile": wal_canonical.exists() and os.path.samefile(wal_overlay, wal_canonical),
+        "state_db_shm_samefile": (not shm_canonical.exists()) or os.path.samefile(shm_overlay, shm_canonical),
         "marker_written_via_overlay": marker.exists(),
         "canonical_marker_exists": (sessions_canonical / marker.name).exists(),
         "paths_printed": False,

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -83,6 +83,11 @@ def _config_report(codex_home: Path) -> dict:
         "user_experimental_legacy": "experimental_legacy_flag = true" in cfg,
         "user_tui_model_availability_nux": "[tui.model_availability_nux]" in cfg and '"gpt-5.5" = 2' in cfg,
         "user_mcp_server": "[mcp_servers.design]" in cfg,
+        "stdio_mcp_remote_fields_absent": "https://figma.invalid/mcp" not in cfg
+        and "FIGMA_ACCESS_TOKEN" not in cfg,
+        "http_mcp_remote_fields_preserved": "[mcp_servers.linear]" in cfg
+        and "https://mcp.linear.app/mcp" in cfg
+        and "LINEAR_API_KEY" in cfg,
         "user_approval_policy": 'approval_policy = "on-request"' in cfg,
         "user_sandbox_mode": 'sandbox_mode = "workspace-write"' in cfg,
         "profile_model_provider_absent": 'model_provider = "profile_provider"' not in cfg,

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -85,6 +85,8 @@ const SessionCodexHome = struct {
     config_source_present: bool = false,
     config_passthrough: bool = false,
     config_overridden_keys: usize = 0,
+    experimental_feature_defaults_injected: usize = 0,
+    config_layout: []const u8 = "root_partitioned",
 
     fn deinit(self: SessionCodexHome, allocator: std.mem.Allocator) void {
         std.fs.cwd().deleteTree(self.path) catch {};
@@ -142,6 +144,46 @@ const RolloutSnapshot = struct {
     }
 };
 
+const ResumeLookupSource = enum {
+    state_db,
+    session_index,
+    filename_scan,
+    not_scanned,
+
+    fn toString(self: ResumeLookupSource) []const u8 {
+        return switch (self) {
+            .state_db => "state_db",
+            .session_index => "session_index",
+            .filename_scan => "filename_scan",
+            .not_scanned => "not_scanned",
+        };
+    }
+};
+
+const RolloutTargetSnapshot = struct {
+    allocator: std.mem.Allocator,
+    path: []u8,
+    entry: RolloutEntry,
+
+    fn deinit(self: *RolloutTargetSnapshot) void {
+        self.allocator.free(self.path);
+    }
+};
+
+const ResumePreflightObservation = struct {
+    lookup_source: ResumeLookupSource = .not_scanned,
+    explicit_target_found_before: ?bool = null,
+    target_snapshot: ?RolloutTargetSnapshot = null,
+
+    fn deinit(self: *ResumePreflightObservation) void {
+        if (self.target_snapshot) |*snapshot| snapshot.deinit();
+    }
+
+    fn rolloutsBefore(self: *const ResumePreflightObservation) usize {
+        return if (self.target_snapshot != null) 1 else 0;
+    }
+};
+
 const ResumeObservation = struct {
     rollouts_before: usize = 0,
     rollouts_after: usize = 0,
@@ -149,12 +191,61 @@ const ResumeObservation = struct {
     created: usize = 0,
     explicit_target_found_before: ?bool = null,
     explicit_target_changed: ?bool = null,
+    lookup_source: ResumeLookupSource = .not_scanned,
 };
 
 const ManagedConfigObservation = struct {
     source_present: bool = false,
     passthrough: bool = false,
     overridden_keys: usize = 0,
+    experimental_feature_defaults_injected: usize = 0,
+    layout: []const u8 = "root_partitioned",
+};
+
+const codex_experimental_feature_defaults = [_][]const u8{
+    "terminal_resize_reflow",
+    "memories",
+    "external_migration",
+    "goals",
+    "prevent_idle_sleep",
+};
+
+const CodexExperimentalFeatureDefaults = struct {
+    seen: [codex_experimental_feature_defaults.len]bool = [_]bool{false} ** codex_experimental_feature_defaults.len,
+
+    fn mark(self: *CodexExperimentalFeatureDefaults, key: []const u8) void {
+        const normalized = std.mem.trim(u8, key, " \t\r\n\"'");
+        inline for (codex_experimental_feature_defaults, 0..) |feature, idx| {
+            if (std.mem.eql(u8, normalized, feature)) {
+                self.seen[idx] = true;
+                return;
+            }
+        }
+    }
+
+    fn writeMissingAsTableEntries(self: *CodexExperimentalFeatureDefaults, writer: anytype) !usize {
+        var injected: usize = 0;
+        inline for (codex_experimental_feature_defaults, 0..) |feature, idx| {
+            if (!self.seen[idx]) {
+                try writer.print("{s} = true\n", .{feature});
+                self.seen[idx] = true;
+                injected += 1;
+            }
+        }
+        return injected;
+    }
+
+    fn writeMissingAsRootDotted(self: *CodexExperimentalFeatureDefaults, writer: anytype) !usize {
+        var injected: usize = 0;
+        inline for (codex_experimental_feature_defaults, 0..) |feature, idx| {
+            if (!self.seen[idx]) {
+                try writer.print("features.{s} = true\n", .{feature});
+                self.seen[idx] = true;
+                injected += 1;
+            }
+        }
+        return injected;
+    }
 };
 
 const ConfigOverrideCheck = struct {
@@ -265,12 +356,21 @@ const codex_session_authority_entries = [_]SessionAuthorityEntry{
     .{ .name = "session_index.jsonl", .kind = .file },
 };
 
+const codex_optional_session_authority_entries = [_]SessionAuthorityEntry{
+    .{ .name = "state_5.sqlite", .kind = .file },
+    .{ .name = "state_5.sqlite-wal", .kind = .file },
+    .{ .name = "state_5.sqlite-shm", .kind = .file },
+};
+
 const ResumeAuthorityCheck = struct {
     mode: ResumeMode,
     authority: SessionAuthorityMode,
     required_total: usize = codex_session_authority_entries.len,
     canonical_present: usize = 0,
     overlay_present: usize = 0,
+    state_db_canonical_present: bool = false,
+    state_db_overlay_present: bool = false,
+    state_db_bridged: bool = false,
     ok: bool = false,
     diagnostic: []const u8 = "not_checked",
 };
@@ -476,7 +576,6 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     defer server.deinit();
     var route_health = health_mod.HealthStore.load(allocator, .{});
     defer route_health.deinit();
-    const codex_auth_repair = broker_loader.repairRefreshableCodexAuthFailures(allocator, parsed.value, &route_health);
     broker_loader.populatePoolFromRouteHealth(&server.pool, parsed.value, opts.profile, &route_health) catch {
         return RunError.PoolPopulateFailed;
     };
@@ -573,11 +672,13 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         return RunError.ConfigOverrideUnavailable;
     }
 
-    var resume_snapshot: ?RolloutSnapshot = null;
-    defer if (resume_snapshot) |*snapshot| snapshot.deinit();
-    if (resume_request.mode == .explicit or resume_request.mode == .last) {
+    var resume_preflight = ResumePreflightObservation{};
+    defer resume_preflight.deinit();
+    if (resume_request.mode == .explicit) {
         if (codex_home.authority_home) |authority_home| {
-            resume_snapshot = try snapshotRollouts(allocator, authority_home);
+            resume_preflight = try lookupExplicitResumePreflight(allocator, authority_home, resume_request.explicit_id.?);
+        } else {
+            resume_preflight.explicit_target_found_before = false;
         }
     }
 
@@ -597,8 +698,8 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         const installed_local_mismatch = envFlag("OMUX_INSTALLED_LOCAL_MISMATCH");
 
         try status_writer.print(
-            "{{\"kind\":\"session_started\",\"adapter\":\"codex\",\"adapter_version\":\"{s}\",\"managed_frame_id\":\"{s}\",\"selected_account\":\"{s}\",\"codex_home_path_printed\":false,\"proxy_port\":{d},\"claim_level\":\"broker_owned\",\"auth_authority\":\"mux_owned_overlay\",\"managed_config\":\"mux_owned_overlay\",\"config_passthrough\":{any},\"user_config_present\":{any},\"config_overridden_keys\":{d},\"config_paths_printed\":false,\"session_authority\":\"{s}\",\"session_paths_printed\":false,\"status_file_present\":{any},\"runtime_identity\":{{\"binary_path\":",
-            .{ cli.version, managed_frame_id, elected.id, proxy_port, codex_home.config_passthrough, codex_home.config_source_present, codex_home.config_overridden_keys, codex_home.session_authority.toString(), status_file_path != null },
+            "{{\"kind\":\"session_started\",\"adapter\":\"codex\",\"adapter_version\":\"{s}\",\"managed_frame_id\":\"{s}\",\"selected_account\":\"{s}\",\"codex_home_path_printed\":false,\"proxy_port\":{d},\"claim_level\":\"broker_owned\",\"auth_authority\":\"mux_owned_overlay\",\"managed_config\":\"mux_owned_overlay\",\"config_layout\":\"{s}\",\"config_passthrough\":{any},\"user_config_present\":{any},\"config_overridden_keys\":{d},\"experimental_feature_defaults_injected\":{d},\"config_paths_printed\":false,\"session_authority\":\"{s}\",\"session_paths_printed\":false,\"pre_spawn_network_refresh\":false,\"status_file_present\":{any},\"runtime_identity\":{{\"binary_path\":",
+            .{ cli.version, managed_frame_id, elected.id, proxy_port, codex_home.config_layout, codex_home.config_passthrough, codex_home.config_source_present, codex_home.config_overridden_keys, codex_home.experimental_feature_defaults_injected, codex_home.session_authority.toString(), status_file_path != null },
         );
         try std.json.stringify(binary_path, .{}, status_writer);
         try status_writer.writeAll(",\"binary_source\":");
@@ -611,19 +712,14 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         try std.json.stringify(command_spelling, .{}, status_writer);
         try status_writer.print(",\"installed_local_mismatch_detected\":{any}", .{installed_local_mismatch});
         try status_writer.writeAll("}}\n");
-        if (codex_auth_repair.attempted != 0 or codex_auth_repair.refreshed != 0 or codex_auth_repair.failed != 0) {
-            try status_writer.print(
-                "{{\"kind\":\"codex_auth_refresh_preflight\",\"attempted\":{d},\"refreshed\":{d},\"failed\":{d},\"skipped\":{d},\"contacts_provider_auth\":true,\"mutates_auth_material\":true,\"mutates_route_health\":true,\"spends_provider_calls\":false}}\n",
-                .{ codex_auth_repair.attempted, codex_auth_repair.refreshed, codex_auth_repair.failed, codex_auth_repair.skipped },
-            );
-        }
         if (resume_request.requested()) {
             try writeResumePreflightStatus(
                 status_writer,
                 resume_request,
                 codex_home.session_authority,
-                if (resume_snapshot) |*snapshot| snapshot.count() else 0,
-                if (resume_snapshot) |*snapshot| findExplicitResumeTarget(snapshot, resume_request.explicit_id) != null else null,
+                resume_preflight.rolloutsBefore(),
+                resume_preflight.explicit_target_found_before,
+                resume_preflight.lookup_source,
             );
         }
     }
@@ -694,7 +790,7 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
             &codex_home,
             source_auth_path,
             resume_request,
-            if (resume_snapshot) |*snapshot| snapshot else null,
+            &resume_preflight,
             .{ .aborted = true, .reason = "child_wait_error", .wait_error = @errorName(e) },
         );
         return e;
@@ -714,7 +810,7 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         &codex_home,
         source_auth_path,
         resume_request,
-        if (resume_snapshot) |*snapshot| snapshot else null,
+        &resume_preflight,
         .{ .term = term },
     );
 
@@ -741,7 +837,7 @@ fn finalizeManagedSession(
     codex_home: *const SessionCodexHome,
     source_auth_path: []const u8,
     resume_request: ResumeRequest,
-    resume_snapshot: ?*RolloutSnapshot,
+    resume_preflight: *const ResumePreflightObservation,
     final_status: FinalSessionStatus,
 ) !void {
     const auth_writeback = observeAuthWriteback(allocator, codex_home.path, source_auth_path, codex_home.auth_initial_hash) catch |e| failed: {
@@ -766,7 +862,7 @@ fn finalizeManagedSession(
     }
     if (resume_request.requested()) {
         const observation = if (codex_home.authority_home) |authority_home|
-            try observeResumeWriteback(allocator, authority_home, resume_snapshot, resume_request)
+            try observeResumeWriteback(allocator, authority_home, resume_preflight, resume_request)
         else
             ResumeObservation{};
         try writeResumeWritebackStatus(status_writer, resume_request, codex_home.session_authority, observation);
@@ -928,6 +1024,8 @@ fn createSessionCodexHomeUnder(
         .config_source_present = config_observation.source_present,
         .config_passthrough = config_observation.passthrough,
         .config_overridden_keys = config_observation.overridden_keys,
+        .experimental_feature_defaults_injected = config_observation.experimental_feature_defaults_injected,
+        .config_layout = config_observation.layout,
     };
 }
 
@@ -977,6 +1075,14 @@ fn bridgeCodexSessionAuthority(
         defer allocator.free(link);
         try std.fs.symLinkAbsolute(target, link, .{ .is_directory = entry.kind == .directory });
     }
+    for (codex_optional_session_authority_entries) |entry| {
+        const target = try std.fs.path.join(allocator, &.{ authority_home, entry.name });
+        defer allocator.free(target);
+        if (!authorityEntryPresent(target, entry.kind)) continue;
+        const link = try std.fs.path.join(allocator, &.{ session_home, entry.name });
+        defer allocator.free(link);
+        try std.fs.symLinkAbsolute(target, link, .{ .is_directory = entry.kind == .directory });
+    }
 }
 
 fn checkResumeAuthority(
@@ -1005,6 +1111,11 @@ fn checkResumeAuthority(
 
     result.ok = true;
     result.diagnostic = "available";
+    result.state_db_canonical_present = authorityStateDbPresent(allocator, authority_home) catch false;
+    result.state_db_overlay_present = authorityStateDbPresent(allocator, codex_home.path) catch false;
+    result.state_db_bridged = result.state_db_canonical_present and result.state_db_overlay_present;
+
+    var legacy_ok = true;
     for (codex_session_authority_entries) |entry| {
         const canonical = try std.fs.path.join(allocator, &.{ authority_home, entry.name });
         defer allocator.free(canonical);
@@ -1014,16 +1125,18 @@ fn checkResumeAuthority(
         if (authorityEntryPresent(canonical, entry.kind)) {
             result.canonical_present += 1;
         } else {
-            result.ok = false;
+            legacy_ok = false;
             result.diagnostic = "canonical_entry_missing";
         }
         if (authorityEntryPresent(overlay, entry.kind)) {
             result.overlay_present += 1;
         } else {
-            result.ok = false;
+            legacy_ok = false;
             result.diagnostic = "overlay_entry_missing";
         }
     }
+    result.ok = result.state_db_bridged or legacy_ok;
+    if (result.ok) result.diagnostic = if (result.state_db_bridged) "state_db_available" else "available";
     return result;
 }
 
@@ -1033,6 +1146,12 @@ fn authorityEntryPresent(path: []const u8, kind: SessionAuthorityEntryKind) bool
         .directory => stat.kind == .directory,
         .file => stat.kind == .file,
     };
+}
+
+fn authorityStateDbPresent(allocator: std.mem.Allocator, home: []const u8) !bool {
+    const path = try std.fs.path.join(allocator, &.{ home, "state_5.sqlite" });
+    defer allocator.free(path);
+    return authorityEntryPresent(path, .file);
 }
 
 fn detectResumeRequest(argv: []const []const u8) ResumeRequest {
@@ -1093,54 +1212,199 @@ fn snapshotRolloutsUnder(
     }
 }
 
-fn findExplicitResumeTarget(snapshot: *const RolloutSnapshot, explicit_id: ?[]const u8) ?[]const u8 {
-    const id = explicit_id orelse return null;
-    var it = snapshot.entries.keyIterator();
-    while (it.next()) |path| {
-        if (std.mem.indexOf(u8, path.*, id) != null) return path.*;
+fn lookupExplicitResumePreflight(
+    allocator: std.mem.Allocator,
+    authority_home: []const u8,
+    explicit_id: []const u8,
+) !ResumePreflightObservation {
+    var result = ResumePreflightObservation{
+        .explicit_target_found_before = false,
+    };
+    errdefer result.deinit();
+
+    if (try stateDbContainsResumeId(allocator, authority_home, explicit_id)) {
+        result.lookup_source = .state_db;
+        result.explicit_target_found_before = true;
+        result.target_snapshot = try findRolloutTargetByFilename(allocator, authority_home, explicit_id);
+        return result;
+    }
+
+    if (try sessionIndexContainsResumeId(allocator, authority_home, explicit_id)) {
+        result.lookup_source = .session_index;
+        result.explicit_target_found_before = true;
+        result.target_snapshot = try findRolloutTargetByFilename(allocator, authority_home, explicit_id);
+        return result;
+    }
+
+    result.lookup_source = .filename_scan;
+    if (try findRolloutTargetByFilename(allocator, authority_home, explicit_id)) |target| {
+        result.explicit_target_found_before = true;
+        result.target_snapshot = target;
+    }
+    return result;
+}
+
+fn stateDbContainsResumeId(
+    allocator: std.mem.Allocator,
+    authority_home: []const u8,
+    explicit_id: []const u8,
+) !bool {
+    for (codex_optional_session_authority_entries) |entry| {
+        const path = try std.fs.path.join(allocator, &.{ authority_home, entry.name });
+        defer allocator.free(path);
+        if (try fileContainsNeedleBounded(allocator, path, explicit_id)) return true;
+    }
+    return false;
+}
+
+fn sessionIndexContainsResumeId(
+    allocator: std.mem.Allocator,
+    authority_home: []const u8,
+    explicit_id: []const u8,
+) !bool {
+    const path = try std.fs.path.join(allocator, &.{ authority_home, "session_index.jsonl" });
+    defer allocator.free(path);
+    return try fileContainsNeedleBounded(allocator, path, explicit_id);
+}
+
+fn fileContainsNeedleBounded(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    needle: []const u8,
+) !bool {
+    if (needle.len == 0) return false;
+    const file = std.fs.cwd().openFile(path, .{}) catch |e| switch (e) {
+        error.FileNotFound, error.AccessDenied, error.NotDir => return false,
+        else => return e,
+    };
+    defer file.close();
+
+    var previous = std.ArrayListUnmanaged(u8){};
+    defer previous.deinit(allocator);
+
+    var buf: [8192]u8 = undefined;
+    while (true) {
+        const n = try file.read(&buf);
+        if (n == 0) break;
+
+        var haystack = std.ArrayListUnmanaged(u8){};
+        defer haystack.deinit(allocator);
+        try haystack.appendSlice(allocator, previous.items);
+        try haystack.appendSlice(allocator, buf[0..n]);
+        if (std.mem.indexOf(u8, haystack.items, needle) != null) return true;
+
+        previous.clearRetainingCapacity();
+        const keep = @min(needle.len - 1, haystack.items.len);
+        if (keep != 0) try previous.appendSlice(allocator, haystack.items[haystack.items.len - keep ..]);
+    }
+    return false;
+}
+
+fn findRolloutTargetByFilename(
+    allocator: std.mem.Allocator,
+    authority_home: []const u8,
+    explicit_id: []const u8,
+) !?RolloutTargetSnapshot {
+    if (explicit_id.len == 0) return null;
+    const sessions_dir = try std.fs.path.join(allocator, &.{ authority_home, "sessions" });
+    defer allocator.free(sessions_dir);
+    return try findRolloutTargetByFilenameUnder(allocator, sessions_dir, explicit_id, 0);
+}
+
+fn findRolloutTargetByFilenameUnder(
+    allocator: std.mem.Allocator,
+    dir_path: []const u8,
+    explicit_id: []const u8,
+    depth: usize,
+) !?RolloutTargetSnapshot {
+    if (depth > 16) return null;
+    var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch |e| switch (e) {
+        error.FileNotFound, error.AccessDenied, error.NotDir => return null,
+        else => return e,
+    };
+    defer dir.close();
+
+    var it = dir.iterate();
+    while (try it.next()) |entry| {
+        const path = try std.fs.path.join(allocator, &.{ dir_path, entry.name });
+        defer allocator.free(path);
+        switch (entry.kind) {
+            .directory => {
+                if (try findRolloutTargetByFilenameUnder(allocator, path, explicit_id, depth + 1)) |found| return found;
+            },
+            .file, .sym_link => {
+                if (!std.mem.endsWith(u8, entry.name, ".jsonl")) continue;
+                if (std.mem.indexOf(u8, entry.name, explicit_id) == null) continue;
+                return try snapshotSingleRolloutTarget(allocator, path);
+            },
+            else => {},
+        }
     }
     return null;
+}
+
+fn snapshotSingleRolloutTarget(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+) !RolloutTargetSnapshot {
+    const stat = try std.fs.cwd().statFile(path);
+    return .{
+        .allocator = allocator,
+        .path = try allocator.dupe(u8, path),
+        .entry = .{
+            .size = stat.size,
+            .mtime = stat.mtime,
+        },
+    };
 }
 
 fn observeResumeWriteback(
     allocator: std.mem.Allocator,
     authority_home: []const u8,
-    before: ?*const RolloutSnapshot,
+    preflight: *const ResumePreflightObservation,
     request: ResumeRequest,
 ) !ResumeObservation {
+    if (request.mode == .explicit) {
+        var observation = ResumeObservation{
+            .rollouts_before = preflight.rolloutsBefore(),
+            .rollouts_after = 0,
+            .explicit_target_found_before = preflight.explicit_target_found_before,
+            .explicit_target_changed = false,
+            .lookup_source = preflight.lookup_source,
+        };
+        if (preflight.target_snapshot) |target| {
+            const after = snapshotSingleRolloutTarget(allocator, target.path) catch |e| switch (e) {
+                error.FileNotFound, error.AccessDenied, error.NotDir => return observation,
+                else => return e,
+            };
+            var after_mut = after;
+            defer after_mut.deinit();
+
+            observation.rollouts_after = 1;
+            const changed = target.entry.size != after.entry.size or target.entry.mtime != after.entry.mtime;
+            if (changed) {
+                observation.changed_existing = 1;
+                observation.explicit_target_changed = true;
+            }
+        }
+        return observation;
+    }
+
     var after = try snapshotRollouts(allocator, authority_home);
     defer after.deinit();
 
     var observation = ResumeObservation{
-        .rollouts_before = if (before) |snapshot| snapshot.count() else 0,
+        .rollouts_before = 0,
         .rollouts_after = after.count(),
-        .explicit_target_found_before = if (request.explicit_id != null and before != null)
-            findExplicitResumeTarget(before.?, request.explicit_id) != null
-        else
-            null,
+        .explicit_target_found_before = null,
         .explicit_target_changed = if (request.explicit_id != null) false else null,
+        .lookup_source = preflight.lookup_source,
     };
 
     var it = after.entries.iterator();
     while (it.next()) |after_entry| {
-        if (before) |snapshot| {
-            if (snapshot.entries.get(after_entry.key_ptr.*)) |before_entry| {
-                const changed = before_entry.size != after_entry.value_ptr.size or
-                    before_entry.mtime != after_entry.value_ptr.mtime;
-                if (changed) {
-                    observation.changed_existing += 1;
-                    if (request.explicit_id) |id| {
-                        if (std.mem.indexOf(u8, after_entry.key_ptr.*, id) != null) {
-                            observation.explicit_target_changed = true;
-                        }
-                    }
-                }
-            } else {
-                observation.created += 1;
-            }
-        } else {
-            observation.created += 1;
-        }
+        _ = after_entry;
+        observation.created += 1;
     }
 
     return observation;
@@ -1160,6 +1424,7 @@ fn writeResumePreflightStatus(
     authority: SessionAuthorityMode,
     rollouts_before: usize,
     explicit_target_found_before: ?bool,
+    lookup_source: ResumeLookupSource,
 ) !void {
     try writer.print(
         "{{\"kind\":\"resume_preflight\",\"mode\":\"{s}\",\"session_authority\":\"{s}\",\"rollouts_before\":{d},\"explicit_id_provided\":{s},\"explicit_target_found_before\":",
@@ -1171,7 +1436,7 @@ fn writeResumePreflightStatus(
         },
     );
     try writeOptionalBool(writer, explicit_target_found_before);
-    try writer.writeAll(",\"session_id_printed\":false,\"path_printed\":false}\n");
+    try writer.print(",\"resume_lookup_source\":\"{s}\",\"session_id_printed\":false,\"path_printed\":false}}\n", .{lookup_source.toString()});
 }
 
 fn writeResumeAuthorityCheckStatus(
@@ -1179,7 +1444,7 @@ fn writeResumeAuthorityCheckStatus(
     check: ResumeAuthorityCheck,
 ) !void {
     try writer.print(
-        "{{\"kind\":\"resume_authority_check\",\"mode\":\"{s}\",\"session_authority\":\"{s}\",\"ok\":{any},\"diagnostic\":\"{s}\",\"required_entries\":{d},\"canonical_present\":{d},\"overlay_present\":{d},\"session_id_printed\":false,\"path_printed\":false}}\n",
+        "{{\"kind\":\"resume_authority_check\",\"mode\":\"{s}\",\"session_authority\":\"{s}\",\"ok\":{any},\"diagnostic\":\"{s}\",\"required_entries\":{d},\"canonical_present\":{d},\"overlay_present\":{d},\"resume_authority_state_db_bridged\":{any},\"state_db_canonical_present\":{any},\"state_db_overlay_present\":{any},\"session_id_printed\":false,\"path_printed\":false}}\n",
         .{
             check.mode.toString(),
             check.authority.toString(),
@@ -1188,6 +1453,9 @@ fn writeResumeAuthorityCheckStatus(
             check.required_total,
             check.canonical_present,
             check.overlay_present,
+            check.state_db_bridged,
+            check.state_db_canonical_present,
+            check.state_db_overlay_present,
         },
     );
 }
@@ -1212,7 +1480,7 @@ fn writeResumeWritebackStatus(
     try writeOptionalBool(writer, observation.explicit_target_found_before);
     try writer.writeAll(",\"explicit_target_changed\":");
     try writeOptionalBool(writer, observation.explicit_target_changed);
-    try writer.writeAll(",\"session_id_printed\":false,\"path_printed\":false}\n");
+    try writer.print(",\"resume_lookup_source\":\"{s}\",\"session_id_printed\":false,\"path_printed\":false}}\n", .{observation.lookup_source.toString()});
 }
 
 fn writeAuthWritebackStatus(
@@ -1416,6 +1684,8 @@ fn writeManagedConfigToml(
     var contents = std.ArrayListUnmanaged(u8){};
     defer contents.deinit(allocator);
     const w = contents.writer(allocator);
+    var managed_root_written = false;
+    var feature_defaults = CodexExperimentalFeatureDefaults{};
 
     if (source_config_home) |home| {
         const source_path = try std.fs.path.join(allocator, &.{ home, "config.toml" });
@@ -1424,7 +1694,8 @@ fn writeManagedConfigToml(
             defer allocator.free(source_bytes);
             observation.source_present = true;
             observation.passthrough = true;
-            observation.overridden_keys = try writeConfigPassthrough(w, source_bytes);
+            observation.overridden_keys = try writeConfigPassthrough(allocator, w, source_bytes, &feature_defaults, &observation.experimental_feature_defaults_injected);
+            managed_root_written = true;
             if (contents.items.len != 0 and contents.items[contents.items.len - 1] != '\n') try w.writeAll("\n");
             try w.writeAll("\n");
         } else |e| switch (e) {
@@ -1433,9 +1704,11 @@ fn writeManagedConfigToml(
         }
     }
 
-    try w.writeAll("# Managed by oauth-mux. Proxy override; unrelated Codex config above is preserved.\n");
-    try w.writeAll("# Anchor: docs/spec/codex-adapter-contract-2026-05-03.md §4\n\n");
-    try w.writeAll("model_provider = \"oauth_mux_openai\"\n\n");
+    if (!managed_root_written) {
+        observation.experimental_feature_defaults_injected += try feature_defaults.writeMissingAsRootDotted(w);
+        if (observation.experimental_feature_defaults_injected != 0) try w.writeAll("\n");
+        try writeManagedConfigRoot(w);
+    }
     observation.overridden_keys += 1;
     try w.print("[model_providers.oauth_mux_openai]\n", .{});
     try w.print("name = \"oauth-mux OpenAI proxy\"\n", .{});
@@ -1450,18 +1723,41 @@ fn writeManagedConfigToml(
     return observation;
 }
 
+fn writeManagedConfigRoot(writer: anytype) !void {
+    try writer.writeAll("# Managed by oauth-mux. Proxy override; unrelated Codex config above is preserved.\n");
+    try writer.writeAll("# Anchor: docs/spec/codex-adapter-contract-2026-05-03.md §4\n\n");
+    try writer.writeAll("model_provider = \"oauth_mux_openai\"\n\n");
+}
+
 fn writeConfigPassthrough(
+    allocator: std.mem.Allocator,
     writer: anytype,
     source_bytes: []const u8,
+    feature_defaults: *CodexExperimentalFeatureDefaults,
+    experimental_feature_defaults_injected: *usize,
 ) !usize {
     var overridden: usize = 0;
+    var root = std.ArrayListUnmanaged(u8){};
+    defer root.deinit(allocator);
+    var tables = std.ArrayListUnmanaged(u8){};
+    defer tables.deinit(allocator);
+
+    var in_root = true;
+    var in_features_table = false;
+    var features_table_seen = false;
     var skip_table = false;
     var lines = std.mem.splitScalar(u8, source_bytes, '\n');
     while (lines.next()) |line| {
         const trimmed_left = std.mem.trimLeft(u8, line, " \t");
         const trimmed = std.mem.trim(u8, line, " \t\r");
-        const starts_table = std.mem.startsWith(u8, trimmed, "[") and !std.mem.startsWith(u8, trimmed, "[[");
+        const starts_table = isTomlTableHeader(trimmed);
         if (starts_table) {
+            if (in_features_table and !skip_table) {
+                experimental_feature_defaults_injected.* += try feature_defaults.writeMissingAsTableEntries(tables.writer(allocator));
+            }
+            in_root = false;
+            in_features_table = isTomlTableHeaderNamed(trimmed, "features");
+            features_table_seen = features_table_seen or in_features_table;
             skip_table = isManagedProviderTable(trimmed);
             if (skip_table) {
                 overridden += 1;
@@ -1469,25 +1765,81 @@ fn writeConfigPassthrough(
             }
         }
         if (skip_table) continue;
-        if (std.mem.startsWith(u8, trimmed_left, "model_provider")) {
-            const rest = trimmed_left["model_provider".len..];
-            const rest_trimmed = std.mem.trimLeft(u8, rest, " \t");
-            if (std.mem.startsWith(u8, rest_trimmed, "=")) {
-                overridden += 1;
-                continue;
+        markExperimentalFeatureAssignment(feature_defaults, trimmed_left, in_root, in_features_table);
+        if (configAssignmentOverridesMuxProvider(trimmed_left)) |classification| {
+            switch (classification) {
+                .model_provider, .managed_provider => {
+                    overridden += 1;
+                    continue;
+                },
             }
         }
-        try writer.writeAll(line);
-        try writer.writeAll("\n");
+        const out = if (in_root) root.writer(allocator) else tables.writer(allocator);
+        try out.writeAll(line);
+        try out.writeAll("\n");
+    }
+    if (in_features_table and !skip_table) {
+        experimental_feature_defaults_injected.* += try feature_defaults.writeMissingAsTableEntries(tables.writer(allocator));
+    }
+    if (!features_table_seen) {
+        experimental_feature_defaults_injected.* += try feature_defaults.writeMissingAsRootDotted(root.writer(allocator));
+    }
+
+    if (root.items.len != 0) {
+        try writer.writeAll(root.items);
+        if (root.items[root.items.len - 1] != '\n') try writer.writeAll("\n");
+    }
+    try writeManagedConfigRoot(writer);
+    if (tables.items.len != 0) {
+        try writer.writeAll(tables.items);
+        if (tables.items[tables.items.len - 1] != '\n') try writer.writeAll("\n");
     }
     return overridden;
+}
+
+fn isTomlTableHeader(trimmed_line: []const u8) bool {
+    var line = trimmed_line;
+    if (std.mem.indexOfScalar(u8, line, '#')) |idx| line = std.mem.trim(u8, line[0..idx], " \t\r");
+    return std.mem.startsWith(u8, line, "[") and std.mem.endsWith(u8, line, "]");
+}
+
+fn isTomlTableHeaderNamed(trimmed_line: []const u8, table_name: []const u8) bool {
+    var line = trimmed_line;
+    if (std.mem.indexOfScalar(u8, line, '#')) |idx| line = std.mem.trim(u8, line[0..idx], " \t\r");
+    if (!std.mem.startsWith(u8, line, "[") or !std.mem.endsWith(u8, line, "]")) return false;
+    if (std.mem.startsWith(u8, line, "[[")) return false;
+    const body = std.mem.trim(u8, line[1 .. line.len - 1], " \t\r");
+    return std.mem.eql(u8, body, table_name);
 }
 
 fn isManagedProviderTable(trimmed_line: []const u8) bool {
     var line = trimmed_line;
     if (std.mem.indexOfScalar(u8, line, '#')) |idx| line = std.mem.trim(u8, line[0..idx], " \t\r");
+    if (std.mem.startsWith(u8, line, "[[") and std.mem.endsWith(u8, line, "]]")) {
+        line = line[1 .. line.len - 1];
+    }
     return std.mem.eql(u8, line, "[model_providers.oauth_mux_openai]") or
         (std.mem.startsWith(u8, line, "[model_providers.oauth_mux_openai.") and std.mem.endsWith(u8, line, "]"));
+}
+
+fn markExperimentalFeatureAssignment(
+    feature_defaults: *CodexExperimentalFeatureDefaults,
+    assignment: []const u8,
+    in_root: bool,
+    in_features_table: bool,
+) void {
+    const eq = std.mem.indexOfScalar(u8, assignment, '=') orelse return;
+    var key = std.mem.trim(u8, assignment[0..eq], " \t\r\n");
+    key = std.mem.trim(u8, key, "\"'");
+    if (in_features_table) {
+        feature_defaults.mark(key);
+        return;
+    }
+    if (in_root and std.mem.startsWith(u8, key, "features.")) {
+        var feature_key = key["features.".len..];
+        feature_key = std.mem.trim(u8, feature_key, "\"'");
+        feature_defaults.mark(feature_key);
+    }
 }
 
 fn checkForwardedConfigOverrides(argv: []const []const u8) ConfigOverrideCheck {
@@ -1690,9 +2042,11 @@ test "resume writeback observation reports existing rollout changes without prin
     const rollout_path = try std.fs.path.join(std.testing.allocator, &.{ canonical_path, "sessions", "2026", "05", "06", "rollout-managed-good-session.jsonl" });
     defer std.testing.allocator.free(rollout_path);
 
-    var before = try snapshotRollouts(std.testing.allocator, canonical_path);
-    defer before.deinit();
-    try std.testing.expectEqual(@as(usize, 1), before.count());
+    var preflight = try lookupExplicitResumePreflight(std.testing.allocator, canonical_path, "managed-good-session");
+    defer preflight.deinit();
+    try std.testing.expectEqual(ResumeLookupSource.filename_scan, preflight.lookup_source);
+    try std.testing.expectEqual(true, preflight.explicit_target_found_before.?);
+    try std.testing.expectEqual(@as(usize, 1), preflight.rolloutsBefore());
 
     {
         const rollout = try std.fs.cwd().openFile(rollout_path, .{ .mode = .write_only });
@@ -1702,13 +2056,14 @@ test "resume writeback observation reports existing rollout changes without prin
     }
 
     const request = ResumeRequest{ .mode = .explicit, .explicit_id = "managed-good-session" };
-    const observation = try observeResumeWriteback(std.testing.allocator, canonical_path, &before, request);
+    const observation = try observeResumeWriteback(std.testing.allocator, canonical_path, &preflight, request);
     try std.testing.expectEqual(@as(usize, 1), observation.rollouts_before);
     try std.testing.expectEqual(@as(usize, 1), observation.rollouts_after);
     try std.testing.expectEqual(@as(usize, 1), observation.changed_existing);
     try std.testing.expectEqual(@as(usize, 0), observation.created);
     try std.testing.expectEqual(true, observation.explicit_target_found_before.?);
     try std.testing.expectEqual(true, observation.explicit_target_changed.?);
+    try std.testing.expectEqual(ResumeLookupSource.filename_scan, observation.lookup_source);
 }
 
 test "createSessionCodexHomeUnder copies auth and does not clobber source config" {
@@ -1761,6 +2116,12 @@ test "createSessionCodexHomeUnder copies auth and does not clobber source config
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "model_provider = \"oauth_mux_openai\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "[model_providers.oauth_mux_openai]") != null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "[model_providers.openai]") == null);
+    try std.testing.expectEqual(@as(usize, 5), codex_home.experimental_feature_defaults_injected);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "features.terminal_resize_reflow = true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "features.memories = true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "features.external_migration = true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "features.goals = true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "features.prevent_idle_sleep = true") != null);
 
     const source_config = try std.fs.path.join(std.testing.allocator, &.{ root_path, "account", "config.toml" });
     defer std.testing.allocator.free(source_config);
@@ -1806,6 +2167,9 @@ test "createSessionCodexHomeUnder preserves canonical config behavior settings" 
             \\name = "stale mux"
             \\base_url = "https://stale.invalid"
             \\
+            \\[tui.model_availability_nux]
+            \\"gpt-5.5" = 2
+            \\
         );
     }
 
@@ -1821,6 +2185,7 @@ test "createSessionCodexHomeUnder preserves canonical config behavior settings" 
     try std.testing.expect(codex_home.config_source_present);
     try std.testing.expect(codex_home.config_passthrough);
     try std.testing.expect(codex_home.config_overridden_keys >= 2);
+    try std.testing.expectEqual(@as(usize, 4), codex_home.experimental_feature_defaults_injected);
 
     const overlay_config = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "config.toml" });
     defer std.testing.allocator.free(overlay_config);
@@ -1832,20 +2197,126 @@ test "createSessionCodexHomeUnder preserves canonical config behavior settings" 
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "sandbox_mode = \"workspace-write\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "experimental_legacy_flag = true") != null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "[features]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "terminal_resize_reflow = true") != null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "multi_agent = true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "external_migration = true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "goals = true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "prevent_idle_sleep = true") != null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "[mcp_servers.design]") != null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "[model_providers.user_provider]") != null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "https://example.invalid/api") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "[tui.model_availability_nux]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "\"gpt-5.5\" = 2") != null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "https://stale.invalid") == null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "model_provider = \"user_provider\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "model_provider = \"oauth_mux_openai\"") != null);
+    const managed_provider_idx = std.mem.indexOf(u8, generated_config, "model_provider = \"oauth_mux_openai\"").?;
+    const tui_table_idx = std.mem.indexOf(u8, generated_config, "[tui.model_availability_nux]").?;
+    const features_idx = std.mem.indexOf(u8, generated_config, "[features]").?;
+    const mcp_idx = std.mem.indexOf(u8, generated_config, "[mcp_servers.design]").?;
+    try std.testing.expect(managed_provider_idx < tui_table_idx);
+    try std.testing.expect(features_idx < mcp_idx);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config[features_idx..mcp_idx], "terminal_resize_reflow = true") != null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "http://127.0.0.1:45678/backend-api/codex") != null);
+}
+
+test "config passthrough preserves explicit experimental feature choices" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("account");
+    try tmp.dir.makePath("canonical");
+    {
+        const auth = try tmp.dir.createFile("account/auth.json", .{ .mode = 0o600 });
+        defer auth.close();
+        try auth.writeAll("{\"tokens\":{\"access_token\":\"fixture\"}}\n");
+    }
+    {
+        const cfg = try tmp.dir.createFile("canonical/config.toml", .{ .mode = 0o600 });
+        defer cfg.close();
+        try cfg.writeAll(
+            \\[features]
+            \\goals = false
+            \\memories = true
+            \\
+        );
+    }
+
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const auth_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "account", "auth.json" });
+    defer std.testing.allocator.free(auth_path);
+    const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
+    defer std.testing.allocator.free(canonical_path);
+
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null, canonical_path);
+    defer codex_home.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 3), codex_home.experimental_feature_defaults_injected);
+
+    const overlay_config = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "config.toml" });
+    defer std.testing.allocator.free(overlay_config);
+    const generated_config = try std.fs.cwd().readFileAlloc(std.testing.allocator, overlay_config, 8192);
+    defer std.testing.allocator.free(generated_config);
+
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "goals = false") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "goals = true") == null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "terminal_resize_reflow = true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "external_migration = true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "prevent_idle_sleep = true") != null);
+}
+
+test "config passthrough partitions root model provider before trailing table" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("account");
+    try tmp.dir.makePath("canonical");
+    {
+        const auth = try tmp.dir.createFile("account/auth.json", .{ .mode = 0o600 });
+        defer auth.close();
+        try auth.writeAll("{\"tokens\":{\"access_token\":\"fixture\"}}\n");
+    }
+    {
+        const cfg = try tmp.dir.createFile("canonical/config.toml", .{ .mode = 0o600 });
+        defer cfg.close();
+        try cfg.writeAll(
+            \\model = "gpt-5.5"
+            \\
+            \\[tui.model_availability_nux]
+            \\"gpt-5.5" = 2
+            \\
+        );
+    }
+
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const auth_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "account", "auth.json" });
+    defer std.testing.allocator.free(auth_path);
+    const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
+    defer std.testing.allocator.free(canonical_path);
+
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null, canonical_path);
+    defer codex_home.deinit(std.testing.allocator);
+
+    const overlay_config = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "config.toml" });
+    defer std.testing.allocator.free(overlay_config);
+    const generated_config = try std.fs.cwd().readFileAlloc(std.testing.allocator, overlay_config, 8192);
+    defer std.testing.allocator.free(generated_config);
+
+    const provider_idx = std.mem.indexOf(u8, generated_config, "model_provider = \"oauth_mux_openai\"").?;
+    const tui_idx = std.mem.indexOf(u8, generated_config, "[tui.model_availability_nux]").?;
+    const managed_table_idx = std.mem.indexOf(u8, generated_config, "[model_providers.oauth_mux_openai]").?;
+    try std.testing.expect(provider_idx < tui_idx);
+    try std.testing.expect(tui_idx < managed_table_idx);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "\"gpt-5.5\" = 2") != null);
 }
 
 test "config passthrough strips profile-scoped model_provider overrides" {
     var buf = std.ArrayListUnmanaged(u8){};
     defer buf.deinit(std.testing.allocator);
-    const overridden = try writeConfigPassthrough(buf.writer(std.testing.allocator),
+    var feature_defaults = CodexExperimentalFeatureDefaults{};
+    var experimental_feature_defaults_injected: usize = 0;
+    const source =
         \\[profiles.work]
         \\model = "gpt-5.5"
         \\model_provider = "user_provider"
@@ -1854,9 +2325,11 @@ test "config passthrough strips profile-scoped model_provider overrides" {
         \\[profiles.work.features]
         \\experimental_apply_patch = true
         \\
-    );
+    ;
+    const overridden = try writeConfigPassthrough(std.testing.allocator, buf.writer(std.testing.allocator), source, &feature_defaults, &experimental_feature_defaults_injected);
 
     try std.testing.expectEqual(@as(usize, 1), overridden);
+    try std.testing.expectEqual(@as(usize, 5), experimental_feature_defaults_injected);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "[profiles.work]") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "model = \"gpt-5.5\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "approval_policy = \"on-request\"") != null);
@@ -1867,7 +2340,7 @@ test "config passthrough strips profile-scoped model_provider overrides" {
 test "forwarded Codex config overrides cannot replace managed provider" {
     const safe_argv = [_][]const u8{
         "--config", "model=\"gpt-5.5\"",
-        "-c", "profiles.work.approval_policy=\"on-request\"",
+        "-c",       "profiles.work.approval_policy=\"on-request\"",
     };
     const safe = checkForwardedConfigOverrides(&safe_argv);
     try std.testing.expect(safe.ok);
@@ -1875,10 +2348,9 @@ test "forwarded Codex config overrides cannot replace managed provider" {
     try std.testing.expectEqual(@as(usize, 0), safe.mux_owned_overrides);
 
     const unsafe_argv = [_][]const u8{
-        "--config", "model_provider=\"openai\"",
-        "--config=profiles.work.model_provider=\"custom\"",
-        "-c=model_providers.oauth_mux_openai.base_url=\"https://example.invalid\"",
-        "--model", "gpt-5.5",
+        "--config",                                         "model_provider=\"openai\"",
+        "--config=profiles.work.model_provider=\"custom\"", "-c=model_providers.oauth_mux_openai.base_url=\"https://example.invalid\"",
+        "--model",                                          "gpt-5.5",
     };
     const unsafe = checkForwardedConfigOverrides(&unsafe_argv);
     try std.testing.expect(!unsafe.ok);
@@ -2083,6 +2555,16 @@ test "createSessionCodexHomeUnder bridges canonical session authority without co
         defer session.close();
         try session.writeAll("{\"fixture\":true}\n");
     }
+    {
+        const state = try tmp.dir.createFile("canonical/state_5.sqlite", .{ .mode = 0o600 });
+        defer state.close();
+        try state.writeAll("managed-good-session");
+    }
+    {
+        const wal = try tmp.dir.createFile("canonical/state_5.sqlite-wal", .{ .mode = 0o600 });
+        defer wal.close();
+        try wal.writeAll("wal");
+    }
 
     const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
     defer std.testing.allocator.free(root_path);
@@ -2102,6 +2584,22 @@ test "createSessionCodexHomeUnder bridges canonical session authority without co
     const expected_sessions_target = try std.fs.path.join(std.testing.allocator, &.{ canonical_path, "sessions" });
     defer std.testing.allocator.free(expected_sessions_target);
     try std.testing.expectEqualStrings(expected_sessions_target, sessions_target);
+
+    var state_link_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const state_link = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "state_5.sqlite" });
+    defer std.testing.allocator.free(state_link);
+    const state_target = try std.fs.readLinkAbsolute(state_link, &state_link_buf);
+    const expected_state_target = try std.fs.path.join(std.testing.allocator, &.{ canonical_path, "state_5.sqlite" });
+    defer std.testing.allocator.free(expected_state_target);
+    try std.testing.expectEqualStrings(expected_state_target, state_target);
+
+    const wal_link = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "state_5.sqlite-wal" });
+    defer std.testing.allocator.free(wal_link);
+    var wal_link_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const wal_target = try std.fs.readLinkAbsolute(wal_link, &wal_link_buf);
+    const expected_wal_target = try std.fs.path.join(std.testing.allocator, &.{ canonical_path, "state_5.sqlite-wal" });
+    defer std.testing.allocator.free(expected_wal_target);
+    try std.testing.expectEqualStrings(expected_wal_target, wal_target);
 
     const bridged_session = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "sessions", "2026", "05", "05", "session.jsonl" });
     defer std.testing.allocator.free(bridged_session);
@@ -2126,4 +2624,90 @@ test "createSessionCodexHomeUnder bridges canonical session authority without co
     const marker_after_overlay_delete = try std.fs.cwd().readFileAlloc(std.testing.allocator, canonical_marker, 1024);
     defer std.testing.allocator.free(marker_after_overlay_delete);
     try std.testing.expectEqualStrings("via overlay\n", marker_after_overlay_delete);
+}
+
+test "resume authority accepts bridged state db as chooser authority" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("account");
+    try tmp.dir.makePath("canonical");
+    {
+        const auth = try tmp.dir.createFile("account/auth.json", .{ .mode = 0o600 });
+        defer auth.close();
+        try auth.writeAll("{\"tokens\":{\"access_token\":\"fixture\"}}\n");
+    }
+    {
+        const state = try tmp.dir.createFile("canonical/state_5.sqlite", .{ .mode = 0o600 });
+        defer state.close();
+        try state.writeAll("managed-good-session");
+    }
+
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const auth_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "account", "auth.json" });
+    defer std.testing.allocator.free(auth_path);
+    const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
+    defer std.testing.allocator.free(canonical_path);
+
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, canonical_path, canonical_path);
+    defer codex_home.deinit(std.testing.allocator);
+
+    const check = try checkResumeAuthority(std.testing.allocator, &codex_home, .{ .mode = .chooser });
+    try std.testing.expect(check.ok);
+    try std.testing.expect(check.state_db_bridged);
+    try std.testing.expectEqualStrings("state_db_available", check.diagnostic);
+}
+
+test "explicit resume preflight prefers state db and targeted rollout stat" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("canonical/sessions/2026/05/06");
+    {
+        const state = try tmp.dir.createFile("canonical/state_5.sqlite", .{ .mode = 0o600 });
+        defer state.close();
+        try state.writeAll("managed-good-session");
+    }
+    {
+        const rollout = try tmp.dir.createFile("canonical/sessions/2026/05/06/rollout-managed-good-session.jsonl", .{ .mode = 0o600 });
+        defer rollout.close();
+        try rollout.writeAll("{\"fixture\":true}\n");
+    }
+
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
+    defer std.testing.allocator.free(canonical_path);
+
+    var preflight = try lookupExplicitResumePreflight(std.testing.allocator, canonical_path, "managed-good-session");
+    defer preflight.deinit();
+    try std.testing.expectEqual(ResumeLookupSource.state_db, preflight.lookup_source);
+    try std.testing.expectEqual(true, preflight.explicit_target_found_before.?);
+    try std.testing.expect(preflight.target_snapshot != null);
+    try std.testing.expectEqual(@as(usize, 1), preflight.rolloutsBefore());
+}
+
+test "explicit resume preflight can use state db without scanning rollout files" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("canonical");
+    {
+        const state = try tmp.dir.createFile("canonical/state_5.sqlite", .{ .mode = 0o600 });
+        defer state.close();
+        try state.writeAll("state-only-session");
+    }
+
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
+    defer std.testing.allocator.free(canonical_path);
+
+    var preflight = try lookupExplicitResumePreflight(std.testing.allocator, canonical_path, "state-only-session");
+    defer preflight.deinit();
+    try std.testing.expectEqual(ResumeLookupSource.state_db, preflight.lookup_source);
+    try std.testing.expectEqual(true, preflight.explicit_target_found_before.?);
+    try std.testing.expect(preflight.target_snapshot == null);
+    try std.testing.expectEqual(@as(usize, 0), preflight.rolloutsBefore());
 }

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -86,6 +86,7 @@ const SessionCodexHome = struct {
     config_passthrough: bool = false,
     config_overridden_keys: usize = 0,
     experimental_feature_defaults_injected: usize = 0,
+    mcp_stdio_unsupported_fields_removed: usize = 0,
     config_layout: []const u8 = "root_partitioned",
 
     fn deinit(self: SessionCodexHome, allocator: std.mem.Allocator) void {
@@ -199,6 +200,7 @@ const ManagedConfigObservation = struct {
     passthrough: bool = false,
     overridden_keys: usize = 0,
     experimental_feature_defaults_injected: usize = 0,
+    mcp_stdio_unsupported_fields_removed: usize = 0,
     layout: []const u8 = "root_partitioned",
 };
 
@@ -254,6 +256,55 @@ const ConfigOverrideCheck = struct {
     mux_owned_overrides: usize = 0,
     model_provider_override: bool = false,
     managed_provider_override: bool = false,
+};
+
+const TomlBufferedTable = struct {
+    active: bool = false,
+    skip: bool = false,
+    features: bool = false,
+    mcp_server: bool = false,
+    mcp_has_command: bool = false,
+    mcp_unsupported_stdio_fields: usize = 0,
+    lines: std.ArrayListUnmanaged(u8) = .{},
+
+    fn deinit(self: *TomlBufferedTable, allocator: std.mem.Allocator) void {
+        self.lines.deinit(allocator);
+    }
+
+    fn reset(self: *TomlBufferedTable) void {
+        self.active = false;
+        self.skip = false;
+        self.features = false;
+        self.mcp_server = false;
+        self.mcp_has_command = false;
+        self.mcp_unsupported_stdio_fields = 0;
+        self.lines.clearRetainingCapacity();
+    }
+
+    fn start(
+        self: *TomlBufferedTable,
+        allocator: std.mem.Allocator,
+        header: []const u8,
+        skip: bool,
+        features: bool,
+        mcp_server: bool,
+    ) !void {
+        self.reset();
+        self.active = true;
+        self.skip = skip;
+        self.features = features;
+        self.mcp_server = mcp_server;
+        if (!skip) {
+            try self.lines.writer(allocator).writeAll(header);
+            try self.lines.writer(allocator).writeAll("\n");
+        }
+    }
+
+    fn appendLine(self: *TomlBufferedTable, allocator: std.mem.Allocator, line: []const u8) !void {
+        if (self.skip) return;
+        try self.lines.writer(allocator).writeAll(line);
+        try self.lines.writer(allocator).writeAll("\n");
+    }
 };
 
 const LaunchTimer = struct {
@@ -698,8 +749,8 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         const installed_local_mismatch = envFlag("OMUX_INSTALLED_LOCAL_MISMATCH");
 
         try status_writer.print(
-            "{{\"kind\":\"session_started\",\"adapter\":\"codex\",\"adapter_version\":\"{s}\",\"managed_frame_id\":\"{s}\",\"selected_account\":\"{s}\",\"codex_home_path_printed\":false,\"proxy_port\":{d},\"claim_level\":\"broker_owned\",\"auth_authority\":\"mux_owned_overlay\",\"managed_config\":\"mux_owned_overlay\",\"config_layout\":\"{s}\",\"config_passthrough\":{any},\"user_config_present\":{any},\"config_overridden_keys\":{d},\"experimental_feature_defaults_injected\":{d},\"config_paths_printed\":false,\"session_authority\":\"{s}\",\"session_paths_printed\":false,\"pre_spawn_network_refresh\":false,\"status_file_present\":{any},\"runtime_identity\":{{\"binary_path\":",
-            .{ cli.version, managed_frame_id, elected.id, proxy_port, codex_home.config_layout, codex_home.config_passthrough, codex_home.config_source_present, codex_home.config_overridden_keys, codex_home.experimental_feature_defaults_injected, codex_home.session_authority.toString(), status_file_path != null },
+            "{{\"kind\":\"session_started\",\"adapter\":\"codex\",\"adapter_version\":\"{s}\",\"managed_frame_id\":\"{s}\",\"selected_account\":\"{s}\",\"codex_home_path_printed\":false,\"proxy_port\":{d},\"claim_level\":\"broker_owned\",\"auth_authority\":\"mux_owned_overlay\",\"managed_config\":\"mux_owned_overlay\",\"config_layout\":\"{s}\",\"config_passthrough\":{any},\"user_config_present\":{any},\"config_overridden_keys\":{d},\"experimental_feature_defaults_injected\":{d},\"mcp_stdio_unsupported_fields_removed\":{d},\"config_paths_printed\":false,\"session_authority\":\"{s}\",\"session_paths_printed\":false,\"pre_spawn_network_refresh\":false,\"status_file_present\":{any},\"runtime_identity\":{{\"binary_path\":",
+            .{ cli.version, managed_frame_id, elected.id, proxy_port, codex_home.config_layout, codex_home.config_passthrough, codex_home.config_source_present, codex_home.config_overridden_keys, codex_home.experimental_feature_defaults_injected, codex_home.mcp_stdio_unsupported_fields_removed, codex_home.session_authority.toString(), status_file_path != null },
         );
         try std.json.stringify(binary_path, .{}, status_writer);
         try status_writer.writeAll(",\"binary_source\":");
@@ -1025,6 +1076,7 @@ fn createSessionCodexHomeUnder(
         .config_passthrough = config_observation.passthrough,
         .config_overridden_keys = config_observation.overridden_keys,
         .experimental_feature_defaults_injected = config_observation.experimental_feature_defaults_injected,
+        .mcp_stdio_unsupported_fields_removed = config_observation.mcp_stdio_unsupported_fields_removed,
         .config_layout = config_observation.layout,
     };
 }
@@ -1694,7 +1746,14 @@ fn writeManagedConfigToml(
             defer allocator.free(source_bytes);
             observation.source_present = true;
             observation.passthrough = true;
-            observation.overridden_keys = try writeConfigPassthrough(allocator, w, source_bytes, &feature_defaults, &observation.experimental_feature_defaults_injected);
+            observation.overridden_keys = try writeConfigPassthrough(
+                allocator,
+                w,
+                source_bytes,
+                &feature_defaults,
+                &observation.experimental_feature_defaults_injected,
+                &observation.mcp_stdio_unsupported_fields_removed,
+            );
             managed_root_written = true;
             if (contents.items.len != 0 and contents.items[contents.items.len - 1] != '\n') try w.writeAll("\n");
             try w.writeAll("\n");
@@ -1735,12 +1794,15 @@ fn writeConfigPassthrough(
     source_bytes: []const u8,
     feature_defaults: *CodexExperimentalFeatureDefaults,
     experimental_feature_defaults_injected: *usize,
+    mcp_stdio_unsupported_fields_removed: *usize,
 ) !usize {
     var overridden: usize = 0;
     var root = std.ArrayListUnmanaged(u8){};
     defer root.deinit(allocator);
     var tables = std.ArrayListUnmanaged(u8){};
     defer tables.deinit(allocator);
+    var current_table = TomlBufferedTable{};
+    defer current_table.deinit(allocator);
 
     var in_root = true;
     var in_features_table = false;
@@ -1752,20 +1814,42 @@ fn writeConfigPassthrough(
         const trimmed = std.mem.trim(u8, line, " \t\r");
         const starts_table = isTomlTableHeader(trimmed);
         if (starts_table) {
-            if (in_features_table and !skip_table) {
-                experimental_feature_defaults_injected.* += try feature_defaults.writeMissingAsTableEntries(tables.writer(allocator));
-            }
+            try flushConfigPassthroughTable(
+                allocator,
+                &tables,
+                &current_table,
+                feature_defaults,
+                experimental_feature_defaults_injected,
+                mcp_stdio_unsupported_fields_removed,
+            );
             in_root = false;
             in_features_table = isTomlTableHeaderNamed(trimmed, "features");
             features_table_seen = features_table_seen or in_features_table;
             skip_table = isManagedProviderTable(trimmed);
             if (skip_table) {
                 overridden += 1;
-                continue;
             }
+            try current_table.start(allocator, line, skip_table, in_features_table, isMcpServerTable(trimmed));
+            continue;
         }
+
+        if (in_root) {
+            markExperimentalFeatureAssignment(feature_defaults, trimmed_left, true, false);
+            if (configAssignmentOverridesMuxProvider(trimmed_left)) |classification| {
+                switch (classification) {
+                    .model_provider, .managed_provider => {
+                        overridden += 1;
+                        continue;
+                    },
+                }
+            }
+            try root.writer(allocator).writeAll(line);
+            try root.writer(allocator).writeAll("\n");
+            continue;
+        }
+
         if (skip_table) continue;
-        markExperimentalFeatureAssignment(feature_defaults, trimmed_left, in_root, in_features_table);
+        markExperimentalFeatureAssignment(feature_defaults, trimmed_left, false, in_features_table);
         if (configAssignmentOverridesMuxProvider(trimmed_left)) |classification| {
             switch (classification) {
                 .model_provider, .managed_provider => {
@@ -1774,13 +1858,25 @@ fn writeConfigPassthrough(
                 },
             }
         }
-        const out = if (in_root) root.writer(allocator) else tables.writer(allocator);
-        try out.writeAll(line);
-        try out.writeAll("\n");
+        if (current_table.mcp_server) {
+            if (tomlAssignmentKey(trimmed_left)) |key| {
+                if (std.mem.eql(u8, key, "command")) {
+                    current_table.mcp_has_command = true;
+                } else if (isUnsupportedStdioMcpFieldKey(key)) {
+                    current_table.mcp_unsupported_stdio_fields += 1;
+                }
+            }
+        }
+        try current_table.appendLine(allocator, line);
     }
-    if (in_features_table and !skip_table) {
-        experimental_feature_defaults_injected.* += try feature_defaults.writeMissingAsTableEntries(tables.writer(allocator));
-    }
+    try flushConfigPassthroughTable(
+        allocator,
+        &tables,
+        &current_table,
+        feature_defaults,
+        experimental_feature_defaults_injected,
+        mcp_stdio_unsupported_fields_removed,
+    );
     if (!features_table_seen) {
         experimental_feature_defaults_injected.* += try feature_defaults.writeMissingAsRootDotted(root.writer(allocator));
     }
@@ -1795,6 +1891,41 @@ fn writeConfigPassthrough(
         if (tables.items[tables.items.len - 1] != '\n') try writer.writeAll("\n");
     }
     return overridden;
+}
+
+fn flushConfigPassthroughTable(
+    allocator: std.mem.Allocator,
+    tables: *std.ArrayListUnmanaged(u8),
+    table: *TomlBufferedTable,
+    feature_defaults: *CodexExperimentalFeatureDefaults,
+    experimental_feature_defaults_injected: *usize,
+    mcp_stdio_unsupported_fields_removed: *usize,
+) !void {
+    if (!table.active) return;
+    defer table.reset();
+    if (table.skip) return;
+    if (table.features) {
+        experimental_feature_defaults_injected.* += try feature_defaults.writeMissingAsTableEntries(table.lines.writer(allocator));
+    }
+    const sanitize_stdio_mcp = table.mcp_server and table.mcp_has_command and table.mcp_unsupported_stdio_fields != 0;
+    if (!sanitize_stdio_mcp) {
+        try tables.writer(allocator).writeAll(table.lines.items);
+        return;
+    }
+
+    var start: usize = 0;
+    while (start < table.lines.items.len) {
+        const next = std.mem.indexOfScalarPos(u8, table.lines.items, start, '\n') orelse table.lines.items.len;
+        const line = table.lines.items[start..next];
+        const had_newline = next < table.lines.items.len;
+        if (isUnsupportedStdioMcpFieldLine(line)) {
+            mcp_stdio_unsupported_fields_removed.* += 1;
+        } else {
+            try tables.writer(allocator).writeAll(line);
+            if (had_newline) try tables.writer(allocator).writeByte('\n');
+        }
+        start = if (had_newline) next + 1 else next;
+    }
 }
 
 fn isTomlTableHeader(trimmed_line: []const u8) bool {
@@ -1822,15 +1953,39 @@ fn isManagedProviderTable(trimmed_line: []const u8) bool {
         (std.mem.startsWith(u8, line, "[model_providers.oauth_mux_openai.") and std.mem.endsWith(u8, line, "]"));
 }
 
+fn isMcpServerTable(trimmed_line: []const u8) bool {
+    var line = trimmed_line;
+    if (std.mem.indexOfScalar(u8, line, '#')) |idx| line = std.mem.trim(u8, line[0..idx], " \t\r");
+    if (!std.mem.startsWith(u8, line, "[") or !std.mem.endsWith(u8, line, "]")) return false;
+    if (std.mem.startsWith(u8, line, "[[")) return false;
+    const body = std.mem.trim(u8, line[1 .. line.len - 1], " \t\r");
+    return std.mem.startsWith(u8, body, "mcp_servers.");
+}
+
+fn tomlAssignmentKey(assignment: []const u8) ?[]const u8 {
+    const eq = std.mem.indexOfScalar(u8, assignment, '=') orelse return null;
+    var key = std.mem.trim(u8, assignment[0..eq], " \t\r\n");
+    if (key.len == 0 or std.mem.startsWith(u8, key, "#")) return null;
+    key = std.mem.trim(u8, key, "\"'");
+    return key;
+}
+
+fn isUnsupportedStdioMcpFieldKey(key: []const u8) bool {
+    return std.mem.eql(u8, key, "url") or std.mem.eql(u8, key, "bearer_token_env_var");
+}
+
+fn isUnsupportedStdioMcpFieldLine(line: []const u8) bool {
+    const key = tomlAssignmentKey(std.mem.trimLeft(u8, line, " \t")) orelse return false;
+    return isUnsupportedStdioMcpFieldKey(key);
+}
+
 fn markExperimentalFeatureAssignment(
     feature_defaults: *CodexExperimentalFeatureDefaults,
     assignment: []const u8,
     in_root: bool,
     in_features_table: bool,
 ) void {
-    const eq = std.mem.indexOfScalar(u8, assignment, '=') orelse return;
-    var key = std.mem.trim(u8, assignment[0..eq], " \t\r\n");
-    key = std.mem.trim(u8, key, "\"'");
+    const key = tomlAssignmentKey(assignment) orelse return;
     if (in_features_table) {
         feature_defaults.mark(key);
         return;
@@ -1884,9 +2039,7 @@ const ConfigOverrideClassification = enum {
 };
 
 fn configAssignmentOverridesMuxProvider(assignment: []const u8) ?ConfigOverrideClassification {
-    const eq = std.mem.indexOfScalar(u8, assignment, '=') orelse return null;
-    var key = std.mem.trim(u8, assignment[0..eq], " \t\r\n");
-    key = std.mem.trim(u8, key, "\"'");
+    const key = tomlAssignmentKey(assignment) orelse return null;
     if (std.mem.eql(u8, key, "model_provider") or std.mem.endsWith(u8, key, ".model_provider")) {
         return .model_provider;
     }
@@ -2157,7 +2310,13 @@ test "createSessionCodexHomeUnder preserves canonical config behavior settings" 
             \\multi_agent = true
             \\
             \\[mcp_servers.design]
+            \\url = "https://figma.invalid/mcp"
+            \\bearer_token_env_var = "FIGMA_ACCESS_TOKEN"
             \\command = "figma-mcp"
+            \\
+            \\[mcp_servers.linear]
+            \\url = "https://mcp.linear.app/mcp"
+            \\bearer_token_env_var = "LINEAR_API_KEY"
             \\
             \\[model_providers.user_provider]
             \\name = "User Provider"
@@ -2186,6 +2345,7 @@ test "createSessionCodexHomeUnder preserves canonical config behavior settings" 
     try std.testing.expect(codex_home.config_passthrough);
     try std.testing.expect(codex_home.config_overridden_keys >= 2);
     try std.testing.expectEqual(@as(usize, 4), codex_home.experimental_feature_defaults_injected);
+    try std.testing.expectEqual(@as(usize, 2), codex_home.mcp_stdio_unsupported_fields_removed);
 
     const overlay_config = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "config.toml" });
     defer std.testing.allocator.free(overlay_config);
@@ -2203,6 +2363,11 @@ test "createSessionCodexHomeUnder preserves canonical config behavior settings" 
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "goals = true") != null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "prevent_idle_sleep = true") != null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "[mcp_servers.design]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "https://figma.invalid/mcp") == null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "FIGMA_ACCESS_TOKEN") == null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "[mcp_servers.linear]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "https://mcp.linear.app/mcp") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "LINEAR_API_KEY") != null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "[model_providers.user_provider]") != null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "https://example.invalid/api") != null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "[tui.model_availability_nux]") != null);
@@ -2316,6 +2481,7 @@ test "config passthrough strips profile-scoped model_provider overrides" {
     defer buf.deinit(std.testing.allocator);
     var feature_defaults = CodexExperimentalFeatureDefaults{};
     var experimental_feature_defaults_injected: usize = 0;
+    var mcp_stdio_unsupported_fields_removed: usize = 0;
     const source =
         \\[profiles.work]
         \\model = "gpt-5.5"
@@ -2326,10 +2492,11 @@ test "config passthrough strips profile-scoped model_provider overrides" {
         \\experimental_apply_patch = true
         \\
     ;
-    const overridden = try writeConfigPassthrough(std.testing.allocator, buf.writer(std.testing.allocator), source, &feature_defaults, &experimental_feature_defaults_injected);
+    const overridden = try writeConfigPassthrough(std.testing.allocator, buf.writer(std.testing.allocator), source, &feature_defaults, &experimental_feature_defaults_injected, &mcp_stdio_unsupported_fields_removed);
 
     try std.testing.expectEqual(@as(usize, 1), overridden);
     try std.testing.expectEqual(@as(usize, 5), experimental_feature_defaults_injected);
+    try std.testing.expectEqual(@as(usize, 0), mcp_stdio_unsupported_fields_removed);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "[profiles.work]") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "model = \"gpt-5.5\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "approval_policy = \"on-request\"") != null);


### PR DESCRIPTION
# What changed
- Injects missing Codex experimental feature defaults into the managed child overlay only: `terminal_resize_reflow`, `memories`, `external_migration`, `goals`, and `prevent_idle_sleep`.
- Preserves canonical `config.toml` values, including explicit `false`, and keeps the canonical config untouched.
- Keeps managed config root-partitioned, bridges `state_5.sqlite*` session authority when present, and reports redacted managed status fields.
- Guards Codex 0.130 MCP schema drift by removing unsupported `url` and `bearer_token_env_var` fields from stdio MCP tables in the overlay only; HTTP MCP tables keep those fields.
- Advances the source/dogfood lane to `0.1.7` candidate while public release/install channels remain `0.1.6` until published.

# Claim boundary
This is managed Codex overlay/config parity and next-turn broker-session hardening. It does not claim unmanaged bare-Codex daemon hot-swap, mid-turn streaming recovery, same-thread provider continuity, universal provider support, or non-Codex stay-afloat proof.

# Validation
- `zig build test`
- `just build`
- `scripts/smoke-codex-cli-ux.sh`
- `scripts/smoke-codex-provider-degraded.sh`
- `scripts/smoke-codex-status-summary.sh`
- `git diff --check origin/main...HEAD`
- `nix develop --command just check-local`

No local Playwright run.