### PR TITLE
Add Codex preflight and managed revalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ What works today:
   profiles, model defaults, and non-managed provider definitions.
 - Lazy account refresh at credential materialization or explicit repair time;
   managed launch reports `pre_spawn_network_refresh:false`.
+- Managed Codex launch/resume auto-revalidates expired Codex quota/rate windows
+  under the Codex stay-afloat policy before route election. Interactive login
+  remains user-mediated.
 - Live managed Codex quota handoff for installed `oauth-mux codex resume`, with
   the strongest preserved proof in
   `docs/evidence/codex-engineered-quota-handoff-20260509/`.
@@ -121,6 +124,11 @@ On macOS, remove the old Mach-O before copying the dogfood binary. Overwriting i
 place can leave stale taskgated/code-signing state on the old vnode and produce
 an immediate `SIGKILL` / status `137`.
 
+The staged `0.1.7` package and installer lanes also include a managed `codex`
+shim. The shim resolves the native upstream Codex executable, passes it through
+`OMUX_CODEX_BIN`, and then enters `oauth-mux codex`. Public package channels do
+not carry that shim until `0.1.7` is published.
+
 ## Usage
 
 Human first run:
@@ -146,11 +154,15 @@ oauth-mux doctor runtime --profile codex-max --capability codex-max --json
 oauth-mux accounts list --provider codex --json
 oauth-mux route explain --profile codex-max --capability codex-max --json
 oauth-mux repair-plan --profile codex-max --capability codex-max --json
+oauth-mux codex preflight --profile codex-max --capability codex-max --json
 oauth-mux codex status-latest --json
 ```
 
-Those commands do not spend provider calls. Live probes, revalidation, and
-provider-spend paths stay behind explicit confirmation.
+Those inspection commands do not spend provider calls. In the `0.1.7` candidate,
+managed Codex launch/resume and admitted stay-afloat execution may spend
+provider calls only to revalidate expired Codex quota/rate windows before route
+election. Live probes, broad revalidation, and non-Codex provider-spend paths
+remain explicit.
 
 ## UX / DX / AX Contract
 
@@ -175,7 +187,8 @@ AX:
 
 - JSON surfaces are redacted and account-label based.
 - Agents do not need token files or raw provider stores to choose a next action.
-- oauth-mux does not silently perform provider-spend actions.
+- Provider-spend behavior is policy-labeled; no-spend inspection surfaces stay
+  separate from managed Codex auto-revalidation and live probes.
 - Diagnostic output should include exact next-action commands.
 
 ## Proof

--- a/dist/homebrew/oauth-mux.rb
+++ b/dist/homebrew/oauth-mux.rb
@@ -25,9 +25,64 @@ class OauthMux < Formula
 
   def install
     bin.install "oauth-mux"
+    (bin/"codex").write <<~EOS
+      #!/bin/sh
+      # OMUX_CODEX_SHIM
+      set -eu
+
+      oauth_mux_bin="#{bin}/oauth-mux"
+
+      real_path() {
+          if command -v realpath >/dev/null 2>&1; then
+              realpath "$1"
+          else
+              dir=$(dirname "$1")
+              base=$(basename "$1")
+              printf '%s/%s\\n' "$(cd "$dir" 2>/dev/null && pwd -P)" "$base"
+          fi
+      }
+
+      is_omux_codex_shim() {
+          grep -q 'OMUX_CODEX_SHIM' "$1" 2>/dev/null
+      }
+
+      find_native_codex() {
+          self=$(real_path "$0")
+          old_ifs=$IFS
+          IFS=:
+          for dir in $PATH; do
+              [ -n "$dir" ] || continue
+              candidate="$dir/codex"
+              [ -x "$candidate" ] || continue
+              candidate_real=$(real_path "$candidate")
+              [ "$candidate_real" != "$self" ] || continue
+              if is_omux_codex_shim "$candidate"; then
+                  continue
+              fi
+              IFS=$old_ifs
+              printf '%s\\n' "$candidate"
+              return 0
+          done
+          IFS=$old_ifs
+          return 1
+      }
+
+      native_codex="${OMUX_CODEX_BIN:-}"
+      if [ -z "$native_codex" ]; then
+          native_codex=$(find_native_codex || true)
+      fi
+      if [ -z "$native_codex" ]; then
+          echo "codex: native Codex CLI not found; set OMUX_CODEX_BIN to the upstream Codex executable" >&2
+          exit 127
+      fi
+
+      OMUX_CODEX_BIN="$native_codex" OMUX_CODEX_SHIM=1 OMUX_COMMAND_SPELLING=codex exec "$oauth_mux_bin" codex "$@"
+    EOS
+    chmod 0755, bin/"codex"
   end
 
   test do
     assert_match "oauth-mux", shell_output("#{bin}/oauth-mux version")
+    assert_match "OMUX_CODEX_SHIM", shell_output("grep OMUX_CODEX_SHIM #{bin}/codex")
   end
 end

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -52,14 +52,74 @@ main() {
     mkdir -p "$INSTALL_DIR"
     mv "$tmpdir/oauth-mux" "$INSTALL_DIR/oauth-mux"
     chmod +x "$INSTALL_DIR/oauth-mux"
+    write_codex_shim "$INSTALL_DIR"
 
     echo "installed oauth-mux to ${INSTALL_DIR}/oauth-mux"
+    echo "installed managed codex shim to ${INSTALL_DIR}/codex"
 
     if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
         echo ""
         echo "add to your PATH:"
         echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
     fi
+}
+
+write_codex_shim() {
+    install_dir="$1"
+    cat >"${install_dir}/codex" <<EOF
+#!/bin/sh
+# OMUX_CODEX_SHIM
+set -eu
+
+oauth_mux_bin="${install_dir}/oauth-mux"
+
+real_path() {
+    if command -v realpath >/dev/null 2>&1; then
+        realpath "\$1"
+    else
+        dir=\$(dirname "\$1")
+        base=\$(basename "\$1")
+        printf '%s/%s\n' "\$(cd "\$dir" 2>/dev/null && pwd -P)" "\$base"
+    fi
+}
+
+is_omux_codex_shim() {
+    grep -q 'OMUX_CODEX_SHIM' "\$1" 2>/dev/null
+}
+
+find_native_codex() {
+    self=\$(real_path "\$0")
+    old_ifs=\$IFS
+    IFS=:
+    for dir in \$PATH; do
+        [ -n "\$dir" ] || continue
+        candidate="\$dir/codex"
+        [ -x "\$candidate" ] || continue
+        candidate_real=\$(real_path "\$candidate")
+        [ "\$candidate_real" != "\$self" ] || continue
+        if is_omux_codex_shim "\$candidate"; then
+            continue
+        fi
+        IFS=\$old_ifs
+        printf '%s\n' "\$candidate"
+        return 0
+    done
+    IFS=\$old_ifs
+    return 1
+}
+
+native_codex="\${OMUX_CODEX_BIN:-}"
+if [ -z "\$native_codex" ]; then
+    native_codex=\$(find_native_codex || true)
+fi
+if [ -z "\$native_codex" ]; then
+    echo "codex: native Codex CLI not found; set OMUX_CODEX_BIN to the upstream Codex executable" >&2
+    exit 127
+fi
+
+OMUX_CODEX_BIN="\$native_codex" OMUX_CODEX_SHIM=1 OMUX_COMMAND_SPELLING=codex exec "\$oauth_mux_bin" codex "\$@"
+EOF
+    chmod +x "${install_dir}/codex"
 }
 
 verify_checksum() {

--- a/dist/npm/bin/codex.js
+++ b/dist/npm/bin/codex.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const marker = "OMUX_CODEX_SHIM";
+const self = fs.realpathSync(__filename);
+const oauthMuxJs = path.join(__dirname, "oauth-mux.js");
+const pathEntries = (process.env.PATH || "").split(path.delimiter).filter(Boolean);
+const candidateNames = process.platform === "win32"
+  ? ["codex.exe", "codex.cmd", "codex.bat", "codex"]
+  : ["codex"];
+
+function isShim(candidate) {
+  try {
+    const real = fs.realpathSync(candidate);
+    if (real === self) return true;
+    const sample = fs.readFileSync(candidate, { encoding: "utf8", flag: "r" }).slice(0, 4096);
+    return sample.includes(marker);
+  } catch {
+    return false;
+  }
+}
+
+function findNativeCodex() {
+  for (const dir of pathEntries) {
+    for (const name of candidateNames) {
+      const candidate = path.join(dir, name);
+      if (!fs.existsSync(candidate)) continue;
+      try {
+        const stat = fs.statSync(candidate);
+        if (!stat.isFile() && !stat.isSymbolicLink()) continue;
+      } catch {
+        continue;
+      }
+      if (isShim(candidate)) continue;
+      return candidate;
+    }
+  }
+  return null;
+}
+
+const nativeCodex = process.env.OMUX_CODEX_BIN || findNativeCodex();
+if (!nativeCodex) {
+  console.error("codex: native Codex CLI not found; set OMUX_CODEX_BIN to the upstream Codex executable");
+  process.exit(127);
+}
+
+const env = {
+  ...process.env,
+  OMUX_CODEX_BIN: nativeCodex,
+  OMUX_CODEX_SHIM: "1",
+  OMUX_COMMAND_SPELLING: "codex",
+};
+const result = spawnSync(process.execPath, [oauthMuxJs, "codex", ...process.argv.slice(2)], {
+  stdio: "inherit",
+  env,
+});
+
+if (result.error) {
+  console.error(`codex: failed to launch oauth-mux: ${result.error.message}`);
+  process.exit(1);
+}
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+}
+process.exit(result.status ?? 1);

--- a/dist/npm/package.json
+++ b/dist/npm/package.json
@@ -10,7 +10,8 @@
     "install.js"
   ],
   "bin": {
-    "oauth-mux": "bin/oauth-mux.js"
+    "oauth-mux": "bin/oauth-mux.js",
+    "codex": "bin/codex.js"
   },
   "scripts": {
     "postinstall": "node install.js"

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -173,16 +173,19 @@ When a Codex experimental feature key is absent, the managed overlay defaults
 including `false`, are preserved, and the canonical `config.toml` is not
 mutated.
 
-`doctor runtime`, `route explain`, `route select`, `stay-afloat next`,
-`stay-afloat --once`, and bounded `stay-afloat --loop` are no-spend surfaces
-when run without `--execute`. They only use local runtime checks plus recorded
-liveness, so they are safe for agents to run before deciding whether a live
-probe or user-driven reauth is warranted. `stay-afloat --execute` is the beta
-foreground execution boundary: it can run one admitted non-interactive action
-or queue an interactive handoff event. Prefer scoped runtime checks such as
-`oauth-mux doctor runtime --profile codex-max --capability codex-max --json`
-when dogfooding a specific stay-afloat route; global runtime doctor is still
-useful for support bundles and full-machine cleanup.
+`doctor runtime`, `route explain`, `route select`, `codex preflight`,
+`stay-afloat next`, `stay-afloat --once`, and bounded `stay-afloat --loop` are
+no-spend surfaces when run without `--execute`. They only use local runtime
+checks plus recorded liveness, so they are safe for agents to run before
+deciding whether a live probe or user-driven reauth is warranted.
+`stay-afloat --execute` is the beta foreground execution boundary: for Codex it
+may run admitted provider-spend revalidation only for expired quota/rate windows
+under the Codex stay-afloat policy, or queue an interactive handoff event.
+Prefer scoped runtime checks such as `oauth-mux doctor runtime --profile
+codex-max --capability codex-max --json` or `oauth-mux codex preflight --profile
+codex-max --capability codex-max --json` when dogfooding a specific stay-afloat
+route; global runtime doctor is still useful for support bundles and
+full-machine cleanup.
 
 `oauth-mux stay-afloat next --json` is the simplest agent handoff: it returns
 an exact `exec_argv` when already afloat, otherwise it returns the typed repair
@@ -388,10 +391,13 @@ Wrappers should call the foreground command contract, not the socket daemon:
 ```bash
 oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json
 oauth-mux stay-afloat --loop --iterations <n> --interval-ms <ms> --profile <profile> --capability <capability> --json
+oauth-mux codex preflight --profile <profile> --capability <capability> --json
 ```
 
 A wrapper may act automatically only on admitted, non-interactive,
-non-mutating work. When JSON reports `action.kind:"fix_runtime"` with
+non-mutating work, except for explicitly admitted Codex expired-window
+revalidation under the Codex stay-afloat policy. When JSON reports
+`action.kind:"fix_runtime"` with
 `action.command:null`, the wrapper should display or broker
 `action.diagnostic_command` in the user-owned process boundary, then rerun
 `stay-afloat` or `route explain`. It must not infer credential liveness from a

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -229,6 +229,15 @@ child config: `terminal_resize_reflow`, `memories`, `external_migration`,
 explicit `false`, win, and oauth-mux does not rewrite the canonical
 `config.toml`.
 
+For a no-spend managed Codex readiness snapshot, use:
+
+```bash
+oauth-mux codex preflight --profile codex-max --capability codex-max --json
+```
+
+The preflight reports install candidates, Codex policy, route readiness, and
+exact next actions. It does not call the provider or mutate route health.
+
 Managed Codex live quota handoff is proven for installed
 `oauth-mux codex resume` status artifacts. The 2026-05-09 engineered evidence
 shows successful primary-route traffic, provider-originated
@@ -373,10 +382,10 @@ are refused in the admission report unless `policy.daemon` explicitly allows
 them. `repair-plan --json` and `route explain --json` include both the effective
 policy and per-route `daemon_probe` / `daemon_repair` decisions.
 
-`oauth-mux stay-afloat --once --json` is the portable stay-afloat dogfood surface. It
-loads the same route/runtime/liveness state, applies the daemon policy, and
-prints what a future background loop would be allowed to do. Without
-`--execute` it remains planning-only and reports `executed:false`.
+`oauth-mux stay-afloat --once --json` is the portable stay-afloat dogfood
+surface. It loads the same route/runtime/liveness state, applies the policy, and
+prints what a future background loop would be allowed to do. Without `--execute`
+it remains planning-only and reports `executed:false`.
 
 Opt-in beta execution is explicit:
 
@@ -386,6 +395,9 @@ oauth-mux stay-afloat --once --execute --profile codex-max --capability codex-ma
 
 Execute mode runs at most one admitted non-interactive action per tick. The
 default policy admits `free_command`, so command-backed probes can refresh
+local evidence. The Codex stay-afloat policy also admits provider-spend
+revalidation for expired Codex quota/rate windows; interactive auth is still
+user-mediated.
 recorded route state without requiring a service manager. Provider-spending
 probes, interactive browser/device auth, and credential mutation remain refused
 unless policy explicitly admits them. Interactive reauth is not run in the

--- a/scripts/release-local.sh
+++ b/scripts/release-local.sh
@@ -116,7 +116,9 @@ sed -E \
   dist/npm/package.json >"$root_pkg_dir/package.json"
 cp dist/npm/install.js "$root_pkg_dir/install.js"
 cp dist/npm/bin/oauth-mux.js "$root_pkg_dir/bin/oauth-mux.js"
+cp dist/npm/bin/codex.js "$root_pkg_dir/bin/codex.js"
 chmod 0755 "$root_pkg_dir/bin/oauth-mux.js"
+chmod 0755 "$root_pkg_dir/bin/codex.js"
 
 if command -v npm >/dev/null 2>&1; then
   printf 'packing npm tarballs...\n'

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -34,7 +34,9 @@ const cli = @import("../../cli.zig");
 const config_mod = @import("../../config.zig");
 const health_mod = @import("../../health.zig");
 const paths = @import("../../paths.zig");
+const pipeline = @import("../../pipeline.zig");
 const shell = @import("../../shell.zig");
+const types = @import("../../types.zig");
 const wire_proxy = @import("wire_proxy.zig");
 
 pub const RunOptions = struct {
@@ -63,6 +65,7 @@ pub const RunError = error{
     NoCodexHome,
     SessionAuthorityUnavailable,
     ConfigOverrideUnavailable,
+    CodexShimRecursion,
 };
 
 const SessionAuthorityMode = enum {
@@ -492,6 +495,283 @@ fn restrictPoolToCodex(pool: *broker.AccountPool) void {
     }
 }
 
+fn codexSelectableCount(pool: *const broker.AccountPool) usize {
+    var count: usize = 0;
+    for (pool.accounts.items) |entry| {
+        if (isCodexAccountId(entry.id) and entry.selectable and entry.availability == .available) count += 1;
+    }
+    return count;
+}
+
+const AutoRevalidationRoute = struct {
+    account: []const u8,
+    capability: []const u8,
+};
+
+const AutoRevalidationSummary = struct {
+    admitted: bool = false,
+    attempted: usize = 0,
+    provider_evidence_routes: usize = 0,
+    available_after: usize = 0,
+    blocked_after: usize = 0,
+    probe_errors: usize = 0,
+    skipped: usize = 0,
+    reason: []const u8 = "not_attempted",
+
+    fn changedRouteHealth(self: AutoRevalidationSummary) bool {
+        return self.provider_evidence_routes != 0 or self.available_after != 0 or self.blocked_after != 0;
+    }
+};
+
+fn maybeAutoRevalidateCodexRoutes(
+    allocator: std.mem.Allocator,
+    cfg: config_mod.Config,
+    store: *health_mod.HealthStore,
+    profile: ?[]const u8,
+    account_filter: ?[]const u8,
+    initial_selectable_routes: usize,
+    target_selectable_routes: usize,
+    writer: anytype,
+    emit_status: bool,
+) !AutoRevalidationSummary {
+    if (!cfg.policy.codex.auto_stay_afloat) return .{ .reason = "codex_auto_stay_afloat_disabled" };
+    if (!cfg.policy.codex.allow_provider_spend) return .{ .reason = "provider_spend_not_allowed" };
+
+    var seen = std.StringHashMap(void).init(allocator);
+    defer {
+        var key_it = seen.keyIterator();
+        while (key_it.next()) |key| allocator.free(key.*);
+        seen.deinit();
+    }
+    var candidates = std.ArrayList(AutoRevalidationRoute).init(allocator);
+    defer {
+        for (candidates.items) |route| {
+            allocator.free(route.account);
+            allocator.free(route.capability);
+        }
+        candidates.deinit();
+    }
+
+    try collectProfileCodexAutoRevalidationRoutes(allocator, cfg, profile, account_filter, &seen, &candidates);
+    try collectHealthCodexAutoRevalidationRoutes(allocator, cfg, store, account_filter, &seen, &candidates);
+
+    var summary = AutoRevalidationSummary{ .admitted = true };
+    if (candidates.items.len == 0) {
+        summary.reason = "no_expired_codex_routes";
+        if (emit_status) try writeAutoRevalidationStatus(writer, summary);
+        return summary;
+    }
+
+    for (candidates.items) |route| {
+        if (initial_selectable_routes + summary.available_after >= target_selectable_routes) break;
+        const key = health_mod.capabilityKey("codex", route.account, route.capability);
+        const health = store.accounts.get(key.slice()) orelse {
+            summary.skipped += 1;
+            continue;
+        };
+        if (!codexHealthNeedsAutoRevalidation(health)) {
+            summary.skipped += 1;
+            continue;
+        }
+
+        summary.attempted += 1;
+        const previous = takeHealthEntry(store, key.slice());
+
+        var ctx = pipeline.Context.init(allocator, cfg, store);
+        defer ctx.deinit();
+        ctx.provider_name = "codex";
+        ctx.account_name = route.account;
+        ctx.capability_name = route.capability;
+
+        const probe_result = pipeline.runProbe(&ctx);
+        var recorded_provider_evidence = true;
+        if (probe_result) |_| {} else |e| {
+            if (autoRevalidationErrorRecordedEvidence(e)) {
+                summary.provider_evidence_routes += 1;
+            } else {
+                recorded_provider_evidence = false;
+                summary.probe_errors += 1;
+                if (store.accounts.get(key.slice()) == null) {
+                    if (previous) |prev| {
+                        try putHealthEntryCopy(store, key.slice(), prev);
+                    }
+                }
+            }
+        }
+
+        if (probe_result) |_| {
+            summary.provider_evidence_routes += 1;
+        } else |_| {}
+        if (recorded_provider_evidence) {
+            if (store.accounts.get(key.slice())) |after| {
+                if (codexHealthAvailable(after)) {
+                    summary.available_after += 1;
+                } else if (codexHealthBlocksRoute(after)) {
+                    summary.blocked_after += 1;
+                }
+            }
+        }
+    }
+
+    store.persist();
+    summary.reason = if (summary.attempted == 0)
+        "no_expired_codex_routes"
+    else if (summary.probe_errors != 0)
+        "auto_revalidation_probe_errors"
+    else if (summary.available_after != 0)
+        "auto_revalidation_found_available_route"
+    else
+        "provider_evidence_still_blocked";
+
+    if (emit_status) try writeAutoRevalidationStatus(writer, summary);
+    return summary;
+}
+
+fn collectProfileCodexAutoRevalidationRoutes(
+    allocator: std.mem.Allocator,
+    cfg: config_mod.Config,
+    profile: ?[]const u8,
+    account_filter: ?[]const u8,
+    seen: *std.StringHashMap(void),
+    out: *std.ArrayList(AutoRevalidationRoute),
+) !void {
+    if (profile) |name| {
+        if (cfg.profiles.map.get(name)) |profile_cfg| {
+            try collectProfileEntriesForCodexAutoRevalidation(allocator, cfg, profile_cfg.providers, account_filter, seen, out);
+        }
+        return;
+    }
+
+    var profiles = cfg.profiles.map.iterator();
+    while (profiles.next()) |entry| {
+        try collectProfileEntriesForCodexAutoRevalidation(allocator, cfg, entry.value_ptr.providers, account_filter, seen, out);
+    }
+}
+
+fn collectProfileEntriesForCodexAutoRevalidation(
+    allocator: std.mem.Allocator,
+    cfg: config_mod.Config,
+    entries: []const []const u8,
+    account_filter: ?[]const u8,
+    seen: *std.StringHashMap(void),
+    out: *std.ArrayList(AutoRevalidationRoute),
+) !void {
+    const provider = cfg.providers.map.get("codex") orelse return;
+    for (entries) |entry| {
+        const parsed = health_mod.parseHealthKey(entry) orelse continue;
+        if (!std.mem.eql(u8, parsed.provider, "codex")) continue;
+        const capability = parsed.capability orelse continue;
+        if (account_filter) |filter| {
+            if (!codexAccountFilterMatches(filter, parsed.account)) continue;
+        }
+        if (provider.accounts.map.get(parsed.account) == null) continue;
+        try appendAutoRevalidationRoute(allocator, seen, out, parsed.account, capability);
+    }
+}
+
+fn collectHealthCodexAutoRevalidationRoutes(
+    allocator: std.mem.Allocator,
+    cfg: config_mod.Config,
+    store: *health_mod.HealthStore,
+    account_filter: ?[]const u8,
+    seen: *std.StringHashMap(void),
+    out: *std.ArrayList(AutoRevalidationRoute),
+) !void {
+    const provider = cfg.providers.map.get("codex") orelse return;
+    var it = store.accounts.iterator();
+    while (it.next()) |entry| {
+        const parsed = health_mod.parseHealthKey(entry.key_ptr.*) orelse continue;
+        if (!std.mem.eql(u8, parsed.provider, "codex")) continue;
+        const capability = parsed.capability orelse continue;
+        if (account_filter) |filter| {
+            if (!codexAccountFilterMatches(filter, parsed.account)) continue;
+        }
+        if (provider.accounts.map.get(parsed.account) == null) continue;
+        if (!codexHealthNeedsAutoRevalidation(entry.value_ptr.*)) continue;
+        try appendAutoRevalidationRoute(allocator, seen, out, parsed.account, capability);
+    }
+}
+
+fn appendAutoRevalidationRoute(
+    allocator: std.mem.Allocator,
+    seen: *std.StringHashMap(void),
+    out: *std.ArrayList(AutoRevalidationRoute),
+    account: []const u8,
+    capability: []const u8,
+) !void {
+    const key = try std.fmt.allocPrint(allocator, "codex:{s}#{s}", .{ account, capability });
+    defer allocator.free(key);
+    if (seen.contains(key)) return;
+    const account_copy = try allocator.dupe(u8, account);
+    errdefer allocator.free(account_copy);
+    const capability_copy = try allocator.dupe(u8, capability);
+    errdefer allocator.free(capability_copy);
+    try seen.put(try allocator.dupe(u8, key), {});
+    try out.append(.{ .account = account_copy, .capability = capability_copy });
+}
+
+fn codexAccountFilterMatches(filter: []const u8, account: []const u8) bool {
+    if (std.mem.eql(u8, filter, account)) return true;
+    if (std.mem.startsWith(u8, filter, "codex:")) return std.mem.eql(u8, filter["codex:".len..], account);
+    return false;
+}
+
+fn codexHealthNeedsAutoRevalidation(health: health_mod.AccountHealth) bool {
+    const now = std.time.timestamp();
+    return switch (health.liveness) {
+        .live => |live| switch (live.availability) {
+            .quota_exhausted => |quota| if (quota.window_resets_at) |reset| reset <= now else false,
+            .rate_limited => health.rate_limited_until != null and health.rate_limited_until.? <= now,
+            .available, .cooldown => false,
+        },
+        .dead, .degraded => false,
+    };
+}
+
+fn codexHealthAvailable(health: health_mod.AccountHealth) bool {
+    return switch (health.liveness) {
+        .live => |live| live.availability == .available,
+        .dead, .degraded => false,
+    };
+}
+
+fn codexHealthBlocksRoute(health: health_mod.AccountHealth) bool {
+    return switch (health.liveness) {
+        .dead, .degraded => true,
+        .live => |live| live.availability != .available,
+    };
+}
+
+fn autoRevalidationErrorRecordedEvidence(e: types.PipelineError) bool {
+    return switch (e) {
+        error.AllAccountsExhausted => true,
+        else => false,
+    };
+}
+
+fn takeHealthEntry(store: *health_mod.HealthStore, key: []const u8) ?health_mod.AccountHealth {
+    if (store.accounts.fetchRemove(key)) |kv| {
+        defer store.allocator.free(kv.key);
+        return kv.value;
+    }
+    return null;
+}
+
+fn putHealthEntryCopy(store: *health_mod.HealthStore, key: []const u8, health: health_mod.AccountHealth) !void {
+    const result = try store.accounts.getOrPut(key);
+    if (!result.found_existing) {
+        result.key_ptr.* = try store.allocator.dupe(u8, key);
+    }
+    result.value_ptr.* = health;
+}
+
+fn writeAutoRevalidationStatus(writer: anytype, summary: AutoRevalidationSummary) !void {
+    try writer.print(
+        "{{\"kind\":\"codex_auto_revalidation\",\"admitted\":{any},\"attempted\":{d},\"provider_evidence_routes\":{d},\"available_after\":{d},\"blocked_after\":{d},\"probe_errors\":{d},\"skipped\":{d},\"reason\":\"{s}\",\"spends_provider_calls\":{any},\"mutates_route_health\":{any}}}\n",
+        .{ summary.admitted, summary.attempted, summary.provider_evidence_routes, summary.available_after, summary.blocked_after, summary.probe_errors, summary.skipped, summary.reason, summary.attempted != 0, summary.changedRouteHealth() },
+    );
+}
+
 fn hasPathSeparator(value: []const u8) bool {
     return std.mem.indexOfScalar(u8, value, '/') != null or std.mem.indexOfScalar(u8, value, '\\') != null;
 }
@@ -505,6 +785,22 @@ fn fileExists(path: []const u8) bool {
     return true;
 }
 
+fn readFilePrefix(path: []const u8, buf: []u8) !usize {
+    var file = if (std.fs.path.isAbsolute(path))
+        try std.fs.openFileAbsolute(path, .{})
+    else
+        try std.fs.cwd().openFile(path, .{});
+    defer file.close();
+    return try file.read(buf);
+}
+
+fn isOauthMuxCodexShim(path: []const u8) bool {
+    var buf: [4096]u8 = undefined;
+    const len = readFilePrefix(path, &buf) catch return false;
+    const data = buf[0..len];
+    return std.mem.indexOf(u8, data, "OMUX_CODEX_SHIM") != null;
+}
+
 fn resolveExecutableFromSearchPath(
     allocator: std.mem.Allocator,
     name: []const u8,
@@ -515,7 +811,13 @@ fn resolveExecutableFromSearchPath(
         if (dir.len == 0) continue;
         const candidate = try std.fs.path.join(allocator, &.{ dir, name });
         errdefer allocator.free(candidate);
-        if (fileExists(candidate)) return candidate;
+        if (fileExists(candidate)) {
+            if (isOauthMuxCodexShim(candidate)) {
+                allocator.free(candidate);
+                continue;
+            }
+            return candidate;
+        }
         allocator.free(candidate);
     }
     return null;
@@ -546,6 +848,10 @@ fn resolveCodexBinary(
             allocator.free(expanded);
             return error.FileNotFound;
         }
+        if (isOauthMuxCodexShim(expanded)) {
+            allocator.free(expanded);
+            return RunError.CodexShimRecursion;
+        }
         return expanded;
     }
 
@@ -563,7 +869,13 @@ fn resolveCodexBinary(
     for (fallback_dirs.items) |dir| {
         const candidate = try std.fs.path.join(allocator, &.{ dir, requested });
         errdefer allocator.free(candidate);
-        if (fileExists(candidate)) return candidate;
+        if (fileExists(candidate)) {
+            if (isOauthMuxCodexShim(candidate)) {
+                allocator.free(candidate);
+                continue;
+            }
+            return candidate;
+        }
         allocator.free(candidate);
     }
 
@@ -632,6 +944,31 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     };
     restrictPoolToCodex(&server.pool);
     try launch_timer.mark(status_writer, emit_status, "config_health_load");
+
+    const initial_selectable_routes = codexSelectableCount(&server.pool);
+    const target_selectable_routes: usize = if (opts.account != null) 1 else 2;
+    if (initial_selectable_routes < target_selectable_routes) {
+        const revalidation = try maybeAutoRevalidateCodexRoutes(
+            allocator,
+            parsed.value,
+            &route_health,
+            opts.profile,
+            opts.account,
+            initial_selectable_routes,
+            target_selectable_routes,
+            status_writer,
+            emit_status,
+        );
+        if (revalidation.changedRouteHealth()) {
+            server.pool.deinit();
+            server.pool = broker.AccountPool.init(allocator);
+            broker_loader.populatePoolFromRouteHealth(&server.pool, parsed.value, opts.profile, &route_health) catch {
+                return RunError.PoolPopulateFailed;
+            };
+            restrictPoolToCodex(&server.pool);
+        }
+        try launch_timer.mark(status_writer, emit_status, "codex_auto_revalidation");
+    }
 
     // 2. Elect an account (honoring --account pin if set).
     const elected = if (opts.account) |pin| pin: {
@@ -780,7 +1117,11 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         try allocator.dupe(u8, "codex");
     defer allocator.free(requested_codex_bin);
     const codex_bin = resolveCodexBinary(allocator, requested_codex_bin) catch |e| {
-        try stderr.print("oauth-mux codex: cannot find Codex CLI {s}; set OMUX_CODEX_BIN to an executable path\n", .{requested_codex_bin});
+        if (e == RunError.CodexShimRecursion) {
+            try stderr.print("oauth-mux codex: resolved Codex CLI {s} is an oauth-mux codex shim; set OMUX_CODEX_BIN to the native Codex executable\n", .{requested_codex_bin});
+        } else {
+            try stderr.print("oauth-mux codex: cannot find Codex CLI {s}; set OMUX_CODEX_BIN to an executable path\n", .{requested_codex_bin});
+        }
         return e;
     };
     defer allocator.free(codex_bin);
@@ -2109,6 +2450,46 @@ test "resolveCodexBinary accepts explicit existing path" {
     const resolved = try resolveCodexBinary(std.testing.allocator, path);
     defer std.testing.allocator.free(resolved);
     try std.testing.expectEqualStrings(path, resolved);
+}
+
+test "resolveCodexBinary rejects explicit oauth-mux codex shim" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const file = try tmp.dir.createFile("codex", .{ .mode = 0o755 });
+    try file.writeAll("#!/bin/sh\n# OMUX_CODEX_SHIM\nexec oauth-mux codex \"$@\"\n");
+    file.close();
+
+    const path = try tmp.dir.realpathAlloc(std.testing.allocator, "codex");
+    defer std.testing.allocator.free(path);
+    try std.testing.expectError(RunError.CodexShimRecursion, resolveCodexBinary(std.testing.allocator, path));
+}
+
+test "resolveExecutableFromSearchPath skips oauth-mux codex shim" {
+    var shim_tmp = std.testing.tmpDir(.{});
+    defer shim_tmp.cleanup();
+    var native_tmp = std.testing.tmpDir(.{});
+    defer native_tmp.cleanup();
+
+    const shim = try shim_tmp.dir.createFile("codex", .{ .mode = 0o755 });
+    try shim.writeAll("#!/bin/sh\n# OMUX_CODEX_SHIM\nexec oauth-mux codex \"$@\"\n");
+    shim.close();
+    const native = try native_tmp.dir.createFile("codex", .{ .mode = 0o755 });
+    try native.writeAll("#!/bin/sh\nexit 0\n");
+    native.close();
+
+    const shim_root = try shim_tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(shim_root);
+    const native_root = try native_tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(native_root);
+    const search_path = try std.fmt.allocPrint(std.testing.allocator, "{s}{c}{s}", .{ shim_root, std.fs.path.delimiter, native_root });
+    defer std.testing.allocator.free(search_path);
+
+    const resolved = (try resolveExecutableFromSearchPath(std.testing.allocator, "codex", search_path)).?;
+    defer std.testing.allocator.free(resolved);
+    const expected = try std.fs.path.join(std.testing.allocator, &.{ native_root, "codex" });
+    defer std.testing.allocator.free(expected);
+    try std.testing.expectEqualStrings(expected, resolved);
 }
 
 test "restrictPoolToCodex blocks non-codex routes" {

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -288,13 +288,13 @@ pub const Proxy = struct {
                         .attempted = attempted.items,
                         .rejections = rejections.items,
                     });
-                    try writeNoAccountSelectableResponse(a, writer, rejections.items);
+                    try writeNoAccountSelectableResponse(a, writer, self.profile, rejections.items);
                 } else {
                     self.logEvent("proxy_no_account_selectable", .{
                         .attempted = attempted.items,
                         .rejections = rejections.items,
                     });
-                    try writeNoAccountSelectableResponse(a, writer, rejections.items);
+                    try writeNoAccountSelectableResponse(a, writer, self.profile, rejections.items);
                 }
                 return;
             };
@@ -1214,18 +1214,27 @@ fn writeStatus(writer: anytype, code: u16, reason: []const u8) !void {
 fn writeNoAccountSelectableResponse(
     allocator: std.mem.Allocator,
     writer: anytype,
+    profile: ?[]const u8,
     rejections: []const CandidateRejection,
 ) !void {
     var body = std.ArrayListUnmanaged(u8){};
     defer body.deinit(allocator);
     const w = body.writer(allocator);
+    const preflight_command = if (profile) |value|
+        try std.fmt.allocPrint(allocator, "oauth-mux codex preflight --profile {s} --json", .{value})
+    else
+        try allocator.dupe(u8, "oauth-mux codex preflight --json");
+    defer allocator.free(preflight_command);
 
     try w.writeAll("{\"error\":{\"type\":\"oauth_mux_no_account_selectable\",\"code\":\"oauth_mux_no_account_selectable\",\"message\":");
     try std.json.stringify(
-        "oauth-mux: no selectable Codex fallback account; route repair is required. Inspect the redacted status artifact or run oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json.",
+        "oauth-mux: no selectable Codex fallback account; route repair is required. Inspect the redacted status artifact or run codex preflight.",
         .{},
         w,
     );
+    try w.writeAll(",\"preflight_command\":");
+    try std.json.stringify(preflight_command, .{}, w);
+    try w.writeAll(",\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mutates_route_health\":false");
     try w.writeAll(",\"rejections\":[");
     for (rejections, 0..) |rejection, idx| {
         if (idx != 0) try w.writeByte(',');
@@ -1532,7 +1541,7 @@ test "writeStatus writes a complete HTTP/1.1 status response" {
     try std.testing.expect(std.mem.endsWith(u8, out, "\r\n\r\n"));
 }
 
-test "writeNoAccountSelectableResponse emits parseable route-repair JSON" {
+test "writeNoAccountSelectableResponse emits parseable preflight JSON" {
     var buf: [1024]u8 = undefined;
     var fbs = std.io.fixedBufferStream(&buf);
     const rejections = [_]CandidateRejection{
@@ -1540,11 +1549,13 @@ test "writeNoAccountSelectableResponse emits parseable route-repair JSON" {
         .{ .account = "codex:max-2", .state = .auth_failed, .reason = "auth_unauthorized" },
     };
 
-    try writeNoAccountSelectableResponse(std.testing.allocator, fbs.writer(), &rejections);
+    try writeNoAccountSelectableResponse(std.testing.allocator, fbs.writer(), "codex-max", &rejections);
     const out = fbs.getWritten();
     try std.testing.expect(std.mem.startsWith(u8, out, "HTTP/1.1 503 Service Unavailable\r\n"));
     try std.testing.expect(std.mem.indexOf(u8, out, "Content-Type: application/json\r\n") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "\"type\":\"oauth_mux_no_account_selectable\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"preflight_command\":\"oauth-mux codex preflight --profile codex-max --json\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"spends_provider_calls\":false") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "\"account\":\"codex:default\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "\"state\":\"quota_exhausted\"") != null);
     try std.testing.expect(std.mem.endsWith(u8, out, "]}}\n"));

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -218,6 +218,7 @@ pub const Command = union(enum) {
         probe_all,
         config_candidate,
         config_merge,
+        preflight,
         managed_plan,
         managed,
         status_latest,
@@ -425,6 +426,7 @@ fn isCodexLegacySubcommand(arg: []const u8) bool {
         eql(arg, "probe-all") or
         eql(arg, "config-candidate") or
         eql(arg, "config-merge") or
+        eql(arg, "preflight") or
         eql(arg, "managed-plan") or
         eql(arg, "managed") or
         eql(arg, "status-latest") or
@@ -1086,6 +1088,8 @@ fn parseCodex(args: []const []const u8) Command {
             result.action = .config_candidate;
         } else if (eql(args[0], "config-merge")) {
             result.action = .config_merge;
+        } else if (eql(args[0], "preflight")) {
+            result.action = .preflight;
         } else if (eql(args[0], "managed-plan")) {
             result.action = .managed_plan;
         } else if (eql(args[0], "managed")) {
@@ -1334,6 +1338,9 @@ pub fn printUsage(writer: anytype) !void {
         \\  codex probe-all [--accounts a,b,c] [--capabilities c1,c2] [--json]
         \\      Probe every selected Codex account/capability route.
         \\
+        \\  codex preflight [--profile name] [--capability c] [--account a] [--json]
+        \\      No-spend managed Codex readiness snapshot: install, policy, routes, and next actions.
+        \\
         \\  codex managed-plan [--profile name] [--capability c] [--json]
         \\      Plan a managed native Codex launch with route-local resume semantics.
         \\
@@ -1412,6 +1419,7 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\  oauth-mux codex live-qa [--accounts a,b,c] [--capabilities c1,c2] [--confirm-spend] [--json]
         \\  oauth-mux codex revalidate-exhausted [--profile name] [--capability c] [--account a] --confirm-spend [--json]
         \\  oauth-mux codex probe-all [--accounts a,b,c] [--capability c] [--json]
+        \\  oauth-mux codex preflight [--profile name] [--capability c] [--account a] [--json]
         \\  oauth-mux codex managed-plan [--profile name] [--capability c] [--json]
         \\  oauth-mux codex managed [--profile name] [--capability c] [--resume id|--resume-last] [--include-non-interactive] [-- codex-args...]
         \\  oauth-mux codex status-latest [--status-file path] [--json]
@@ -1692,6 +1700,21 @@ test "parse codex managed plan" {
             try std.testing.expect(codex.json);
         },
         else => return error.Unexpected,
+    }
+}
+
+test "parse codex preflight" {
+    const args = [_][]const u8{ "codex", "preflight", "--profile", "codex-max", "--capability", "codex-max", "--account", "max-2", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .codex => |codex| {
+            try std.testing.expect(codex.action == .preflight);
+            try std.testing.expectEqualStrings("codex-max", codex.profile.?);
+            try std.testing.expectEqualStrings("codex-max", codex.capabilities);
+            try std.testing.expectEqualStrings("max-2", codex.account.?);
+            try std.testing.expect(codex.json);
+        },
+        else => return error.TestUnexpectedCommand,
     }
 }
 
@@ -2502,7 +2525,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from init' -l codex-max -d 'Generate Codex Max scaffold'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from setup' -a 'codex' -d 'Setup target'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'resume run setup onboard canary live-qa revalidate-exhausted probe-all managed-plan managed status-latest broker-plan broker-session-plan broker-session-smoke broker-run broker-fallback-drill broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'resume run setup onboard canary live-qa revalidate-exhausted probe-all preflight managed-plan managed status-latest broker-plan broker-session-plan broker-session-smoke broker-run broker-fallback-drill broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex run' -l profile -s p -d 'Profile name' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex run' -l account -d 'Route account id' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex run' -l session-home -d 'Canonical Codex session authority home' -r

--- a/src/config.zig
+++ b/src/config.zig
@@ -22,12 +22,19 @@ pub const Defaults = struct {
 
 pub const PolicyConfig = struct {
     daemon: DaemonPolicyConfig = .{},
+    codex: CodexPolicyConfig = .{},
 };
 
 pub const DaemonPolicyConfig = struct {
     allowed_budgets: []const types.ActionBudget = &.{ .free_local, .free_command },
     allow_interactive: bool = false,
     allow_mutating: bool = false,
+};
+
+pub const CodexPolicyConfig = struct {
+    auto_stay_afloat: bool = true,
+    allow_provider_spend: bool = true,
+    allow_interactive_auth: bool = false,
 };
 
 pub const ProviderConfig = struct {
@@ -232,6 +239,24 @@ pub fn daemonPolicyAllowsBudget(policy: DaemonPolicyConfig, budget: types.Action
         if (allowed == budget) return true;
     }
     return false;
+}
+
+pub fn effectiveDaemonPolicyForProvider(policy: PolicyConfig, provider_name: []const u8) DaemonPolicyConfig {
+    var effective = policy.daemon;
+    if (std.mem.eql(u8, provider_name, "codex") and policy.codex.auto_stay_afloat) {
+        if (policy.codex.allow_provider_spend) {
+            effective.allowed_budgets = &.{
+                .free_local,
+                .free_command,
+                .cheap_provider,
+                .spend_provider,
+            };
+        }
+        if (policy.codex.allow_interactive_auth) {
+            effective.allow_interactive = true;
+        }
+    }
+    return effective;
 }
 
 fn validateProviderConfig(cfg: Config, provider_name: []const u8, prov: ProviderConfig, writer: anytype, ok: *bool) !void {
@@ -787,6 +812,19 @@ test "default daemon policy admits only local and command budgets" {
     try std.testing.expect(!daemonPolicyAllowsBudget(policy.daemon, .spend_provider));
     try std.testing.expect(!policy.daemon.allow_interactive);
     try std.testing.expect(!policy.daemon.allow_mutating);
+}
+
+test "default Codex policy admits provider spend only for Codex stay-afloat" {
+    const policy = PolicyConfig{};
+    const codex = effectiveDaemonPolicyForProvider(policy, "codex");
+    try std.testing.expect(daemonPolicyAllowsBudget(codex, .spend_provider));
+    try std.testing.expect(daemonPolicyAllowsBudget(codex, .cheap_provider));
+    try std.testing.expect(!codex.allow_interactive);
+    try std.testing.expect(!codex.allow_mutating);
+
+    const claude = effectiveDaemonPolicyForProvider(policy, "claude");
+    try std.testing.expect(!daemonPolicyAllowsBudget(claude, .spend_provider));
+    try std.testing.expect(!daemonPolicyAllowsBudget(claude, .cheap_provider));
 }
 
 test "validate rejects unknown provider kind without definition" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -3165,6 +3165,7 @@ fn collectRepairPlanRoutes(
         const profile = cfg.profiles.map.get(profile_name) orelse return error.ConfigValidationError;
         for (profile.providers) |provider_ref| {
             const parsed = parseRepairRouteSpec(provider_ref) orelse return error.ConfigValidationError;
+            if (!repairRouteMatchesAccountFilter(parsed, args.account)) continue;
             try routes.append(.{
                 .provider = parsed.provider,
                 .account = parsed.account,
@@ -3212,6 +3213,16 @@ fn collectRepairPlanRoutes(
         }
     }
     return routes;
+}
+
+fn repairRouteMatchesAccountFilter(route: RepairPlanRoute, account_filter: ?[]const u8) bool {
+    const filter = account_filter orelse return true;
+    if (std.mem.eql(u8, filter, route.account)) return true;
+    if (std.mem.indexOfScalar(u8, filter, ':')) |colon| {
+        if (!std.mem.eql(u8, filter[0..colon], route.provider)) return false;
+        return std.mem.eql(u8, filter[colon + 1 ..], route.account);
+    }
+    return false;
 }
 
 fn parseRepairRouteSpec(spec: []const u8) ?RepairPlanRoute {
@@ -3344,7 +3355,7 @@ fn writeRepairPlanRouteJson(
         try writer.writeAll("null");
     }
     try writer.writeAll(",\"admission\":");
-    try writeRouteAdmissionJson(writer, cfg.policy, action, budget);
+    try writeRouteAdmissionJson(writer, cfg.policy, action, budget, route);
     try writer.writeAll(",\"runtime\":");
     try writeRuntimeReadinessJson(writer, runtime);
     try writer.writeAll(",\"liveness\":");
@@ -3424,7 +3435,22 @@ fn writePolicyJson(writer: anytype, policy: config.PolicyConfig) !void {
     try writer.writeAll(if (policy.daemon.allow_interactive) "true" else "false");
     try writer.writeAll(",\"allow_mutating\":");
     try writer.writeAll(if (policy.daemon.allow_mutating) "true" else "false");
-    try writer.writeAll("}}");
+    try writer.writeAll("},\"codex\":{");
+    try writer.writeAll("\"auto_stay_afloat\":");
+    try writer.writeAll(if (policy.codex.auto_stay_afloat) "true" else "false");
+    try writer.writeAll(",\"allow_provider_spend\":");
+    try writer.writeAll(if (policy.codex.allow_provider_spend) "true" else "false");
+    try writer.writeAll(",\"allow_interactive_auth\":");
+    try writer.writeAll(if (policy.codex.allow_interactive_auth) "true" else "false");
+    const codex_effective = config.effectiveDaemonPolicyForProvider(policy, "codex");
+    try writer.writeAll(",\"effective_daemon\":{");
+    try writer.writeAll("\"allowed_budgets\":");
+    try writeBudgetArrayJson(writer, codex_effective.allowed_budgets);
+    try writer.writeAll(",\"allow_interactive\":");
+    try writer.writeAll(if (codex_effective.allow_interactive) "true" else "false");
+    try writer.writeAll(",\"allow_mutating\":");
+    try writer.writeAll(if (codex_effective.allow_mutating) "true" else "false");
+    try writer.writeAll("}}}");
 }
 
 fn writeBudgetArrayJson(writer: anytype, budgets: []const types.ActionBudget) !void {
@@ -3441,12 +3467,16 @@ fn writeRouteAdmissionJson(
     policy: config.PolicyConfig,
     action: RepairAction,
     probe_budget: ?types.ActionBudget,
+    route: RepairPlanRoute,
 ) !void {
-    const probe = daemonProbeAdmission(policy.daemon, probe_budget);
-    const repair = daemonRepairAdmission(policy.daemon, action);
+    const effective_policy = config.effectiveDaemonPolicyForProvider(policy, route.provider);
+    const probe = daemonProbeAdmission(effective_policy, probe_budget);
+    const repair = daemonRepairAdmission(effective_policy, action);
 
     try writer.writeByte('{');
-    try writer.writeAll("\"daemon_probe\":");
+    try writer.writeAll("\"effective_policy\":");
+    try std.json.stringify(if (std.mem.eql(u8, route.provider, "codex") and policy.codex.auto_stay_afloat) "codex_auto_stay_afloat" else "daemon_default", .{}, writer);
+    try writer.writeAll(",\"daemon_probe\":");
     try writeAdmissionDecisionJson(writer, probe);
     try writer.writeAll(",\"daemon_repair\":");
     try writeAdmissionDecisionJson(writer, repair);
@@ -4568,7 +4598,7 @@ fn runDaemonTick(
             if (iterations > 1 and idx + 1 < iterations) try writer.writeByte('\n');
         }
 
-        const stats = daemonTickStats(parsed.value.policy.daemon, evaluations.items, observed_at);
+        const stats = daemonTickStats(parsed.value.policy, evaluations.items, observed_at);
         sleepBetweenDaemonTicks(args, idx, iterations, stats, observed_at);
     }
 
@@ -4613,7 +4643,7 @@ fn writeDaemonTickSnapshot(
     var snapshot = std.ArrayList(u8).init(allocator);
     defer snapshot.deinit();
     const writer = snapshot.writer();
-    const stats = daemonTickStats(cfg.policy.daemon, evaluations, observed_at);
+    const stats = daemonTickStats(cfg.policy, evaluations, observed_at);
 
     try writer.writeAll("{\"version\":");
     try std.json.stringify(cli.version, .{}, writer);
@@ -4952,7 +4982,7 @@ fn executeDaemonTickActions(
     }
 
     for (evaluations) |evaluation| {
-        const decision = daemonTickDecision(cfg.policy.daemon, evaluation, std.time.timestamp());
+        const decision = daemonTickDecision(cfg.policy, evaluation, std.time.timestamp());
         if (std.mem.eql(u8, decision.phase, "repair") and evaluation.action.interactive) {
             try queueDaemonHandoff(allocator, args, evaluation, decision, executions);
             return false;
@@ -5505,7 +5535,7 @@ fn writeRouteEvaluationJson(
     try writer.writeAll(",\"probe_budget\":");
     if (evaluation.budget) |budget| try std.json.stringify(@tagName(budget), .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"admission\":");
-    try writeRouteAdmissionJson(writer, cfg.policy, evaluation.action, evaluation.budget);
+    try writeRouteAdmissionJson(writer, cfg.policy, evaluation.action, evaluation.budget, evaluation.route);
     try writer.writeAll(",\"runtime\":");
     try writeRuntimeReadinessJson(writer, evaluation.runtime);
     try writer.writeAll(",\"liveness\":");
@@ -5590,7 +5620,7 @@ fn writeDaemonTickText(
 
     try writer.writeAll("\n  routes:\n");
     for (evaluations) |evaluation| {
-        const decision = daemonTickDecision(cfg.policy.daemon, evaluation, observed_at);
+        const decision = daemonTickDecision(cfg.policy, evaluation, observed_at);
         try writer.print("    {s}:{s}", .{ evaluation.route.provider, evaluation.route.account });
         if (evaluation.route.capability) |capability| try writer.print("#{s}", .{capability});
         try writer.print(" selectable={s} runtime={s} tick={s} admitted={s} reason={s}", .{
@@ -5647,7 +5677,7 @@ fn writeDaemonTickJsonObject(
     observed_at: i64,
     include_version: bool,
 ) !void {
-    const stats = daemonTickStats(cfg.policy.daemon, evaluations, observed_at);
+    const stats = daemonTickStats(cfg.policy, evaluations, observed_at);
 
     try writer.writeByte('{');
     if (include_version) {
@@ -5703,7 +5733,7 @@ fn writeDaemonTickJsonObject(
         try writer.writeAll("\"route\":");
         try writeRouteEvaluationJson(writer, allocator, cfg, evaluation, selected);
         try writer.writeAll(",\"tick\":");
-        try writeDaemonTickDecisionJson(writer, daemonTickDecision(cfg.policy.daemon, evaluation, observed_at));
+        try writeDaemonTickDecisionJson(writer, daemonTickDecision(cfg.policy, evaluation, observed_at));
         try writer.writeByte('}');
     }
     try writer.writeAll("]}");
@@ -5825,7 +5855,7 @@ fn writeDaemonTickDecisionJson(writer: anytype, decision: DaemonTickDecision) !v
     try writer.writeByte('}');
 }
 
-fn daemonTickStats(policy: config.DaemonPolicyConfig, evaluations: []const RouteEvaluation, observed_at: i64) DaemonTickStats {
+fn daemonTickStats(policy: config.PolicyConfig, evaluations: []const RouteEvaluation, observed_at: i64) DaemonTickStats {
     var stats = DaemonTickStats{ .routes = evaluations.len };
     for (evaluations) |evaluation| {
         if (evaluation.selectable) stats.selectable += 1;
@@ -5847,7 +5877,7 @@ fn daemonTickStats(policy: config.DaemonPolicyConfig, evaluations: []const Route
     return stats;
 }
 
-fn daemonTickDecision(policy: config.DaemonPolicyConfig, evaluation: RouteEvaluation, observed_at: i64) DaemonTickDecision {
+fn daemonTickDecision(policy: config.PolicyConfig, evaluation: RouteEvaluation, observed_at: i64) DaemonTickDecision {
     if (evaluation.selectable) {
         return .{
             .phase = "none",
@@ -5861,7 +5891,7 @@ fn daemonTickDecision(policy: config.DaemonPolicyConfig, evaluation: RouteEvalua
     const schedule = daemonTickSchedule(evaluation.action, observed_at);
 
     if (evaluation.action.command == .probe) {
-        const admission = daemonProbeAdmission(policy, evaluation.budget);
+        const admission = daemonProbeAdmission(config.effectiveDaemonPolicyForProvider(policy, evaluation.route.provider), evaluation.budget);
         return .{
             .phase = "probe",
             .action = "probe",
@@ -5874,7 +5904,7 @@ fn daemonTickDecision(policy: config.DaemonPolicyConfig, evaluation: RouteEvalua
     }
 
     if (evaluation.action.command != .none or evaluation.action.mutating or evaluation.action.interactive) {
-        const admission = daemonRepairAdmission(policy, evaluation.action);
+        const admission = daemonRepairAdmission(config.effectiveDaemonPolicyForProvider(policy, evaluation.route.provider), evaluation.action);
         return .{
             .phase = "repair",
             .action = @tagName(evaluation.action.kind),
@@ -5887,7 +5917,7 @@ fn daemonTickDecision(policy: config.DaemonPolicyConfig, evaluation: RouteEvalua
         };
     }
 
-    const admission = daemonRepairAdmission(policy, evaluation.action);
+    const admission = daemonRepairAdmission(config.effectiveDaemonPolicyForProvider(policy, evaluation.route.provider), evaluation.action);
     return .{
         .phase = "observe",
         .action = @tagName(evaluation.action.kind),
@@ -8403,6 +8433,7 @@ fn runCodex(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Cod
         .probe_all => try runCodexProbeAll(allocator, writer, args),
         .config_candidate => try runCodexConfigCandidate(allocator, writer, args, root),
         .config_merge => try runCodexConfigMerge(allocator, writer, args),
+        .preflight => try runCodexPreflight(allocator, writer, args),
         .managed_plan => try runCodexManagedPlan(allocator, writer, args),
         .managed => try runCodexManaged(allocator, writer, args),
         .status_latest => try runCodexStatusLatest(allocator, writer, args),
@@ -9202,6 +9233,226 @@ fn runCodexBrokerSessionPlan(allocator: std.mem.Allocator, writer: anytype, args
     } else {
         try writeCodexBrokerSessionPlanText(writer, allocator, parsed.value, evaluations.items, selected_index, args.profile, capability);
     }
+}
+
+fn runCodexPreflight(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs) !void {
+    const parsed = try config.load(allocator);
+    defer parsed.deinit();
+
+    var validation_messages = std.ArrayList(u8).init(allocator);
+    defer validation_messages.deinit();
+    const config_valid = if (config.validate(parsed.value, validation_messages.writer())) |_| true else |_| false;
+
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+
+    const capability = firstCommaValue(args.capabilities);
+    var routes = try collectRepairPlanRoutes(allocator, parsed.value, .{
+        .profile = args.profile,
+        .provider = if (args.profile == null) "codex" else null,
+        .account = args.account,
+        .capability = capability,
+        .json = args.json,
+    });
+    defer routes.deinit();
+
+    var evaluations = std.ArrayList(RouteEvaluation).init(allocator);
+    defer evaluations.deinit();
+    try collectRouteEvaluations(allocator, parsed.value, &store, routes.items, &evaluations);
+
+    const selected_index = try firstSelectableCodexBrokerRouteIndex(allocator, parsed.value, evaluations.items);
+    const summary = try summarizeCodexBrokerSessionPlan(allocator, parsed.value, evaluations.items, selected_index);
+    const session_start_ready = selected_index != null;
+    const fallback_ready = codexBrokerSessionSpareFallbackReady(session_start_ready, summary.selectable_fallback_routes);
+    const ok = config_valid and session_start_ready;
+
+    if (args.json) {
+        try writer.writeAll("{\"version\":");
+        try std.json.stringify(cli.version, .{}, writer);
+        try writer.writeAll(",\"mode\":\"codex_preflight\"");
+        try writer.writeAll(",\"spends_provider_calls\":false,\"mutates_user_config\":false,\"mutates_route_health\":false");
+        try writer.writeAll(",\"ok\":");
+        try writer.writeAll(if (ok) "true" else "false");
+        try writer.writeAll(",\"config_valid\":");
+        try writer.writeAll(if (config_valid) "true" else "false");
+        try writer.writeAll(",\"profile\":");
+        if (args.profile) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+        try writer.writeAll(",\"capability\":");
+        if (capability) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+        try writer.writeAll(",\"account_filter\":");
+        if (args.account) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+        try writer.writeAll(",\"policy\":");
+        try writePolicyJson(writer, parsed.value.policy);
+        try writer.writeAll(",\"install\":");
+        try writeCodexPreflightInstallJson(writer, allocator);
+        try writer.writeAll(",\"route_summary\":");
+        try writeCodexPreflightRouteSummaryJson(writer, summary, session_start_ready, fallback_ready);
+        try writer.writeAll(",\"selected\":");
+        if (selected_index) |idx| {
+            try writeRouteSelectionJson(writer, evaluations.items[idx].route);
+        } else {
+            try writer.writeAll("null");
+        }
+        try writer.writeAll(",\"next_actions\":");
+        try writeCodexPreflightNextActionsJson(writer, allocator, args.profile, capability, session_start_ready, fallback_ready);
+        if (!config_valid and validation_messages.items.len != 0) {
+            try writer.writeAll(",\"config_validation_hint\":");
+            try std.json.stringify(std.mem.trim(u8, validation_messages.items, " \t\r\n"), .{}, writer);
+        }
+        try writer.writeAll("}\n");
+        return;
+    }
+
+    try writer.writeAll("oauth-mux Codex preflight\n\n");
+    if (args.profile) |value| try writer.print("  profile: {s}\n", .{value});
+    if (capability) |value| try writer.print("  capability: {s}\n", .{value});
+    try writer.print("  config valid: {s}\n", .{if (config_valid) "yes" else "no"});
+    try writer.print("  session start ready: {s}\n", .{if (session_start_ready) "yes" else "no"});
+    try writer.print("  fallback ready: {s}\n", .{if (fallback_ready) "yes" else "no"});
+    try writer.print("  routes: total={d} selectable={d} broker-ready={d} selectable-fallback={d}\n", .{
+        summary.routes_total,
+        summary.selectable_routes,
+        summary.selectable_broker_routes,
+        summary.selectable_fallback_routes,
+    });
+    if (!ok) {
+        try writer.writeAll("\nNext actions:\n");
+        try writeCodexPreflightNextActionsText(writer, args.profile, capability, session_start_ready, fallback_ready);
+    }
+}
+
+fn writeCodexPreflightInstallJson(writer: anytype, allocator: std.mem.Allocator) !void {
+    const self_path = std.fs.selfExePathAlloc(allocator) catch try allocator.dupe(u8, "unknown");
+    defer allocator.free(self_path);
+    try writer.writeAll("{\"active_oauth_mux\":");
+    try std.json.stringify(self_path, .{}, writer);
+    try writer.writeAll(",\"oauth_mux_candidates\":");
+    try writePathCandidateArrayJson(writer, allocator, "oauth-mux");
+    try writer.writeAll(",\"codex_candidates\":");
+    try writePathCandidateArrayJson(writer, allocator, "codex");
+    try writer.writeAll(",\"managed_codex_shim_supported\":true,\"native_codex_env\":\"OMUX_CODEX_BIN\"}");
+}
+
+fn writePathCandidateArrayJson(writer: anytype, allocator: std.mem.Allocator, name: []const u8) !void {
+    try writer.writeByte('[');
+    var first = true;
+    const path_env = std.process.getEnvVarOwned(allocator, "PATH") catch |e| switch (e) {
+        error.EnvironmentVariableNotFound => {
+            try writer.writeByte(']');
+            return;
+        },
+        else => return e,
+    };
+    defer allocator.free(path_env);
+    var it = std.mem.tokenizeScalar(u8, path_env, std.fs.path.delimiter);
+    while (it.next()) |dir| {
+        if (dir.len == 0) continue;
+        const candidate = try std.fs.path.join(allocator, &.{ dir, name });
+        defer allocator.free(candidate);
+        if (!fileExists(candidate)) continue;
+        if (!first) try writer.writeByte(',');
+        first = false;
+        try std.json.stringify(candidate, .{}, writer);
+    }
+    try writer.writeByte(']');
+}
+
+fn writeCodexPreflightRouteSummaryJson(
+    writer: anytype,
+    summary: CodexBrokerSessionSummary,
+    session_start_ready: bool,
+    fallback_ready: bool,
+) !void {
+    try writer.print(
+        "{{\"routes_total\":{d},\"broker_ready_routes\":{d},\"unreadable_routes\":{d},\"selectable_routes\":{d},\"selectable_broker_routes\":{d},\"selectable_fallback_routes\":{d},\"blocked_broker_routes\":{d},\"auth_unready_routes\":{d},\"session_start_ready\":{any},\"fallback_ready\":{any},\"single_route_at_risk\":{any}}}",
+        .{
+            summary.routes_total,
+            summary.broker_ready_routes,
+            summary.unreadable_routes,
+            summary.selectable_routes,
+            summary.selectable_broker_routes,
+            summary.selectable_fallback_routes,
+            summary.blocked_broker_routes,
+            summary.auth_unready_routes,
+            session_start_ready,
+            fallback_ready,
+            codexBrokerSessionSingleRouteAtRisk(session_start_ready, summary.selectable_fallback_routes),
+        },
+    );
+}
+
+fn writeCodexPreflightNextActionsJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    profile: ?[]const u8,
+    capability: ?[]const u8,
+    session_start_ready: bool,
+    fallback_ready: bool,
+) !void {
+    try writer.writeByte('[');
+    var first = true;
+    if (!session_start_ready or !fallback_ready) {
+        const refresh = try codexPreflightStayAfloatCommand(allocator, profile, capability);
+        defer allocator.free(refresh);
+        try writeCommaJsonString(writer, &first, refresh);
+    }
+    if (!session_start_ready) {
+        const plan = try codexPreflightPlanCommand(allocator, profile, capability);
+        defer allocator.free(plan);
+        try writeCommaJsonString(writer, &first, plan);
+    }
+    try writer.writeByte(']');
+}
+
+fn writeCodexPreflightNextActionsText(
+    writer: anytype,
+    profile: ?[]const u8,
+    capability: ?[]const u8,
+    session_start_ready: bool,
+    fallback_ready: bool,
+) !void {
+    if (!session_start_ready or !fallback_ready) {
+        const refresh = try codexPreflightStayAfloatCommand(std.heap.page_allocator, profile, capability);
+        defer std.heap.page_allocator.free(refresh);
+        try writer.print("  {s}\n", .{refresh});
+    }
+    if (!session_start_ready) {
+        const plan = try codexPreflightPlanCommand(std.heap.page_allocator, profile, capability);
+        defer std.heap.page_allocator.free(plan);
+        try writer.print("  {s}\n", .{plan});
+    }
+}
+
+fn writeCommaJsonString(writer: anytype, first: *bool, value: []const u8) !void {
+    if (!first.*) try writer.writeByte(',');
+    first.* = false;
+    try std.json.stringify(value, .{}, writer);
+}
+
+fn codexPreflightStayAfloatCommand(allocator: std.mem.Allocator, profile: ?[]const u8, capability: ?[]const u8) ![]u8 {
+    if (profile) |p| {
+        if (capability) |c| {
+            return try std.fmt.allocPrint(allocator, "oauth-mux stay-afloat --once --execute --profile {s} --capability {s} --json", .{ p, c });
+        }
+        return try std.fmt.allocPrint(allocator, "oauth-mux stay-afloat --once --execute --profile {s} --json", .{p});
+    }
+    if (capability) |c| {
+        return try std.fmt.allocPrint(allocator, "oauth-mux stay-afloat --once --execute --provider codex --capability {s} --json", .{c});
+    }
+    return try allocator.dupe(u8, "oauth-mux stay-afloat --once --execute --provider codex --json");
+}
+
+fn codexPreflightPlanCommand(allocator: std.mem.Allocator, profile: ?[]const u8, capability: ?[]const u8) ![]u8 {
+    if (profile) |p| {
+        if (capability) |c| {
+            return try std.fmt.allocPrint(allocator, "oauth-mux codex broker-session-plan --profile {s} --capability {s} --json", .{ p, c });
+        }
+        return try std.fmt.allocPrint(allocator, "oauth-mux codex broker-session-plan --profile {s} --json", .{p});
+    }
+    if (capability) |c| {
+        return try std.fmt.allocPrint(allocator, "oauth-mux codex broker-session-plan --capability {s} --json", .{c});
+    }
+    return try allocator.dupe(u8, "oauth-mux codex broker-session-plan --json");
 }
 
 fn runCodexManagedPlan(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs) !void {
@@ -15491,8 +15742,8 @@ test "writePolicyJson exposes effective daemon admission policy" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"allow_mutating\":false") != null);
 }
 
-test "daemon tick refuses spend provider probe by default" {
-    const decision = daemonTickDecision((config.PolicyConfig{}).daemon, .{
+test "daemon tick admits Codex spend provider probe by default" {
+    const decision = daemonTickDecision(config.PolicyConfig{}, .{
         .route = .{ .provider = "codex", .account = "max-1", .capability = "codex-max" },
         .runtime = .ready,
         .health = null,
@@ -15510,8 +15761,8 @@ test "daemon tick refuses spend provider probe by default" {
     }, 1000);
 
     try std.testing.expectEqualStrings("probe", decision.phase);
-    try std.testing.expect(!decision.admitted);
-    try std.testing.expectEqualStrings("budget_not_allowed", decision.reason);
+    try std.testing.expect(decision.admitted);
+    try std.testing.expectEqualStrings("allowed_by_policy", decision.reason);
     try std.testing.expectEqual(types.ActionBudget.spend_provider, decision.budget.?);
     try std.testing.expect(!decision.executed);
     try std.testing.expectEqual(@as(?i64, 1000), decision.next_tick_after);
@@ -15522,7 +15773,7 @@ test "daemon tick reports selectable route as no-op" {
     const health = health_mod.AccountHealth{
         .liveness = .{ .live = .{ .availability = .available } },
     };
-    const decision = daemonTickDecision((config.PolicyConfig{}).daemon, .{
+    const decision = daemonTickDecision(config.PolicyConfig{}, .{
         .route = .{ .provider = "codex", .account = "max-2", .capability = "codex-max" },
         .runtime = .ready,
         .health = health,
@@ -15546,7 +15797,7 @@ test "daemon tick reports selectable route as no-op" {
 
 test "daemon tick schedules interactive handoff recheck without admitting silent auth" {
     const route = RepairPlanRoute{ .provider = "codex", .account = "max-1", .capability = "codex-max" };
-    const decision = daemonTickDecision((config.PolicyConfig{}).daemon, .{
+    const decision = daemonTickDecision(config.PolicyConfig{}, .{
         .route = route,
         .runtime = .{ .needs_reauth = .{ .methods = &.{"upstream_cli_login"}, .reason = "session_file_missing" } },
         .health = null,
@@ -15566,7 +15817,7 @@ test "daemon tick schedules interactive handoff recheck without admitting silent
 }
 
 test "daemon tick schedules runtime repair recheck" {
-    const decision = daemonTickDecision((config.PolicyConfig{}).daemon, .{
+    const decision = daemonTickDecision(config.PolicyConfig{}, .{
         .route = .{ .provider = "codex", .account = "max-1", .capability = "codex-max" },
         .runtime = .{ .unwritable_store = "/tmp/oauth-mux-test/store" },
         .health = null,
@@ -15622,7 +15873,7 @@ test "daemon tick stats carries earliest schedule reason" {
             .skip_reason = "unwritable_store",
         },
     };
-    const stats = daemonTickStats((config.PolicyConfig{}).daemon, &evaluations, 1000);
+    const stats = daemonTickStats(config.PolicyConfig{}, &evaluations, 1000);
 
     try std.testing.expectEqual(@as(?i64, 1300), stats.next_tick_after);
     try std.testing.expect(stats.next_tick_reason != null);


### PR DESCRIPTION
## Summary

- add `oauth-mux codex preflight` as a no-spend JSON/text readiness snapshot for install, policy, route, and next-action truth
- add Codex-specific stay-afloat policy defaults so managed Codex can revalidate expired quota/rate windows before route election while keeping interactive auth user-mediated
- add managed `codex` shims for npm, curl installer, and Homebrew, with `OMUX_CODEX_BIN` native-binary passthrough and resolver recursion guards
- update no-spend/spend-boundary docs for README, onboarding, and adoption surfaces

## Validation

- `git diff --check`
- `zig build test`
- `./scripts/smoke-codex-cli-ux.sh`
- `./scripts/smoke-codex-status-summary.sh`
- `node --check dist/npm/bin/codex.js && node --check dist/npm/bin/oauth-mux.js`
- `ruby -c dist/homebrew/oauth-mux.rb`
- `sh -n dist/install.sh`
- `just check-local`

## Notes

- No local Playwright run was performed.
- Public package truth remains `0.1.6` until this candidate is released.
