### PR TITLE
Label Codex preflight next actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ oauth-mux codex preflight --profile codex-max --capability codex-max --json
 and `codex` PATH candidates, whether active `codex` is the managed oauth-mux
 shim, the first native Codex binary, and the `OMUX_CODEX_BIN` escape hatch. Use
 that before debugging stale package or managed-versus-unmanaged Codex behavior.
+Its JSON separates `agent_safe_next_actions` from
+`spend_confirmed_next_actions`; text output uses matching no-spend diagnostics
+and spend-confirmed repair sections.
 
 On macOS, remove the old Mach-O before copying the dogfood binary. Overwriting in
 place can leave stale taskgated/code-signing state on the old vnode and produce

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -399,7 +399,9 @@ oauth-mux codex preflight --profile <profile> --capability <capability> --json
 
 A wrapper may act automatically only on admitted, non-interactive,
 non-mutating work, except for explicitly admitted Codex expired-window
-revalidation under the Codex stay-afloat policy. When JSON reports
+revalidation under the Codex stay-afloat policy. For `codex preflight`, wrappers
+should consume `agent_safe_next_actions` automatically and reserve
+`spend_confirmed_next_actions` for a user-approved repair step. When JSON reports
 `action.kind:"fix_runtime"` with
 `action.command:null`, the wrapper should display or broker
 `action.diagnostic_command` in the user-owned process boundary, then rerun

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -238,7 +238,10 @@ oauth-mux codex preflight --profile codex-max --capability codex-max --json
 The preflight reports install candidates, active `codex` shim/native
 classification, the first native Codex binary, Codex policy, route readiness,
 compact blocked-route reason counts, redacted blocked route actions, and exact
-next actions. It does not call the provider or mutate route health.
+next actions. It does not call the provider or mutate route health. JSON
+clients should prefer `agent_safe_next_actions` for no-spend automation and
+treat `spend_confirmed_next_actions` as user-approved repair only; text output
+uses the same no-spend diagnostics and spend-confirmed repair labels.
 
 Managed Codex live quota handoff is proven for installed
 `oauth-mux codex resume` status artifacts. The 2026-05-09 engineered evidence

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -302,6 +302,16 @@ jq -e '
   and (.blocked_routes | length) == 3
   and all(.blocked_routes[]; .provider == "codex" and .capability == "codex-max" and .selectable == false and .broker_ready == false and .blocked_reason == "auth_broker_unready" and .action.mutating == false)
   and (.next_actions | index("oauth-mux stay-afloat --once --execute --profile codex-max --capability codex-max --json") != null)
+  and (.agent_safe_next_actions | length) == 1
+  and .agent_safe_next_actions[0].command == "oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json"
+  and .agent_safe_next_actions[0].agent_safe == true
+  and .agent_safe_next_actions[0].may_spend_provider_calls == false
+  and .agent_safe_next_actions[0].mutates_route_health == false
+  and (.spend_confirmed_next_actions | length) == 1
+  and .spend_confirmed_next_actions[0].command == "oauth-mux stay-afloat --once --execute --profile codex-max --capability codex-max --json"
+  and .spend_confirmed_next_actions[0].agent_safe == false
+  and .spend_confirmed_next_actions[0].may_spend_provider_calls == true
+  and .spend_confirmed_next_actions[0].mutates_route_health == true
 ' "$codex_preflight_json" >/dev/null
 expect_not_contains "$(cat "$codex_preflight_json")" "$store_root/max-1" "codex preflight does not print concrete Codex store paths"
 test ! -e "$store_root"
@@ -315,6 +325,11 @@ expect_contains "$codex_preflight_text" "    active codex is oauth-mux shim:" "c
 expect_contains "$codex_preflight_text" "    native codex:" "codex preflight text reports native codex"
 expect_contains "$codex_preflight_text" "    native codex env: OMUX_CODEX_BIN" "codex preflight text reports native codex env override"
 expect_contains "$codex_preflight_text" "  config valid: yes" "codex preflight text still reports route readiness"
+expect_contains "$codex_preflight_text" "No-spend diagnostics:" "codex preflight text labels no-spend diagnostics"
+expect_contains "$codex_preflight_text" "oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json" "codex preflight text reports no-spend broker plan"
+expect_contains "$codex_preflight_text" "Spend-confirmed repair:" "codex preflight text labels spend-confirmed repair"
+expect_contains "$codex_preflight_text" "oauth-mux stay-afloat --once --execute --profile codex-max --capability codex-max --json" "codex preflight text reports executable repair"
+expect_contains "$codex_preflight_text" "budget=spend_provider agent_safe=false may_spend_provider_calls=true mutates_route_health=true" "codex preflight text labels executable repair risk"
 test ! -e "$store_root"
 test ! -e "$legacy_store_root"
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -9299,6 +9299,10 @@ fn runCodexPreflight(allocator: std.mem.Allocator, writer: anytype, args: cli.Co
         }
         try writer.writeAll(",\"next_actions\":");
         try writeCodexPreflightNextActionsJson(writer, allocator, args.profile, capability, session_start_ready, fallback_ready);
+        try writer.writeAll(",\"agent_safe_next_actions\":");
+        try writeCodexPreflightAgentSafeNextActionsJson(writer, allocator, args.profile, capability, session_start_ready, fallback_ready);
+        try writer.writeAll(",\"spend_confirmed_next_actions\":");
+        try writeCodexPreflightSpendConfirmedNextActionsJson(writer, allocator, args.profile, capability, session_start_ready, fallback_ready);
         if (!config_valid and validation_messages.items.len != 0) {
             try writer.writeAll(",\"config_validation_hint\":");
             try std.json.stringify(std.mem.trim(u8, validation_messages.items, " \t\r\n"), .{}, writer);
@@ -9324,8 +9328,7 @@ fn runCodexPreflight(allocator: std.mem.Allocator, writer: anytype, args: cli.Co
     });
     try writeCodexPreflightBlockedRoutesText(writer, allocator, parsed.value, evaluations.items, selected_index);
     if (!ok) {
-        try writer.writeAll("\nNext actions:\n");
-        try writeCodexPreflightNextActionsText(writer, args.profile, capability, session_start_ready, fallback_ready);
+        try writeCodexPreflightNextActionsText(writer, allocator, args.profile, capability, session_start_ready, fallback_ready);
     }
 }
 
@@ -9679,34 +9682,135 @@ fn writeCodexPreflightNextActionsJson(
     try writer.writeByte('[');
     var first = true;
     if (!session_start_ready or !fallback_ready) {
-        const refresh = try codexPreflightStayAfloatCommand(allocator, profile, capability);
-        defer allocator.free(refresh);
-        try writeCommaJsonString(writer, &first, refresh);
-    }
-    if (!session_start_ready) {
         const plan = try codexPreflightPlanCommand(allocator, profile, capability);
         defer allocator.free(plan);
         try writeCommaJsonString(writer, &first, plan);
     }
+    if (!session_start_ready or !fallback_ready) {
+        const refresh = try codexPreflightStayAfloatCommand(allocator, profile, capability);
+        defer allocator.free(refresh);
+        try writeCommaJsonString(writer, &first, refresh);
+    }
     try writer.writeByte(']');
+}
+
+fn writeCodexPreflightAgentSafeNextActionsJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    profile: ?[]const u8,
+    capability: ?[]const u8,
+    session_start_ready: bool,
+    fallback_ready: bool,
+) !void {
+    try writer.writeByte('[');
+    var first = true;
+    if (!session_start_ready or !fallback_ready) {
+        const plan = try codexPreflightPlanCommand(allocator, profile, capability);
+        defer allocator.free(plan);
+        try writeCodexPreflightActionObjectJson(writer, &first, .{
+            .kind = "broker_session_plan",
+            .label = "no-spend broker route plan",
+            .command = plan,
+            .budget = "free_local",
+            .agent_safe = true,
+            .may_spend_provider_calls = false,
+            .mutates_user_config = false,
+            .mutates_route_health = false,
+            .interactive = false,
+        });
+    }
+    try writer.writeByte(']');
+}
+
+fn writeCodexPreflightSpendConfirmedNextActionsJson(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    profile: ?[]const u8,
+    capability: ?[]const u8,
+    session_start_ready: bool,
+    fallback_ready: bool,
+) !void {
+    try writer.writeByte('[');
+    var first = true;
+    if (!session_start_ready or !fallback_ready) {
+        const refresh = try codexPreflightStayAfloatCommand(allocator, profile, capability);
+        defer allocator.free(refresh);
+        try writeCodexPreflightActionObjectJson(writer, &first, .{
+            .kind = "stay_afloat_execute",
+            .label = "spend-confirmed route health repair",
+            .command = refresh,
+            .budget = "spend_provider",
+            .agent_safe = false,
+            .may_spend_provider_calls = true,
+            .mutates_user_config = false,
+            .mutates_route_health = true,
+            .interactive = false,
+        });
+    }
+    try writer.writeByte(']');
+}
+
+const CodexPreflightActionObject = struct {
+    kind: []const u8,
+    label: []const u8,
+    command: []const u8,
+    budget: []const u8,
+    agent_safe: bool,
+    may_spend_provider_calls: bool,
+    mutates_user_config: bool,
+    mutates_route_health: bool,
+    interactive: bool,
+};
+
+fn writeCodexPreflightActionObjectJson(
+    writer: anytype,
+    first: *bool,
+    action: CodexPreflightActionObject,
+) !void {
+    if (!first.*) try writer.writeByte(',');
+    first.* = false;
+    try writer.writeByte('{');
+    try writer.writeAll("\"kind\":");
+    try std.json.stringify(action.kind, .{}, writer);
+    try writer.writeAll(",\"label\":");
+    try std.json.stringify(action.label, .{}, writer);
+    try writer.writeAll(",\"command\":");
+    try std.json.stringify(action.command, .{}, writer);
+    try writer.writeAll(",\"budget\":");
+    try std.json.stringify(action.budget, .{}, writer);
+    try writer.writeAll(",\"agent_safe\":");
+    try writer.writeAll(if (action.agent_safe) "true" else "false");
+    try writer.writeAll(",\"may_spend_provider_calls\":");
+    try writer.writeAll(if (action.may_spend_provider_calls) "true" else "false");
+    try writer.writeAll(",\"mutates_user_config\":");
+    try writer.writeAll(if (action.mutates_user_config) "true" else "false");
+    try writer.writeAll(",\"mutates_route_health\":");
+    try writer.writeAll(if (action.mutates_route_health) "true" else "false");
+    try writer.writeAll(",\"interactive\":");
+    try writer.writeAll(if (action.interactive) "true" else "false");
+    try writer.writeByte('}');
 }
 
 fn writeCodexPreflightNextActionsText(
     writer: anytype,
+    allocator: std.mem.Allocator,
     profile: ?[]const u8,
     capability: ?[]const u8,
     session_start_ready: bool,
     fallback_ready: bool,
 ) !void {
     if (!session_start_ready or !fallback_ready) {
-        const refresh = try codexPreflightStayAfloatCommand(std.heap.page_allocator, profile, capability);
-        defer std.heap.page_allocator.free(refresh);
-        try writer.print("  {s}\n", .{refresh});
-    }
-    if (!session_start_ready) {
-        const plan = try codexPreflightPlanCommand(std.heap.page_allocator, profile, capability);
-        defer std.heap.page_allocator.free(plan);
+        const plan = try codexPreflightPlanCommand(allocator, profile, capability);
+        defer allocator.free(plan);
+        try writer.writeAll("\nNo-spend diagnostics:\n");
         try writer.print("  {s}\n", .{plan});
+    }
+    if (!session_start_ready or !fallback_ready) {
+        const refresh = try codexPreflightStayAfloatCommand(allocator, profile, capability);
+        defer allocator.free(refresh);
+        try writer.writeAll("\nSpend-confirmed repair:\n");
+        try writer.print("  {s}\n", .{refresh});
+        try writer.writeAll("    budget=spend_provider agent_safe=false may_spend_provider_calls=true mutates_route_health=true\n");
     }
 }
 


### PR DESCRIPTION
## Summary

- split `codex preflight` repair guidance into `agent_safe_next_actions` and `spend_confirmed_next_actions`
- show matching no-spend diagnostics and spend-confirmed repair sections in text output
- keep legacy `next_actions` for compatibility, now ordered with the no-spend plan first
- document wrapper behavior and cover the new lanes in first-run e2e

## Why

The preflight command is no-spend, but its unlabeled next-action list could lead an agent or wrapper to run `stay-afloat --execute` without distinguishing it from safe inspection. The new fields make the automation boundary explicit while preserving existing consumers.

## Validation

- `zig build test`
- `zig build && scripts/first-run-e2e.sh`
- `git diff --check`
- `just check-local`
