### PR TITLE
Explain Codex preflight route blockers

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -235,8 +235,9 @@ For a no-spend managed Codex readiness snapshot, use:
 oauth-mux codex preflight --profile codex-max --capability codex-max --json
 ```
 
-The preflight reports install candidates, Codex policy, route readiness, and
-exact next actions. It does not call the provider or mutate route health.
+The preflight reports install candidates, Codex policy, route readiness, compact
+blocked-route reason counts, redacted blocked route actions, and exact next
+actions. It does not call the provider or mutate route health.
 
 Managed Codex live quota handoff is proven for installed
 `oauth-mux codex resume` status artifacts. The 2026-05-09 engineered evidence

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -277,6 +277,27 @@ jq -e '
   else true end)
 ' "$route_explain_json" >/dev/null
 
+printf 'first-run e2e: codex preflight explains blocked route reasons without mutation\n'
+codex_preflight_json="$tmp/codex-preflight-codex-max.json"
+run_json "$codex_preflight_json" codex preflight --profile codex-max --capability codex-max --json
+jq -e '
+  .mode == "codex_preflight"
+  and .spends_provider_calls == false
+  and .mutates_user_config == false
+  and .mutates_route_health == false
+  and .ok == false
+  and .route_summary.routes_total == 3
+  and .route_summary.selectable_routes == 0
+  and (.blocked_route_reasons | length) == 1
+  and (.blocked_route_reasons[] | select(.reason == "auth_broker_unready" and .count == 3))
+  and (.blocked_routes | length) == 3
+  and all(.blocked_routes[]; .provider == "codex" and .capability == "codex-max" and .selectable == false and .broker_ready == false and .blocked_reason == "auth_broker_unready" and .action.mutating == false)
+  and (.next_actions | index("oauth-mux stay-afloat --once --execute --profile codex-max --capability codex-max --json") != null)
+' "$codex_preflight_json" >/dev/null
+expect_not_contains "$(cat "$codex_preflight_json")" "$store_root/max-1" "codex preflight does not print concrete Codex store paths"
+test ! -e "$store_root"
+test ! -e "$legacy_store_root"
+
 printf 'first-run e2e: stay-afloat exposes runtime diagnostics without automatic repair\n'
 stay_afloat_json="$tmp/stay-afloat-codex-max.json"
 run_json "$stay_afloat_json" stay-afloat --once --profile codex-max --capability codex-max --json

--- a/src/main.zig
+++ b/src/main.zig
@@ -9287,6 +9287,10 @@ fn runCodexPreflight(allocator: std.mem.Allocator, writer: anytype, args: cli.Co
         try writeCodexPreflightInstallJson(writer, allocator);
         try writer.writeAll(",\"route_summary\":");
         try writeCodexPreflightRouteSummaryJson(writer, summary, session_start_ready, fallback_ready);
+        try writer.writeAll(",\"blocked_route_reasons\":");
+        try writeCodexPreflightBlockedReasonSummaryJson(writer, allocator, parsed.value, evaluations.items, selected_index);
+        try writer.writeAll(",\"blocked_routes\":");
+        try writeCodexPreflightBlockedRoutesJson(writer, allocator, parsed.value, evaluations.items, selected_index);
         try writer.writeAll(",\"selected\":");
         if (selected_index) |idx| {
             try writeRouteSelectionJson(writer, evaluations.items[idx].route);
@@ -9315,6 +9319,7 @@ fn runCodexPreflight(allocator: std.mem.Allocator, writer: anytype, args: cli.Co
         summary.selectable_broker_routes,
         summary.selectable_fallback_routes,
     });
+    try writeCodexPreflightBlockedRoutesText(writer, allocator, parsed.value, evaluations.items, selected_index);
     if (!ok) {
         try writer.writeAll("\nNext actions:\n");
         try writeCodexPreflightNextActionsText(writer, args.profile, capability, session_start_ready, fallback_ready);
@@ -9379,6 +9384,131 @@ fn writeCodexPreflightRouteSummaryJson(
             codexBrokerSessionSingleRouteAtRisk(session_start_ready, summary.selectable_fallback_routes),
         },
     );
+}
+
+fn codexPreflightRouteSessionReady(evaluation: RouteEvaluation, plan: CodexBrokerTokenPlan) bool {
+    return plan.can_supply and evaluation.selectable;
+}
+
+fn codexPreflightRouteBlockedReason(evaluation: RouteEvaluation, selected: bool, plan: CodexBrokerTokenPlan) []const u8 {
+    _ = selected;
+    if (!plan.can_supply) return "auth_broker_unready";
+    return evaluation.skip_reason;
+}
+
+fn writeCodexPreflightBlockedReasonSummaryJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+) !void {
+    try writer.writeByte('[');
+    var first = true;
+    for (evaluations, 0..) |evaluation, idx| {
+        const selected = if (selected_index) |selected_idx| idx == selected_idx else false;
+        const plan = try inspectCodexBrokerRoute(allocator, cfg, evaluation.route);
+        if (codexPreflightRouteSessionReady(evaluation, plan)) continue;
+        const reason = codexPreflightRouteBlockedReason(evaluation, selected, plan);
+
+        var seen = false;
+        for (evaluations[0..idx], 0..) |previous, previous_idx| {
+            const previous_selected = if (selected_index) |selected_idx| previous_idx == selected_idx else false;
+            const previous_plan = try inspectCodexBrokerRoute(allocator, cfg, previous.route);
+            if (codexPreflightRouteSessionReady(previous, previous_plan)) continue;
+            const previous_reason = codexPreflightRouteBlockedReason(previous, previous_selected, previous_plan);
+            if (std.mem.eql(u8, previous_reason, reason)) {
+                seen = true;
+                break;
+            }
+        }
+        if (seen) continue;
+
+        var count: usize = 0;
+        for (evaluations, 0..) |candidate, candidate_idx| {
+            const candidate_selected = if (selected_index) |selected_idx| candidate_idx == selected_idx else false;
+            const candidate_plan = try inspectCodexBrokerRoute(allocator, cfg, candidate.route);
+            if (codexPreflightRouteSessionReady(candidate, candidate_plan)) continue;
+            const candidate_reason = codexPreflightRouteBlockedReason(candidate, candidate_selected, candidate_plan);
+            if (std.mem.eql(u8, candidate_reason, reason)) count += 1;
+        }
+
+        if (!first) try writer.writeByte(',');
+        first = false;
+        try writer.writeAll("{\"reason\":");
+        try std.json.stringify(reason, .{}, writer);
+        try writer.print(",\"count\":{d}", .{count});
+        try writer.writeByte('}');
+    }
+    try writer.writeByte(']');
+}
+
+fn writeCodexPreflightBlockedRoutesJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+) !void {
+    try writer.writeByte('[');
+    var first = true;
+    for (evaluations, 0..) |evaluation, idx| {
+        const selected = if (selected_index) |selected_idx| idx == selected_idx else false;
+        const plan = try inspectCodexBrokerRoute(allocator, cfg, evaluation.route);
+        if (codexPreflightRouteSessionReady(evaluation, plan)) continue;
+        if (!first) try writer.writeByte(',');
+        first = false;
+        try writer.writeByte('{');
+        try writer.writeAll("\"provider\":");
+        try std.json.stringify(evaluation.route.provider, .{}, writer);
+        try writer.writeAll(",\"account\":");
+        try std.json.stringify(evaluation.route.account, .{}, writer);
+        try writer.writeAll(",\"capability\":");
+        if (evaluation.route.capability) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+        try writer.writeAll(",\"selectable\":");
+        try writer.writeAll(if (evaluation.selectable) "true" else "false");
+        try writer.writeAll(",\"broker_ready\":");
+        try writer.writeAll(if (plan.can_supply) "true" else "false");
+        try writer.writeAll(",\"route_role\":");
+        try std.json.stringify(codexBrokerSessionRouteRole(evaluation, selected, plan), .{}, writer);
+        try writer.writeAll(",\"blocked_reason\":");
+        try std.json.stringify(codexPreflightRouteBlockedReason(evaluation, selected, plan), .{}, writer);
+        try writer.writeAll(",\"skip_reason\":");
+        try std.json.stringify(evaluation.skip_reason, .{}, writer);
+        try writer.writeAll(",\"liveness\":");
+        if (evaluation.health) |health| try writeLivenessJson(writer, health.liveness) else try writer.writeAll("null");
+        try writer.writeAll(",\"action\":");
+        try writeRepairActionJson(writer, allocator, evaluation.action, evaluation.route);
+        try writer.writeByte('}');
+    }
+    try writer.writeByte(']');
+}
+
+fn writeCodexPreflightBlockedRoutesText(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    evaluations: []const RouteEvaluation,
+    selected_index: ?usize,
+) !void {
+    var blocked_count: usize = 0;
+    for (evaluations, 0..) |evaluation, idx| {
+        const selected = if (selected_index) |selected_idx| idx == selected_idx else false;
+        const plan = try inspectCodexBrokerRoute(allocator, cfg, evaluation.route);
+        if (codexPreflightRouteSessionReady(evaluation, plan)) continue;
+        if (blocked_count == 0) try writer.writeAll("  blocked routes:\n");
+        blocked_count += 1;
+        const role = codexBrokerSessionRouteRole(evaluation, selected, plan);
+        const reason = codexPreflightRouteBlockedReason(evaluation, selected, plan);
+        try writer.print("    - {s}:{s}", .{ evaluation.route.provider, evaluation.route.account });
+        if (evaluation.route.capability) |value| try writer.print("#{s}", .{value});
+        try writer.print(" reason={s} role={s} action={s}", .{ reason, role, @tagName(evaluation.action.kind) });
+        if (try repairCommandAlloc(allocator, evaluation.action.command, evaluation.route)) |command| {
+            defer allocator.free(command);
+            try writer.print(" command=\"{s}\"", .{command});
+        }
+        try writer.writeByte('\n');
+    }
 }
 
 fn writeCodexPreflightNextActionsJson(


### PR DESCRIPTION
## Summary
- add compact `blocked_route_reasons` and redacted `blocked_routes` to `oauth-mux codex preflight --json`
- include blocked route reason/action lines in text preflight output
- add a first-run e2e regression proving preflight explains blocked Codex Max routes without provider spend, route-health mutation, user-config mutation, or path leakage
- update onboarding docs to describe the richer preflight output

## Root Cause
When managed Codex startup could not select a route, the no-spend preflight only reported aggregate route counts. Operators and agents still had to jump to the larger broker-session-plan output to learn whether routes were blocked by expired quota windows, reauth, missing broker auth, or another route state.

## Validation
- `zig build test`
- `zig build && scripts/first-run-e2e.sh`
- `./zig-out/bin/oauth-mux codex preflight --profile codex-max --capability codex-max --json`
- `git diff --check`
- `just check-local`