### PR TITLE
Handle Codex provider-degraded retries

### DIFF
--- a/justfile
+++ b/justfile
@@ -260,6 +260,13 @@ smoke-codex-401-propagation-local:
     zig build
     ./scripts/smoke-codex-401-propagation.sh
 
+smoke-codex-provider-degraded:
+    nix develop --command just smoke-codex-provider-degraded-local
+
+smoke-codex-provider-degraded-local:
+    zig build
+    ./scripts/smoke-codex-provider-degraded.sh
+
 # ── Codex cassette replay smoke (no provider traffic) ──
 
 smoke-codex-cassette-replay:

--- a/scripts/check-local.sh
+++ b/scripts/check-local.sh
@@ -21,6 +21,7 @@ done
 ./scripts/smoke-codex-tier-insufficient.sh
 ./scripts/smoke-codex-all-exhausted.sh
 ./scripts/smoke-codex-401-propagation.sh
+./scripts/smoke-codex-provider-degraded.sh
 ./scripts/smoke-codex-cassette-replay.sh
 ./scripts/smoke-codex-capture-review.sh
 ./scripts/smoke-codex-status-summary.sh

--- a/scripts/smoke-codex-provider-degraded.sh
+++ b/scripts/smoke-codex-provider-degraded.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# Provider-degraded smoke: 5xx responses are provider failures, not credential
+# failures. The proxy should retry a selectable fallback before Codex sees the
+# 5xx, and should pass through a no-fallback provider 5xx without emitting the
+# route-repair no-account body.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$ROOT/zig-out/bin/oauth-mux"
+
+if [[ ! -x "$BIN" ]]; then
+    echo "smoke-codex-provider-degraded: oauth-mux binary not built at $BIN" >&2
+    echo "  run: just build" >&2
+    exit 64
+fi
+
+if ! command -v jq >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then
+    echo "smoke-codex-provider-degraded: jq and python3 required" >&2
+    exit 64
+fi
+
+TMP="$(mktemp -d -t omux-provider-degraded.XXXXXX)"
+UPSTREAM_PIDS=()
+
+cleanup() {
+    for pid in "${UPSTREAM_PIDS[@]}"; do
+        if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+        fi
+    done
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+ID_TOKEN="h.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9wbGFuX3R5cGUiOiJwcm8iLCJjaGF0Z3B0X2FjY291bnRfaXNfZmVkcmFtcCI6dHJ1ZX19.s"
+
+assert_grep() {
+    local label=$1 pattern=$2 file=$3
+    if grep -q -E "$pattern" "$file"; then
+        echo "  ✓ $label"
+    else
+        echo "  ✗ $label" >&2
+        echo "    pattern: $pattern" >&2
+        cat "$file" >&2
+        return 1
+    fi
+}
+
+assert_no_grep() {
+    local label=$1 pattern=$2 file=$3
+    if grep -q -E "$pattern" "$file"; then
+        echo "  ✗ $label (unexpected match for: $pattern)" >&2
+        cat "$file" >&2
+        return 1
+    else
+        echo "  ✓ $label"
+    fi
+}
+
+wait_for_port() {
+    local portfile=$1
+    for _ in {1..40}; do
+        [[ -s "$portfile" ]] && return 0
+        sleep 0.05
+    done
+    echo "stub upstream did not bind" >&2
+    return 1
+}
+
+write_two_account_fixture() {
+    local dir=$1
+    mkdir -p "$dir/account-A" "$dir/account-B" "$dir/state"
+    cat >"$dir/account-A/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"$ID_TOKEN","refresh_token":"RT-A","account_id":"acc-A-id"},"auth_mode":"Chatgpt"}
+EOF
+    cat >"$dir/account-B/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"$ID_TOKEN","refresh_token":"RT-B","account_id":"acc-B-id"},"auth_mode":"Chatgpt"}
+EOF
+    cat >"$dir/oauth-mux.config.json" <<EOF
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "kind": "codex",
+      "accounts": {
+        "max-1": { "priority": 30, "config_dir": "$dir/account-A", "secret": { "backend": "file", "path": "$dir/account-A/auth.json" } },
+        "max-2": { "priority": 20, "config_dir": "$dir/account-B", "secret": { "backend": "file", "path": "$dir/account-B/auth.json" } }
+      }
+    }
+  },
+  "profiles": {
+    "codex-max": { "providers": ["codex:max-1#codex-max", "codex:max-2#codex-max"] }
+  }
+}
+EOF
+    cat >"$dir/state/health.json" <<'EOF'
+{"version":2,"accounts":[
+  {"key":"codex:max-1#codex-max","last_probe_source":"capability_probe","last_probe_hint_class":"none","last_probe_decision":"use_this","liveness":{"state":"live","availability":"available"}},
+  {"key":"codex:max-2#codex-max","last_probe_source":"capability_probe","last_probe_hint_class":"none","last_probe_decision":"use_this","liveness":{"state":"live","availability":"available"}}
+]}
+EOF
+}
+
+write_one_account_fixture() {
+    local dir=$1
+    mkdir -p "$dir/account-A" "$dir/state"
+    cat >"$dir/account-A/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"$ID_TOKEN","refresh_token":"RT-A","account_id":"acc-A-id"},"auth_mode":"Chatgpt"}
+EOF
+    cat >"$dir/oauth-mux.config.json" <<EOF
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "kind": "codex",
+      "accounts": {
+        "max-1": { "priority": 30, "config_dir": "$dir/account-A", "secret": { "backend": "file", "path": "$dir/account-A/auth.json" } }
+      }
+    }
+  },
+  "profiles": {
+    "codex-max": { "providers": ["codex:max-1#codex-max"] }
+  }
+}
+EOF
+    cat >"$dir/state/health.json" <<'EOF'
+{"version":2,"accounts":[
+  {"key":"codex:max-1#codex-max","last_probe_source":"capability_probe","last_probe_hint_class":"none","last_probe_decision":"use_this","liveness":{"state":"live","availability":"available"}}
+]}
+EOF
+}
+
+run_fallback_case() {
+    local case_dir="$TMP/fallback"
+    local portfile="$case_dir/upstream.port"
+    local uplog="$case_dir/upstream.log"
+    local ndjson="$case_dir/adapter.ndjson"
+    local adapter_stderr="$case_dir/adapter.stderr"
+    local stub_report="$case_dir/stub-codex.report"
+    mkdir -p "$case_dir"
+    write_two_account_fixture "$case_dir"
+    mkdir -p "$case_dir/bin"
+    cat >"$case_dir/bin/codex" <<'EOF'
+#!/usr/bin/env sh
+exit 0
+EOF
+    chmod +x "$case_dir/bin/codex"
+
+    OMUX_STUB_PORT=0 \
+      OMUX_STUB_PORTFILE="$portfile" \
+      OMUX_STUB_OK_BEFORE_429=99 \
+      OMUX_STUB_LOGFILE="$uplog" \
+      OMUX_STUB_ACCOUNT_STATUS_JSON='{"acc-A-id":503}' \
+      python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$case_dir/upstream.stderr" &
+    local upstream_pid=$!
+    UPSTREAM_PIDS+=("$upstream_pid")
+    wait_for_port "$portfile"
+    local upstream_port
+    upstream_port="$(cat "$portfile" | tr -d '[:space:]')"
+    echo "smoke-codex-provider-degraded: fallback stub pid=$upstream_pid port=$upstream_port max-1=503 max-2=200"
+
+    OMUX_CONFIG="$case_dir/oauth-mux.config.json" \
+      OMUX_STATE_DIR="$case_dir/state" \
+      OMUX_UPSTREAM_HOST="127.0.0.1:$upstream_port" \
+      OMUX_UPSTREAM_SCHEME="http" \
+      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_STUB_CODEX_TURNS=3 \
+      OMUX_STUB_CODEX_REPORT="$stub_report" \
+      "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$ndjson" 2>"$adapter_stderr" || {
+        echo "adapter exited nonzero in fallback case" >&2
+        cat "$ndjson" >&2 || true
+        cat "$adapter_stderr" >&2 || true
+        exit 1
+    }
+
+    echo "smoke-codex-provider-degraded: fallback assertions"
+    assert_grep "max-1 503 classified provider_5xx" '"kind":"proxy_turn".*"account":"codex:max-1".*"status":503.*"classification":"provider_5xx".*"delivered_to_codex":false' "$ndjson"
+    assert_grep "provider same-turn retry fired" '"kind":"proxy_provider_same_turn_retry".*"from":"codex:max-1".*"to":"codex:max-2".*"reason":"provider_5xx"' "$ndjson"
+    assert_grep "fallback account returned 200" '"kind":"proxy_turn".*"account":"codex:max-2".*"status":200.*"classification":"ok"' "$ndjson"
+    assert_no_grep "provider retry did not use quota retry event" '"kind":"proxy_same_turn_retry".*"reason":"provider_5xx"' "$ndjson"
+    assert_no_grep "no route-repair body leaked on provider fallback" 'oauth_mux_no_account_selectable' "$stub_report"
+
+    local got_200
+    got_200="$(jq -r '.turns | map(select(.status == 200)) | length' "$stub_report")"
+    if [[ "$got_200" -eq 3 ]]; then
+        echo "  ✓ stub-codex saw all 3 turns return 200"
+    else
+        echo "  ✗ stub-codex saw $got_200 200s (expected 3)" >&2
+        jq .turns "$stub_report" >&2
+        exit 1
+    fi
+
+    local plan_after selected_after
+    plan_after="$(
+      PATH="$case_dir/bin:$PATH" \
+      OMUX_CONFIG="$case_dir/oauth-mux.config.json" \
+      OMUX_STATE_DIR="$case_dir/state" \
+      "$BIN" codex broker-session-plan --profile codex-max --capability codex-max --json
+    )"
+    selected_after="$(jq -r '.selected.account' <<<"$plan_after")"
+    if [[ "$selected_after" == "max-2" ]]; then
+        echo "  ✓ broker-session-plan avoids provider-degraded max-1"
+    else
+        echo "  ✗ broker-session-plan selected $selected_after after max-1 provider 503" >&2
+        jq . <<<"$plan_after" >&2
+        exit 1
+    fi
+}
+
+run_no_fallback_case() {
+    local case_dir="$TMP/no-fallback"
+    local portfile="$case_dir/upstream.port"
+    local ndjson="$case_dir/adapter.ndjson"
+    local adapter_stderr="$case_dir/adapter.stderr"
+    local stub_report="$case_dir/stub-codex.report"
+    mkdir -p "$case_dir"
+    write_one_account_fixture "$case_dir"
+
+    OMUX_STUB_PORT=0 \
+      OMUX_STUB_PORTFILE="$portfile" \
+      OMUX_STUB_ALWAYS_STATUS=503 \
+      python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$case_dir/upstream.stderr" &
+    local upstream_pid=$!
+    UPSTREAM_PIDS+=("$upstream_pid")
+    wait_for_port "$portfile"
+    local upstream_port
+    upstream_port="$(cat "$portfile" | tr -d '[:space:]')"
+    echo "smoke-codex-provider-degraded: no-fallback stub pid=$upstream_pid port=$upstream_port always=503"
+
+    OMUX_CONFIG="$case_dir/oauth-mux.config.json" \
+      OMUX_STATE_DIR="$case_dir/state" \
+      OMUX_UPSTREAM_HOST="127.0.0.1:$upstream_port" \
+      OMUX_UPSTREAM_SCHEME="http" \
+      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_STUB_CODEX_TURNS=1 \
+      OMUX_STUB_CODEX_REPORT="$stub_report" \
+      "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$ndjson" 2>"$adapter_stderr" || {
+        echo "adapter exited nonzero in no-fallback case" >&2
+        cat "$ndjson" >&2 || true
+        cat "$adapter_stderr" >&2 || true
+        exit 1
+    }
+
+    echo "smoke-codex-provider-degraded: no-fallback assertions"
+    assert_grep "single account 503 classified provider_5xx" '"kind":"proxy_turn".*"account":"codex:max-1".*"status":503.*"classification":"provider_5xx".*"delivered_to_codex":false' "$ndjson"
+    assert_grep "provider retry unavailable event fired" '"kind":"proxy_provider_retry_unavailable".*"from":"codex:max-1".*"delivered_to_codex":true' "$ndjson"
+    assert_no_grep "no quota all-exhausted event for provider 503" '"kind":"quota_handoff_failed_no_account_selectable"' "$ndjson"
+    assert_no_grep "no route-repair response for provider 503" 'oauth_mux_no_account_selectable' "$stub_report"
+
+    local got_503
+    got_503="$(jq -r '.turns | map(select(.status == 503 and (.body_head | contains("forced status 503")))) | length' "$stub_report")"
+    if [[ "$got_503" -eq 1 ]]; then
+        echo "  ✓ stub-codex saw original provider 503 body"
+    else
+        echo "  ✗ stub-codex did not see original provider 503 body" >&2
+        jq .turns "$stub_report" >&2
+        exit 1
+    fi
+}
+
+run_fallback_case
+run_no_fallback_case
+
+echo
+echo "smoke-codex-provider-degraded: all assertions passed."

--- a/scripts/smoke-codex-status-summary.sh
+++ b/scripts/smoke-codex-status-summary.sh
@@ -37,7 +37,7 @@ cat >"$FALLBACK" <<'EOF'
 {"kind":"proxy_turn","account":"codex:max-1","method":"POST","path_kind":"responses","status":429,"classification":"quota_exhausted","body_class":"usage_limit_reached","delivered_to_codex":false}
 {"kind":"proxy_same_turn_retry","from":"codex:max-1","to":"codex:max-2","reason":"quota_exhausted","dropped":"x-codex-turn-state"}
 {"kind":"proxy_turn","account":"codex:max-2","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true}
-{"kind":"proxy_no_account_selectable","attempted":["codex:max-2"],"rejections":[{"account":"codex:max-2","state":"credential_unavailable","reason":"ConnectionResetByPeer"}]}
+{"kind":"proxy_provider_retry_unavailable","attempted":["codex:max-2"],"rejections":[{"account":"codex:max-2","state":"provider_degraded","reason":"ConnectionResetByPeer"}]}
 {"kind":"proxy_turn","account":"codex:max-2","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true}
 {"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":true}
 EOF

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -36,17 +36,20 @@
 //!      On auth_unauthorized, try the same fallback shape before Codex sees
 //!      the 401. If fallback is unavailable, return the buffered 401 so Codex
 //!      can still run its native refresh loop.
+//!      On provider_5xx, try another account before Codex sees the provider
+//!      outage. If no fallback is selectable, return the provider failure as
+//!      provider-degraded evidence rather than marking credentials dead.
 //!   7. Stream the final response body verbatim back to codex (SSE works
 //!      because chunked-transfer is forwarded byte-for-byte).
 //!
 //! Phase 2 scope (honestly labelled limitations):
 //!   - Synchronous, single-connection-at-a-time (codex sends one
 //!     request per turn). No request pipelining.
-//!   - **Streaming for 200/3xx/5xx; buffered for 401/429.** SSE turns
+//!   - **Streaming for 200/3xx; buffered for 4xx/5xx.** SSE turns
 //!     stream byte-for-byte from upstream to codex via Connection:close
-//!     framing — the TUI animation moves in real time. 401 and 429 responses
-//!     are small and need a retry decision before any bytes reach Codex, so
-//!     they stay buffered (with a 64 KiB cap).
+//!     framing — the TUI animation moves in real time. Error responses are
+//!     small and need a retry decision before any bytes reach Codex, so they
+//!     stay buffered (with a 64 KiB cap).
 //!   - No WebSocket upgrade support; if codex requests a WS upgrade
 //!     we propagate the upstream's response (which on `chatgpt.com`
 //!     is HTTP 426 / falls back to chunked). Phase 2.2 adds WS.
@@ -73,6 +76,7 @@ pub const RouteState = enum {
     quota_exhausted,
     rate_limited,
     tier_insufficient,
+    provider_degraded,
     credential_unavailable,
 };
 
@@ -228,6 +232,7 @@ pub const Proxy = struct {
         var pending_buffered: ?BufferedResponse = null;
         var pending_failure_kind: ?broker_types.QuotaKind = null;
         var pending_failure_account: ?[]const u8 = null;
+        var pending_transport_error: ?[]const u8 = null;
         var prior_attempt_account: ?[]const u8 = null;
 
         while (true) {
@@ -246,6 +251,25 @@ pub const Proxy = struct {
                         .account = pending_failure_account orelse "",
                     });
                     try writeBufferedStoredResponse(writer, pending_buffered.?);
+                } else if (pending_kind != null and pending_kind.? == .provider_5xx) {
+                    self.logEvent("proxy_provider_retry_unavailable", .{
+                        .from = pending_failure_account orelse "",
+                        .err = pending_transport_error orelse @errorName(err),
+                        .attempted = attempted.items,
+                        .rejections = rejections.items,
+                        .delivered_to_codex = true,
+                    });
+                    if (pending_buffered) |buffered| {
+                        try writeBufferedStoredResponse(writer, buffered);
+                    } else {
+                        try writeProviderUnavailableResponse(
+                            a,
+                            writer,
+                            pending_failure_account orelse "",
+                            pending_transport_error orelse @errorName(err),
+                            rejections.items,
+                        );
+                    }
                 } else if (pending_kind != null and (pending_kind.? == .quota_exhausted or pending_kind.? == .rate_limited)) {
                     self.logEvent("proxy_same_turn_retry_unavailable", .{
                         .from = pending_failure_account orelse "",
@@ -287,6 +311,7 @@ pub const Proxy = struct {
                 self.recordDurableRouteState(elected.id, .credential_unavailable, 0, null);
                 pending_failure_kind = null;
                 pending_failure_account = elected.id;
+                pending_transport_error = null;
                 prior_attempt_account = elected.id;
                 continue;
             };
@@ -336,11 +361,12 @@ pub const Proxy = struct {
 
             // ── 4. Forward to upstream + stream/buffer response ────
             const status_and_class = forwardAndStream(a, req, out_headers, writer) catch |err| {
-                appendRejection(a, &rejections, elected.id, .credential_unavailable, @errorName(err)) catch {};
+                appendRejection(a, &rejections, elected.id, .provider_degraded, @errorName(err)) catch {};
                 self.logEvent("proxy_upstream_failed", .{ .account = elected.id, .err = @errorName(err) });
-                self.recordDurableRouteState(elected.id, .credential_unavailable, 0, null);
-                pending_failure_kind = null;
+                self.recordDurableRouteState(elected.id, .provider_degraded, 503, 60);
+                pending_failure_kind = .provider_5xx;
                 pending_failure_account = elected.id;
+                pending_transport_error = @errorName(err);
                 prior_attempt_account = elected.id;
                 continue;
             };
@@ -366,6 +392,7 @@ pub const Proxy = struct {
             pending_buffered = status_and_class.buffered_response;
             pending_failure_kind = status_and_class.classification.kind;
             pending_failure_account = elected.id;
+            pending_transport_error = null;
             prior_attempt_account = elected.id;
             continue;
         }
@@ -438,6 +465,16 @@ pub const Proxy = struct {
             return;
         }
 
+        if (reason == .provider_5xx) {
+            self.logEvent("proxy_provider_same_turn_retry", .{
+                .from = from,
+                .to = to,
+                .reason = @tagName(reason),
+                .dropped = "x-codex-turn-state",
+            });
+            return;
+        }
+
         self.logEvent("proxy_same_turn_retry", .{
             .from = from,
             .to = to,
@@ -490,6 +527,7 @@ pub const Proxy = struct {
                 .window = .unknown,
             } },
             .tier_insufficient => .{ .degraded = .tier_insufficient },
+            .provider_degraded => .provider_degraded,
             .credential_unavailable => .{ .dead = .auth_permanently_failed },
         };
 
@@ -504,10 +542,12 @@ pub const Proxy = struct {
                 .quota_exhausted => .quota_exhausted,
                 .rate_limited => .rate_limit,
                 .tier_insufficient => .tier_insufficient,
+                .provider_degraded => .provider_degraded,
             },
             switch (state) {
                 .available => .use_this,
                 .rate_limited => .wait_and_retry,
+                .provider_degraded => .try_next_provider,
                 .auth_failed, .quota_exhausted, .tier_insufficient, .credential_unavailable => .try_next_account,
             },
         );
@@ -543,8 +583,8 @@ pub const Proxy = struct {
 
 fn shouldRetrySameTurn(kind: broker_types.QuotaKind) bool {
     return switch (kind) {
-        .quota_exhausted, .rate_limited, .auth_unauthorized => true,
-        .ok, .tier_insufficient, .provider_5xx => false,
+        .quota_exhausted, .rate_limited, .auth_unauthorized, .provider_5xx => true,
+        .ok, .tier_insufficient => false,
     };
 }
 
@@ -555,7 +595,7 @@ fn routeStateFromClassification(kind: broker_types.QuotaKind) RouteState {
         .quota_exhausted => .quota_exhausted,
         .rate_limited => .rate_limited,
         .tier_insufficient => .tier_insufficient,
-        .provider_5xx => .credential_unavailable,
+        .provider_5xx => .provider_degraded,
     };
 }
 
@@ -628,6 +668,7 @@ fn appendPoolRejections(
 fn routeStateFromPoolAccount(account: account_pool_mod.AccountSummary) RouteState {
     if (!account.selectable) {
         if (account.liveness == .dead) return .auth_failed;
+        if (account.liveness == .degraded) return .provider_degraded;
         if (account.availability == .quota_exhausted) return .quota_exhausted;
         if (account.availability == .rate_limited) return .rate_limited;
         return .credential_unavailable;
@@ -646,6 +687,7 @@ fn poolAccountRejectionReason(account: account_pool_mod.AccountSummary, state: R
         .quota_exhausted => "quota_exhausted",
         .rate_limited => "rate_limited",
         .tier_insufficient => "tier_insufficient",
+        .provider_degraded => "provider_degraded",
         .credential_unavailable => "not_selectable",
         .available => "not_selectable",
     };
@@ -655,6 +697,7 @@ fn poolAccountRejectionReason(account: account_pool_mod.AccountSummary, state: R
         .quota_exhausted => "quota_exhausted",
         .rate_limited => "rate_limited",
         .tier_insufficient => "tier_insufficient",
+        .provider_degraded => "provider_degraded",
         .credential_unavailable => "credential_unavailable",
     };
 }
@@ -987,7 +1030,7 @@ const StatusAndClassification = struct {
     /// Never contains raw response bytes.
     body_class: ?[]const u8 = null,
     /// True if the body was streamed verbatim to the client (no buffer);
-    /// false if it was buffered for classification (429 path) or never
+    /// false if it was buffered for classification/retry or never
     /// arrived (early failure).
     streamed: bool,
     /// Present when the response was buffered and has not yet been written to
@@ -999,14 +1042,13 @@ const StatusAndClassification = struct {
 /// Forward the inbound request to chatgpt.com and write the response
 /// directly to the client writer.
 ///
-/// 401 and 429 responses are buffered so the proxy can decide whether to
+/// 4xx and 5xx responses are buffered so the proxy can decide whether to
 /// retry against a fallback account before any bytes reach Codex. 429 also
 /// needs the body to classify usage_limit_reached vs usage_not_included.
 ///
-/// All other responses (200 streaming SSE, 5xx) are streamed
-/// byte-for-byte from upstream's reader to the client. Connection-close
-/// framing is used so we don't have to re-chunk std.http.Client's
-/// already-decoded body bytes.
+/// Non-error responses (including 200 streaming SSE) are streamed byte-for-byte
+/// from upstream's reader to the client. Connection-close framing is used so we
+/// don't have to re-chunk std.http.Client's already-decoded body bytes.
 fn forwardAndStream(
     a: std.mem.Allocator,
     req: Request,
@@ -1049,32 +1091,16 @@ fn forwardAndStream(
 
     const status_u16: u16 = @intFromEnum(http_req.response.status);
 
-    // 401 and 429 are retry decision points, so they must be buffered before
-    // anything is written to Codex.
-    if (status_u16 == 401 or status_u16 == 429) {
-        // Cap at 64 KiB — chatgpt.com's 429 JSON bodies are small.
+    // Error responses are retry decision points, so they must be buffered
+    // before anything is written to Codex.
+    if (status_u16 >= 400 and status_u16 < 600) {
+        // Cap at 64 KiB — chatgpt.com's error JSON/HTML bodies are small.
         const body = try http_req.reader().readAllAlloc(a, 64 * 1024);
         const classification = classify(a, status_u16, body);
         return .{
             .status = status_u16,
             .classification = classification,
             .body_class = classification.body_class orelse classifyHttpErrorBody(body),
-            .streamed = false,
-            .buffered_response = .{
-                .status = status_u16,
-                .headers = try captureResponseHeaders(a, http_req.response),
-                .body = body,
-            },
-        };
-    }
-
-    if (status_u16 >= 400 and status_u16 < 500 and status_u16 != 401) {
-        const body = try http_req.reader().readAllAlloc(a, 64 * 1024);
-        const classification = classify(a, status_u16, body);
-        return .{
-            .status = status_u16,
-            .classification = classification,
-            .body_class = classifyHttpErrorBody(body),
             .streamed = false,
             .buffered_response = .{
                 .status = status_u16,
@@ -1220,6 +1246,47 @@ fn writeNoAccountSelectableResponse(
     try writer.writeAll(body.items);
 }
 
+fn writeProviderUnavailableResponse(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    account: []const u8,
+    err: []const u8,
+    rejections: []const CandidateRejection,
+) !void {
+    var body = std.ArrayListUnmanaged(u8){};
+    defer body.deinit(allocator);
+    const w = body.writer(allocator);
+
+    try w.writeAll("{\"error\":{\"type\":\"oauth_mux_provider_unavailable\",\"code\":\"oauth_mux_provider_unavailable\",\"message\":");
+    try std.json.stringify(
+        "oauth-mux: provider transport failed and no fallback account was selectable. This is provider-degraded evidence, not credential-dead evidence; inspect the redacted status artifact and retry when the provider recovers.",
+        .{},
+        w,
+    );
+    try w.writeAll(",\"account\":");
+    try std.json.stringify(account, .{}, w);
+    try w.writeAll(",\"transport_error\":");
+    try std.json.stringify(err, .{}, w);
+    try w.writeAll(",\"rejections\":[");
+    for (rejections, 0..) |rejection, idx| {
+        if (idx != 0) try w.writeByte(',');
+        try w.writeAll("{\"account\":");
+        try std.json.stringify(rejection.account, .{}, w);
+        try w.writeAll(",\"state\":");
+        try std.json.stringify(@tagName(rejection.state), .{}, w);
+        try w.writeAll(",\"reason\":");
+        try std.json.stringify(rejection.reason, .{}, w);
+        try w.writeByte('}');
+    }
+    try w.writeAll("]}}\n");
+
+    try writer.writeAll("HTTP/1.1 503 Service Unavailable\r\n");
+    try writer.writeAll("Content-Type: application/json\r\n");
+    try writer.print("Content-Length: {d}\r\n", .{body.items.len});
+    try writer.writeAll("Connection: close\r\n\r\n");
+    try writer.writeAll(body.items);
+}
+
 /// Write headers that are safe to forward to the client unchanged.
 /// Drops hop-by-hop headers (RFC 7230 §6.1) and transfer-coding
 /// metadata since we manage framing ourselves below.
@@ -1247,7 +1314,7 @@ fn captureResponseHeaders(a: std.mem.Allocator, response: std.http.Client.Respon
     return headers;
 }
 
-/// 429 path: write status + headers + Content-Length + buffered body.
+/// Buffered-error path: write status + headers + Content-Length + body.
 fn writeBufferedResponse(
     writer: anytype,
     response: std.http.Client.Response,
@@ -1375,6 +1442,11 @@ test "classify 503 -> provider_5xx" {
     try std.testing.expectEqual(broker_types.QuotaKind.provider_5xx, c.kind);
 }
 
+test "provider_5xx retries same turn and records provider-degraded route state" {
+    try std.testing.expect(shouldRetrySameTurn(.provider_5xx));
+    try std.testing.expectEqual(RouteState.provider_degraded, routeStateFromClassification(.provider_5xx));
+}
+
 test "classify 429 + usage_limit_reached -> quota_exhausted with resets_at" {
     const body =
         \\{"error":{"type":"usage_limit_reached","plan_type":"pro","resets_at":1788000000}}
@@ -1476,6 +1548,28 @@ test "writeNoAccountSelectableResponse emits parseable route-repair JSON" {
     try std.testing.expect(std.mem.indexOf(u8, out, "\"account\":\"codex:default\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "\"state\":\"quota_exhausted\"") != null);
     try std.testing.expect(std.mem.endsWith(u8, out, "]}}\n"));
+}
+
+test "writeProviderUnavailableResponse emits provider-degraded JSON" {
+    var buf: [1536]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(&buf);
+    const rejections = [_]CandidateRejection{
+        .{ .account = "codex:max-1", .state = .provider_degraded, .reason = "ConnectionResetByPeer" },
+    };
+
+    try writeProviderUnavailableResponse(
+        std.testing.allocator,
+        fbs.writer(),
+        "codex:max-1",
+        "ConnectionResetByPeer",
+        &rejections,
+    );
+    const out = fbs.getWritten();
+    try std.testing.expect(std.mem.startsWith(u8, out, "HTTP/1.1 503 Service Unavailable\r\n"));
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"type\":\"oauth_mux_provider_unavailable\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"transport_error\":\"ConnectionResetByPeer\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"state\":\"provider_degraded\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "credential-dead") != null);
 }
 
 test "HeaderList.remove drops matching headers, case-insensitive" {
@@ -1703,6 +1797,7 @@ test "appendPoolRejections emits complete terminal candidate vector" {
     try pool.add(.{ .id = "codex:max-1", .selectable = false, .liveness = .live, .availability = .quota_exhausted });
     try pool.add(.{ .id = "codex:max-2", .selectable = false, .liveness = .dead, .availability = .available });
     try pool.add(.{ .id = "codex:max-3", .selectable = true, .liveness = .live, .availability = .rate_limited });
+    try pool.add(.{ .id = "codex:max-4", .selectable = false, .liveness = .degraded, .availability = .unknown });
 
     var attempted = std.ArrayListUnmanaged([]const u8){};
     defer attempted.deinit(std.testing.allocator);
@@ -1713,8 +1808,9 @@ test "appendPoolRejections emits complete terminal candidate vector" {
     try appendRejection(std.testing.allocator, &rejections, "codex:max-1", .quota_exhausted, "quota_exhausted");
     try appendPoolRejections(std.testing.allocator, &pool, &attempted, &rejections);
 
-    try std.testing.expectEqual(@as(usize, 3), rejections.items.len);
+    try std.testing.expectEqual(@as(usize, 4), rejections.items.len);
     try std.testing.expectEqual(RouteState.quota_exhausted, rejections.items[0].state);
     try std.testing.expectEqual(RouteState.auth_failed, rejections.items[1].state);
     try std.testing.expectEqual(RouteState.rate_limited, rejections.items[2].state);
+    try std.testing.expectEqual(RouteState.provider_degraded, rejections.items[3].state);
 }


### PR DESCRIPTION
## Summary

- Buffer Codex 4xx/5xx error responses before delivery so provider 5xx can be classified and retried against a selectable fallback account.
- Record upstream transport failures and provider 5xx as provider-degraded evidence instead of credential/auth-dead state.
- Add a provider-degraded Codex smoke covering 503 fallback and no-fallback pass-through, and include it in `check-local`.

## Root Cause

The wire proxy treated upstream transport failures and `provider_5xx` classifications as `credential_unavailable`, which persisted as `auth_permanently_failed`. It also streamed 5xx responses immediately, so the proxy could not try an eligible fallback before Codex saw provider-side failure.

## Validation

- `nix develop --command just test`
- `nix develop --command just smoke-codex-provider-degraded-local`
- `./scripts/smoke-codex-all-exhausted.sh`
- `./scripts/smoke-codex-401-propagation.sh`
- `./scripts/smoke-codex-status-summary.sh`
- `./scripts/smoke-codex-acceptance.sh`
- `nix develop --command just check-local`

No local Playwright run.
