### PR TITLE
Add managed Codex trace boundaries

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -43,7 +43,7 @@ Each event uses schema `oauth-mux.trace.v1` and includes:
 - `attributes`
 - `redaction`
 
-The first traced decisions are:
+The traced decisions are:
 
 - `health.normalize`: persisted transient provider degradation recovered for
   route selection after its retry window expires.
@@ -54,6 +54,21 @@ The first traced decisions are:
   oauth-mux-managed Codex admin commands without printing `CODEX_HOME`.
 - `codex.shim.pass_through`: installed `codex` shim admin-command pass-through
   without route election or native binary path output.
+- `codex.managed.overlay`: managed Codex `CODEX_HOME` overlay shape, config
+  passthrough/injection counts, session-authority mode, and proxy port without
+  printing overlay, config, auth, or session paths.
+- `codex.managed.session_start`, `codex.managed.child_spawn`, and
+  `codex.managed.session_end`: broker-owned managed session lifecycle without
+  printing token material, raw account ids, `CODEX_HOME`, or session ids.
+- `codex.proxy.turn`: per-request Codex proxy classification, path kind,
+  status, claim level, streaming/delivery flags, and selected route label.
+- `codex.proxy.retry`: same-turn retry boundary, including reason and the
+  class of sticky header dropped before switching account routes.
+- `codex.proxy.no_account_selectable`: terminal no-account condition with only
+  aggregate rejection counts and next-action availability.
+- `codex.proxy.upstream_failure` and `codex.proxy.provider_unavailable`:
+  provider/transport failure boundaries without promoting them to credential
+  death and without printing token or path material.
 
 Trace output must not include OAuth token bytes, raw provider account ids, raw
 Codex session ids, or local auth/config file paths. Attach `trace.ndjson` to a

--- a/scripts/smoke-codex-all-exhausted.sh
+++ b/scripts/smoke-codex-all-exhausted.sh
@@ -26,6 +26,7 @@ UPLOG="$TMP/upstream.log"
 NDJSON="$TMP/adapter.ndjson"
 ADAPTER_STDERR="$TMP/adapter.stderr"
 STUB_REPORT="$TMP/stub-codex.report"
+TRACE_FILE="$TMP/trace.ndjson"
 
 cleanup() {
     if [[ -n "${UPSTREAM_PID:-}" ]] && kill -0 "$UPSTREAM_PID" 2>/dev/null; then
@@ -91,6 +92,10 @@ OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_UPSTREAM_HOST="127.0.0.1:$UPSTREAM_PORT" \
   OMUX_UPSTREAM_SCHEME="http" \
   OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+  OMUX_TRACE=1 \
+  OMUX_TRACE_FILE="$TRACE_FILE" \
+  OMUX_TRACE_ID="cccccccccccccccccccccccccccccccc" \
+  OMUX_SPAN_ID="dddddddddddddddd" \
   OMUX_STUB_CODEX_TURNS=5 \
   OMUX_STUB_CODEX_REPORT="$STUB_REPORT" \
   "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$NDJSON" 2>"$ADAPTER_STDERR" || {
@@ -123,6 +128,19 @@ assert_grep "fallback quota 429 was not delivered before no-account failure" '"k
 assert_grep "same-turn retry unavailable after all accounts exhausted" '"kind":"proxy_same_turn_retry_unavailable"' "$NDJSON"
 assert_grep "proxy_no_account_selectable event fired" '"kind":"proxy_no_account_selectable"' "$NDJSON"
 
+jq -e 'select(.name == "codex.managed.overlay" and .attributes.auth_authority == "mux_owned_overlay" and .attributes.config_paths_printed == false)' "$TRACE_FILE" >/dev/null
+echo "  ✓ trace captured managed overlay without config paths"
+jq -e 'select(.name == "codex.managed.session_start" and .attributes.claim_level == "broker_owned" and .attributes.codex_home_path_printed == false)' "$TRACE_FILE" >/dev/null
+echo "  ✓ trace captured managed session start without CODEX_HOME path"
+jq -e 'select(.name == "codex.proxy.turn" and .attributes.classification == "quota_exhausted" and .attributes.delivered_to_codex == false)' "$TRACE_FILE" >/dev/null
+echo "  ✓ trace captured proxy quota turn"
+jq -e 'select(.name == "codex.proxy.retry" and .attributes.reason == "quota_exhausted" and .attributes.raw_account_id_printed == false)' "$TRACE_FILE" >/dev/null
+echo "  ✓ trace captured proxy retry boundary"
+jq -e 'select(.name == "codex.proxy.no_account_selectable" and .attributes.pending_failure == "quota_exhausted" and .attributes.rejections_total == 2 and .attributes.quota_exhausted == 2)' "$TRACE_FILE" >/dev/null
+echo "  ✓ trace captured no-account rejection summary"
+jq -e 'select(.name == "codex.managed.session_end" and .attributes.terminal_event == "session_ended" and .attributes.synthetic_swap_observed == true)' "$TRACE_FILE" >/dev/null
+echo "  ✓ trace captured managed session end"
+
 if grep -q '"kind":"session_started"' "$ADAPTER_STDERR"; then
     echo "  ✗ adapter status frames leaked to stderr despite --json-status-file" >&2
     exit 1
@@ -146,6 +164,15 @@ else
     jq .turns "$STUB_REPORT" >&2
     exit 1
 fi
+
+for leak in AT-allexh-A AT-allexh-B RT-A RT-B acc-A-id acc-B-id "$TMP/account-A/auth.json" "$TMP/account-B/auth.json"; do
+    if grep -Fq "$leak" "$TRACE_FILE"; then
+        echo "  ✗ trace leaked sensitive value: $leak" >&2
+        cat "$TRACE_FILE" >&2
+        exit 1
+    fi
+done
+echo "  ✓ trace did not leak tokens, raw account ids, or auth paths"
 
 PID_STABLE=$(jq -r .pid_stable "$STUB_REPORT")
 if [[ "$PID_STABLE" == "true" ]]; then

--- a/scripts/smoke-codex-provider-degraded.sh
+++ b/scripts/smoke-codex-provider-degraded.sh
@@ -139,6 +139,7 @@ run_fallback_case() {
     local ndjson="$case_dir/adapter.ndjson"
     local adapter_stderr="$case_dir/adapter.stderr"
     local stub_report="$case_dir/stub-codex.report"
+    local trace_file="$case_dir/trace.ndjson"
     mkdir -p "$case_dir"
     write_two_account_fixture "$case_dir"
     mkdir -p "$case_dir/bin"
@@ -166,6 +167,8 @@ EOF
       OMUX_UPSTREAM_HOST="127.0.0.1:$upstream_port" \
       OMUX_UPSTREAM_SCHEME="http" \
       OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_TRACE=1 \
+      OMUX_TRACE_FILE="$trace_file" \
       OMUX_STUB_CODEX_TURNS=3 \
       OMUX_STUB_CODEX_REPORT="$stub_report" \
       "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$ndjson" 2>"$adapter_stderr" || {
@@ -181,6 +184,10 @@ EOF
     assert_grep "fallback account returned 200" '"kind":"proxy_turn".*"account":"codex:max-2".*"status":200.*"classification":"ok"' "$ndjson"
     assert_no_grep "provider retry did not use quota retry event" '"kind":"proxy_same_turn_retry".*"reason":"provider_5xx"' "$ndjson"
     assert_no_grep "no route-repair body leaked on provider fallback" 'oauth_mux_no_account_selectable' "$stub_report"
+    jq -e 'select(.name == "codex.proxy.turn" and .attributes.classification == "provider_5xx" and .attributes.delivered_to_codex == false)' "$trace_file" >/dev/null
+    echo "  ✓ trace captured provider 5xx turn"
+    jq -e 'select(.name == "codex.proxy.retry" and .attributes.reason == "provider_5xx" and .attributes.raw_account_id_printed == false)' "$trace_file" >/dev/null
+    echo "  ✓ trace captured provider retry boundary"
 
     local got_200
     got_200="$(jq -r '.turns | map(select(.status == 200)) | length' "$stub_report")"
@@ -215,6 +222,7 @@ run_no_fallback_case() {
     local ndjson="$case_dir/adapter.ndjson"
     local adapter_stderr="$case_dir/adapter.stderr"
     local stub_report="$case_dir/stub-codex.report"
+    local trace_file="$case_dir/trace.ndjson"
     mkdir -p "$case_dir"
     write_one_account_fixture "$case_dir"
 
@@ -234,6 +242,8 @@ run_no_fallback_case() {
       OMUX_UPSTREAM_HOST="127.0.0.1:$upstream_port" \
       OMUX_UPSTREAM_SCHEME="http" \
       OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_TRACE=1 \
+      OMUX_TRACE_FILE="$trace_file" \
       OMUX_STUB_CODEX_TURNS=1 \
       OMUX_STUB_CODEX_REPORT="$stub_report" \
       "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$ndjson" 2>"$adapter_stderr" || {
@@ -248,6 +258,8 @@ run_no_fallback_case() {
     assert_grep "provider retry unavailable event fired" '"kind":"proxy_provider_retry_unavailable".*"from":"codex:max-1".*"delivered_to_codex":true' "$ndjson"
     assert_no_grep "no quota all-exhausted event for provider 503" '"kind":"quota_handoff_failed_no_account_selectable"' "$ndjson"
     assert_no_grep "no route-repair response for provider 503" 'oauth_mux_no_account_selectable' "$stub_report"
+    jq -e 'select(.name == "codex.proxy.provider_unavailable" and .attributes.transport_error == "NoAccountSelectable" and .attributes.delivered_to_codex == true)' "$trace_file" >/dev/null
+    echo "  ✓ trace captured provider-unavailable terminal boundary"
 
     local got_503
     got_503="$(jq -r '.turns | map(select(.status == 503 and (.body_head | contains("forced status 503")))) | length' "$stub_report")"
@@ -258,10 +270,76 @@ run_no_fallback_case() {
         jq .turns "$stub_report" >&2
         exit 1
     fi
+
+    for leak in "$ID_TOKEN" RT-A acc-A-id "$case_dir/account-A/auth.json"; do
+        if grep -Fq "$leak" "$trace_file"; then
+            echo "  ✗ trace leaked sensitive value: $leak" >&2
+            cat "$trace_file" >&2
+            exit 1
+        fi
+    done
+    echo "  ✓ trace did not leak provider-degraded auth material"
+}
+
+run_transport_failure_case() {
+    local case_dir="$TMP/transport-failure"
+    local ndjson="$case_dir/adapter.ndjson"
+    local adapter_stderr="$case_dir/adapter.stderr"
+    local stub_report="$case_dir/stub-codex.report"
+    local trace_file="$case_dir/trace.ndjson"
+    mkdir -p "$case_dir"
+    write_one_account_fixture "$case_dir"
+
+    local closed_port
+    closed_port="$(
+      python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+    )"
+    echo "smoke-codex-provider-degraded: transport-failure closed_port=$closed_port"
+
+    OMUX_CONFIG="$case_dir/oauth-mux.config.json" \
+      OMUX_STATE_DIR="$case_dir/state" \
+      OMUX_UPSTREAM_HOST="127.0.0.1:$closed_port" \
+      OMUX_UPSTREAM_SCHEME="http" \
+      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_TRACE=1 \
+      OMUX_TRACE_FILE="$trace_file" \
+      OMUX_STUB_CODEX_TURNS=1 \
+      OMUX_STUB_CODEX_REPORT="$stub_report" \
+      "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$ndjson" 2>"$adapter_stderr" || {
+        echo "adapter exited nonzero in transport-failure case" >&2
+        cat "$ndjson" >&2 || true
+        cat "$adapter_stderr" >&2 || true
+        exit 1
+    }
+
+    echo "smoke-codex-provider-degraded: transport-failure assertions"
+    assert_grep "transport failure recorded upstream failure" '"kind":"proxy_upstream_failed".*"account":"codex:max-1"' "$ndjson"
+    assert_grep "transport failure delivered provider unavailable" '"kind":"proxy_provider_retry_unavailable".*"from":"codex:max-1".*"delivered_to_codex":true' "$ndjson"
+    jq -e 'select(.name == "codex.proxy.upstream_failure" and .attributes.path_kind == "responses" and .attributes.raw_account_id_printed == false)' "$trace_file" >/dev/null
+    echo "  ✓ trace captured upstream transport failure"
+    jq -e 'select(.name == "codex.proxy.provider_unavailable" and .attributes.delivered_to_codex == true)' "$trace_file" >/dev/null
+    echo "  ✓ trace captured provider-unavailable transport boundary"
+
+    local got_503
+    got_503="$(jq -r '[.turns[] | select(.status == 503 and (.body_head | contains("oauth_mux_provider_unavailable")))] | length' "$stub_report")"
+    if [[ "$got_503" -eq 1 ]]; then
+        echo "  ✓ stub-codex saw oauth_mux_provider_unavailable body"
+    else
+        echo "  ✗ stub-codex did not see provider-unavailable body" >&2
+        jq .turns "$stub_report" >&2
+        exit 1
+    fi
 }
 
 run_fallback_case
 run_no_fallback_case
+run_transport_failure_case
 
 echo
 echo "smoke-codex-provider-degraded: all assertions passed."

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -36,6 +36,7 @@ const health_mod = @import("../../health.zig");
 const paths = @import("../../paths.zig");
 const pipeline = @import("../../pipeline.zig");
 const shell = @import("../../shell.zig");
+const trace = @import("../../trace.zig");
 const types = @import("../../types.zig");
 const wire_proxy = @import("wire_proxy.zig");
 
@@ -483,6 +484,87 @@ fn envFlag(name: []const u8) bool {
 
 fn isCodexAccountId(account_id: []const u8) bool {
     return std.mem.startsWith(u8, account_id, "codex:");
+}
+
+fn codexAccountLabel(account_id: []const u8) []const u8 {
+    const colon = std.mem.indexOfScalar(u8, account_id, ':') orelse return account_id;
+    if (colon + 1 >= account_id.len) return account_id;
+    return account_id[colon + 1 ..];
+}
+
+fn traceManagedOverlay(
+    allocator: std.mem.Allocator,
+    account_id: []const u8,
+    profile: ?[]const u8,
+    proxy_port: u16,
+    codex_home: *const SessionCodexHome,
+) void {
+    trace.append(allocator, "codex.managed.overlay", .info, &.{
+        trace.string("provider", "codex"),
+        trace.string("account_label", codexAccountLabel(account_id)),
+        trace.string("profile", profile orelse "none"),
+        trace.string("auth_authority", "mux_owned_overlay"),
+        trace.string("managed_config", "mux_owned_overlay"),
+        trace.string("config_layout", codex_home.config_layout),
+        trace.string("session_authority", codex_home.session_authority.toString()),
+        trace.boolean("config_passthrough", codex_home.config_passthrough),
+        trace.boolean("user_config_present", codex_home.config_source_present),
+        trace.uint("config_overridden_keys", @intCast(codex_home.config_overridden_keys)),
+        trace.uint("experimental_feature_defaults_injected", @intCast(codex_home.experimental_feature_defaults_injected)),
+        trace.uint("mcp_stdio_unsupported_fields_removed", @intCast(codex_home.mcp_stdio_unsupported_fields_removed)),
+        trace.uint("proxy_port", proxy_port),
+        trace.boolean("codex_home_path_printed", false),
+        trace.boolean("config_paths_printed", false),
+        trace.boolean("session_paths_printed", false),
+        trace.boolean("token_material_printed", false),
+    });
+}
+
+fn traceManagedSessionStart(
+    allocator: std.mem.Allocator,
+    account_id: []const u8,
+    profile: ?[]const u8,
+    forwarded_arg_count: usize,
+    resume_mode: ResumeMode,
+    codex_home: *const SessionCodexHome,
+) void {
+    trace.append(allocator, "codex.managed.session_start", .info, &.{
+        trace.string("provider", "codex"),
+        trace.string("account_label", codexAccountLabel(account_id)),
+        trace.string("profile", profile orelse "none"),
+        trace.string("claim_level", "broker_owned"),
+        trace.string("resume_mode", resume_mode.toString()),
+        trace.string("session_authority", codex_home.session_authority.toString()),
+        trace.uint("forwarded_arg_count", @intCast(forwarded_arg_count)),
+        trace.boolean("child_stdio_inherited", true),
+        trace.boolean("codex_home_path_printed", false),
+        trace.boolean("session_ids_printed", false),
+        trace.boolean("token_material_printed", false),
+    });
+}
+
+fn traceManagedSessionEnd(
+    allocator: std.mem.Allocator,
+    proxy: *const wire_proxy.Proxy,
+    codex_home: *const SessionCodexHome,
+    aborted: bool,
+    reason: []const u8,
+    exit_code: i32,
+    term: ?std.process.Child.Term,
+) void {
+    trace.append(allocator, "codex.managed.session_end", if (aborted) .warn else .info, &.{
+        trace.string("provider", "codex"),
+        trace.string("terminal_event", if (aborted) "session_aborted" else "session_ended"),
+        trace.string("reason", reason),
+        trace.int("exit_code", exit_code),
+        trace.string("term_kind", if (term) |value| childTermKind(value) else "none"),
+        trace.int("term_code", if (term) |value| childTermCode(value) else -1),
+        trace.string("final_claim_level", proxy.peakClaimLevel().toString()),
+        trace.string("session_authority", codex_home.session_authority.toString()),
+        trace.boolean("synthetic_swap_observed", proxy.syntheticSwapSeen()),
+        trace.boolean("codex_home_path_printed", false),
+        trace.boolean("token_material_printed", false),
+    });
 }
 
 fn restrictPoolToCodex(pool: *broker.AccountPool) void {
@@ -1037,6 +1119,7 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         opts.isolated_session_store,
     );
     defer codex_home.deinit(allocator);
+    traceManagedOverlay(allocator, elected.id, opts.profile, proxy_port, &codex_home);
     try launch_timer.mark(status_writer, emit_status, "overlay_creation");
 
     const resume_request = detectResumeRequest(opts.forward_argv);
@@ -1145,6 +1228,8 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     if (opts.profile) |p| try env_map.put("OMUX_ACTIVE_PROFILE", p);
     try launch_timer.mark(status_writer, emit_status, "env_build");
 
+    traceManagedSessionStart(allocator, elected.id, opts.profile, opts.forward_argv.len, resume_request.mode, &codex_home);
+
     // 8. Spawn codex as child with inherited stdio (so the user gets
     // the real codex TUI). The adapter stays alive in parent.
     var child = std.process.Child.init(argv.items, allocator);
@@ -1154,8 +1239,22 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     child.env_map = &env_map;
     child.spawn() catch |e| {
         try stderr.print("oauth-mux codex: spawn: {s}\n", .{@errorName(e)});
+        trace.append(allocator, "codex.managed.child_spawn", .err, &.{
+            trace.string("provider", "codex"),
+            trace.string("account_label", codexAccountLabel(elected.id)),
+            trace.string("error", @errorName(e)),
+            trace.boolean("codex_home_path_printed", false),
+            trace.boolean("token_material_printed", false),
+        });
         return e;
     };
+    trace.append(allocator, "codex.managed.child_spawn", .info, &.{
+        trace.string("provider", "codex"),
+        trace.string("account_label", codexAccountLabel(elected.id)),
+        trace.boolean("stdio_inherited", true),
+        trace.boolean("codex_home_path_printed", false),
+        trace.boolean("token_material_printed", false),
+    });
     try launch_timer.mark(status_writer, emit_status, "child_spawn");
 
     // 9. Start the proxy thread. It loops on serveOne until the
@@ -1244,22 +1343,6 @@ fn finalizeManagedSession(
     }
     const auth_failure = proxy.authFailureObservation();
 
-    if (!emit_status) return;
-
-    try writeAuthWritebackStatus(status_writer, auth_writeback);
-    for (auth_failure.accounts) |account_observation| {
-        if (account_observation.auth_unauthorized_turns == 0) continue;
-        const auth_health = recordManagedAuthFailureHealth(allocator, account_observation, auth_writeback);
-        try writeManagedAuthHealthStatus(status_writer, account_observation, auth_health);
-    }
-    if (resume_request.requested()) {
-        const observation = if (codex_home.authority_home) |authority_home|
-            try observeResumeWriteback(allocator, authority_home, resume_preflight, resume_request)
-        else
-            ResumeObservation{};
-        try writeResumeWritebackStatus(status_writer, resume_request, codex_home.session_authority, observation);
-    }
-
     const exit_code: i32 = if (final_status.term) |term| switch (term) {
         .Exited => |c| c,
         else => -1,
@@ -1274,6 +1357,32 @@ fn finalizeManagedSession(
                 terminal_reason = reason;
             }
         }
+    }
+
+    traceManagedSessionEnd(
+        allocator,
+        proxy,
+        codex_home,
+        terminal_aborted,
+        terminal_reason,
+        exit_code,
+        final_status.term,
+    );
+
+    if (!emit_status) return;
+
+    try writeAuthWritebackStatus(status_writer, auth_writeback);
+    for (auth_failure.accounts) |account_observation| {
+        if (account_observation.auth_unauthorized_turns == 0) continue;
+        const auth_health = recordManagedAuthFailureHealth(allocator, account_observation, auth_writeback);
+        try writeManagedAuthHealthStatus(status_writer, account_observation, auth_health);
+    }
+    if (resume_request.requested()) {
+        const observation = if (codex_home.authority_home) |authority_home|
+            try observeResumeWriteback(allocator, authority_home, resume_preflight, resume_request)
+        else
+            ResumeObservation{};
+        try writeResumeWritebackStatus(status_writer, resume_request, codex_home.session_authority, observation);
     }
 
     if (terminal_aborted) {

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -64,6 +64,7 @@ const std = @import("std");
 const broker_types = @import("../../broker/types.zig");
 const account_pool_mod = @import("../../broker/account_pool.zig");
 const health_mod = @import("../../health.zig");
+const trace = @import("../../trace.zig");
 const core_types = @import("../../types.zig");
 
 const DEFAULT_UPSTREAM_HOST = "chatgpt.com";
@@ -259,6 +260,7 @@ pub const Proxy = struct {
                         .rejections = rejections.items,
                         .delivered_to_codex = true,
                     });
+                    self.traceProviderUnavailable(req, pending_failure_account orelse "", pending_transport_error orelse @errorName(err), rejections.items);
                     if (pending_buffered) |buffered| {
                         try writeBufferedStoredResponse(writer, buffered);
                     } else {
@@ -288,12 +290,14 @@ pub const Proxy = struct {
                         .attempted = attempted.items,
                         .rejections = rejections.items,
                     });
+                    self.traceNoAccountSelectable(req, pending_kind, attempted.items, rejections.items);
                     try writeNoAccountSelectableResponse(a, writer, self.profile, rejections.items);
                 } else {
                     self.logEvent("proxy_no_account_selectable", .{
                         .attempted = attempted.items,
                         .rejections = rejections.items,
                     });
+                    self.traceNoAccountSelectable(req, pending_kind, attempted.items, rejections.items);
                     try writeNoAccountSelectableResponse(a, writer, self.profile, rejections.items);
                 }
                 return;
@@ -363,6 +367,7 @@ pub const Proxy = struct {
             const status_and_class = forwardAndStream(a, req, out_headers, writer) catch |err| {
                 appendRejection(a, &rejections, elected.id, .provider_degraded, @errorName(err)) catch {};
                 self.logEvent("proxy_upstream_failed", .{ .account = elected.id, .err = @errorName(err) });
+                self.traceUpstreamFailure(req, elected.id, @errorName(err));
                 self.recordDurableRouteState(elected.id, .provider_degraded, 503, 60);
                 pending_failure_kind = .provider_5xx;
                 pending_failure_account = elected.id;
@@ -423,6 +428,21 @@ pub const Proxy = struct {
             .streamed = status_and_class.streamed,
             .delivered_to_codex = delivered_to_codex,
         });
+        trace.append(self.allocator, "codex.proxy.turn", if (status_and_class.classification.kind == .ok) .info else .warn, &.{
+            trace.string("provider", "codex"),
+            trace.string("account_label", accountLabel(account_id)),
+            trace.string("method", req.method),
+            trace.string("path_kind", pathKind(req.path)),
+            trace.uint("status", status_and_class.status),
+            trace.string("classification", @tagName(status_and_class.classification.kind)),
+            trace.string("body_class", status_and_class.body_class orelse "none"),
+            trace.string("claim_level", self.peak_claim.toString()),
+            trace.boolean("streamed", status_and_class.streamed),
+            trace.boolean("delivered_to_codex", delivered_to_codex),
+            trace.boolean("token_material_printed", false),
+            trace.boolean("raw_account_id_printed", false),
+            trace.boolean("session_ids_printed", false),
+        });
     }
 
     fn applyClassification(
@@ -462,6 +482,7 @@ pub const Proxy = struct {
                 .reason = @tagName(reason),
                 .dropped = "x-codex-turn-state",
             });
+            self.traceRetry(from, to, reason);
             return;
         }
 
@@ -472,6 +493,7 @@ pub const Proxy = struct {
                 .reason = @tagName(reason),
                 .dropped = "x-codex-turn-state",
             });
+            self.traceRetry(from, to, reason);
             return;
         }
 
@@ -481,6 +503,7 @@ pub const Proxy = struct {
             .reason = @tagName(reason),
             .dropped = "x-codex-turn-state",
         });
+        self.traceRetry(from, to, reason);
     }
 
     fn recordDurableClassification(
@@ -554,6 +577,92 @@ pub const Proxy = struct {
         store.persist();
     }
 
+    fn traceRetry(
+        self: *Proxy,
+        from: []const u8,
+        to: []const u8,
+        reason: broker_types.QuotaKind,
+    ) void {
+        trace.append(self.allocator, "codex.proxy.retry", .warn, &.{
+            trace.string("provider", "codex"),
+            trace.string("from_account_label", accountLabel(from)),
+            trace.string("to_account_label", accountLabel(to)),
+            trace.string("reason", @tagName(reason)),
+            trace.string("dropped_header_class", "turn_state"),
+            trace.boolean("token_material_printed", false),
+            trace.boolean("raw_account_id_printed", false),
+            trace.boolean("session_ids_printed", false),
+        });
+    }
+
+    fn traceNoAccountSelectable(
+        self: *Proxy,
+        req: Request,
+        pending_kind: ?broker_types.QuotaKind,
+        attempted: []const []const u8,
+        rejections: []const CandidateRejection,
+    ) void {
+        trace.append(self.allocator, "codex.proxy.no_account_selectable", .warn, &.{
+            trace.string("provider", "codex"),
+            trace.string("profile", self.profile orelse "none"),
+            trace.string("method", req.method),
+            trace.string("path_kind", pathKind(req.path)),
+            trace.string("pending_failure", if (pending_kind) |kind| @tagName(kind) else "none"),
+            trace.uint("attempted_count", @intCast(attempted.len)),
+            trace.uint("rejections_total", @intCast(rejections.len)),
+            trace.uint("auth_failed", @intCast(countRejectionsByState(rejections, .auth_failed))),
+            trace.uint("quota_exhausted", @intCast(countRejectionsByState(rejections, .quota_exhausted))),
+            trace.uint("rate_limited", @intCast(countRejectionsByState(rejections, .rate_limited))),
+            trace.uint("tier_insufficient", @intCast(countRejectionsByState(rejections, .tier_insufficient))),
+            trace.uint("provider_degraded", @intCast(countRejectionsByState(rejections, .provider_degraded))),
+            trace.uint("credential_unavailable", @intCast(countRejectionsByState(rejections, .credential_unavailable))),
+            trace.boolean("agent_safe_next_action_available", true),
+            trace.boolean("spend_confirmed_next_action_available", true),
+            trace.boolean("token_material_printed", false),
+            trace.boolean("raw_account_id_printed", false),
+            trace.boolean("session_ids_printed", false),
+        });
+    }
+
+    fn traceProviderUnavailable(
+        self: *Proxy,
+        req: Request,
+        account_id: []const u8,
+        err: []const u8,
+        rejections: []const CandidateRejection,
+    ) void {
+        trace.append(self.allocator, "codex.proxy.provider_unavailable", .warn, &.{
+            trace.string("provider", "codex"),
+            trace.string("account_label", accountLabel(account_id)),
+            trace.string("method", req.method),
+            trace.string("path_kind", pathKind(req.path)),
+            trace.string("transport_error", err),
+            trace.uint("rejections_total", @intCast(rejections.len)),
+            trace.boolean("delivered_to_codex", true),
+            trace.boolean("token_material_printed", false),
+            trace.boolean("raw_account_id_printed", false),
+            trace.boolean("session_ids_printed", false),
+        });
+    }
+
+    fn traceUpstreamFailure(
+        self: *Proxy,
+        req: Request,
+        account_id: []const u8,
+        err: []const u8,
+    ) void {
+        trace.append(self.allocator, "codex.proxy.upstream_failure", .warn, &.{
+            trace.string("provider", "codex"),
+            trace.string("account_label", accountLabel(account_id)),
+            trace.string("method", req.method),
+            trace.string("path_kind", pathKind(req.path)),
+            trace.string("transport_error", err),
+            trace.boolean("token_material_printed", false),
+            trace.boolean("raw_account_id_printed", false),
+            trace.boolean("session_ids_printed", false),
+        });
+    }
+
     fn logEvent(self: *Proxy, kind: []const u8, fields: anytype) void {
         // Minimal NDJSON log frame; never includes token material.
         var buf = std.ArrayListUnmanaged(u8){};
@@ -597,6 +706,12 @@ fn routeStateFromClassification(kind: broker_types.QuotaKind) RouteState {
         .tier_insufficient => .tier_insufficient,
         .provider_5xx => .provider_degraded,
     };
+}
+
+fn accountLabel(account_id: []const u8) []const u8 {
+    const colon = std.mem.indexOfScalar(u8, account_id, ':') orelse return account_id;
+    if (colon + 1 >= account_id.len) return account_id;
+    return account_id[colon + 1 ..];
 }
 
 fn retryAfterSeconds(now_unix: i64, resets_at: ?i64, kind: broker_types.QuotaKind) ?u32 {


### PR DESCRIPTION
## Summary

Adds the next redacted tracing slice for managed Codex sessions:

- trace managed overlay creation, config/session authority shape, child spawn, and session end
- trace proxy turn classification, same-turn retry boundaries, no-account rejection summaries, provider 5xx, and closed-port transport failures
- keep trace payloads aggregate/redacted: no token bytes, raw provider account ids, Codex session ids, CODEX_HOME paths, auth paths, or config paths
- document the expanded trace event surface

## Why

`OMUX_TRACE=1` needs to be useful when operator failures happen inside the managed Codex/proxy path, especially 503/no-account/provider-degraded/transport-failure cases. The prior trace slice covered preflight, route evaluation, native command resolution, and shim pass-through; this extends it into the long-running managed harness boundary without changing CLI behavior or route state semantics.

## Validation

- `git diff --check`
- `zig build test`
- `zig build --summary all`
- `./scripts/smoke-trace.sh`
- `./scripts/smoke-codex-all-exhausted.sh`
- `./scripts/smoke-codex-provider-degraded.sh`
- `nix develop --command just check-local`

No local Playwright/browser testing was run.

Linear: TIN-1148
