### PR TITLE
Add redacted oauth-mux tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ What works today:
 - Live managed Codex quota handoff for installed `oauth-mux codex resume`, with
   the strongest preserved proof in
   `docs/evidence/codex-engineered-quota-handoff-20260509/`.
-- Redacted JSON diagnostics for agents and operators.
+- Redacted JSON diagnostics and opt-in trace JSONL for agents and operators.
 
 Still research or open:
 
@@ -170,6 +170,17 @@ oauth-mux codex preflight --profile codex-max --capability codex-max --json
 oauth-mux codex status-latest --json
 ```
 
+When shell, install, auth, and route-health state disagree, enable the redacted
+trace sink:
+
+```bash
+OMUX_TRACE=1 \
+OMUX_TRACE_FILE=/tmp/oauth-mux-trace.ndjson \
+oauth-mux codex preflight --profile codex-max --capability codex-max --json
+```
+
+See `docs/tracing.md` for the trace schema and redaction contract.
+
 Those inspection commands do not spend provider calls. In the `0.1.7` candidate,
 managed Codex launch/resume and admitted stay-afloat execution may spend
 provider calls only to revalidate expired Codex quota/rate windows before route
@@ -198,6 +209,8 @@ Use `just release-proof <version>` before any registry mutation. Direct
 AX:
 
 - JSON surfaces are redacted and account-label based.
+- Trace events are opt-in and must not print token bytes, raw provider account
+  ids, raw Codex session ids, or local auth/config file paths.
 - Agents do not need token files or raw provider stores to choose a next action.
 - Provider-spend behavior is policy-labeled; no-spend inspection surfaces stay
   separate from managed Codex auto-revalidation and live probes.
@@ -213,6 +226,7 @@ Keep the claim ladder tied to evidence:
   lanes.
 - `docs/lifecycle.md`: application lifecycle, managed Codex flow, agent-safe
   control plane, and claim levels.
+- `docs/tracing.md`: opt-in trace schema, sink selection, and redaction rules.
 - `docs/evidence/codex-engineered-quota-handoff-20260509/`: current headline
   managed Codex quota-handoff proof.
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -74,6 +74,19 @@ present and valid, counts configured providers/accounts/profiles, reports
 whether health state exists, and prints the next safe commands for the current
 state.
 
+When local shell, install, auth, or route-health state disagree, enable the
+redacted trace sink:
+
+```bash
+OMUX_TRACE=1 \
+OMUX_TRACE_FILE=/tmp/oauth-mux-trace.ndjson \
+oauth-mux codex preflight --profile codex-max --capability codex-max --json
+```
+
+The trace format is documented in `docs/tracing.md`. It is designed for
+operator and agent debugging without printing token bytes, raw provider account
+ids, raw Codex session ids, or local auth/config file paths.
+
 `oauth-mux doctor runtime --json` is the no-spend runtime report. It checks
 upstream binary availability, configured account store directories, local write
 access via a temporary marker file, and expected session-file presence. It does

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,0 +1,61 @@
+# oauth-mux Tracing
+
+`oauth-mux` can emit redacted JSONL trace events for route, auth, runtime, and
+native Codex command decisions. Tracing is off by default.
+
+Enable it with one global flag:
+
+```bash
+OMUX_TRACE=1 oauth-mux codex preflight --profile codex-max --capability codex-max --json
+```
+
+By default, events are appended to:
+
+```text
+$OMUX_STATE_DIR/trace.ndjson
+```
+
+If `OMUX_STATE_DIR` is unset, the normal oauth-mux state directory is used. To
+send traces to a specific file:
+
+```bash
+OMUX_TRACE=1 \
+OMUX_TRACE_FILE=/tmp/oauth-mux-trace.ndjson \
+oauth-mux route explain --profile codex-max --capability codex-max --json
+```
+
+For external trace correlation, callers may provide:
+
+```bash
+OMUX_TRACE_ID=11111111111111111111111111111111
+OMUX_SPAN_ID=2222222222222222
+OMUX_PARENT_SPAN_ID=3333333333333333
+```
+
+Each event uses schema `oauth-mux.trace.v1` and includes:
+
+- `ts_unix_ms`
+- `name`
+- `severity`
+- `trace_id`
+- `span_id`
+- `parent_span_id`
+- `attributes`
+- `redaction`
+
+The first traced decisions are:
+
+- `health.normalize`: persisted transient provider degradation recovered for
+  route selection after its retry window expires.
+- `route.evaluate`: no-spend route runtime, liveness, action, and selectability.
+- `codex.native_binary.resolve`: native Codex binary resolution without printing
+  absolute paths.
+- `codex.native_command.spawn` and `codex.native_command.exit`: explicit
+  oauth-mux-managed Codex admin commands without printing `CODEX_HOME`.
+- `codex.shim.pass_through`: installed `codex` shim admin-command pass-through
+  without route election or native binary path output.
+
+Trace output must not include OAuth token bytes, raw provider account ids, raw
+Codex session ids, or local auth/config file paths. Attach `trace.ndjson` to a
+support issue only after confirming it was produced by the current version and
+does not include local shell output from other tools.

--- a/scripts/check-local.sh
+++ b/scripts/check-local.sh
@@ -14,6 +14,7 @@ done
 ./scripts/e2e-local.sh
 ./scripts/first-run-e2e.sh
 ./scripts/stay-afloat-wrapper-doc-smoke.sh
+./scripts/smoke-trace.sh
 ./scripts/smoke-broker.sh
 ./scripts/smoke-codex-cli-ux.sh
 ./scripts/smoke-codex-acceptance.sh

--- a/scripts/install-local-dogfood.sh
+++ b/scripts/install-local-dogfood.sh
@@ -117,6 +117,57 @@ if [ -z "\$native_codex" ]; then
     exit 127
 fi
 
+trace_enabled() {
+    case "\${OMUX_TRACE:-}" in
+        ""|0|false|FALSE|off|OFF|no|NO)
+            return 1
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+trace_file_path() {
+    if [ -n "\${OMUX_TRACE_FILE:-}" ]; then
+        printf '%s\n' "\$OMUX_TRACE_FILE"
+        return 0
+    fi
+    if [ -n "\${OMUX_STATE_DIR:-}" ]; then
+        printf '%s/trace.ndjson\n' "\$OMUX_STATE_DIR"
+        return 0
+    fi
+    case "\$(uname -s 2>/dev/null || true)" in
+        Darwin)
+            printf '%s/Library/Application Support/oauth-mux/trace.ndjson\n' "\${HOME:-/tmp}"
+            ;;
+        *)
+            printf '%s/.local/state/oauth-mux/trace.ndjson\n' "\${HOME:-/tmp}"
+            ;;
+    esac
+}
+
+trace_shim_event() {
+    trace_enabled || return 0
+    trace_file=\$(trace_file_path)
+    trace_dir=\$(dirname "\$trace_file")
+    mkdir -p "\$trace_dir" 2>/dev/null || return 0
+    ts="\$(date +%s)000"
+    case "\${1:-none}" in
+        --help|-h|help|--version|-V|version|login|logout|auth|mcp|completion|completions|resume|run)
+            first_arg="\${1:-none}"
+            ;;
+        *)
+            first_arg="other"
+            ;;
+    esac
+    trace_id="\${OMUX_TRACE_ID:-00000000000000000000000000000000}"
+    span_id="\${OMUX_SPAN_ID:-0000000000000000}"
+    case "\$trace_id" in *[!0123456789abcdefABCDEF]*|"") trace_id="00000000000000000000000000000000" ;; esac
+    case "\$span_id" in *[!0123456789abcdefABCDEF]*|"") span_id="0000000000000000" ;; esac
+    printf '{"schema":"oauth-mux.trace.v1","ts_unix_ms":%s,"name":"%s","severity":"info","trace_id":"%s","span_id":"%s","parent_span_id":null,"attributes":{"first_arg":"%s","native_binary_path_printed":false,"path_printed":false},"redaction":{"tokens":false,"raw_account_ids":false,"session_ids":false,"paths":false}}\n' "\$ts" "\$2" "\$trace_id" "\$span_id" "\$first_arg" >>"\$trace_file" 2>/dev/null || true
+}
+
 should_pass_native() {
     case "\${1:-}" in
         --help|-h|help|--version|-V|version|login|logout|auth|mcp|completion|completions)
@@ -129,9 +180,11 @@ should_pass_native() {
 }
 
 if should_pass_native "\${1:-}"; then
+    trace_shim_event "\${1:-none}" "codex.shim.pass_through"
     exec "\$native_codex" "\$@"
 fi
 
+trace_shim_event "\${1:-none}" "codex.shim.managed_entry"
 OMUX_CODEX_BIN="\$native_codex" OMUX_CODEX_SHIM=1 OMUX_COMMAND_SPELLING=codex exec "\$oauth_mux_bin" codex "\$@"
 EOF
   chmod 0755 "$codex_target"

--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -376,6 +376,7 @@ DOGFOOD_BIN="$TMP/dogfood-bin"
 NATIVE_CODEX="$TMP/native-codex"
 NATIVE_REPORT="$TMP/native-codex.report"
 NATIVE_STDOUT="$TMP/native-codex.stdout"
+SHIM_TRACE="$TMP/shim-trace.ndjson"
 mkdir -p "$DOGFOOD_BIN"
 cat >"$NATIVE_CODEX" <<'EOF'
 #!/usr/bin/env bash
@@ -404,18 +405,28 @@ INSTALL_DIR="$DOGFOOD_BIN" \
 
 OMUX_CODEX_BIN="$NATIVE_CODEX" \
   OMUX_NATIVE_CODEX_REPORT="$NATIVE_REPORT" \
+  OMUX_TRACE=1 \
+  OMUX_TRACE_FILE="$SHIM_TRACE" \
+  OMUX_TRACE_ID="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+  OMUX_SPAN_ID="bbbbbbbbbbbbbbbb" \
   "$DOGFOOD_BIN/codex" --version >"$NATIVE_STDOUT"
 assert_grep "shim --version used native codex" 'codex-cli-native-stub' "$NATIVE_STDOUT"
 assert_grep "shim --version argv recorded by native" '^--version$' "$NATIVE_REPORT"
+jq -e 'select(.name == "codex.shim.pass_through" and .attributes.first_arg == "--version" and .attributes.native_binary_path_printed == false and .redaction.paths == false)' "$SHIM_TRACE" >/dev/null
+echo "  ✓ shim --version emitted redacted pass-through trace"
 
 rm -f "$NATIVE_REPORT" "$NATIVE_STDOUT"
 XDG_DATA_HOME="$TMP/native-xdg" \
   OMUX_CODEX_BIN="$NATIVE_CODEX" \
   OMUX_NATIVE_CODEX_REPORT="$NATIVE_REPORT" \
+  OMUX_TRACE=1 \
+  OMUX_TRACE_FILE="$SHIM_TRACE" \
   "$DOGFOOD_BIN/codex" login --help >"$NATIVE_STDOUT"
 assert_grep "shim login used native codex" 'native-login-stub' "$NATIVE_STDOUT"
 assert_grep "shim login argv recorded by native" '^login$' "$NATIVE_REPORT"
 assert_grep "shim login help argv recorded by native" '^--help$' "$NATIVE_REPORT"
+jq -e 'select(.name == "codex.shim.pass_through" and .attributes.first_arg == "login" and .attributes.native_binary_path_printed == false and .redaction.tokens == false)' "$SHIM_TRACE" >/dev/null
+echo "  ✓ shim login emitted redacted pass-through trace"
 if [[ -e "$TMP/native-xdg/oauth-mux/codex/max-1" ]]; then
     echo "  ✗ shim login created mux account directory instead of passing through native Codex" >&2
     find "$TMP/native-xdg" -maxdepth 4 -print >&2 || true

--- a/scripts/smoke-trace.sh
+++ b/scripts/smoke-trace.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# No-spend trace smoke: global tracing emits redacted, OTEL-friendly JSONL for
+# route decisions and transient health normalization.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$ROOT/zig-out/bin/oauth-mux"
+
+if [[ ! -x "$BIN" ]]; then
+    echo "smoke-trace: oauth-mux binary not built at $BIN" >&2
+    echo "  run: just build" >&2
+    exit 64
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "smoke-trace: jq required" >&2
+    exit 64
+fi
+
+TMP="$(mktemp -d -t omux-trace.XXXXXX)"
+STATE_DIR="$TMP/state"
+TRACE_FILE="$TMP/trace.ndjson"
+PREFLIGHT_JSON="$TMP/preflight.json"
+SESSION_ID="019def98-6b1e-79b1-81a4-985e5242da23"
+SECRET_REFRESH="RT-trace-should-not-leak"
+RAW_ACCOUNT_ID="acc-trace-raw-id-should-not-leak"
+
+cleanup() {
+    rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP/account-A" "$STATE_DIR"
+
+ID_TOKEN="h.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9wbGFuX3R5cGUiOiJwcm8iLCJjaGF0Z3B0X2FjY291bnRfaXNfZmVkcmFtcCI6dHJ1ZX19.s"
+SECRET_TOKEN="$ID_TOKEN"
+cat >"$TMP/account-A/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"$SECRET_TOKEN","refresh_token":"$SECRET_REFRESH","account_id":"$RAW_ACCOUNT_ID"},"auth_mode":"Chatgpt"}
+EOF
+
+cat >"$TMP/oauth-mux.config.json" <<EOF
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "kind": "codex",
+      "accounts": {
+        "max-1": { "priority": 30, "config_dir": "$TMP/account-A", "secret": { "backend": "file", "path": "$TMP/account-A/auth.json" } }
+      }
+    }
+  },
+  "profiles": {
+    "codex-max": { "providers": ["codex:max-1#codex-max"] }
+  }
+}
+EOF
+
+cat >"$STATE_DIR/health.json" <<'EOF'
+{"version":2,"accounts":[
+  {"key":"codex:max-1","last_probe_source":"broker_run_live","last_probe_hint_class":"provider_degraded","last_probe_decision":"try_next_provider","liveness":{"state":"degraded","reason":"provider_degraded","since":1,"retry_at":1}},
+  {"key":"codex:max-1#codex-max","last_probe_source":"capability_probe","last_probe_hint_class":"none","last_probe_decision":"use_this","liveness":{"state":"live","availability":"available"}}
+]}
+EOF
+
+OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+  OMUX_STATE_DIR="$STATE_DIR" \
+  OMUX_TRACE=1 \
+  OMUX_TRACE_FILE="$TRACE_FILE" \
+  OMUX_TRACE_ID="11111111111111111111111111111111" \
+  OMUX_SPAN_ID="2222222222222222" \
+  "$BIN" codex preflight --profile codex-max --capability codex-max --json >"$PREFLIGHT_JSON"
+
+jq -e '.mode == "codex_preflight" and .route_summary.routes_total == 1' "$PREFLIGHT_JSON" >/dev/null
+
+if [[ ! -s "$TRACE_FILE" ]]; then
+    echo "smoke-trace: trace file missing or empty" >&2
+    exit 1
+fi
+
+jq -e 'select(.schema == "oauth-mux.trace.v1" and .trace_id == "11111111111111111111111111111111" and .span_id == "2222222222222222")' "$TRACE_FILE" >/dev/null
+jq -e 'select(.name == "health.normalize" and .attributes.before_liveness == "degraded:provider_degraded" and .attributes.after_liveness == "available")' "$TRACE_FILE" >/dev/null
+jq -e 'select(.name == "route.evaluate" and .attributes.provider == "codex" and .attributes.account_label == "max-1")' "$TRACE_FILE" >/dev/null
+jq -e 'select(.redaction.tokens == false and .redaction.raw_account_ids == false and .redaction.session_ids == false and .redaction.paths == false)' "$TRACE_FILE" >/dev/null
+
+assert_not_leaked() {
+    local label=$1 needle=$2
+    if grep -Fq "$needle" "$TRACE_FILE"; then
+        echo "smoke-trace: leaked $label in trace output" >&2
+        cat "$TRACE_FILE" >&2
+        exit 1
+    fi
+    echo "  ✓ did not leak $label"
+}
+
+assert_not_leaked "access token" "$SECRET_TOKEN"
+assert_not_leaked "refresh token" "$SECRET_REFRESH"
+assert_not_leaked "raw account id" "$RAW_ACCOUNT_ID"
+assert_not_leaked "auth file path" "$TMP/account-A/auth.json"
+assert_not_leaked "session id" "$SESSION_ID"
+
+echo "smoke-trace: all assertions passed."

--- a/src/broker_loader.zig
+++ b/src/broker_loader.zig
@@ -13,6 +13,7 @@ const broker_types = @import("broker/types.zig");
 const health_mod = @import("health.zig");
 const oauth = @import("oauth.zig");
 const paths = @import("paths.zig");
+const trace = @import("trace.zig");
 const types = @import("types.zig");
 
 /// Populate `pool` with one entry per `<provider>:<account>` defined in
@@ -169,6 +170,7 @@ fn routeHealthForPoolAccount(
     const account_key = health_mod.accountKey(provider, account);
     if (store.accounts.get(account_key.slice())) |account_health| {
         const effective = health_mod.effectiveHealthForRouteSelection(account_health, now);
+        tracePoolHealthNormalization(allocator, provider, account, null, "account", account_health.liveness, effective.liveness);
         if (accountLivenessBlocksRoute(effective.liveness)) {
             if (authMaterialRepairHealth(allocator, cfg, provider, account, account_health)) |repaired| return repaired;
             return effective;
@@ -185,6 +187,7 @@ fn routeHealthForPoolAccount(
                 const capability_key = health_mod.capabilityKey(provider, account, capability);
                 if (store.accounts.get(capability_key.slice())) |capability_health| {
                     const effective = health_mod.effectiveHealthForRouteSelection(capability_health, now);
+                    tracePoolHealthNormalization(allocator, provider, account, capability, "capability", capability_health.liveness, effective.liveness);
                     if (accountLivenessBlocksRoute(effective.liveness)) {
                         if (authMaterialRepairHealth(allocator, cfg, provider, account, capability_health)) |repaired| return repaired;
                     }
@@ -196,12 +199,46 @@ fn routeHealthForPoolAccount(
 
     if (store.accounts.get(account_key.slice())) |account_health| {
         const effective = health_mod.effectiveHealthForRouteSelection(account_health, now);
+        tracePoolHealthNormalization(allocator, provider, account, null, "account", account_health.liveness, effective.liveness);
         if (accountLivenessBlocksRoute(effective.liveness)) {
             if (authMaterialRepairHealth(allocator, cfg, provider, account, account_health)) |repaired| return repaired;
         }
         return effective;
     }
     return null;
+}
+
+fn tracePoolHealthNormalization(
+    allocator: std.mem.Allocator,
+    provider_name: []const u8,
+    account_label: []const u8,
+    capability: ?[]const u8,
+    source_scope: []const u8,
+    before: types.CredentialLiveness,
+    after: types.CredentialLiveness,
+) void {
+    var before_buf: [128]u8 = undefined;
+    var after_buf: [128]u8 = undefined;
+    const before_summary = livenessSummaryIntoBuffer(before, &before_buf);
+    const after_summary = livenessSummaryIntoBuffer(after, &after_buf);
+    if (std.mem.eql(u8, before_summary, after_summary)) return;
+
+    trace.append(allocator, "health.normalize", .info, &.{
+        trace.string("provider", provider_name),
+        trace.string("account_label", account_label),
+        trace.string("capability", capability orelse "none"),
+        trace.string("source_scope", source_scope),
+        trace.string("before_liveness", before_summary),
+        trace.string("after_liveness", after_summary),
+        trace.boolean("token_material_printed", false),
+        trace.boolean("path_printed", false),
+    });
+}
+
+fn livenessSummaryIntoBuffer(liveness: types.CredentialLiveness, buf: []u8) []const u8 {
+    var stream = std.io.fixedBufferStream(buf);
+    health_mod.writeLivenessSummary(stream.writer(), liveness) catch return "unavailable";
+    return stream.getWritten();
 }
 
 fn accountLivenessBlocksRoute(liveness: types.CredentialLiveness) bool {

--- a/src/main.zig
+++ b/src/main.zig
@@ -14,6 +14,7 @@ const daemon = @import("daemon.zig");
 const repair_state = @import("repair_state.zig");
 const runtime_mod = @import("runtime.zig");
 const secret_mod = @import("secret.zig");
+const trace = @import("trace.zig");
 const broker = @import("broker/mod.zig");
 const broker_loader = @import("broker_loader.zig");
 const codex_adapter = @import("adapters/codex/main.zig");
@@ -23,6 +24,7 @@ comptime {
     _ = broker;
     _ = broker_loader;
     _ = codex_adapter;
+    _ = trace;
     _ = @import("adapters/codex/app_server_client.zig");
     _ = @import("adapters/codex/wire_proxy.zig");
 }
@@ -431,7 +433,7 @@ fn writeAccountsListText(
             for (def.capabilities) |capability| {
                 const route = RepairPlanRoute{ .provider = provider_name, .account = account_name, .capability = capability.name };
                 const runtime = try routeRuntimeReadiness(allocator, cfg, route, def);
-                const health = routeHealth(store, route);
+                const health = routeHealth(allocator, store, route);
                 const selectable = routeSelectable(runtime, health);
                 try writer.print("    {s} proof={s} selectable={s} runtime={s}", .{
                     capability.name,
@@ -570,7 +572,7 @@ fn writeAccountCapabilityJson(
 ) !void {
     const route = RepairPlanRoute{ .provider = provider_name, .account = account_name, .capability = capability.name };
     const runtime = try routeRuntimeReadiness(allocator, cfg, route, def);
-    const health = routeHealth(store, route);
+    const health = routeHealth(allocator, store, route);
     const budget = routeProbeBudget(def, capability.name);
     const action = repairActionFor(route, def, runtime, health, budget);
     const selectable = routeSelectable(runtime, health);
@@ -3263,7 +3265,7 @@ fn writeRepairPlanText(
     for (routes) |route| {
         const def = config.resolveProviderDefinition(cfg, route.provider);
         const runtime = try routeRuntimeReadiness(allocator, cfg, route, def);
-        const health = routeHealth(store, route);
+        const health = routeHealth(allocator, store, route);
         const budget = routeProbeBudget(def, route.capability);
         const action = repairActionFor(route, def, runtime, health, budget);
 
@@ -3327,7 +3329,7 @@ fn writeRepairPlanRouteJson(
 ) !void {
     const def = config.resolveProviderDefinition(cfg, route.provider);
     const runtime = try routeRuntimeReadiness(allocator, cfg, route, def);
-    const health = routeHealth(store, route);
+    const health = routeHealth(allocator, store, route);
     const budget = routeProbeBudget(def, route.capability);
     const action = repairActionFor(route, def, runtime, health, budget);
 
@@ -3592,11 +3594,11 @@ fn daemonRepairAdmission(policy: config.DaemonPolicyConfig, action: RepairAction
     };
 }
 
-fn routeHealth(store: *health_mod.HealthStore, route: RepairPlanRoute) ?health_mod.AccountHealth {
+fn routeHealth(allocator: std.mem.Allocator, store: *health_mod.HealthStore, route: RepairPlanRoute) ?health_mod.AccountHealth {
     const now = std.time.timestamp();
     const account_key = health_mod.accountKey(route.provider, route.account);
     const account_health = if (store.accounts.get(account_key.slice())) |health|
-        health_mod.effectiveHealthForRouteSelection(health, now)
+        effectiveHealthForRouteSelectionTraced(allocator, route, health, now, "account")
     else
         null;
     if (account_health) |health| {
@@ -3606,11 +3608,56 @@ fn routeHealth(store: *health_mod.HealthStore, route: RepairPlanRoute) ?health_m
     if (route.capability) |capability| {
         const capability_key = health_mod.capabilityKey(route.provider, route.account, capability);
         if (store.accounts.get(capability_key.slice())) |health| {
-            return health_mod.effectiveHealthForRouteSelection(health, now);
+            return effectiveHealthForRouteSelectionTraced(allocator, route, health, now, "capability");
         }
     }
 
     return account_health;
+}
+
+fn effectiveHealthForRouteSelectionTraced(
+    allocator: std.mem.Allocator,
+    route: RepairPlanRoute,
+    raw: health_mod.AccountHealth,
+    now: i64,
+    source_scope: []const u8,
+) health_mod.AccountHealth {
+    const effective = health_mod.effectiveHealthForRouteSelection(raw, now);
+    traceHealthNormalization(allocator, route.provider, route.account, route.capability, source_scope, raw.liveness, effective.liveness);
+    return effective;
+}
+
+fn traceHealthNormalization(
+    allocator: std.mem.Allocator,
+    provider_name: []const u8,
+    account_label: []const u8,
+    capability: ?[]const u8,
+    source_scope: []const u8,
+    before: types.CredentialLiveness,
+    after: types.CredentialLiveness,
+) void {
+    var before_buf: [128]u8 = undefined;
+    var after_buf: [128]u8 = undefined;
+    const before_summary = livenessSummaryIntoBuffer(before, &before_buf);
+    const after_summary = livenessSummaryIntoBuffer(after, &after_buf);
+    if (std.mem.eql(u8, before_summary, after_summary)) return;
+
+    trace.append(allocator, "health.normalize", .info, &.{
+        trace.string("provider", provider_name),
+        trace.string("account_label", account_label),
+        trace.string("capability", capability orelse "none"),
+        trace.string("source_scope", source_scope),
+        trace.string("before_liveness", before_summary),
+        trace.string("after_liveness", after_summary),
+        trace.boolean("token_material_printed", false),
+        trace.boolean("path_printed", false),
+    });
+}
+
+fn livenessSummaryIntoBuffer(liveness: types.CredentialLiveness, buf: []u8) []const u8 {
+    var stream = std.io.fixedBufferStream(buf);
+    health_mod.writeLivenessSummary(stream.writer(), liveness) catch return "unavailable";
+    return stream.getWritten();
 }
 
 fn routeProbeBudget(def: provider_schema.ProviderDefinition, capability: ?[]const u8) ?types.ActionBudget {
@@ -5178,10 +5225,11 @@ fn collectRouteEvaluations(
     for (routes) |route| {
         const def = config.resolveProviderDefinition(cfg, route.provider);
         const runtime = try routeRuntimeReadiness(allocator, cfg, route, def);
-        const health = routeHealth(store, route);
+        const health = routeHealth(allocator, store, route);
         const budget = routeProbeBudget(def, route.capability);
         const action = repairActionFor(route, def, runtime, health, budget);
         const selectable = routeSelectable(runtime, health);
+        const skip_reason = if (selectable) "available" else routeSkipReason(runtime, health);
         try evaluations.append(.{
             .route = route,
             .runtime = runtime,
@@ -5189,9 +5237,39 @@ fn collectRouteEvaluations(
             .budget = budget,
             .action = action,
             .selectable = selectable,
-            .skip_reason = if (selectable) "available" else routeSkipReason(runtime, health),
+            .skip_reason = skip_reason,
         });
+        traceRouteEvaluation(allocator, route, runtime, health, action, selectable, skip_reason);
     }
+}
+
+fn traceRouteEvaluation(
+    allocator: std.mem.Allocator,
+    route: RepairPlanRoute,
+    runtime: types.RuntimeReadiness,
+    route_health_value: ?health_mod.AccountHealth,
+    action: RepairAction,
+    selectable: bool,
+    skip_reason: []const u8,
+) void {
+    var liveness_buf: [128]u8 = undefined;
+    const liveness_summary = if (route_health_value) |current|
+        livenessSummaryIntoBuffer(current.liveness, &liveness_buf)
+    else
+        "unrecorded";
+
+    trace.append(allocator, "route.evaluate", .info, &.{
+        trace.string("provider", route.provider),
+        trace.string("account_label", route.account),
+        trace.string("capability", route.capability orelse "none"),
+        trace.string("runtime", runtimeReadinessSummary(runtime)),
+        trace.string("liveness", liveness_summary),
+        trace.string("action", @tagName(action.kind)),
+        trace.string("skip_reason", skip_reason),
+        trace.boolean("selectable", selectable),
+        trace.boolean("token_material_printed", false),
+        trace.boolean("path_printed", false),
+    });
 }
 
 fn firstSelectableRoute(evaluations: []const RouteEvaluation) ?usize {
@@ -15823,15 +15901,44 @@ fn getEnvOwnedOrNull(allocator: std.mem.Allocator, name: []const u8) !?[]const u
 fn resolveNativeCodexBinary(allocator: std.mem.Allocator) ![]const u8 {
     if (try getEnvOwnedOrNull(allocator, "OMUX_CODEX_BIN")) |env_path| {
         errdefer allocator.free(env_path);
-        if (env_path.len != 0 and fileExists(env_path) and !(try isOauthMuxShimPath(allocator, env_path))) return env_path;
+        if (env_path.len != 0 and fileExists(env_path) and !(try isOauthMuxShimPath(allocator, env_path))) {
+            trace.append(allocator, "codex.native_binary.resolve", .info, &.{
+                trace.string("source", "OMUX_CODEX_BIN"),
+                trace.boolean("selected", true),
+                trace.boolean("path_printed", false),
+            });
+            return env_path;
+        }
+        trace.append(allocator, "codex.native_binary.resolve", .warn, &.{
+            trace.string("source", "OMUX_CODEX_BIN"),
+            trace.boolean("selected", false),
+            trace.string("reason", "missing_or_oauth_mux_shim"),
+            trace.boolean("path_printed", false),
+        });
         allocator.free(env_path);
     }
 
     var candidates = try collectPathCandidates(allocator, "codex");
     defer candidates.deinit(allocator);
     if (try firstNativeCodexCandidate(allocator, candidates.paths.items)) |path_value| {
+        const shim_candidates = countOauthMuxShimCandidates(allocator, candidates.paths.items) catch 0;
+        trace.append(allocator, "codex.native_binary.resolve", .info, &.{
+            trace.string("source", "PATH"),
+            trace.boolean("selected", true),
+            trace.uint("candidate_count", candidates.paths.items.len),
+            trace.uint("oauth_mux_shim_candidates", shim_candidates),
+            trace.boolean("path_printed", false),
+        });
         return try allocator.dupe(u8, path_value);
     }
+    const shim_candidates = countOauthMuxShimCandidates(allocator, candidates.paths.items) catch 0;
+    trace.append(allocator, "codex.native_binary.resolve", .err, &.{
+        trace.string("source", "PATH"),
+        trace.boolean("selected", false),
+        trace.uint("candidate_count", candidates.paths.items.len),
+        trace.uint("oauth_mux_shim_candidates", shim_candidates),
+        trace.boolean("path_printed", false),
+    });
     return error.CodexNativeBinaryNotFound;
 }
 
@@ -15855,11 +15962,24 @@ fn runCodexCli(allocator: std.mem.Allocator, account_dir: []const u8, codex_args
     child.stderr_behavior = .Inherit;
     child.env_map = &env_map;
 
+    trace.append(allocator, "codex.native_command.spawn", .info, &.{
+        trace.string("command", if (codex_args.len > 0) codex_args[0] else "none"),
+        trace.boolean("codex_home_path_printed", false),
+        trace.boolean("native_binary_path_printed", false),
+    });
+
     const term = child.spawnAndWait() catch return error.CodexCommandFailed;
-    return switch (term) {
+    const ok = switch (term) {
         .Exited => |code| code == 0,
         else => false,
     };
+    trace.append(allocator, "codex.native_command.exit", if (ok) .info else .warn, &.{
+        trace.string("command", if (codex_args.len > 0) codex_args[0] else "none"),
+        trace.boolean("ok", ok),
+        trace.boolean("codex_home_path_printed", false),
+        trace.boolean("native_binary_path_printed", false),
+    });
+    return ok;
 }
 
 test "matchesProvider filters account keys" {

--- a/src/trace.zig
+++ b/src/trace.zig
@@ -1,0 +1,266 @@
+const std = @import("std");
+const paths = @import("paths.zig");
+
+pub const schema = "oauth-mux.trace.v1";
+
+pub const Severity = enum {
+    debug,
+    info,
+    warn,
+    err,
+
+    fn label(self: Severity) []const u8 {
+        return switch (self) {
+            .debug => "debug",
+            .info => "info",
+            .warn => "warn",
+            .err => "error",
+        };
+    }
+};
+
+pub const AttrValue = union(enum) {
+    string: []const u8,
+    boolean: bool,
+    int: i64,
+    uint: u64,
+    null_value,
+};
+
+pub const Attr = struct {
+    key: []const u8,
+    value: AttrValue,
+};
+
+pub fn string(key: []const u8, value: []const u8) Attr {
+    return .{ .key = key, .value = .{ .string = value } };
+}
+
+pub fn boolean(key: []const u8, value: bool) Attr {
+    return .{ .key = key, .value = .{ .boolean = value } };
+}
+
+pub fn int(key: []const u8, value: i64) Attr {
+    return .{ .key = key, .value = .{ .int = value } };
+}
+
+pub fn uint(key: []const u8, value: u64) Attr {
+    return .{ .key = key, .value = .{ .uint = value } };
+}
+
+pub fn nullValue(key: []const u8) Attr {
+    return .{ .key = key, .value = .null_value };
+}
+
+pub fn enabled(allocator: std.mem.Allocator) bool {
+    const value = std.process.getEnvVarOwned(allocator, "OMUX_TRACE") catch |e| switch (e) {
+        error.EnvironmentVariableNotFound => return false,
+        error.OutOfMemory => return false,
+        else => return false,
+    };
+    defer allocator.free(value);
+    return traceValueEnabled(value);
+}
+
+pub fn append(allocator: std.mem.Allocator, name: []const u8, severity: Severity, attrs: []const Attr) void {
+    if (!enabled(allocator)) return;
+    appendInternal(allocator, name, severity, attrs) catch {};
+}
+
+pub fn writeEventForTest(writer: anytype, name: []const u8, severity: Severity, attrs: []const Attr) !void {
+    try writeEvent(writer, .{
+        .ts_unix_ms = 1_800_000_000_000,
+        .trace_id = "00000000000000000000000000000000",
+        .span_id = "0000000000000000",
+        .parent_span_id = null,
+    }, name, severity, attrs);
+}
+
+const EventContext = struct {
+    ts_unix_ms: i64,
+    trace_id: []const u8,
+    span_id: []const u8,
+    parent_span_id: ?[]const u8,
+};
+
+fn appendInternal(allocator: std.mem.Allocator, name: []const u8, severity: Severity, attrs: []const Attr) !void {
+    const trace_path = try traceFilePath(allocator);
+    defer allocator.free(trace_path);
+    try ensureParentDir(trace_path);
+
+    const file = try createOrAppendFile(trace_path);
+    defer file.close();
+    try file.seekFromEnd(0);
+
+    const ctx = try eventContext(allocator);
+    defer ctx.deinit(allocator);
+
+    try writeEvent(file.writer(), ctx.value, name, severity, attrs);
+    try file.writeAll("\n");
+}
+
+const OwnedEventContext = struct {
+    value: EventContext,
+    trace_id_owned: ?[]const u8 = null,
+    span_id_owned: ?[]const u8 = null,
+    parent_span_id_owned: ?[]const u8 = null,
+
+    fn deinit(self: OwnedEventContext, allocator: std.mem.Allocator) void {
+        if (self.trace_id_owned) |value| allocator.free(value);
+        if (self.span_id_owned) |value| allocator.free(value);
+        if (self.parent_span_id_owned) |value| allocator.free(value);
+    }
+};
+
+fn eventContext(allocator: std.mem.Allocator) !OwnedEventContext {
+    const trace_id = try envOrDefault(allocator, "OMUX_TRACE_ID", "00000000000000000000000000000000");
+    errdefer if (trace_id.owned) |value| allocator.free(value);
+    const span_id = try envOrDefault(allocator, "OMUX_SPAN_ID", "0000000000000000");
+    errdefer if (span_id.owned) |value| allocator.free(value);
+    const parent_span_id = std.process.getEnvVarOwned(allocator, "OMUX_PARENT_SPAN_ID") catch |e| switch (e) {
+        error.EnvironmentVariableNotFound => null,
+        else => return e,
+    };
+
+    return .{
+        .value = .{
+            .ts_unix_ms = std.time.milliTimestamp(),
+            .trace_id = trace_id.value,
+            .span_id = span_id.value,
+            .parent_span_id = parent_span_id,
+        },
+        .trace_id_owned = trace_id.owned,
+        .span_id_owned = span_id.owned,
+        .parent_span_id_owned = parent_span_id,
+    };
+}
+
+const EnvValue = struct {
+    value: []const u8,
+    owned: ?[]const u8 = null,
+};
+
+fn envOrDefault(allocator: std.mem.Allocator, name: []const u8, default: []const u8) !EnvValue {
+    const value = std.process.getEnvVarOwned(allocator, name) catch |e| switch (e) {
+        error.EnvironmentVariableNotFound => return .{ .value = default },
+        else => return e,
+    };
+    if (value.len == 0) {
+        allocator.free(value);
+        return .{ .value = default };
+    }
+    return .{ .value = value, .owned = value };
+}
+
+fn traceFilePath(allocator: std.mem.Allocator) ![]const u8 {
+    if (std.process.getEnvVarOwned(allocator, "OMUX_TRACE_FILE")) |value| {
+        if (value.len == 0) {
+            allocator.free(value);
+        } else {
+            defer allocator.free(value);
+            return try paths.absolutePath(allocator, value);
+        }
+    } else |e| switch (e) {
+        error.EnvironmentVariableNotFound => {},
+        else => return e,
+    }
+
+    const state_dir = try paths.stateDir(allocator);
+    defer allocator.free(state_dir);
+    return std.fs.path.join(allocator, &.{ state_dir, "trace.ndjson" });
+}
+
+fn ensureParentDir(path_value: []const u8) !void {
+    if (std.fs.path.dirname(path_value)) |dir| {
+        std.fs.cwd().makePath(dir) catch |e| switch (e) {
+            error.PathAlreadyExists => {},
+            else => return e,
+        };
+    }
+}
+
+fn createOrAppendFile(path_value: []const u8) !std.fs.File {
+    if (std.fs.path.isAbsolute(path_value)) {
+        return std.fs.createFileAbsolute(path_value, .{
+            .truncate = false,
+            .mode = 0o600,
+            .lock = .exclusive,
+        });
+    }
+    return std.fs.cwd().createFile(path_value, .{
+        .truncate = false,
+        .mode = 0o600,
+        .lock = .exclusive,
+    });
+}
+
+fn writeEvent(writer: anytype, ctx: EventContext, name: []const u8, severity: Severity, attrs: []const Attr) !void {
+    try writer.writeAll("{\"schema\":");
+    try std.json.stringify(schema, .{}, writer);
+    try writer.print(",\"ts_unix_ms\":{d}", .{ctx.ts_unix_ms});
+    try writer.writeAll(",\"name\":");
+    try std.json.stringify(name, .{}, writer);
+    try writer.writeAll(",\"severity\":");
+    try std.json.stringify(severity.label(), .{}, writer);
+    try writer.writeAll(",\"trace_id\":");
+    try std.json.stringify(ctx.trace_id, .{}, writer);
+    try writer.writeAll(",\"span_id\":");
+    try std.json.stringify(ctx.span_id, .{}, writer);
+    try writer.writeAll(",\"parent_span_id\":");
+    if (ctx.parent_span_id) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"attributes\":{");
+    for (attrs, 0..) |attr, idx| {
+        if (idx != 0) try writer.writeByte(',');
+        try std.json.stringify(attr.key, .{}, writer);
+        try writer.writeByte(':');
+        try writeAttrValue(writer, attr.value);
+    }
+    try writer.writeAll("},\"redaction\":{\"tokens\":false,\"raw_account_ids\":false,\"session_ids\":false,\"paths\":false}}");
+}
+
+fn writeAttrValue(writer: anytype, value: AttrValue) !void {
+    switch (value) {
+        .string => |v| try std.json.stringify(v, .{}, writer),
+        .boolean => |v| try writer.writeAll(if (v) "true" else "false"),
+        .int => |v| try writer.print("{d}", .{v}),
+        .uint => |v| try writer.print("{d}", .{v}),
+        .null_value => try writer.writeAll("null"),
+    }
+}
+
+test "trace events use stable redacted OTEL-friendly shape" {
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+
+    try writeEventForTest(buf.writer(), "route.evaluate", .info, &.{
+        string("provider", "codex"),
+        string("account_label", "max-1"),
+        boolean("selectable", true),
+        uint("route_count", 4),
+    });
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"schema\":\"oauth-mux.trace.v1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"trace_id\":\"00000000000000000000000000000000\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"span_id\":\"0000000000000000\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"name\":\"route.evaluate\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"tokens\":false") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"paths\":false") != null);
+}
+
+test "trace disabled values stay disabled" {
+    try std.testing.expect(!traceValueEnabled(""));
+    try std.testing.expect(!traceValueEnabled("0"));
+    try std.testing.expect(!traceValueEnabled("false"));
+    try std.testing.expect(!traceValueEnabled("off"));
+    try std.testing.expect(traceValueEnabled("1"));
+    try std.testing.expect(traceValueEnabled("otel"));
+}
+
+fn traceValueEnabled(value: []const u8) bool {
+    if (value.len == 0) return false;
+    if (std.ascii.eqlIgnoreCase(value, "0")) return false;
+    if (std.ascii.eqlIgnoreCase(value, "false")) return false;
+    if (std.ascii.eqlIgnoreCase(value, "off")) return false;
+    if (std.ascii.eqlIgnoreCase(value, "no")) return false;
+    return true;
+}


### PR DESCRIPTION
## Summary

- add opt-in `OMUX_TRACE` JSONL tracing with OTEL-friendly fields and redaction flags
- trace route evaluation, transient health normalization, native Codex binary resolution, explicit mux Codex admin command spawn/exit, and installed shim native pass-through
- document tracing in README, onboarding, and `docs/tracing.md`; add a no-spend smoke that checks redaction

## Validation

- `git diff --check`
- `zig build test`
- `zig build`
- `./scripts/smoke-trace.sh`
- `./scripts/smoke-codex-cli-ux.sh`
- `./scripts/smoke-codex-tier-insufficient.sh && ./scripts/smoke-codex-all-exhausted.sh`
- `nix develop --command just check-local`

Related: TIN-1148

No local Playwright run.
