### PR TITLE
Refresh oauth-mux productionization truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ Keep the claim ladder tied to evidence:
 
 - `docs/qa-handoff-matrix.md`: route states, handoff patterns, and current Codex
   truth.
+- `docs/productionization-ledger.md`: UX/DX/AX stance, feature ledger,
+  adapter strategy, daemon beta boundary, release posture, and tracker map.
 - `docs/release-install-lanes.md`: public package lanes versus local dogfood
   lanes.
 - `docs/lifecycle.md`: application lifecycle, managed Codex flow, agent-safe

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@ Start here when you need the right document without reading every spec.
 
 - `qa-handoff-matrix.md`: canonical account labels, route states, handoff
   patterns, and current Codex truth.
+- `productionization-ledger.md`: current UX/DX/AX stance, feature ledger,
+  adapter roadmap, release posture, daemon beta boundary, and tracker map.
 - `release-install-lanes.md`: installer, package, CI/CD, and local dogfood lane
   contract.
 - `live-provider-qa.md`: manual live-provider QA runbook and spend-gated

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -1,20 +1,27 @@
 # Daemon Boundary
 
-The daemon exists, but it is not a production dependency yet.
+The daemon exists, but it is not a hidden production dependency yet. The
+near-term product lane is a beta daemon that hosts the same foreground tick
+engine and mediation semantics already used by `stay-afloat`, not a separate
+route warmer or unmanaged process hot-swapper.
 
 ## Current Decision
 
 Keep daemon usage optional until provider-specific refresh semantics are proven
 for each OAuth-backed harness. The default production path remains explicit
-selection, explicit probe, env injection, and exec handoff.
+selection, explicit probe, env injection, managed broker mediation, and exec
+handoff.
 
 For the current product line, the socket daemon is not the stay-afloat product
 surface. It remains local experimental status/control plumbing. Wrappers,
 package recipes, CI jobs, and agents should call the foreground tick contract:
 `oauth-mux stay-afloat ...` or the lower-level `oauth-mux daemon tick ...`.
-If a production background daemon is added later, it must be a deliberate beta
-promotion of the same foreground tick engine, not a semantic fork of the socket
-stub.
+The beta daemon promotion must be a deliberate host for the same foreground
+tick engine, not a semantic fork of the socket stub. It may publish status,
+schedule ticks, and queue user-mediated handoffs. It must not claim same-thread
+continuity, mid-turn streaming recovery, per-request muxing, or unmanaged
+hot-swap until a provider/native hook, request proxy, or adapter-owned process
+boundary proves that level.
 
 The 2026-04-30 stay-afloat review keeps this boundary in place. Real Codex
 dogfood proved route-scoped fallback from `codex:max-1#codex-max` quota
@@ -29,10 +36,10 @@ and no seamless daemon handoff occurred. Manual logout/login restored future
 into a seamless fallback path.
 
 The current paid Codex Max route matrix is also newer than the original
-2026-04-30 example: `max-1#codex-max` is selected after spend-gated
-revalidation, `max-4#codex-max` is the spare fallback, and `max-2#codex-max`
-plus `max-3#codex-max` remain provider quota-exhausted for `codex-max`.
-Dashboard credit or mini/Spark availability must not be treated as Max route
+2026-04-30 example: the 2026-05-16 no-spend refresh has `max-1#codex-max`,
+`max-2#codex-max`, `max-3#codex-max`, and `max-4#codex-max` all selectable and
+broker-ready, with a selected route plus three spare fallbacks. Dashboard
+credit or mini/Spark availability must not be treated as Max route
 availability; use provider execution evidence per route and capability.
 
 `oauth-mux doctor runtime`, `oauth-mux route explain`, `oauth-mux route

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -1,6 +1,6 @@
 # Install Beta Matrix
 
-Updated: 2026-05-10
+Updated: 2026-05-16
 
 This matrix tracks clean-install proof for the public adoption surfaces. It is
 operator evidence, not a credential runbook: do not paste OAuth stores, `.env`
@@ -22,7 +22,7 @@ The lane contract and current operator rules live in
 | Homebrew formula | 0.1.6 | macOS arm64 + hosted Ubuntu dry-run | public `jesssullivan/omux` tap | Pass | Clean local uninstall/untap followed by `just homebrew-qa 0.1.6` installed from `Jesssullivan/homebrew-omux`; hosted registry dry-run `25199131583` checked out the public tap and passed the Homebrew lane. |
 | deb package | 0.1.6 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25195456319` installed package and ran `/usr/bin/oauth-mux version`. |
 | rpm package | 0.1.6 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25195456319` installed package and ran `/usr/bin/oauth-mux version`. |
-| Codex route dogfood | 0.1.6 | macOS arm64 | installed user-local binary | Pass with current route not afloat | Historical npm snapshots remain below. Current post-handoff truth: `codex-max` is `not_afloat`; `max-1`, `max-2`, and `max-4` are quota-exhausted; `max-3` is runtime-ready but recorded auth-dead. |
+| Codex route dogfood | 0.1.7 candidate | macOS arm64 | installed user-local binary | Pass with four selectable routes | Current 2026-05-16 no-spend truth: `codex-max` has four selectable broker-ready routes, `session_start_ready:true`, `fallback_ready:true`, and `single_route_at_risk:false`. Public package channels remain `0.1.6`. |
 | lab dogfood | 0.1.6 | macOS arm64 | public npm one-shot | Pass | Installed `oauth-mux doctor --json` reports `ok: true` against local config/state. |
 | first-run source e2e | main | macOS arm64 | source checkout | Pass | `just first-run-e2e` runs with temporary HOME/XDG roots and proves no-config `init --codex-max`, JSON diagnostics, runtime diagnostics, redacted report, no-spend route explanation/select refusal, and non-mutating Codex help. |
 

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -1,0 +1,131 @@
+# Productionization Ledger
+
+Updated: 2026-05-16
+
+This ledger is the short operator map for oauth-mux productionization. It is
+subordinate to the broker contract and Codex adapter contract, and it should be
+refreshed when release truth, route evidence, or tracker state changes.
+
+## Current Snapshot
+
+- Repo state: `main` is clean against `origin/main`; no open GitHub PRs were
+  present in the 2026-05-16 refresh.
+- CI state: the latest checked `main` CI runs were green through run
+  `25930367658`.
+- Version truth: local/source dogfood is `0.1.7`; public npm, GitHub Release,
+  and Homebrew remain `0.1.6`.
+- Installed dogfood: active `oauth-mux` resolves to the user-local binary and
+  active `codex` resolves to the oauth-mux-managed shim; native Codex is still
+  discoverable for pass-through.
+- Codex route truth: `codex-max` currently has four selectable broker-ready
+  routes, `session_start_ready:true`, `fallback_ready:true`, and
+  `single_route_at_risk:false`.
+- Latest local status truth: `oauth-mux codex status-latest --json` currently
+  reports `successful_live_quota_handoff`; status artifacts are rolling local
+  evidence and must be refreshed before being used in public claims.
+- Daemon truth: `oauth-mux daemon status --json` still reports
+  `contract:"experimental_socket_stub"`; the beta daemon lane must host the
+  same foreground tick engine and must not claim unmanaged hot-swap.
+
+## Feature Ledger
+
+| Feature | Current level | Notes |
+| --- | --- | --- |
+| Managed Codex launch/resume | Live-proven | Reference adapter path for `oauth-mux codex` and `oauth-mux codex resume`. |
+| Codex quota handoff | Live-proven for managed Codex | Strongest preserved proof lives in `docs/evidence/codex-engineered-quota-handoff-20260509/`. |
+| Session authority bridge | Implemented | Managed auth/config overlays bridge canonical Codex session authority, including `state_5.sqlite*` when present. |
+| Config/TOML preservation | Implemented | Root-partitioned Codex config passthrough keeps user settings, MCP servers, profiles, model defaults, approval/sandbox policy, and non-managed provider definitions. |
+| Experimental Codex settings injection | Implemented | Defaults can be injected without treating user config as disposable. |
+| Native Codex shim pass-through | Implemented | Admin/login/help/version paths bypass route election and exec native Codex. |
+| Route-health recovery | Implemented | Transient provider degradation can recover after retry windows without becoming permanent auth death. |
+| Redacted diagnostics and tracing | Implemented | JSON diagnostics and `OMUX_TRACE=1` support route/session/auth/runtime debugging without token, raw account id, session id, or path leakage. |
+| Agent-safe reauth mediation | Contracted, partial surfaces | CLI JSON exposes consent/action fields; future MCP tools must mirror CLI semantics. |
+| Beta daemon | Experimental | Foreground tick engine and daemon-hosted beta may mediate status/handoffs; not a hidden dependency and not unmanaged hot-swap. |
+| Claude adapter | Provider-proof only | `auth-status` and account-store isolation are the first proof lane; no Claude stay-afloat claim. |
+| OMO, Pi, OpenCode, Kimi | Adapter-candidate only | Adjacent agent-control-plane proof does not equal oauth-mux keepalive support. |
+
+## UX, DX, AX Stance
+
+UX:
+
+- The managed harness should feel like the upstream harness.
+- Handoffs are labeled and user-mediated when upstream auth is required.
+- A daemon beta may improve observation and mediation, but current Codex UX must
+  not depend on a hidden background service.
+
+DX:
+
+- `just build`, `just test`, and `just check-local` remain the local development
+  gates.
+- `just release-proof <version>` is required before any registry mutation.
+- Installed-command dogfood must use `oauth-mux version --json`,
+  `which -a oauth-mux`, `which -a codex`, and `codex preflight` to prove the
+  exact binary and shim path under test.
+
+AX:
+
+- Agents use no-spend inspection surfaces first: `discover`, `providers list`,
+  `accounts list`, `doctor runtime`, `route explain`, `repair-plan`,
+  `stay-afloat --once`, `codex preflight`, `status-latest`, and
+  `daemon status`.
+- Agents must not read token files, run upstream login, spend provider calls, or
+  mutate credential stores without explicit consent.
+- Trace and status artifacts are support material only after redaction review.
+
+## Adapter Strategy
+
+Codex remains the reference adapter until its negative/cassette matrix and
+release truth are stable. Claude is the next likely adapter proof because it has
+a narrow command-owned `auth-status` surface and account-store isolation to
+validate. OMO, Pi, OpenCode, and Kimi should first get adapter contracts that
+answer token shape, auth storage, reload boundary, quota signal, failure signal,
+wire interception, process topology, and session authority. Until then, they may
+consume oauth-mux diagnostics or future MCP repair prompts, but oauth-mux must
+not claim to keep them alive.
+
+## Release And Distribution Posture
+
+Hold `0.1.7` as a release candidate until the truth docs, tracker state,
+negative cassettes, and daemon beta boundary are current. Public install copy
+must continue to say `0.1.6` until npm, GitHub Release, and Homebrew are
+actually published and verified.
+
+The release lanes remain:
+
+- worktree dogfood;
+- user-local dogfood;
+- Nix package;
+- GitHub Release tarballs and installer;
+- npm;
+- Homebrew;
+- deb/rpm packages.
+
+Remote/browser validation should use the repo's remote execution lane when a
+browser is needed; local Playwright is not part of this CLI proof path.
+
+## Tracker Map
+
+| Theme | Linear | GitHub | Current stance |
+| --- | --- | --- | --- |
+| Broker daemon and adapter contract | TIN-738 | #67 | Anchor remains open until daemon beta and second-adapter validation are honest. |
+| Codex next-turn broker switch | TIN-916 | #131 | Codex is the reference path; keep evidence distinct from same-thread or mid-turn claims. |
+| Live Codex account-swap acceptance | TIN-951 | #177 | Spend-confirmed only; requires selected route plus spare fallback and redacted artifacts. |
+| Wire cassette coverage | TIN-950 | #176 | Needed before treating negative permutations as stable release proof. |
+| Harness session authority bridge | TIN-979 | #191 | Implementation exists, but tracker should be reconciled against current bridge proof. |
+| OTEL-friendly tracing | TIN-1148 | PR #225/#226 lineage | Implemented trace schema should become the standard support-bundle path. |
+| Provider proof beyond Codex | TIN-736 | #68 | Claude next; other agents stay adapter-candidate only. |
+
+## Acceptance Gates
+
+- No-spend state refresh passes with current installed binary:
+  `doctor`, `providers list`, `accounts list`, `route explain`,
+  `codex preflight`, `broker-session-plan`, `stay-afloat next`,
+  `status-latest`, and `daemon status`.
+- Local validation passes: `zig build test`, targeted Codex smokes, and
+  `nix develop --command just check-local`.
+- Public release validation passes: `just release-proof <version>`, release
+  proof workflow, npm dry run/publish workflow as appropriate, Homebrew QA, and
+  system package QA.
+- Public copy does not claim same-thread continuity, mid-turn recovery,
+  unmanaged daemon hot-swap, non-Codex stay-afloat, universal provider support,
+  or public `0.1.7` availability before publication.

--- a/docs/qa-handoff-matrix.md
+++ b/docs/qa-handoff-matrix.md
@@ -1,6 +1,6 @@
 # QA Handoff Matrix
 
-Updated: 2026-05-10
+Updated: 2026-05-16
 
 This matrix keeps handoff, reauth, resume, account-label, and cassette/live QA
 claims in one place. It is subordinate to the broker and Codex adapter specs.
@@ -76,9 +76,16 @@ capability, such as `codex:max-3#codex-max`.
   `oauth-mux codex resume`.
 - The strongest preserved proof is
   `docs/evidence/codex-engineered-quota-handoff-20260509/`.
-- Current no-spend route truth after that burn is `not_afloat` for
-  `codex-max`: `max-1`, `max-2`, and `max-4` are quota-exhausted; `max-3` is
-  runtime-ready but recorded `auth_permanently_failed`.
+- Current no-spend route truth from the 2026-05-16 refresh is afloat for
+  `codex-max`: `max-1`, `max-2`, `max-3`, and `max-4` are selectable,
+  broker-ready, and `available`.
+- `oauth-mux codex preflight --profile codex-max --capability codex-max --json`
+  reports `session_start_ready:true`, `fallback_ready:true`, and
+  `single_route_at_risk:false`.
+- `oauth-mux codex status-latest --json` currently reports
+  `successful_live_quota_handoff`. Status artifacts are rolling local evidence;
+  refresh this command before copying current-state claims into public release
+  notes or tracker comments.
 
 ## Next QA Targets
 
@@ -87,4 +94,6 @@ capability, such as `codex:max-3#codex-max`.
 3. Live or cassette-backed tier-insufficient before credited fallback.
 4. Reset-window repair after quota reset with no manual health reset.
 5. API-credit false-positive guard for subscription-backed Codex.
-6. Same-thread continuity study, explicitly separate from managed handoff.
+6. Beta daemon status/handoff mediation proof that preserves the foreground
+   tick semantics and does not claim unmanaged hot-swap.
+7. Same-thread continuity study, explicitly separate from managed handoff.

--- a/docs/spec/future-adapter-roadmap-2026-05-10.md
+++ b/docs/spec/future-adapter-roadmap-2026-05-10.md
@@ -29,6 +29,7 @@ Every adapter needs:
 | Adapter | First proof target | Handoff shape to study | Main unknowns |
 | --- | --- | --- | --- |
 | Claude Code | isolated account-store `auth-status` | native CLI config-dir selection first; current-process handoff later only if a hook exists | subscription vs Console/API billing, quota text shape, account-store isolation |
+| OMO / OpenCode frontends | route inventory and config/profile isolation | consume oauth-mux diagnostics or future MCP repair prompts first; prepared launch only until protocol evidence exists | whether the agent frontend exposes provider auth state, quota state, request proxy hooks, or reloadable credentials |
 | Pi | account inventory and login-state doctor | likely prepared launch or HTTP/MCP proxy, pending protocol evidence | auth storage, quota signal shape, CLI/API boundary |
 | opencode | config/profile isolation and command probe | prepared launch first; request proxy only if HTTP path is observable | provider plugin model, auth ownership, model/provider routing |
 | Kimi | provider-schema proof and command/API probe | command adapter or HTTP proxy depending on available CLI/API | OAuth vs API key, quota/rate/tier error taxonomy |
@@ -53,6 +54,8 @@ metadata.
 ## Do Not Claim
 
 - Do not claim "provider supported" when only one capability is proven.
+- Do not treat adjacent agent-control-plane route proof as oauth-mux
+  stay-afloat support.
 - Do not claim seamless handoff from a prepared launch.
 - Do not claim quota fallback from auth fallback.
 - Do not generalize API credits or unrelated model availability into
@@ -68,5 +71,5 @@ metadata.
    quota/fallback proof is a separate lane.
 3. Promote Figma as a token/resource taxonomy proof, not as a harness
    stay-afloat proof.
-4. Add Pi/opencode/Kimi only after provider docs or local CLI behavior identify
-   concrete auth and quota states to model.
+4. Add OMO/OpenCode/Pi/Kimi only after provider docs or local CLI behavior
+   identify concrete auth, quota, reload, and process-boundary states to model.


### PR DESCRIPTION
## Summary

- add a productionization ledger for current UX/DX/AX stance, feature status, adapter strategy, daemon beta boundary, release posture, and tracker mapping
- refresh Codex route truth in QA and install matrices from stale not-afloat state to the current four-route selectable no-spend state
- clarify that beta daemon work hosts the foreground tick/mediation engine and does not claim unmanaged hot-swap
- keep OMO/OpenCode/Pi/Kimi framed as adapter-contract candidates rather than current oauth-mux stay-afloat support

## Validation

- git diff --check
- zig build test
- just check-local

No local Playwright was run.