### PR TITLE
Strengthen managed runtime identity evidence

### DIFF
--- a/docs/release-install-lanes.md
+++ b/docs/release-install-lanes.md
@@ -44,9 +44,9 @@ Detailed historical evidence stays in `docs/install-beta-matrix.md` and
   `OMUX_REGISTRY_DRY_RUN_CONFIRM=registry-dry-run`.
 - Homebrew and system package checks are package-lane QA. They do not prove
   unreleased worktree behavior unless the package was rebuilt from that tree.
-- For live Codex acceptance, use an installed binary on PATH and preserve
-  `runtime_identity` in the status artifact. Repo-local wrapper runs are not
-  acceptance evidence.
+- For live Codex acceptance, use an installed binary on PATH and preserve the
+  status artifact `runtime_identity`, including `binary_source` and
+  `binary_sha256`. Repo-local wrapper runs are not acceptance evidence.
 
 ## Local Dogfood Provenance
 

--- a/docs/spec/codex-live-acceptance-checklist-2026-05-08.md
+++ b/docs/spec/codex-live-acceptance-checklist-2026-05-08.md
@@ -25,8 +25,8 @@ Requirements:
 
 - `oauth-mux` resolves to an installed executable on PATH.
 - The status artifact records `runtime_identity.binary_path`,
-  `binary_source`, `build_id`, `version`, `command_spelling`, and
-  `installed_local_mismatch_detected:false`.
+  `binary_source`, `binary_sha256`, `build_id`, `version`, `path_printed`,
+  `command_spelling`, and `installed_local_mismatch_detected:false`.
 - The operator does not pass a repo-local `./zig-out/bin/oauth-mux` path, a
   wrapper, or an arg-heavy dogfood helper.
 - The operator does not repair the failure with logout/login/manual resume

--- a/scripts/smoke-codex-acceptance.sh
+++ b/scripts/smoke-codex-acceptance.sh
@@ -180,6 +180,8 @@ assert_grep "session_started reports canonical session bridge" '"session_authori
 assert_grep "session_started redacts session paths" '"session_paths_printed":false' "$NDJSON"
 assert_grep "session_started records runtime identity" '"runtime_identity":\{' "$NDJSON"
 assert_grep "runtime identity marks repo-local binary" '"binary_source":"repo_local"' "$NDJSON"
+assert_grep "runtime identity records binary sha" '"binary_sha256":"[0-9a-f]{64}"' "$NDJSON"
+assert_grep "runtime identity marks path printed" '"path_printed":true' "$NDJSON"
 assert_grep "runtime identity records installed/local mismatch bit" '"installed_local_mismatch_detected":false' "$NDJSON"
 assert_grep "proxy_turn 200 ok"         '"kind":"proxy_turn".*"status":200.*"classification":"ok"' "$NDJSON"
 assert_grep "proxy_turn 429 quota_exhausted" '"kind":"proxy_turn".*"status":429.*"classification":"quota_exhausted"' "$NDJSON"

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -35,6 +35,7 @@ const config_mod = @import("../../config.zig");
 const health_mod = @import("../../health.zig");
 const paths = @import("../../paths.zig");
 const pipeline = @import("../../pipeline.zig");
+const runtime_mod = @import("../../runtime.zig");
 const shell = @import("../../shell.zig");
 const trace = @import("../../trace.zig");
 const types = @import("../../types.zig");
@@ -1154,31 +1155,17 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     }
 
     if (emit_status) {
-        const binary_path = std.fs.selfExePathAlloc(allocator) catch try allocator.dupe(u8, "unknown");
-        defer allocator.free(binary_path);
-        const binary_source = try getEnvOwnedOrDefault(
-            allocator,
-            "OMUX_BINARY_SOURCE",
-            if (std.mem.indexOf(u8, binary_path, "/zig-out/bin/oauth-mux") != null) "repo_local" else "path_or_installed",
-        );
-        defer allocator.free(binary_source);
-        const build_id = try getEnvOwnedOrDefault(allocator, "OMUX_BUILD_ID", cli.version);
-        defer allocator.free(build_id);
+        const runtime_identity = try runtime_mod.oauthMuxRuntimeIdentity(allocator, cli.version);
+        defer runtime_identity.deinit(allocator);
         const command_spelling = try getEnvOwnedOrDefault(allocator, "OMUX_COMMAND_SPELLING", "oauth-mux codex");
         defer allocator.free(command_spelling);
         const installed_local_mismatch = envFlag("OMUX_INSTALLED_LOCAL_MISMATCH");
 
         try status_writer.print(
-            "{{\"kind\":\"session_started\",\"adapter\":\"codex\",\"adapter_version\":\"{s}\",\"managed_frame_id\":\"{s}\",\"selected_account\":\"{s}\",\"codex_home_path_printed\":false,\"proxy_port\":{d},\"claim_level\":\"broker_owned\",\"auth_authority\":\"mux_owned_overlay\",\"managed_config\":\"mux_owned_overlay\",\"config_layout\":\"{s}\",\"config_passthrough\":{any},\"user_config_present\":{any},\"config_overridden_keys\":{d},\"experimental_feature_defaults_injected\":{d},\"mcp_stdio_unsupported_fields_removed\":{d},\"config_paths_printed\":false,\"session_authority\":\"{s}\",\"session_paths_printed\":false,\"pre_spawn_network_refresh\":false,\"status_file_present\":{any},\"runtime_identity\":{{\"binary_path\":",
+            "{{\"kind\":\"session_started\",\"adapter\":\"codex\",\"adapter_version\":\"{s}\",\"managed_frame_id\":\"{s}\",\"selected_account\":\"{s}\",\"codex_home_path_printed\":false,\"proxy_port\":{d},\"claim_level\":\"broker_owned\",\"auth_authority\":\"mux_owned_overlay\",\"managed_config\":\"mux_owned_overlay\",\"config_layout\":\"{s}\",\"config_passthrough\":{any},\"user_config_present\":{any},\"config_overridden_keys\":{d},\"experimental_feature_defaults_injected\":{d},\"mcp_stdio_unsupported_fields_removed\":{d},\"config_paths_printed\":false,\"session_authority\":\"{s}\",\"session_paths_printed\":false,\"pre_spawn_network_refresh\":false,\"status_file_present\":{any},\"runtime_identity\":{{",
             .{ cli.version, managed_frame_id, elected.id, proxy_port, codex_home.config_layout, codex_home.config_passthrough, codex_home.config_source_present, codex_home.config_overridden_keys, codex_home.experimental_feature_defaults_injected, codex_home.mcp_stdio_unsupported_fields_removed, codex_home.session_authority.toString(), status_file_path != null },
         );
-        try std.json.stringify(binary_path, .{}, status_writer);
-        try status_writer.writeAll(",\"binary_source\":");
-        try std.json.stringify(binary_source, .{}, status_writer);
-        try status_writer.writeAll(",\"build_id\":");
-        try std.json.stringify(build_id, .{}, status_writer);
-        try status_writer.writeAll(",\"version\":");
-        try std.json.stringify(cli.version, .{}, status_writer);
+        try runtime_identity.writeJsonFields(status_writer);
         try status_writer.writeAll(",\"command_spelling\":");
         try std.json.stringify(command_spelling, .{}, status_writer);
         try status_writer.print(",\"installed_local_mismatch_detected\":{any}", .{installed_local_mismatch});

--- a/src/main.zig
+++ b/src/main.zig
@@ -306,67 +306,14 @@ pub fn main() !void {
 }
 
 fn writeVersionJson(allocator: std.mem.Allocator, writer: anytype) !void {
-    const binary_path = std.fs.selfExePathAlloc(allocator) catch try allocator.dupe(u8, "unknown");
-    defer allocator.free(binary_path);
-
-    const binary_sha256 = hashFileSha256Hex(allocator, binary_path) catch null;
-    defer if (binary_sha256) |sha| allocator.free(sha);
-
-    const build_id = std.process.getEnvVarOwned(allocator, "OMUX_BUILD_ID") catch try allocator.dupe(u8, cli.version);
-    defer allocator.free(build_id);
+    const identity = try runtime_mod.oauthMuxRuntimeIdentity(allocator, cli.version);
+    defer identity.deinit(allocator);
 
     try writer.writeAll("{\"version\":");
     try std.json.stringify(cli.version, .{}, writer);
-    try writer.writeAll(",\"runtime_identity\":{\"binary_path\":");
-    try std.json.stringify(binary_path, .{}, writer);
-    try writer.writeAll(",\"binary_source\":");
-    try std.json.stringify(classifyOauthMuxBinarySource(binary_path), .{}, writer);
-    try writer.writeAll(",\"binary_sha256\":");
-    if (binary_sha256) |sha| {
-        try std.json.stringify(sha, .{}, writer);
-    } else {
-        try writer.writeAll("null");
-    }
-    try writer.writeAll(",\"build_id\":");
-    try std.json.stringify(build_id, .{}, writer);
-    try writer.writeAll(",\"version\":");
-    try std.json.stringify(cli.version, .{}, writer);
-    try writer.writeAll(",\"path_printed\":true,\"binary_sha256_available\":");
-    try writer.writeAll(if (binary_sha256 != null) "true" else "false");
-    try writer.writeAll("}}\n");
-}
-
-fn classifyOauthMuxBinarySource(path: []const u8) []const u8 {
-    if (std.mem.indexOf(u8, path, "/zig-out/bin/oauth-mux") != null) return "repo_local";
-    if (std.mem.indexOf(u8, path, "/.local/bin/oauth-mux") != null) return "user_local";
-    if (std.mem.indexOf(u8, path, "/Cellar/oauth-mux/") != null) return "homebrew";
-    if (std.mem.indexOf(u8, path, "/opt/homebrew/bin/oauth-mux") != null) return "homebrew";
-    if (std.mem.indexOf(u8, path, "/usr/local/bin/oauth-mux") != null) return "homebrew";
-    if (std.mem.startsWith(u8, path, "/nix/store/")) return "nix_store";
-    if (std.mem.indexOf(u8, path, "/node_modules/") != null) return "npm";
-    return "path_or_installed";
-}
-
-fn hashFileSha256Hex(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
-    if (std.mem.eql(u8, path, "unknown")) return error.UnknownPath;
-
-    const file = try std.fs.openFileAbsolute(path, .{});
-    defer file.close();
-
-    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-    var buf: [8192]u8 = undefined;
-    while (true) {
-        const n = try file.read(&buf);
-        if (n == 0) break;
-        hasher.update(buf[0..n]);
-    }
-
-    var digest: [32]u8 = undefined;
-    hasher.final(&digest);
-
-    const hex = try allocator.alloc(u8, digest.len * 2);
-    _ = std.fmt.bufPrint(hex, "{s}", .{std.fmt.fmtSliceHexLower(&digest)}) catch unreachable;
-    return hex;
+    try writer.writeAll(",\"runtime_identity\":");
+    try identity.writeJson(writer);
+    try writer.writeAll("}\n");
 }
 
 fn exitCodeFromPipelineError(e: anyerror) u8 {

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -6,6 +6,97 @@ const provider_schema = @import("provider_schema.zig");
 const repair_state = @import("repair_state.zig");
 const types = @import("types.zig");
 
+pub const OauthMuxRuntimeIdentity = struct {
+    binary_path: []const u8,
+    binary_source: []const u8,
+    binary_sha256: ?[]const u8,
+    build_id: []const u8,
+    version: []const u8,
+
+    pub fn deinit(self: OauthMuxRuntimeIdentity, allocator: std.mem.Allocator) void {
+        allocator.free(self.binary_path);
+        if (self.binary_sha256) |sha| allocator.free(sha);
+        allocator.free(self.build_id);
+    }
+
+    pub fn writeJson(self: OauthMuxRuntimeIdentity, writer: anytype) !void {
+        try writer.writeByte('{');
+        try self.writeJsonFields(writer);
+        try writer.writeByte('}');
+    }
+
+    pub fn writeJsonFields(self: OauthMuxRuntimeIdentity, writer: anytype) !void {
+        try writer.writeAll("\"binary_path\":");
+        try std.json.stringify(self.binary_path, .{}, writer);
+        try writer.writeAll(",\"binary_source\":");
+        try std.json.stringify(self.binary_source, .{}, writer);
+        try writer.writeAll(",\"binary_sha256\":");
+        if (self.binary_sha256) |sha| {
+            try std.json.stringify(sha, .{}, writer);
+        } else {
+            try writer.writeAll("null");
+        }
+        try writer.writeAll(",\"build_id\":");
+        try std.json.stringify(self.build_id, .{}, writer);
+        try writer.writeAll(",\"version\":");
+        try std.json.stringify(self.version, .{}, writer);
+        try writer.writeAll(",\"path_printed\":true,\"binary_sha256_available\":");
+        try writer.writeAll(if (self.binary_sha256 != null) "true" else "false");
+    }
+};
+
+pub fn oauthMuxRuntimeIdentity(allocator: std.mem.Allocator, version: []const u8) !OauthMuxRuntimeIdentity {
+    const binary_path = std.fs.selfExePathAlloc(allocator) catch try allocator.dupe(u8, "unknown");
+    errdefer allocator.free(binary_path);
+
+    const binary_sha256 = hashFileSha256Hex(allocator, binary_path) catch null;
+    errdefer if (binary_sha256) |sha| allocator.free(sha);
+
+    const build_id = std.process.getEnvVarOwned(allocator, "OMUX_BUILD_ID") catch try allocator.dupe(u8, version);
+    errdefer allocator.free(build_id);
+
+    return .{
+        .binary_path = binary_path,
+        .binary_source = classifyOauthMuxBinarySource(binary_path),
+        .binary_sha256 = binary_sha256,
+        .build_id = build_id,
+        .version = version,
+    };
+}
+
+pub fn classifyOauthMuxBinarySource(path_value: []const u8) []const u8 {
+    if (std.mem.indexOf(u8, path_value, "/zig-out/bin/oauth-mux") != null) return "repo_local";
+    if (std.mem.indexOf(u8, path_value, "/.local/bin/oauth-mux") != null) return "user_local";
+    if (std.mem.indexOf(u8, path_value, "/Cellar/oauth-mux/") != null) return "homebrew";
+    if (std.mem.indexOf(u8, path_value, "/opt/homebrew/bin/oauth-mux") != null) return "homebrew";
+    if (std.mem.indexOf(u8, path_value, "/usr/local/bin/oauth-mux") != null) return "homebrew";
+    if (std.mem.startsWith(u8, path_value, "/nix/store/")) return "nix_store";
+    if (std.mem.indexOf(u8, path_value, "/node_modules/") != null) return "npm";
+    return "path_or_installed";
+}
+
+pub fn hashFileSha256Hex(allocator: std.mem.Allocator, path_value: []const u8) ![]u8 {
+    if (std.mem.eql(u8, path_value, "unknown")) return error.UnknownPath;
+
+    const file = try std.fs.openFileAbsolute(path_value, .{});
+    defer file.close();
+
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    var buf: [8192]u8 = undefined;
+    while (true) {
+        const n = try file.read(&buf);
+        if (n == 0) break;
+        hasher.update(buf[0..n]);
+    }
+
+    var digest: [32]u8 = undefined;
+    hasher.final(&digest);
+
+    const hex = try allocator.alloc(u8, digest.len * 2);
+    _ = std.fmt.bufPrint(hex, "{s}", .{std.fmt.fmtSliceHexLower(&digest)}) catch unreachable;
+    return hex;
+}
+
 pub const RouteRef = struct {
     provider: []const u8,
     account: []const u8,
@@ -321,6 +412,15 @@ pub fn fileExists(path_value: []const u8) bool {
 
 fn pathDelimiter() u8 {
     return if (builtin.os.tag == .windows) ';' else ':';
+}
+
+test "classify oauth mux binary source" {
+    try std.testing.expectEqualStrings("repo_local", classifyOauthMuxBinarySource("/repo/zig-out/bin/oauth-mux"));
+    try std.testing.expectEqualStrings("user_local", classifyOauthMuxBinarySource("/Users/me/.local/bin/oauth-mux"));
+    try std.testing.expectEqualStrings("homebrew", classifyOauthMuxBinarySource("/opt/homebrew/Cellar/oauth-mux/0.1.7/bin/oauth-mux"));
+    try std.testing.expectEqualStrings("nix_store", classifyOauthMuxBinarySource("/nix/store/abc-oauth-mux-0.1.7/bin/oauth-mux"));
+    try std.testing.expectEqualStrings("npm", classifyOauthMuxBinarySource("/tmp/app/node_modules/.bin/oauth-mux"));
+    try std.testing.expectEqualStrings("path_or_installed", classifyOauthMuxBinarySource("/usr/bin/oauth-mux"));
 }
 
 test "routeReadiness reports missing command capability binary" {


### PR DESCRIPTION
## Summary

- move oauth-mux executable identity capture into a shared runtime helper
- include the same binary source, SHA-256, build id, version, and path-printing fields in managed Codex session_started status artifacts
- update the Codex acceptance smoke and install/acceptance docs for the stronger runtime_identity shape

## Validation

- git diff --check
- zig build test
- zig build && ./zig-out/bin/oauth-mux version --json | jq -e '.version and .runtime_identity.binary_path and .runtime_identity.binary_source and .runtime_identity.binary_sha256 and .runtime_identity.path_printed == true and .runtime_identity.binary_sha256_available == true'
- scripts/smoke-codex-acceptance.sh
- just check-local

No local Playwright/browser tests were run.