### PR TITLE
Add local dogfood install shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,23 +111,24 @@ brew install jesssullivan/omux/oauth-mux
 Local `0.1.7` candidate dogfood should keep provenance explicit:
 
 ```bash
-just build
-mkdir -p ~/.local/bin
-rm -f ~/.local/bin/oauth-mux
-cp ./zig-out/bin/oauth-mux ~/.local/bin/oauth-mux
-shasum -a 256 ./zig-out/bin/oauth-mux ~/.local/bin/oauth-mux
+just install-local-dogfood
 which -a oauth-mux
+which -a codex
 oauth-mux version
+oauth-mux codex preflight --profile codex-max --capability codex-max --json
 ```
 
 On macOS, remove the old Mach-O before copying the dogfood binary. Overwriting in
 place can leave stale taskgated/code-signing state on the old vnode and produce
 an immediate `SIGKILL` / status `137`.
 
-The staged `0.1.7` package and installer lanes also include a managed `codex`
-shim. The shim resolves the native upstream Codex executable, passes it through
-`OMUX_CODEX_BIN`, and then enters `oauth-mux codex`. Public package channels do
-not carry that shim until `0.1.7` is published.
+`just install-local-dogfood` uses that remove-then-copy lane, verifies the
+installed binary hash against `./zig-out/bin/oauth-mux`, and installs a managed
+`codex` shim in the same user-local bin directory. The shim resolves the native
+upstream Codex executable, passes it through `OMUX_CODEX_BIN`, and then enters
+`oauth-mux codex`. It refuses to replace a non-oauth-mux `codex` already in that
+directory unless `OMUX_DOGFOOD_REPLACE_CODEX=1` is set. Public package channels
+do not carry that shim until `0.1.7` is published.
 
 ## Usage
 

--- a/docs/release-install-lanes.md
+++ b/docs/release-install-lanes.md
@@ -11,7 +11,7 @@ Detailed historical evidence stays in `docs/install-beta-matrix.md` and
 | Lane | User command | Source of artifact | Proof gate | Claim |
 | --- | --- | --- | --- | --- |
 | Worktree dogfood | `./zig-out/bin/oauth-mux ...` | current checkout | `zig build`, `just check-local` | unreleased behavior only |
-| User-local dogfood | `oauth-mux ...` with PATH resolving to `~/.local/bin` | copied worktree binary | hash match with `./zig-out/bin/oauth-mux`, version check | installed-command dogfood for current checkout |
+| User-local dogfood | `oauth-mux ...` and managed `codex ...` with PATH resolving to `~/.local/bin` | copied worktree binary plus user-local shim | hash match with `./zig-out/bin/oauth-mux`, version check, preflight check | installed-command dogfood for current checkout |
 | Nix package | `nix build .#` | flake package | `./result/bin/oauth-mux version` | package derivation proof |
 | GitHub Release | downloaded tarball | `dist/out/v*/artifacts` from release workflow | checksum verify and tarball smoke | public raw binary lane |
 | npm | `npm install -g oauth-mux` / `npx oauth-mux` | CI-generated npm tarballs | npm install smoke and `npm view` | public JS package lane |
@@ -53,13 +53,11 @@ Detailed historical evidence stays in `docs/install-beta-matrix.md` and
 Before dogfooding unreleased behavior:
 
 ```bash
-just build
-mkdir -p ~/.local/bin
-rm -f ~/.local/bin/oauth-mux
-cp ./zig-out/bin/oauth-mux ~/.local/bin/oauth-mux
-shasum -a 256 ./zig-out/bin/oauth-mux ~/.local/bin/oauth-mux
+just install-local-dogfood
 which -a oauth-mux
+which -a codex
 oauth-mux version
+oauth-mux codex preflight --profile codex-max --capability codex-max --json
 ```
 
 Expected:
@@ -67,6 +65,10 @@ Expected:
 - `./zig-out/bin/oauth-mux` and `~/.local/bin/oauth-mux` hashes match.
 - `which -a oauth-mux` resolves `~/.local/bin/oauth-mux` before Homebrew when
   testing unreleased behavior.
+- `which -a codex` resolves `~/.local/bin/codex` before the native upstream
+  Codex CLI when testing managed Codex behavior.
+- `oauth-mux codex preflight --json` is handled by oauth-mux, not by the native
+  Codex CLI usage parser.
 - Homebrew may report the same source version while still being a different
   binary hash; treat it as the package lane.
 
@@ -78,6 +80,11 @@ file first, then copy the new build so the installed file has a fresh vnode and
 the hash still matches the worktree binary. Re-signing the installed copy is a
 separate repair fallback, but it changes the hash and no longer proves byte
 identity with `./zig-out/bin/oauth-mux`.
+
+The local installer refuses to replace an existing non-oauth-mux
+`~/.local/bin/codex` unless `OMUX_DOGFOOD_REPLACE_CODEX=1` is set. Use
+`OMUX_DOGFOOD_INSTALL_CODEX_SHIM=0` when you need installed-command dogfood for
+`oauth-mux` without shadowing the native `codex` command.
 
 ## UX, DX, AX Gates
 

--- a/justfile
+++ b/justfile
@@ -30,6 +30,9 @@ run *ARGS:
 version: build
     ./zig-out/bin/oauth-mux version
 
+install-local-dogfood:
+    nix develop --command ./scripts/install-local-dogfood.sh
+
 status: build
     ./zig-out/bin/oauth-mux status --json
 

--- a/scripts/check-local.sh
+++ b/scripts/check-local.sh
@@ -5,6 +5,7 @@ set -eu
 
 zig build test
 zig build
+bash -n ./scripts/install-local-dogfood.sh
 
 for cfg in examples/*.config.json; do
   OMUX_CONFIG="$PWD/$cfg" ./zig-out/bin/oauth-mux config validate

--- a/scripts/install-local-dogfood.sh
+++ b/scripts/install-local-dogfood.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+install_dir="${INSTALL_DIR:-$HOME/.local/bin}"
+install_codex_shim="${OMUX_DOGFOOD_INSTALL_CODEX_SHIM:-1}"
+replace_existing_codex="${OMUX_DOGFOOD_REPLACE_CODEX:-0}"
+binary_src="$repo_root/zig-out/bin/oauth-mux"
+oauth_mux_target="$install_dir/oauth-mux"
+codex_target="$install_dir/codex"
+
+hash_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{ print $1 }'
+  else
+    shasum -a 256 "$1" | awk '{ print $1 }'
+  fi
+}
+
+real_path() {
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "$1"
+  else
+    local dir base
+    dir="$(dirname "$1")"
+    base="$(basename "$1")"
+    printf '%s/%s\n' "$(cd "$dir" 2>/dev/null && pwd -P)" "$base"
+  fi
+}
+
+is_omux_codex_shim() {
+  grep -q 'OMUX_CODEX_SHIM' "$1" 2>/dev/null
+}
+
+find_native_codex() {
+  if [ -n "${OMUX_CODEX_BIN:-}" ]; then
+    if [ -x "$OMUX_CODEX_BIN" ] && ! is_omux_codex_shim "$OMUX_CODEX_BIN"; then
+      printf '%s\n' "$OMUX_CODEX_BIN"
+      return 0
+    fi
+  fi
+
+  local self_real candidate candidate_real
+  self_real=""
+  if [ -e "$codex_target" ]; then
+    self_real="$(real_path "$codex_target")"
+  fi
+
+  IFS=: read -r -a path_entries <<<"${PATH:-}"
+  for dir in "${path_entries[@]}"; do
+    [ -n "$dir" ] || continue
+    candidate="$dir/codex"
+    [ -x "$candidate" ] || continue
+    candidate_real="$(real_path "$candidate")"
+    [ -z "$self_real" ] || [ "$candidate_real" != "$self_real" ] || continue
+    if is_omux_codex_shim "$candidate"; then
+      continue
+    fi
+    printf '%s\n' "$candidate"
+    return 0
+  done
+
+  return 1
+}
+
+write_codex_shim() {
+  cat >"$codex_target" <<EOF
+#!/bin/sh
+# OMUX_CODEX_SHIM
+set -eu
+
+oauth_mux_bin="${oauth_mux_target}"
+
+real_path() {
+    if command -v realpath >/dev/null 2>&1; then
+        realpath "\$1"
+    else
+        dir=\$(dirname "\$1")
+        base=\$(basename "\$1")
+        printf '%s/%s\n' "\$(cd "\$dir" 2>/dev/null && pwd -P)" "\$base"
+    fi
+}
+
+is_omux_codex_shim() {
+    grep -q 'OMUX_CODEX_SHIM' "\$1" 2>/dev/null
+}
+
+find_native_codex() {
+    self=\$(real_path "\$0")
+    old_ifs=\$IFS
+    IFS=:
+    for dir in \$PATH; do
+        [ -n "\$dir" ] || continue
+        candidate="\$dir/codex"
+        [ -x "\$candidate" ] || continue
+        candidate_real=\$(real_path "\$candidate")
+        [ "\$candidate_real" != "\$self" ] || continue
+        if is_omux_codex_shim "\$candidate"; then
+            continue
+        fi
+        IFS=\$old_ifs
+        printf '%s\n' "\$candidate"
+        return 0
+    done
+    IFS=\$old_ifs
+    return 1
+}
+
+native_codex="\${OMUX_CODEX_BIN:-}"
+if [ -z "\$native_codex" ]; then
+    native_codex=\$(find_native_codex || true)
+fi
+if [ -z "\$native_codex" ]; then
+    echo "codex: native Codex CLI not found; set OMUX_CODEX_BIN to the upstream Codex executable" >&2
+    exit 127
+fi
+
+OMUX_CODEX_BIN="\$native_codex" OMUX_CODEX_SHIM=1 OMUX_COMMAND_SPELLING=codex exec "\$oauth_mux_bin" codex "\$@"
+EOF
+  chmod 0755 "$codex_target"
+}
+
+if [ "${OMUX_DOGFOOD_SKIP_BUILD:-0}" != "1" ]; then
+  zig build
+fi
+
+if [ ! -x "$binary_src" ]; then
+  printf 'missing built oauth-mux binary at %s\n' "$binary_src" >&2
+  exit 1
+fi
+
+mkdir -p "$install_dir"
+
+native_codex=""
+if [ "$install_codex_shim" != "0" ]; then
+  native_codex="$(find_native_codex || true)"
+  if [ -z "$native_codex" ]; then
+    printf 'native Codex CLI not found before shim install; set OMUX_CODEX_BIN or run with OMUX_DOGFOOD_INSTALL_CODEX_SHIM=0\n' >&2
+    exit 1
+  fi
+  if [ -e "$codex_target" ] && ! is_omux_codex_shim "$codex_target" && [ "$replace_existing_codex" != "1" ]; then
+    printf 'refusing to replace non-oauth-mux codex at %s\n' "$codex_target" >&2
+    printf 'set OMUX_DOGFOOD_REPLACE_CODEX=1 to replace it, or OMUX_DOGFOOD_INSTALL_CODEX_SHIM=0 to skip the shim\n' >&2
+    exit 1
+  fi
+fi
+
+rm -f "$oauth_mux_target"
+cp "$binary_src" "$oauth_mux_target"
+chmod 0755 "$oauth_mux_target"
+
+src_hash="$(hash_file "$binary_src")"
+installed_hash="$(hash_file "$oauth_mux_target")"
+if [ "$src_hash" != "$installed_hash" ]; then
+  printf 'installed binary hash mismatch\nsource:    %s  %s\ninstalled: %s  %s\n' "$src_hash" "$binary_src" "$installed_hash" "$oauth_mux_target" >&2
+  exit 1
+fi
+
+if [ "$install_codex_shim" != "0" ]; then
+  rm -f "$codex_target"
+  write_codex_shim
+fi
+
+printf 'installed oauth-mux dogfood binary: %s\n' "$oauth_mux_target"
+printf 'oauth-mux sha256: %s\n' "$installed_hash"
+if [ "$install_codex_shim" != "0" ]; then
+  printf 'installed managed codex shim: %s\n' "$codex_target"
+  printf 'native Codex CLI resolved before install: %s\n' "$native_codex"
+fi
+printf 'PATH oauth-mux: %s\n' "$(command -v oauth-mux || true)"
+printf 'PATH codex: %s\n' "$(command -v codex || true)"


### PR DESCRIPTION
## Summary
- add `just install-local-dogfood` as the repo-managed user-local dogfood lane
- install `~/.local/bin/oauth-mux` with remove-then-copy hash verification
- install a guarded managed `~/.local/bin/codex` shim that resolves the native Codex CLI through `OMUX_CODEX_BIN`
- document the split managed/unmanaged Codex path and add the installer syntax check to `check-local`

## Root Cause
The local candidate dogfood docs only copied `oauth-mux`, while the new managed `codex` shim lived in package and installer lanes. That left machines able to run a current `oauth-mux` binary while `codex` still resolved to the unmanaged upstream CLI.

## Validation
- `just install-local-dogfood`
- `which -a oauth-mux` -> `/Users/jess/.local/bin/oauth-mux` first
- `which -a codex` -> `/Users/jess/.local/bin/codex` first, native Codex remains `/Users/jess/.nix-profile/bin/codex`
- `oauth-mux codex preflight --profile codex-max --capability codex-max --json` handled by oauth-mux and reports no-spend/no-mutation preflight
- `shasum -a 256 ./zig-out/bin/oauth-mux ~/.local/bin/oauth-mux` hashes match
- `git diff --check`
- `just check-local`