### PR TITLE
Fail closed on stale Codex auth material

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -515,6 +515,13 @@ The refresh path now uses that same admission gate. File-backed credentials can
 be replaced atomically, but automatic refresh only runs for providers whose
 definition declares `repair.owner = "oauth_mux_refresh"` and whose backend
 reports `automatic_refresh_admitted: true`. Codex remains upstream-CLI-owned.
+Managed Codex credential materialization has one narrower guard: if a selected
+mux-owned Codex account store already contains an expired access token,
+oauth-mux attempts the account's refresh token before handing credentials to
+the broker. If that refresh is missing or fails, the materializer fails closed
+and records `credential_unavailable` instead of sending a known-stale access
+token upstream and misclassifying the provider's 401 as permanent auth death.
+This is lazy per-route materialization, not broad pre-spawn route warming.
 
 If `repair-plan --profile codex-max` reports a config validation error, the
 active config is not the starter Codex Max shape. That usually means the

--- a/docs/spec/oauth-mux-formal-model.md
+++ b/docs/spec/oauth-mux-formal-model.md
@@ -330,6 +330,7 @@ DeadReason =
     token_revoked
   | account_deleted
   | auth_permanently_failed
+  | credential_unavailable
 ```
 
 Dead credentials require user action: login again, rotate the secret, or remove

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -551,7 +551,7 @@ pub const Proxy = struct {
             } },
             .tier_insufficient => .{ .degraded = .tier_insufficient },
             .provider_degraded => .provider_degraded,
-            .credential_unavailable => .{ .dead = .auth_permanently_failed },
+            .credential_unavailable => .{ .dead = .credential_unavailable },
         };
 
         store.recordHttpClassification(key.slice(), status, classification);

--- a/src/broker_loader.zig
+++ b/src/broker_loader.zig
@@ -362,27 +362,42 @@ fn refreshCodexAccountAuthFile(
     _ = account;
 }
 
-fn maybeRefreshCodexAuthBeforeMaterialize(
+const CodexAuthRefreshState = enum {
+    not_needed,
+    needed,
+    unavailable,
+};
+
+fn refreshCodexAuthState(allocator: std.mem.Allocator, bytes: []const u8) CodexAuthRefreshState {
+    var material = parseCodexAuthRefreshMaterial(allocator, bytes) catch return .not_needed;
+    defer material.deinit(allocator);
+    const exp = jwtExpiresAt(allocator, material.access_token) catch return .not_needed;
+    if (exp > std.time.timestamp() + 300) return .not_needed;
+    return if (material.refresh_token != null) .needed else .unavailable;
+}
+
+fn refreshCodexAuthBeforeMaterialize(
     allocator: std.mem.Allocator,
     cfg: config_mod.Config,
     provider: []const u8,
     account: []const u8,
     acct_cfg: config_mod.AccountConfig,
     bytes: []const u8,
-) bool {
+) broker_types.BrokerError!bool {
     if (!std.mem.eql(u8, provider, "codex")) return false;
     if (acct_cfg.config_dir == null) return false;
-    if (!codexAuthShouldRefresh(allocator, bytes)) return false;
-    refreshCodexAccountAuthFile(allocator, cfg, provider, account, acct_cfg) catch return false;
+    switch (refreshCodexAuthState(allocator, bytes)) {
+        .not_needed => return false,
+        .unavailable => return broker_types.BrokerError.SecretUnavailable,
+        .needed => {},
+    }
+    refreshCodexAccountAuthFile(allocator, cfg, provider, account, acct_cfg) catch
+        return broker_types.BrokerError.SecretUnavailable;
     return true;
 }
 
 fn codexAuthShouldRefresh(allocator: std.mem.Allocator, bytes: []const u8) bool {
-    var material = parseCodexAuthRefreshMaterial(allocator, bytes) catch return false;
-    defer material.deinit(allocator);
-    if (material.refresh_token == null) return false;
-    const exp = jwtExpiresAt(allocator, material.access_token) catch return false;
-    return exp <= std.time.timestamp() + 300;
+    return refreshCodexAuthState(allocator, bytes) == .needed;
 }
 
 const CodexAuthRefreshMaterial = struct {
@@ -636,7 +651,7 @@ pub fn materializeChatgpt(
         return broker_types.BrokerError.SecretUnavailable;
     defer allocator.free(bytes);
 
-    if (maybeRefreshCodexAuthBeforeMaterialize(allocator, cfg, provider, account, acct_cfg, bytes)) {
+    if (try refreshCodexAuthBeforeMaterialize(allocator, cfg, provider, account, acct_cfg, bytes)) {
         const refreshed_bytes = readFileAlloc(allocator, path) catch
             return broker_types.BrokerError.SecretUnavailable;
         allocator.free(bytes);
@@ -787,6 +802,12 @@ test "codex auth refresh detection uses access token exp" {
         \\{"tokens":{"access_token":"h.eyJleHAiOjF9.s","refresh_token":"rt","account_id":"acc"}}
     ;
     try std.testing.expect(codexAuthShouldRefresh(std.testing.allocator, expired_auth));
+    try std.testing.expectEqual(
+        CodexAuthRefreshState.unavailable,
+        refreshCodexAuthState(std.testing.allocator,
+            \\{"tokens":{"access_token":"h.eyJleHAiOjF9.s","account_id":"acc"}}
+        ),
+    );
 
     const future_exp = std.time.timestamp() + 3600;
     var payload_buf: [64]u8 = undefined;
@@ -798,6 +819,109 @@ test "codex auth refresh detection uses access token exp" {
     , .{encoded});
     defer std.testing.allocator.free(fresh_auth);
     try std.testing.expect(!codexAuthShouldRefresh(std.testing.allocator, fresh_auth));
+}
+
+test "materializeChatgpt refuses expired codex token when refresh is unavailable" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const auth_file = try tmp.dir.createFile("auth.json", .{ .mode = 0o600 });
+    try auth_file.writeAll(
+        \\{"tokens":{"access_token":"h.eyJleHAiOjF9.s","account_id":"acc"}}
+    );
+    auth_file.close();
+
+    const auth_path = try tmp.dir.realpathAlloc(std.testing.allocator, "auth.json");
+    defer std.testing.allocator.free(auth_path);
+    const config_dir = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(config_dir);
+
+    const cfg_json = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "providers": {{
+        \\    "codex": {{
+        \\      "kind": "codex",
+        \\      "accounts": {{
+        \\        "max-1": {{
+        \\          "config_dir": "{s}",
+        \\          "secret": {{ "backend": "file", "path": "{s}" }}
+        \\        }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{}},
+        \\  "strategies": {{}}
+        \\}}
+    ,
+        .{ config_dir, auth_path },
+    );
+    defer std.testing.allocator.free(cfg_json);
+
+    var parsed = try config_mod.loadFromBytes(std.testing.allocator, cfg_json);
+    defer parsed.deinit();
+
+    try std.testing.expectError(
+        broker_types.BrokerError.SecretUnavailable,
+        materializeChatgpt(parsed.value, std.testing.allocator, "codex:max-1"),
+    );
+}
+
+test "materializeChatgpt refuses stale codex token when refresh fails" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const auth_file = try tmp.dir.createFile("auth.json", .{ .mode = 0o600 });
+    try auth_file.writeAll(
+        \\{"tokens":{"access_token":"h.eyJleHAiOjF9.s","refresh_token":"rt","account_id":"acc"}}
+    );
+    auth_file.close();
+
+    const auth_path = try tmp.dir.realpathAlloc(std.testing.allocator, "auth.json");
+    defer std.testing.allocator.free(auth_path);
+    const config_dir = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(config_dir);
+
+    const cfg_json = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "provider_definitions": {{
+        \\    "codex-test": {{
+        \\      "name": "codex-test",
+        \\      "auth": {{
+        \\        "token_endpoint": "://invalid",
+        \\        "client_id": "client"
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "providers": {{
+        \\    "codex": {{
+        \\      "kind": "codex-test",
+        \\      "accounts": {{
+        \\        "max-1": {{
+        \\          "config_dir": "{s}",
+        \\          "secret": {{ "backend": "file", "path": "{s}" }}
+        \\        }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{}},
+        \\  "strategies": {{}}
+        \\}}
+    ,
+        .{ config_dir, auth_path },
+    );
+    defer std.testing.allocator.free(cfg_json);
+
+    var parsed = try config_mod.loadFromBytes(std.testing.allocator, cfg_json);
+    defer parsed.deinit();
+
+    try std.testing.expectError(
+        broker_types.BrokerError.SecretUnavailable,
+        materializeChatgpt(parsed.value, std.testing.allocator, "codex:max-1"),
+    );
 }
 
 test "buildRefreshedCodexAuthJson preserves account id and retained refresh token" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -17267,13 +17267,15 @@ test "Codex preflight repair summary counts auth and provider blockers" {
         .mediation = .provider_degraded,
     });
     codexPreflightClassifyRepairRoute(&summary, "auth_permanently_failed", reauth);
+    codexPreflightClassifyRepairRoute(&summary, "credential_unavailable", reauth);
     codexPreflightFinalizeRepairSummary(&summary);
 
-    try std.testing.expectEqual(@as(usize, 4), summary.blocked_routes);
+    try std.testing.expectEqual(@as(usize, 5), summary.blocked_routes);
     try std.testing.expectEqual(@as(usize, 2), summary.token_revoked_routes);
     try std.testing.expectEqual(@as(usize, 1), summary.provider_degraded_routes);
     try std.testing.expectEqual(@as(usize, 1), summary.auth_permanently_failed_routes);
-    try std.testing.expectEqual(@as(usize, 3), summary.auth_handoff_routes);
+    try std.testing.expectEqual(@as(usize, 1), summary.credential_unavailable_routes);
+    try std.testing.expectEqual(@as(usize, 4), summary.auth_handoff_routes);
     try std.testing.expect(summary.user_handoff_required);
     try std.testing.expectEqualStrings("token_revoked", summary.dominant_blocker.?);
     try std.testing.expectEqual(@as(usize, 2), summary.dominant_blocker_count);

--- a/src/types.zig
+++ b/src/types.zig
@@ -238,6 +238,7 @@ pub const DeadReason = enum {
     token_revoked,
     account_deleted,
     auth_permanently_failed,
+    credential_unavailable,
 };
 
 // ── Provider Extensibility ──


### PR DESCRIPTION
## Summary

- fail closed when managed Codex credential materialization sees an expired access token but refresh is unavailable or fails
- preserve `credential_unavailable` as a durable route-health reason instead of collapsing it into `auth_permanently_failed`
- document the lazy per-route materialization guard and extend the formal dead-reason model

## Root Cause

The broker materializer refreshed expiring Codex auth opportunistically, but if refresh failed it returned the original stale access token. The proxy could then send that known-stale token upstream, receive a 401, and persist the route as auth-dead/token-revoked or permanent auth failure. That made local refresh/materialization failures look like provider-verified account death.

## Validation

- `zig build test`
- `zig build`
- `git diff --check`
- `scripts/smoke-codex-cli-ux.sh`
- `scripts/smoke-codex-status-summary.sh`
- `just check-local`

No local Playwright/browser tests were run.