### PR TITLE
Expose runtime identity in version JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,14 @@ just install-local-dogfood
 which -a oauth-mux
 which -a codex
 oauth-mux version
+oauth-mux version --json
 oauth-mux codex preflight --profile codex-max --capability codex-max --json
 ```
+
+`version --json` prints the active executable path classification and SHA-256
+under `runtime_identity`. Use it when public packages and local dogfood have
+nearby version strings and you need machine-readable proof of the exact binary
+that will run.
 
 `codex preflight` prints the active `oauth-mux` path, all visible `oauth-mux`
 and `codex` PATH candidates, whether active `codex` is the managed oauth-mux

--- a/docs/release-install-lanes.md
+++ b/docs/release-install-lanes.md
@@ -57,12 +57,16 @@ just install-local-dogfood
 which -a oauth-mux
 which -a codex
 oauth-mux version
+oauth-mux version --json
 oauth-mux codex preflight --profile codex-max --capability codex-max --json
 ```
 
 Expected:
 
 - `./zig-out/bin/oauth-mux` and `~/.local/bin/oauth-mux` hashes match.
+- `oauth-mux version --json` reports the active executable's
+  `runtime_identity.binary_source` and `runtime_identity.binary_sha256`, so
+  agents can compare dogfood/package binaries without a separate hash command.
 - `which -a oauth-mux` resolves `~/.local/bin/oauth-mux` before Homebrew when
   testing unreleased behavior.
 - `which -a codex` resolves `~/.local/bin/codex` before the native upstream

--- a/scripts/check-local.sh
+++ b/scripts/check-local.sh
@@ -5,6 +5,7 @@ set -eu
 
 zig build test
 zig build
+./zig-out/bin/oauth-mux version --json | jq -e '.version and .runtime_identity.binary_path and .runtime_identity.binary_sha256 and .runtime_identity.path_printed == true' >/dev/null
 bash -n ./scripts/install-local-dogfood.sh
 
 for cfg in examples/*.config.json; do

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -38,7 +38,7 @@ pub const Command = union(enum) {
     daemon_events: DaemonEventsArgs,
     daemon_handoffs: DaemonHandoffsArgs,
     daemon_tick: DaemonTickArgs,
-    version_cmd,
+    version_cmd: VersionArgs,
     help,
     codex_help,
 
@@ -311,6 +311,10 @@ pub const Command = union(enum) {
         capability: ?[]const u8 = null,
         json: bool = false,
     };
+
+    pub const VersionArgs = struct {
+        json: bool = false,
+    };
 };
 
 pub fn parse(args: []const []const u8) Command {
@@ -348,7 +352,7 @@ pub fn parse(args: []const []const u8) Command {
         return parseCodex(rest);
     }
     if (eql(cmd, "mcp")) return parseMcp(rest);
-    if (eql(cmd, "version") or eql(cmd, "--version") or eql(cmd, "-v")) return .version_cmd;
+    if (eql(cmd, "version") or eql(cmd, "--version") or eql(cmd, "-v")) return parseVersion(rest);
     if (eql(cmd, "daemon")) {
         if (rest.len > 0) {
             if (eql(rest[0], "run")) return parseDaemonRun(rest[1..]);
@@ -374,6 +378,14 @@ pub fn parse(args: []const []const u8) Command {
 
 fn parseExec(args: []const []const u8) Command {
     return .{ .exec = parseExecArgs(args) };
+}
+
+fn parseVersion(args: []const []const u8) Command {
+    var result = Command.VersionArgs{};
+    for (args) |arg| {
+        if (eql(arg, "--json")) result.json = true;
+    }
+    return .{ .version_cmd = result };
 }
 
 fn parseCodexAdapter(args: []const []const u8, strict_run: bool) Command {
@@ -1388,7 +1400,7 @@ pub fn printUsage(writer: anytype) !void {
         \\
         \\  completions <shell> Generate shell completions (fish|zsh|bash).
         \\
-        \\  version            Print version.
+        \\  version [--json]   Print version; --json includes runtime binary identity.
         \\  help               Print this help.
         \\
         \\Environment:
@@ -2610,7 +2622,19 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
 test "parse version" {
     const args = [_][]const u8{"--version"};
     const cmd = parse(&args);
-    try std.testing.expect(cmd == .version_cmd);
+    switch (cmd) {
+        .version_cmd => |parsed| try std.testing.expect(!parsed.json),
+        else => return error.UnexpectedCommand,
+    }
+}
+
+test "parse version json" {
+    const args = [_][]const u8{ "version", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .version_cmd => |parsed| try std.testing.expect(parsed.json),
+        else => return error.UnexpectedCommand,
+    }
 }
 
 test "parse empty" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -45,7 +45,13 @@ pub fn main() !void {
     const stdout = std.io.getStdOut().writer();
 
     switch (cmd) {
-        .version_cmd => try stdout.print("oauth-mux {s}\n", .{cli.version}),
+        .version_cmd => |version_args| {
+            if (version_args.json) {
+                try writeVersionJson(allocator, stdout);
+            } else {
+                try stdout.print("oauth-mux {s}\n", .{cli.version});
+            }
+        },
         .help => try cli.printUsage(stdout),
         .codex_help => try cli.printCodexUsage(stdout),
 
@@ -297,6 +303,70 @@ pub fn main() !void {
             };
         },
     }
+}
+
+fn writeVersionJson(allocator: std.mem.Allocator, writer: anytype) !void {
+    const binary_path = std.fs.selfExePathAlloc(allocator) catch try allocator.dupe(u8, "unknown");
+    defer allocator.free(binary_path);
+
+    const binary_sha256 = hashFileSha256Hex(allocator, binary_path) catch null;
+    defer if (binary_sha256) |sha| allocator.free(sha);
+
+    const build_id = std.process.getEnvVarOwned(allocator, "OMUX_BUILD_ID") catch try allocator.dupe(u8, cli.version);
+    defer allocator.free(build_id);
+
+    try writer.writeAll("{\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"runtime_identity\":{\"binary_path\":");
+    try std.json.stringify(binary_path, .{}, writer);
+    try writer.writeAll(",\"binary_source\":");
+    try std.json.stringify(classifyOauthMuxBinarySource(binary_path), .{}, writer);
+    try writer.writeAll(",\"binary_sha256\":");
+    if (binary_sha256) |sha| {
+        try std.json.stringify(sha, .{}, writer);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"build_id\":");
+    try std.json.stringify(build_id, .{}, writer);
+    try writer.writeAll(",\"version\":");
+    try std.json.stringify(cli.version, .{}, writer);
+    try writer.writeAll(",\"path_printed\":true,\"binary_sha256_available\":");
+    try writer.writeAll(if (binary_sha256 != null) "true" else "false");
+    try writer.writeAll("}}\n");
+}
+
+fn classifyOauthMuxBinarySource(path: []const u8) []const u8 {
+    if (std.mem.indexOf(u8, path, "/zig-out/bin/oauth-mux") != null) return "repo_local";
+    if (std.mem.indexOf(u8, path, "/.local/bin/oauth-mux") != null) return "user_local";
+    if (std.mem.indexOf(u8, path, "/Cellar/oauth-mux/") != null) return "homebrew";
+    if (std.mem.indexOf(u8, path, "/opt/homebrew/bin/oauth-mux") != null) return "homebrew";
+    if (std.mem.indexOf(u8, path, "/usr/local/bin/oauth-mux") != null) return "homebrew";
+    if (std.mem.startsWith(u8, path, "/nix/store/")) return "nix_store";
+    if (std.mem.indexOf(u8, path, "/node_modules/") != null) return "npm";
+    return "path_or_installed";
+}
+
+fn hashFileSha256Hex(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    if (std.mem.eql(u8, path, "unknown")) return error.UnknownPath;
+
+    const file = try std.fs.openFileAbsolute(path, .{});
+    defer file.close();
+
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    var buf: [8192]u8 = undefined;
+    while (true) {
+        const n = try file.read(&buf);
+        if (n == 0) break;
+        hasher.update(buf[0..n]);
+    }
+
+    var digest: [32]u8 = undefined;
+    hasher.final(&digest);
+
+    const hex = try allocator.alloc(u8, digest.len * 2);
+    _ = std.fmt.bufPrint(hex, "{s}", .{std.fmt.fmtSliceHexLower(&digest)}) catch unreachable;
+    return hex;
 }
 
 fn exitCodeFromPipelineError(e: anyerror) u8 {


### PR DESCRIPTION
## Summary
- add `oauth-mux version --json` with runtime binary path, source classification, SHA-256, build id, and version
- keep `oauth-mux version` human-compatible
- document the JSON provenance check in README and release install lanes
- add the JSON shape to `check-local` so dogfood/package ambiguity stays guarded

## Tracker
- Addresses part of #205 by making the active runtime binary identity machine-readable without a manual hash command.

## Validation
- `git diff --check`
- `zig build test`
- `zig build && ./zig-out/bin/oauth-mux version && ./zig-out/bin/oauth-mux version --json | jq -e ...`
- `just check-local`

No local Playwright/browser tests were run.