### PR TITLE
Fix Codex shim login and route health recovery

### DIFF
--- a/scripts/install-local-dogfood.sh
+++ b/scripts/install-local-dogfood.sh
@@ -117,6 +117,21 @@ if [ -z "\$native_codex" ]; then
     exit 127
 fi
 
+should_pass_native() {
+    case "\${1:-}" in
+        --help|-h|help|--version|-V|version|login|logout|auth|mcp|completion|completions)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+if should_pass_native "\${1:-}"; then
+    exec "\$native_codex" "\$@"
+fi
+
 OMUX_CODEX_BIN="\$native_codex" OMUX_CODEX_SHIM=1 OMUX_COMMAND_SPELLING=codex exec "\$oauth_mux_bin" codex "\$@"
 EOF
   chmod 0755 "$codex_target"

--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -371,6 +371,59 @@ else
     exit 1
 fi
 
+echo "smoke-codex-cli-ux: managed codex shim passes native admin commands through"
+DOGFOOD_BIN="$TMP/dogfood-bin"
+NATIVE_CODEX="$TMP/native-codex"
+NATIVE_REPORT="$TMP/native-codex.report"
+NATIVE_STDOUT="$TMP/native-codex.stdout"
+mkdir -p "$DOGFOOD_BIN"
+cat >"$NATIVE_CODEX" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ -n "${OMUX_NATIVE_CODEX_REPORT:-}" ]]; then
+    printf '%s\n' "$@" >"$OMUX_NATIVE_CODEX_REPORT"
+fi
+case "${1:-}" in
+    --version|-V|version)
+        printf '%s\n' 'codex-cli-native-stub 0.0.0'
+        ;;
+    login)
+        printf '%s\n' 'native-login-stub'
+        ;;
+    *)
+        printf '%s\n' 'native-codex-stub'
+        ;;
+esac
+EOF
+chmod 0755 "$NATIVE_CODEX"
+
+INSTALL_DIR="$DOGFOOD_BIN" \
+  OMUX_DOGFOOD_SKIP_BUILD=1 \
+  OMUX_CODEX_BIN="$NATIVE_CODEX" \
+  "$ROOT/scripts/install-local-dogfood.sh" >"$TMP/dogfood-install.stdout"
+
+OMUX_CODEX_BIN="$NATIVE_CODEX" \
+  OMUX_NATIVE_CODEX_REPORT="$NATIVE_REPORT" \
+  "$DOGFOOD_BIN/codex" --version >"$NATIVE_STDOUT"
+assert_grep "shim --version used native codex" 'codex-cli-native-stub' "$NATIVE_STDOUT"
+assert_grep "shim --version argv recorded by native" '^--version$' "$NATIVE_REPORT"
+
+rm -f "$NATIVE_REPORT" "$NATIVE_STDOUT"
+XDG_DATA_HOME="$TMP/native-xdg" \
+  OMUX_CODEX_BIN="$NATIVE_CODEX" \
+  OMUX_NATIVE_CODEX_REPORT="$NATIVE_REPORT" \
+  "$DOGFOOD_BIN/codex" login --help >"$NATIVE_STDOUT"
+assert_grep "shim login used native codex" 'native-login-stub' "$NATIVE_STDOUT"
+assert_grep "shim login argv recorded by native" '^login$' "$NATIVE_REPORT"
+assert_grep "shim login help argv recorded by native" '^--help$' "$NATIVE_REPORT"
+if [[ -e "$TMP/native-xdg/oauth-mux/codex/max-1" ]]; then
+    echo "  ✗ shim login created mux account directory instead of passing through native Codex" >&2
+    find "$TMP/native-xdg" -maxdepth 4 -print >&2 || true
+    exit 1
+else
+    echo "  ✓ shim login did not bootstrap mux account dirs"
+fi
+
 echo "smoke-codex-cli-ux: no-profile codex election is provider-scoped"
 NO_PROFILE_NDJSON="$TMP/no-profile/status.ndjson"
 NO_PROFILE_STDERR="$TMP/no-profile.stderr"

--- a/src/broker_loader.zig
+++ b/src/broker_loader.zig
@@ -162,14 +162,16 @@ fn routeHealthForPoolAccount(
     account_id: []const u8,
     store: *health_mod.HealthStore,
 ) ?health_mod.AccountHealth {
+    const now = std.time.timestamp();
     const colon = std.mem.indexOfScalar(u8, account_id, ':') orelse return null;
     const provider = account_id[0..colon];
     const account = account_id[colon + 1 ..];
     const account_key = health_mod.accountKey(provider, account);
     if (store.accounts.get(account_key.slice())) |account_health| {
-        if (accountLivenessBlocksRoute(account_health.liveness)) {
+        const effective = health_mod.effectiveHealthForRouteSelection(account_health, now);
+        if (accountLivenessBlocksRoute(effective.liveness)) {
             if (authMaterialRepairHealth(allocator, cfg, provider, account, account_health)) |repaired| return repaired;
-            return account_health;
+            return effective;
         }
     }
 
@@ -182,20 +184,22 @@ fn routeHealthForPoolAccount(
                 const capability = profile_entry[hash + 1 ..];
                 const capability_key = health_mod.capabilityKey(provider, account, capability);
                 if (store.accounts.get(capability_key.slice())) |capability_health| {
-                    if (accountLivenessBlocksRoute(capability_health.liveness)) {
+                    const effective = health_mod.effectiveHealthForRouteSelection(capability_health, now);
+                    if (accountLivenessBlocksRoute(effective.liveness)) {
                         if (authMaterialRepairHealth(allocator, cfg, provider, account, capability_health)) |repaired| return repaired;
                     }
-                    return capability_health;
+                    return effective;
                 }
             }
         }
     }
 
     if (store.accounts.get(account_key.slice())) |account_health| {
-        if (accountLivenessBlocksRoute(account_health.liveness)) {
+        const effective = health_mod.effectiveHealthForRouteSelection(account_health, now);
+        if (accountLivenessBlocksRoute(effective.liveness)) {
             if (authMaterialRepairHealth(allocator, cfg, provider, account, account_health)) |repaired| return repaired;
         }
-        return account_health;
+        return effective;
     }
     return null;
 }
@@ -752,8 +756,7 @@ test "codex auth refresh detection uses access token exp" {
     const payload = try std.fmt.bufPrint(&payload_buf, "{{\"exp\":{d}}}", .{future_exp});
     var encoded_buf: [128]u8 = undefined;
     const encoded = std.base64.url_safe_no_pad.Encoder.encode(&encoded_buf, payload);
-    const fresh_auth = try std.fmt.allocPrint(
-        std.testing.allocator,
+    const fresh_auth = try std.fmt.allocPrint(std.testing.allocator,
         \\{{"tokens":{{"access_token":"h.{s}.s","refresh_token":"rt","account_id":"acc"}}}}
     , .{encoded});
     defer std.testing.allocator.free(fresh_auth);
@@ -913,6 +916,94 @@ test "populatePoolFromRouteHealth mirrors broker-session-plan route health" {
             try std.testing.expectEqual(broker.account_pool_mod.Availability.unknown, entry.availability);
         }
     }
+}
+
+test "populatePoolFromRouteHealth lets expired provider degradation yield to capability health" {
+    const cfg_json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "/tmp/a" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "codex-max": { "providers": ["codex:max-1#codex-max"] }
+        \\  }
+        \\}
+    ;
+    var parsed = try config_mod.loadFromBytes(std.testing.allocator, cfg_json);
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    const now = std.time.timestamp();
+    const account_health = try store.getOrCreate("codex:max-1");
+    account_health.liveness = .{ .degraded = .{
+        .reason = .provider_degraded,
+        .since = now - 120,
+        .retry_at = now - 1,
+    } };
+    account_health.last_probe_hint_class = .provider_degraded;
+    account_health.last_probe_decision = .try_next_provider;
+    const capability_health = try store.getOrCreate("codex:max-1#codex-max");
+    capability_health.liveness = .{ .live = .{ .availability = .available } };
+    capability_health.last_probe_hint_class = .none;
+    capability_health.last_probe_decision = .use_this;
+
+    var pool = broker.AccountPool.init(std.testing.allocator);
+    defer pool.deinit();
+    try populatePoolFromRouteHealth(&pool, parsed.value, "codex-max", &store);
+
+    const elected = try pool.elect(null, null, &.{});
+    try std.testing.expectEqualStrings("codex:max-1", elected.id);
+    try std.testing.expectEqual(broker.account_pool_mod.Availability.available, elected.availability);
+}
+
+test "populatePoolFromRouteHealth keeps auth-dead account health global" {
+    const cfg_json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "/tmp/a" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "codex-max": { "providers": ["codex:max-1#codex-max"] }
+        \\  }
+        \\}
+    ;
+    var parsed = try config_mod.loadFromBytes(std.testing.allocator, cfg_json);
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    const now = std.time.timestamp();
+    const account_health = try store.getOrCreate("codex:max-1");
+    account_health.liveness = .{ .dead = .{
+        .reason = .token_revoked,
+        .since = now - 120,
+    } };
+    account_health.last_probe_hint_class = .auth_dead;
+    account_health.last_probe_decision = .try_next_account;
+    const capability_health = try store.getOrCreate("codex:max-1#codex-max");
+    capability_health.liveness = .{ .live = .{ .availability = .available } };
+    capability_health.last_probe_hint_class = .none;
+    capability_health.last_probe_decision = .use_this;
+
+    var pool = broker.AccountPool.init(std.testing.allocator);
+    defer pool.deinit();
+    try populatePoolFromRouteHealth(&pool, parsed.value, "codex-max", &store);
+
+    try std.testing.expectError(broker_types.BrokerError.NoAccountSelectable, pool.elect(null, null, &.{}));
+    try std.testing.expectEqual(broker.account_pool_mod.Liveness.dead, pool.accounts.items[0].liveness);
 }
 
 test "populatePoolFromRouteHealth treats newer auth material as route repair evidence" {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1915,6 +1915,16 @@ test "parse codex probe-all with capability alias" {
 }
 
 test "parse codex login account" {
+    const login_args = [_][]const u8{ "codex", "login", "max-2" };
+    const login_cmd = parse(&login_args);
+    switch (login_cmd) {
+        .codex => |codex| {
+            try std.testing.expect(codex.action == .login);
+            try std.testing.expectEqualStrings("max-2", codex.account.?);
+        },
+        else => return error.Unexpected,
+    }
+
     const args = [_][]const u8{ "codex", "login-device", "max-2" };
     const cmd = parse(&args);
     switch (cmd) {

--- a/src/health.zig
+++ b/src/health.zig
@@ -173,6 +173,44 @@ pub fn decisionFromClassification(classification: types.HttpClassification) type
     };
 }
 
+pub fn effectiveHealthForRouteSelection(health: AccountHealth, now: i64) AccountHealth {
+    var result = health;
+    recoverExpiredTransientHealth(&result, now);
+    return result;
+}
+
+pub fn recoverExpiredTransientHealth(health: *AccountHealth, now: i64) void {
+    switch (health.liveness) {
+        .degraded => |d| {
+            const retry_at = d.retry_at orelse return;
+            if (now < retry_at) return;
+            if (!degradedReasonIsTransientForRouteSelection(d.reason)) return;
+            health.liveness = .{ .live = .{ .availability = .available } };
+            health.last_probe_retry_after_s = null;
+            health.last_probe_hint_class = .none;
+            health.last_probe_decision = .use_this;
+            health.consecutive_failures = 0;
+        },
+        else => {},
+    }
+}
+
+pub fn degradedReasonIsTransientForRouteSelection(reason: types.DegradedReason) bool {
+    return switch (reason) {
+        .provider_degraded => true,
+        .tier_insufficient,
+        .subscription_paused,
+        .scope_insufficient,
+        .audience_mismatch,
+        .schema_invalid,
+        .terms_required,
+        .step_up_required,
+        .pending_verification,
+        .unknown_4xx,
+        => false,
+    };
+}
+
 pub const HealthStore = struct {
     allocator: std.mem.Allocator,
     accounts: std.StringHashMap(AccountHealth),
@@ -997,6 +1035,43 @@ test "HealthStore account decisions dominate capability route decisions" {
         types.MuxDecision.try_next_account,
         store.muxDecisionFor("codex", "max-1", "codex-max"),
     );
+}
+
+test "effectiveHealthForRouteSelection recovers only expired transient degradation" {
+    const now: i64 = 1_800_000_000;
+
+    const recovered = effectiveHealthForRouteSelection(.{
+        .liveness = .{ .degraded = .{
+            .reason = .provider_degraded,
+            .since = now - 120,
+            .retry_at = now - 1,
+        } },
+        .last_probe_hint_class = .provider_degraded,
+        .last_probe_decision = .try_next_provider,
+        .consecutive_failures = 1,
+    }, now);
+    switch (recovered.liveness) {
+        .live => |live| switch (live.availability) {
+            .available => {},
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqual(ProbeHintClass.none, recovered.last_probe_hint_class.?);
+    try std.testing.expectEqual(types.MuxDecision.use_this, recovered.last_probe_decision.?);
+    try std.testing.expectEqual(@as(u32, 0), recovered.consecutive_failures);
+
+    const still_blocked = effectiveHealthForRouteSelection(.{
+        .liveness = .{ .degraded = .{
+            .reason = .step_up_required,
+            .since = now - 7200,
+            .retry_at = now - 1,
+        } },
+    }, now);
+    switch (still_blocked.liveness) {
+        .degraded => |degraded| try std.testing.expectEqual(types.DegradedReason.step_up_required, degraded.reason),
+        else => return error.TestUnexpectedResult,
+    }
 }
 
 test "parseHealthKey supports account and capability routes" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -3150,7 +3150,7 @@ fn executeCodexLoginDeviceRepair(
     const config_dir = account.config_dir orelse return false;
     const expanded = try paths.expandTilde(allocator, config_dir);
     defer allocator.free(expanded);
-    return try runCodexCli(allocator, expanded, &.{ "codex", "login", "--device-auth" });
+    return try runCodexCli(allocator, expanded, &.{ "login", "--device-auth" });
 }
 
 fn collectRepairPlanRoutes(
@@ -3593,15 +3593,21 @@ fn daemonRepairAdmission(policy: config.DaemonPolicyConfig, action: RepairAction
 }
 
 fn routeHealth(store: *health_mod.HealthStore, route: RepairPlanRoute) ?health_mod.AccountHealth {
+    const now = std.time.timestamp();
     const account_key = health_mod.accountKey(route.provider, route.account);
-    const account_health = store.accounts.get(account_key.slice());
+    const account_health = if (store.accounts.get(account_key.slice())) |health|
+        health_mod.effectiveHealthForRouteSelection(health, now)
+    else
+        null;
     if (account_health) |health| {
         if (accountLivenessBlocksRoute(health.liveness)) return health;
     }
 
     if (route.capability) |capability| {
         const capability_key = health_mod.capabilityKey(route.provider, route.account, capability);
-        if (store.accounts.get(capability_key.slice())) |health| return health;
+        if (store.accounts.get(capability_key.slice())) |health| {
+            return health_mod.effectiveHealthForRouteSelection(health, now);
+        }
     }
 
     return account_health;
@@ -8409,21 +8415,21 @@ fn runCodex(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Cod
             try bootstrapOneCodexDir(allocator, writer, root, account);
             const dir = try codexAccountDir(allocator, root, account);
             defer allocator.free(dir);
-            if (!try runCodexCli(allocator, dir, &.{ "codex", "login" })) return error.CodexCommandFailed;
+            if (!try runCodexCli(allocator, dir, &.{"login"})) return error.CodexCommandFailed;
         },
         .login_device => {
             const account = singleCodexAccount(args) orelse return error.MissingAccount;
             try bootstrapOneCodexDir(allocator, writer, root, account);
             const dir = try codexAccountDir(allocator, root, account);
             defer allocator.free(dir);
-            if (!try runCodexCli(allocator, dir, &.{ "codex", "login", "--device-auth" })) return error.CodexCommandFailed;
+            if (!try runCodexCli(allocator, dir, &.{ "login", "--device-auth" })) return error.CodexCommandFailed;
         },
         .login_status => {
             const account = singleCodexAccount(args) orelse return error.MissingAccount;
             const dir = try codexAccountDir(allocator, root, account);
             defer allocator.free(dir);
             try writer.print("=== {s} ===\nCODEX_HOME={s}\n", .{ account, dir });
-            if (!try runCodexCli(allocator, dir, &.{ "codex", "login", "status" })) return error.CodexCommandFailed;
+            if (!try runCodexCli(allocator, dir, &.{ "login", "status" })) return error.CodexCommandFailed;
         },
         .login_status_all => try runCodexLoginStatusAll(allocator, writer, args, root),
         .onboard => try runCodexOnboard(allocator, writer, args, root),
@@ -8467,21 +8473,21 @@ fn runCodexOnboard(allocator: std.mem.Allocator, writer: anytype, args: cli.Comm
         defer allocator.free(dir);
 
         try writer.print("\n=== {s} ===\nCODEX_HOME={s}\n", .{ account, dir });
-        if (try runCodexCli(allocator, dir, &.{ "codex", "login", "status" })) continue;
+        if (try runCodexCli(allocator, dir, &.{ "login", "status" })) continue;
         if (args.status_only) {
             failures += 1;
             continue;
         }
 
         const login_argv = if (args.device)
-            &[_][]const u8{ "codex", "login", "--device-auth" }
+            &[_][]const u8{ "login", "--device-auth" }
         else
-            &[_][]const u8{ "codex", "login" };
+            &[_][]const u8{"login"};
         if (!try runCodexCli(allocator, dir, login_argv)) {
             failures += 1;
             continue;
         }
-        if (!try runCodexCli(allocator, dir, &.{ "codex", "login", "status" })) failures += 1;
+        if (!try runCodexCli(allocator, dir, &.{ "login", "status" })) failures += 1;
     }
 
     try writer.writeAll("\n=== oauth-mux discovery ===\n");
@@ -9617,6 +9623,8 @@ const CodexPreflightRepairSummary = struct {
     quota_exhausted_routes: usize = 0,
     rate_limited_routes: usize = 0,
     tier_insufficient_routes: usize = 0,
+    token_revoked_routes: usize = 0,
+    provider_degraded_routes: usize = 0,
     auth_permanently_failed_routes: usize = 0,
     credential_unavailable_routes: usize = 0,
     not_afloat_routes: usize = 0,
@@ -9639,6 +9647,8 @@ fn codexPreflightClassifyRepairRoute(summary: *CodexPreflightRepairSummary, reas
     if (std.mem.eql(u8, reason, "quota_exhausted")) summary.quota_exhausted_routes += 1;
     if (std.mem.eql(u8, reason, "rate_limited")) summary.rate_limited_routes += 1;
     if (std.mem.eql(u8, reason, "tier_insufficient")) summary.tier_insufficient_routes += 1;
+    if (std.mem.eql(u8, reason, "token_revoked")) summary.token_revoked_routes += 1;
+    if (std.mem.eql(u8, reason, "provider_degraded")) summary.provider_degraded_routes += 1;
     if (std.mem.eql(u8, reason, "auth_permanently_failed")) summary.auth_permanently_failed_routes += 1;
     if (std.mem.eql(u8, reason, "credential_unavailable")) summary.credential_unavailable_routes += 1;
     if (std.mem.eql(u8, reason, "not_afloat")) summary.not_afloat_routes += 1;
@@ -9679,6 +9689,8 @@ fn codexPreflightFinalizeRepairSummary(summary: *CodexPreflightRepairSummary) vo
     codexPreflightSetDominantBlocker(summary, "quota_exhausted", summary.quota_exhausted_routes);
     codexPreflightSetDominantBlocker(summary, "rate_limited", summary.rate_limited_routes);
     codexPreflightSetDominantBlocker(summary, "tier_insufficient", summary.tier_insufficient_routes);
+    codexPreflightSetDominantBlocker(summary, "token_revoked", summary.token_revoked_routes);
+    codexPreflightSetDominantBlocker(summary, "provider_degraded", summary.provider_degraded_routes);
     codexPreflightSetDominantBlocker(summary, "auth_permanently_failed", summary.auth_permanently_failed_routes);
     codexPreflightSetDominantBlocker(summary, "credential_unavailable", summary.credential_unavailable_routes);
     codexPreflightSetDominantBlocker(summary, "not_afloat", summary.not_afloat_routes);
@@ -9737,6 +9749,8 @@ fn writeCodexPreflightRepairSummaryJson(
     try writer.print(",\"quota_exhausted_routes\":{d}", .{summary.quota_exhausted_routes});
     try writer.print(",\"rate_limited_routes\":{d}", .{summary.rate_limited_routes});
     try writer.print(",\"tier_insufficient_routes\":{d}", .{summary.tier_insufficient_routes});
+    try writer.print(",\"token_revoked_routes\":{d}", .{summary.token_revoked_routes});
+    try writer.print(",\"provider_degraded_routes\":{d}", .{summary.provider_degraded_routes});
     try writer.print(",\"auth_permanently_failed_routes\":{d}", .{summary.auth_permanently_failed_routes});
     try writer.print(",\"credential_unavailable_routes\":{d}", .{summary.credential_unavailable_routes});
     try writer.print(",\"not_afloat_routes\":{d}", .{summary.not_afloat_routes});
@@ -9772,6 +9786,8 @@ fn writeCodexPreflightRepairSummaryText(
     if (summary.quota_exhausted_routes != 0) try writer.print(" quota_exhausted={d}", .{summary.quota_exhausted_routes});
     if (summary.rate_limited_routes != 0) try writer.print(" rate_limited={d}", .{summary.rate_limited_routes});
     if (summary.tier_insufficient_routes != 0) try writer.print(" tier_insufficient={d}", .{summary.tier_insufficient_routes});
+    if (summary.token_revoked_routes != 0) try writer.print(" token_revoked={d}", .{summary.token_revoked_routes});
+    if (summary.provider_degraded_routes != 0) try writer.print(" provider_degraded={d}", .{summary.provider_degraded_routes});
     if (summary.auth_permanently_failed_routes != 0) try writer.print(" auth_permanently_failed={d}", .{summary.auth_permanently_failed_routes});
     if (summary.credential_unavailable_routes != 0) try writer.print(" credential_unavailable={d}", .{summary.credential_unavailable_routes});
     if (summary.not_afloat_routes != 0) try writer.print(" not_afloat={d}", .{summary.not_afloat_routes});
@@ -15610,7 +15626,7 @@ fn runCodexLoginStatusAll(allocator: std.mem.Allocator, writer: anytype, args: c
         const dir = try codexAccountDir(allocator, root, account);
         defer allocator.free(dir);
         try writer.print("=== {s} ===\nCODEX_HOME={s}\n", .{ account, dir });
-        if (!try runCodexCli(allocator, dir, &.{ "codex", "login", "status" })) failures += 1;
+        if (!try runCodexCli(allocator, dir, &.{ "login", "status" })) failures += 1;
     }
     if (failures != 0) return error.CodexCommandFailed;
 }
@@ -15804,10 +15820,34 @@ fn getEnvOwnedOrNull(allocator: std.mem.Allocator, name: []const u8) !?[]const u
     };
 }
 
-fn runCodexCli(allocator: std.mem.Allocator, account_dir: []const u8, argv: []const []const u8) !bool {
+fn resolveNativeCodexBinary(allocator: std.mem.Allocator) ![]const u8 {
+    if (try getEnvOwnedOrNull(allocator, "OMUX_CODEX_BIN")) |env_path| {
+        errdefer allocator.free(env_path);
+        if (env_path.len != 0 and fileExists(env_path) and !(try isOauthMuxShimPath(allocator, env_path))) return env_path;
+        allocator.free(env_path);
+    }
+
+    var candidates = try collectPathCandidates(allocator, "codex");
+    defer candidates.deinit(allocator);
+    if (try firstNativeCodexCandidate(allocator, candidates.paths.items)) |path_value| {
+        return try allocator.dupe(u8, path_value);
+    }
+    return error.CodexNativeBinaryNotFound;
+}
+
+fn runCodexCli(allocator: std.mem.Allocator, account_dir: []const u8, codex_args: []const []const u8) !bool {
+    const codex_bin = try resolveNativeCodexBinary(allocator);
+    defer allocator.free(codex_bin);
+
+    var argv = try allocator.alloc([]const u8, codex_args.len + 1);
+    defer allocator.free(argv);
+    argv[0] = codex_bin;
+    @memcpy(argv[1..], codex_args);
+
     var env_map = try std.process.getEnvMap(allocator);
     defer env_map.deinit();
     try env_map.put("CODEX_HOME", account_dir);
+    _ = env_map.remove("OMUX_CODEX_SHIM");
 
     var child = std.process.Child.init(argv, allocator);
     child.stdin_behavior = .Inherit;
@@ -16589,6 +16629,44 @@ test "Codex preflight repair summary separates revalidation from user handoff" {
     try std.testing.expect(summary.spend_confirmed_repair_available);
     try std.testing.expect(summary.user_handoff_required);
     try std.testing.expectEqualStrings("revalidation_needed", summary.dominant_blocker.?);
+    try std.testing.expectEqual(@as(usize, 2), summary.dominant_blocker_count);
+}
+
+test "Codex preflight repair summary counts auth and provider blockers" {
+    var summary = CodexPreflightRepairSummary{
+        .route_repair_required = true,
+        .agent_safe_inspection_available = true,
+    };
+
+    const reauth = RepairAction{
+        .kind = .reauth,
+        .severity = "error",
+        .message = "reauth is owned by upstream CLI",
+        .mediation = .user_handoff,
+        .owner = .upstream_cli_login,
+        .command = .codex_login_device,
+        .budget = .interactive,
+        .interactive = true,
+        .mutating = true,
+    };
+    codexPreflightClassifyRepairRoute(&summary, "token_revoked", reauth);
+    codexPreflightClassifyRepairRoute(&summary, "token_revoked", reauth);
+    codexPreflightClassifyRepairRoute(&summary, "provider_degraded", .{
+        .kind = .try_next_provider,
+        .severity = "warning",
+        .message = "provider appears degraded",
+        .mediation = .provider_degraded,
+    });
+    codexPreflightClassifyRepairRoute(&summary, "auth_permanently_failed", reauth);
+    codexPreflightFinalizeRepairSummary(&summary);
+
+    try std.testing.expectEqual(@as(usize, 4), summary.blocked_routes);
+    try std.testing.expectEqual(@as(usize, 2), summary.token_revoked_routes);
+    try std.testing.expectEqual(@as(usize, 1), summary.provider_degraded_routes);
+    try std.testing.expectEqual(@as(usize, 1), summary.auth_permanently_failed_routes);
+    try std.testing.expectEqual(@as(usize, 3), summary.auth_handoff_routes);
+    try std.testing.expect(summary.user_handoff_required);
+    try std.testing.expectEqualStrings("token_revoked", summary.dominant_blocker.?);
     try std.testing.expectEqual(@as(usize, 2), summary.dominant_blocker_count);
 }
 


### PR DESCRIPTION
## Summary

- pass native Codex admin commands through the managed `codex` shim (`login`, `mcp`, `--version`, help, completions)
- make explicit `oauth-mux codex login*` commands resolve and exec the native Codex binary instead of plain `codex` from PATH
- normalize expired transient `provider_degraded` route health during route population while keeping auth-dead/token-revoked evidence global
- count `token_revoked` and `provider_degraded` in Codex preflight repair summaries and dominant blocker selection

## Root Cause

The installed `codex` shim forwarded every Codex invocation back through `oauth-mux codex ...`, so native admin flows like `codex login` could recurse into mux account bootstrap and repeatedly target the default mux account. Separately, route selection and preflight read raw persisted health records directly, so expired provider-side degradation could keep masking capability-specific available evidence.

## Validation

- `zig build test`
- `zig build`
- `scripts/smoke-codex-cli-ux.sh`
- `scripts/smoke-codex-concurrent-sessions.sh`
- `scripts/smoke-codex-status-summary.sh`
- `git diff --check`
- `nix develop --command just check-local`

## Dogfood

- refreshed `/Users/jess/.local/bin/oauth-mux` and `/Users/jess/.local/bin/codex`
- installed hash matches `./zig-out/bin/oauth-mux`
- `codex --version` and `codex login --help` now pass through to native Codex
- current no-spend `codex-max` preflight has one selectable route; remaining blockers are `token_revoked` x2 and `auth_permanently_failed` x1
