### PR TITLE
Expose upstream login handoff plans

### DIFF
--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -39,7 +39,7 @@ refreshed when release truth, route evidence, or tracker state changes.
 | Native Codex shim pass-through | Implemented | Admin/login/help/version paths bypass route election and exec native Codex. |
 | Route-health recovery | Implemented | Transient provider degradation can recover after retry windows without becoming permanent auth death. |
 | Redacted diagnostics and tracing | Implemented | JSON diagnostics and `OMUX_TRACE=1` support route/session/auth/runtime debugging without token, raw account id, session id, or path leakage. |
-| Agent-safe reauth mediation | Contracted, partial surfaces | CLI JSON exposes consent/action fields; future MCP tools must mirror CLI semantics. |
+| Agent-safe reauth mediation | Contracted, partial surfaces | CLI JSON exposes consent/action fields and safe handoff-plan commands for upstream-owned login surfaces; future MCP tools must mirror CLI semantics. |
 | Beta daemon | Experimental | Foreground tick engine and daemon-hosted beta may mediate status/handoffs; not a hidden dependency and not unmanaged hot-swap. |
 | Claude adapter | Provider-proof only | `auth-status` and account-store isolation are the first proof lane; no Claude stay-afloat claim. |
 | OMO, Pi, OpenCode, Kimi | Adapter-candidate only | Adjacent agent-control-plane proof does not equal oauth-mux keepalive support. |

--- a/docs/provider-repair-contracts.md
+++ b/docs/provider-repair-contracts.md
@@ -28,6 +28,7 @@ The action now has three distinct identity fields:
   "mutating": true,
   "budget": "interactive",
   "command": "oauth-mux codex login-device max-1",
+  "handoff_plan_command": null,
   "diagnostic_command": null
 }
 ```
@@ -35,6 +36,9 @@ The action now has three distinct identity fields:
 - `kind` is the precise route action.
 - `mediation` is how an agent, wrapper, or user should handle the action.
 - `repair_owner` identifies who owns credential repair when there is one.
+- `command` is the executable oauth-mux repair handoff when oauth-mux has one.
+- `handoff_plan_command` is a no-spend planning command for upstream-owned
+  handoffs that do not yet have an oauth-mux executable repair command.
 
 `stay-afloat next --json` wraps the same action contract in a single
 agent-facing decision. Selectable routes return `ready_for_exec:true` with an
@@ -117,6 +121,10 @@ Claude:
 - Upstream CLI login owns session repair.
 - Handoff may not have an oauth-mux executable command yet; `command:null` is
   valid when the safe action is to surface upstream login instructions.
+- In that case `handoff_plan_command` points agents to
+  `oauth-mux enroll plan claude --account <account> --json`, which returns the
+  user-mediated `CLAUDE_CONFIG_DIR` login instruction without oauth-mux running
+  Claude login or mutating credentials.
 
 Figma:
 

--- a/docs/spec/in-agent-reauth-handoff-contract-2026-05-14.md
+++ b/docs/spec/in-agent-reauth-handoff-contract-2026-05-14.md
@@ -86,6 +86,7 @@ Canonical shape:
   "mutating": true,
   "spends_provider_calls": false,
   "command": "oauth-mux codex login-device max-1",
+  "handoff_plan_command": null,
   "redaction": {
     "token_values_printed": false,
     "raw_account_ids_printed": false,
@@ -98,6 +99,11 @@ Canonical shape:
 The command is displayable. It is not agent-executable by default. A future
 permission broker may approve execution, but that approval must be explicit and
 auditable.
+
+Some upstream-owned providers do not have an oauth-mux executable repair
+command yet. In those cases `command` remains `null` and
+`handoff_plan_command` points to a no-spend planning command the agent can show
+to the user.
 
 After a user completes the upstream login, the agent should ask for an evidence
 refresh rather than assuming success:
@@ -156,6 +162,14 @@ claude auth status --json
 
 That proves account-store isolation and command-owned auth status only. It does
 not prove Claude quota, model-call availability, or in-session stay-afloat.
+For Claude reauth, `repair-plan` may return `command:null` with:
+
+```bash
+oauth-mux enroll plan claude --account <account> --json
+```
+
+That is the safe agent step. It returns the user-mediated `CLAUDE_CONFIG_DIR`
+login instruction; oauth-mux still must not run Claude login silently.
 
 ### MCP Resource Tokens
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -3304,6 +3304,10 @@ fn writeRepairPlanText(
             defer allocator.free(command);
             try writer.print("    command: {s}\n", .{command});
         }
+        if (try handoffPlanCommandAlloc(allocator, action, route)) |command| {
+            defer allocator.free(command);
+            try writer.print("    handoff_plan: {s}\n", .{command});
+        }
         if (try runtimeDiagnosticCommandAlloc(allocator, action, route)) |command| {
             defer allocator.free(command);
             try writer.print("    diagnostic: {s}\n", .{command});
@@ -3431,6 +3435,13 @@ fn writeRepairActionJson(
     }
     try writer.writeAll(",\"command\":");
     if (try repairCommandAlloc(allocator, action.command, route)) |command| {
+        defer allocator.free(command);
+        try std.json.stringify(command, .{}, writer);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"handoff_plan_command\":");
+    if (try handoffPlanCommandAlloc(allocator, action, route)) |command| {
         defer allocator.free(command);
         try std.json.stringify(command, .{}, writer);
     } else {
@@ -3876,6 +3887,17 @@ fn repairCommandAlloc(
             try std.fmt.allocPrint(allocator, "oauth-mux probe --provider {s} --account {s} --json", .{ route.provider, route.account }),
         .codex_login_device => try std.fmt.allocPrint(allocator, "oauth-mux codex login-device {s}", .{route.account}),
     };
+}
+
+fn handoffPlanCommandAlloc(
+    allocator: std.mem.Allocator,
+    action: RepairAction,
+    route: RepairPlanRoute,
+) !?[]const u8 {
+    if (action.mediation != .user_handoff) return null;
+    if (action.command != .none) return null;
+    if (action.owner == null or action.owner.? != .upstream_cli_login) return null;
+    return try std.fmt.allocPrint(allocator, "oauth-mux enroll plan {s} --account {s} --json", .{ route.provider, route.account });
 }
 
 fn runtimeDiagnosticCommandAlloc(
@@ -5394,6 +5416,10 @@ fn writeRouteText(
                 defer allocator.free(command);
                 try writer.print(" command={s}", .{command});
             }
+            if (try handoffPlanCommandAlloc(allocator, evaluation.action, evaluation.route)) |command| {
+                defer allocator.free(command);
+                try writer.print(" handoff_plan={s}", .{command});
+            }
             if (try runtimeDiagnosticCommandAlloc(allocator, evaluation.action, evaluation.route)) |command| {
                 defer allocator.free(command);
                 try writer.print(" diagnostic={s}", .{command});
@@ -5451,6 +5477,10 @@ fn writeStayAfloatMediationText(
         if (try repairCommandAlloc(allocator, candidate.action.command, candidate.route)) |command| {
             defer allocator.free(command);
             try writer.print("  command: {s}\n", .{command});
+        }
+        if (try handoffPlanCommandAlloc(allocator, candidate.action, candidate.route)) |command| {
+            defer allocator.free(command);
+            try writer.print("  handoff_plan: {s}\n", .{command});
         }
         if (try runtimeDiagnosticCommandAlloc(allocator, candidate.action, candidate.route)) |command| {
             defer allocator.free(command);
@@ -17510,6 +17540,7 @@ test "writeRepairActionJson emits codex reauth command without running it" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"interactive\":true") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"mutating\":true") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"command\":\"oauth-mux codex login-device max-1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"handoff_plan_command\":null") != null);
 }
 
 test "Codex preflight user-mediated action emits login handoff lane" {
@@ -17544,6 +17575,7 @@ test "writeRepairActionJson emits claude upstream handoff without codex command"
     try std.testing.expectEqual(types.RepairOwner.upstream_cli_login, action.owner.?);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"repair_owner\":\"upstream_cli_login\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"command\":null") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"handoff_plan_command\":\"oauth-mux enroll plan claude --account pro --json\"") != null);
 }
 
 test "figma scope degradation carries provider-scope mediation" {


### PR DESCRIPTION
## Summary

- Adds `handoff_plan_command` to repair action JSON for upstream-owned reauth cases that intentionally have no executable oauth-mux repair command.
- Surfaces the handoff plan in text repair/route/stay-afloat output so agents can prompt users safely.
- Documents the Claude boundary: the safe next step is `oauth-mux enroll plan claude --account <account> --json`, not silent Claude login or a claimed Claude stay-afloat adapter.

## Validation

- `git diff --check`
- `zig build test`
- `nix develop --command just check-local`
