### PR TITLE
Recover expired route retry windows

### DIFF
--- a/src/broker_loader.zig
+++ b/src/broker_loader.zig
@@ -1000,6 +1000,51 @@ test "populatePoolFromRouteHealth lets expired provider degradation yield to cap
     try std.testing.expectEqual(broker.account_pool_mod.Availability.available, elected.availability);
 }
 
+test "populatePoolFromRouteHealth lets expired account rate limit yield to capability health" {
+    const cfg_json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "/tmp/a" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "codex-max": { "providers": ["codex:max-1#codex-max"] }
+        \\  }
+        \\}
+    ;
+    var parsed = try config_mod.loadFromBytes(std.testing.allocator, cfg_json);
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    const now = std.time.timestamp();
+    const account_health = try store.getOrCreate("codex:max-1");
+    account_health.liveness = .{ .live = .{ .availability = .{ .rate_limited = .{
+        .retry_after_s = 60,
+        .limited_at = now - 120,
+        .window = .unknown,
+    } } } };
+    account_health.last_probe_hint_class = .rate_limit;
+    account_health.last_probe_decision = .wait_and_retry;
+    const capability_health = try store.getOrCreate("codex:max-1#codex-max");
+    capability_health.liveness = .{ .live = .{ .availability = .available } };
+    capability_health.last_probe_hint_class = .none;
+    capability_health.last_probe_decision = .use_this;
+
+    var pool = broker.AccountPool.init(std.testing.allocator);
+    defer pool.deinit();
+    try populatePoolFromRouteHealth(&pool, parsed.value, "codex-max", &store);
+
+    const elected = try pool.elect(null, null, &.{});
+    try std.testing.expectEqualStrings("codex:max-1", elected.id);
+    try std.testing.expectEqual(broker.account_pool_mod.Availability.available, elected.availability);
+}
+
 test "populatePoolFromRouteHealth keeps auth-dead account health global" {
     const cfg_json =
         \\{

--- a/src/health.zig
+++ b/src/health.zig
@@ -181,6 +181,27 @@ pub fn effectiveHealthForRouteSelection(health: AccountHealth, now: i64) Account
 
 pub fn recoverExpiredTransientHealth(health: *AccountHealth, now: i64) void {
     switch (health.liveness) {
+        .live => |live| switch (live.availability) {
+            .rate_limited => |rl| {
+                const retry_at = health.rate_limited_until orelse rl.limited_at + @as(i64, rl.retry_after_s);
+                if (now < retry_at) return;
+                health.liveness = .{ .live = .{ .availability = .available } };
+                health.rate_limited_until = null;
+                health.last_probe_retry_after_s = null;
+                health.last_probe_hint_class = .none;
+                health.last_probe_decision = .use_this;
+                health.consecutive_failures = 0;
+            },
+            .cooldown => |cooldown| {
+                if (now < cooldown.until) return;
+                health.liveness = .{ .live = .{ .availability = .available } };
+                health.last_probe_retry_after_s = null;
+                health.last_probe_hint_class = .none;
+                health.last_probe_decision = .use_this;
+                health.consecutive_failures = 0;
+            },
+            .available, .quota_exhausted => {},
+        },
         .degraded => |d| {
             const retry_at = d.retry_at orelse return;
             if (now < retry_at) return;
@@ -1070,6 +1091,64 @@ test "effectiveHealthForRouteSelection recovers only expired transient degradati
     }, now);
     switch (still_blocked.liveness) {
         .degraded => |degraded| try std.testing.expectEqual(types.DegradedReason.step_up_required, degraded.reason),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "effectiveHealthForRouteSelection recovers expired live retry windows" {
+    const now: i64 = 1_800_000_000;
+
+    const recovered_rate_limit = effectiveHealthForRouteSelection(.{
+        .liveness = .{ .live = .{ .availability = .{ .rate_limited = .{
+            .retry_after_s = 60,
+            .limited_at = now - 120,
+            .window = .unknown,
+        } } } },
+        .last_probe_retry_after_s = 60,
+        .last_probe_hint_class = .rate_limit,
+        .last_probe_decision = .wait_and_retry,
+        .consecutive_failures = 3,
+    }, now);
+    switch (recovered_rate_limit.liveness) {
+        .live => |live| switch (live.availability) {
+            .available => {},
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expectEqual(ProbeHintClass.none, recovered_rate_limit.last_probe_hint_class.?);
+    try std.testing.expectEqual(types.MuxDecision.use_this, recovered_rate_limit.last_probe_decision.?);
+    try std.testing.expectEqual(@as(u32, 0), recovered_rate_limit.consecutive_failures);
+
+    const blocked_rate_limit = effectiveHealthForRouteSelection(.{
+        .liveness = .{ .live = .{ .availability = .{ .rate_limited = .{
+            .retry_after_s = 60,
+            .limited_at = now - 10,
+            .window = .unknown,
+        } } } },
+    }, now);
+    switch (blocked_rate_limit.liveness) {
+        .live => |live| switch (live.availability) {
+            .rate_limited => {},
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+
+    const recovered_cooldown = effectiveHealthForRouteSelection(.{
+        .liveness = .{ .live = .{ .availability = .{ .cooldown = .{
+            .until = now - 1,
+            .reason = "test",
+        } } } },
+        .last_probe_hint_class = .failure,
+        .last_probe_decision = .wait_and_retry,
+        .consecutive_failures = 1,
+    }, now);
+    switch (recovered_cooldown.liveness) {
+        .live => |live| switch (live.availability) {
+            .available => {},
+            else => return error.TestUnexpectedResult,
+        },
         else => return error.TestUnexpectedResult,
     }
 }


### PR DESCRIPTION
## Summary
- recover expired live rate-limit and cooldown windows in route-election health normalization
- keep quota exhaustion and auth-dead lanes blocked for explicit revalidation/reauth
- add regression coverage for expired account-level rate limits yielding to capability health

## Root cause
The broker route loader uses effectiveHealthForRouteSelection(), but that normalizer only recovered transient degraded provider state. A persisted live/rate_limited record could remain non-selectable after its retry window elapsed, so a 60-second Codex 429 could still produce NoAccountSelectable/503 during managed fallback election.

## Validation
- zig build test
- git diff --check
- scripts/smoke-codex-cli-ux.sh
- scripts/smoke-codex-status-summary.sh
- scripts/smoke-codex-concurrent-sessions.sh
- just check-local
- repo binary no-spend preflight changed local codex-max from 0 selectable routes to max-3 selected after the expired rate-limit window