### PR TITLE
Trace managed Codex binary resolution

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -49,7 +49,9 @@ The traced decisions are:
   route selection after its retry window expires.
 - `route.evaluate`: no-spend route runtime, liveness, action, and selectability.
 - `codex.native_binary.resolve`: native Codex binary resolution without printing
-  absolute paths.
+  absolute paths. Managed Codex launches include `adapter:"managed_codex"` so a
+  support trace can distinguish mux-owned launch resolution from explicit
+  admin-command resolution.
 - `codex.native_command.spawn` and `codex.native_command.exit`: explicit
   oauth-mux-managed Codex admin commands without printing `CODEX_HOME`.
 - `codex.shim.pass_through`: installed `codex` shim admin-command pass-through

--- a/scripts/smoke-codex-acceptance.sh
+++ b/scripts/smoke-codex-acceptance.sh
@@ -58,6 +58,7 @@ NDJSON="$TMP/adapter.ndjson"
 ADAPTER_STDERR="$TMP/adapter.stderr"
 STUB_PIDFILE="$TMP/stub-codex.pid"
 STUB_REPORT="$TMP/stub-codex.report"
+TRACE_FILE="$TMP/trace.ndjson"
 CANONICAL_SESSION_HOME="$TMP/canonical-codex"
 
 cleanup() {
@@ -140,6 +141,8 @@ OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_UPSTREAM_SCHEME="http" \
   OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
   OMUX_CODEX_SESSION_HOME="$CANONICAL_SESSION_HOME" \
+  OMUX_TRACE=1 \
+  OMUX_TRACE_FILE="$TRACE_FILE" \
   OMUX_STUB_CANONICAL_SESSION_HOME="$CANONICAL_SESSION_HOME" \
   OMUX_STUB_CODEX_TURNS=3 \
   OMUX_STUB_CODEX_PIDFILE="$STUB_PIDFILE" \
@@ -191,6 +194,14 @@ assert_grep "same-turn retry dropped x-codex-turn-state" '"dropped":"x-codex-tur
 assert_grep "claim_level remains broker_owned" '"claim_level":"broker_owned"' "$NDJSON"
 assert_grep "session_ended final_claim_level broker_owned" '"kind":"session_ended".*"final_claim_level":"broker_owned"' "$NDJSON"
 assert_grep "session_ended records synthetic swap" '"kind":"session_ended".*"synthetic_swap_observed":true' "$NDJSON"
+
+jq -e 'select(.name == "codex.native_binary.resolve" and .attributes.adapter == "managed_codex" and .attributes.source == "OMUX_CODEX_BIN" and .attributes.selected == true and .attributes.native_binary_path_printed == false)' "$TRACE_FILE" >/dev/null
+echo "  ✓ trace captures managed Codex binary resolution without path output"
+if grep -Fq "$ROOT/scripts/test-stub-codex.py" "$TRACE_FILE"; then
+    echo "  ✗ trace leaked managed Codex binary path" >&2
+    cat "$TRACE_FILE" >&2
+    exit 1
+fi
 
 if grep -q '"kind":"session_started"' "$ADAPTER_STDERR"; then
     echo "  ✗ adapter status frames leaked to stderr despite --json-status-file" >&2
@@ -268,7 +279,7 @@ else
 fi
 
 echo
-echo "smoke-codex-acceptance: all 23 assertions passed."
+echo "smoke-codex-acceptance: all 24 assertions passed."
 echo "  full ndjson: $NDJSON"
 echo "  stub upstream log: $UPLOG"
 echo "  stub codex report: $STUB_REPORT"

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -570,6 +570,24 @@ fn traceManagedSessionEnd(
     });
 }
 
+fn traceManagedCodexBinaryResolution(
+    allocator: std.mem.Allocator,
+    source: []const u8,
+    requested: []const u8,
+    selected: bool,
+    reason: []const u8,
+) void {
+    trace.append(allocator, "codex.native_binary.resolve", if (selected) .info else .warn, &.{
+        trace.string("adapter", "managed_codex"),
+        trace.string("source", source),
+        trace.string("requested_kind", if (hasPathSeparator(requested)) "path" else "search_name"),
+        trace.boolean("selected", selected),
+        trace.string("reason", reason),
+        trace.boolean("path_printed", false),
+        trace.boolean("native_binary_path_printed", false),
+    });
+}
+
 fn restrictPoolToCodex(pool: *broker.AccountPool) void {
     for (pool.accounts.items) |*entry| {
         if (isCodexAccountId(entry.id)) continue;
@@ -1185,10 +1203,15 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     }
 
     // 6. Build argv: `codex` plus any forwarded user args.
-    const requested_codex_bin = std.process.getEnvVarOwned(allocator, "OMUX_CODEX_BIN") catch
-        try allocator.dupe(u8, "codex");
+    const requested_codex_bin_from_env = std.process.getEnvVarOwned(allocator, "OMUX_CODEX_BIN") catch |e| switch (e) {
+        error.EnvironmentVariableNotFound => null,
+        else => return e,
+    };
+    const requested_codex_bin_source: []const u8 = if (requested_codex_bin_from_env == null) "PATH" else "OMUX_CODEX_BIN";
+    const requested_codex_bin = requested_codex_bin_from_env orelse try allocator.dupe(u8, "codex");
     defer allocator.free(requested_codex_bin);
     const codex_bin = resolveCodexBinary(allocator, requested_codex_bin) catch |e| {
+        traceManagedCodexBinaryResolution(allocator, requested_codex_bin_source, requested_codex_bin, false, @errorName(e));
         if (e == RunError.CodexShimRecursion) {
             try stderr.print("oauth-mux codex: resolved Codex CLI {s} is an oauth-mux codex shim; set OMUX_CODEX_BIN to the native Codex executable\n", .{requested_codex_bin});
         } else {
@@ -1197,6 +1220,7 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         return e;
     };
     defer allocator.free(codex_bin);
+    traceManagedCodexBinaryResolution(allocator, requested_codex_bin_source, requested_codex_bin, true, "selected");
     try launch_timer.mark(status_writer, emit_status, "binary_resolution");
 
     var argv = std.ArrayListUnmanaged([]const u8){};


### PR DESCRIPTION
## Summary

- emit redacted `codex.native_binary.resolve` trace events from the managed Codex launch path
- label managed launch resolution with `adapter: managed_codex` and avoid printing native binary paths
- extend the managed Codex acceptance smoke to assert the trace event and path redaction

## Validation

- `git diff --check`
- `zig build test`
- `zig build`
- `./scripts/smoke-trace.sh`
- `./scripts/smoke-codex-acceptance.sh`
- `nix develop --command just check-local`

Related: TIN-1148

No local Playwright run.