### PR TITLE
v0.1.7 release: tighten package parity gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ diagnostic infrastructure. They are not product success.
 
 Source and local dogfood are `0.1.7` candidate. Public npm, GitHub Release, and
 Homebrew install lanes still publish `0.1.6`.
+The current public Homebrew tap installs the `0.1.6` binary, but its formula
+metadata can parse the stable version incorrectly; the `0.1.7` release gate now
+checks Homebrew's parsed version explicitly.
 
 What works today:
 
@@ -118,6 +121,9 @@ oauth-mux version
 oauth-mux version --json
 oauth-mux codex preflight --profile codex-max --capability codex-max --json
 ```
+
+If `which -a oauth-mux` resolves Homebrew before the user-local dogfood binary,
+adjust PATH or invoke `./zig-out/bin/oauth-mux` directly for source-tree proof.
 
 `version --json` prints the active executable path classification and SHA-256
 under `runtime_identity`. Use it when public packages and local dogfood have

--- a/dist/homebrew/oauth-mux.rb
+++ b/dist/homebrew/oauth-mux.rb
@@ -2,6 +2,7 @@ class OauthMux < Formula
   desc "OAuth fallback muxing for AI harness subscriptions"
   homepage "https://omux.xoxd.ai"
   license "MIT"
+  version "${VERSION}"
 
   on_macos do
     if Hardware::CPU.arm?

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -66,6 +66,11 @@ infrastructure, not public adoption copy.
 The DRY release/install lane contract is `docs/release-install-lanes.md`; keep
 new UX/DX/AX installer copy aligned with that file rather than duplicating
 package-state tables here.
+As of the `0.1.7` release-candidate tranche, public packages still resolve to
+`0.1.6`; the public Homebrew tap also has a formula metadata defect where the
+installed binary is correct but `brew info --json=v2` does not report a stable
+version of `0.1.6`. Do not promote `0.1.7` install copy until npm, GitHub
+Release, Homebrew, and system package verification have all passed.
 
 When validating unreleased source behavior, install or invoke the worktree build
 deliberately and record provenance:

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -16,10 +16,10 @@ The lane contract and current operator rules live in
 | npm global install | 0.1.6 | macOS arm64 | public npm registry | Pass | Public registry reports `oauth-mux@0.1.6` plus all six platform packages. |
 | npm one-shot | 0.1.6 | macOS arm64 | public npm registry | Pass | `npx -y oauth-mux@0.1.6 version` returns `oauth-mux 0.1.6`. |
 | user-local dogfood install | 0.1.7 candidate | macOS arm64 | current worktree copied to `~/.local/bin` | Pass | Remove the old installed file before copying; `./zig-out/bin/oauth-mux` and `~/.local/bin/oauth-mux` hashes match. Use this lane for unreleased installed-command dogfood. |
-| Nix package | 0.1.6 | macOS arm64 remote builder | `nix build .#` | Pass | `result -> /nix/store/a7izjlmdm21x37glihb9aa34xaa1rfia-oauth-mux-0.1.6`; `./result/bin/oauth-mux version` returns `0.1.6`. |
+| Nix package | 0.1.7 candidate | macOS arm64 | source flake | Candidate | `nix eval .#packages.aarch64-darwin.default.version` reports `0.1.7`; `nix flake check` now includes a package smoke gate. |
 | GitHub release tarball | 0.1.6 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Release workflow `25195318899` published all tarballs, packages, checksums, formula, and installer. |
 | `curl | sh` installer | 0.1.6 | macOS arm64 and `../lab` | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass | Default installer repo is canonical; no `REPO=...` override needed. |
-| Homebrew formula | 0.1.6 | macOS arm64 + hosted Ubuntu dry-run | public `jesssullivan/omux` tap | Pass | Clean local uninstall/untap followed by `just homebrew-qa 0.1.6` installed from `Jesssullivan/homebrew-omux`; hosted registry dry-run `25199131583` checked out the public tap and passed the Homebrew lane. |
+| Homebrew formula | 0.1.6 | macOS arm64 + hosted Ubuntu dry-run | public `jesssullivan/omux` tap | Binary pass, metadata defect | Installed binary reports `oauth-mux 0.1.6`, but `brew info --json=v2` currently parses the stable formula version incorrectly. `0.1.7` release proof must reject this. |
 | deb package | 0.1.6 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25195456319` installed package and ran `/usr/bin/oauth-mux version`. |
 | rpm package | 0.1.6 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25195456319` installed package and ran `/usr/bin/oauth-mux version`. |
 | Codex route dogfood | 0.1.7 candidate | macOS arm64 | installed user-local binary | Pass with four selectable routes | Current 2026-05-16 no-spend truth: `codex-max` has four selectable broker-ready routes, `session_start_ready:true`, `fallback_ready:true`, and `single_route_at_risk:false`. Public package channels remain `0.1.6`. |
@@ -94,6 +94,16 @@ Expected output includes:
 ```text
 Homebrew install QA passed for oauth-mux 0.1.6 via jesssullivan/omux/oauth-mux
 ```
+
+Current public `0.1.6` caveat:
+
+```bash
+brew info jesssullivan/omux/oauth-mux --json=v2
+```
+
+The installed keg is `0.1.6`, but the formula's parsed
+`formulae[0].versions.stable` is not `0.1.6`. Treat that as a release metadata
+defect, not as proof that the binary failed.
 
 First-run source e2e:
 
@@ -201,3 +211,5 @@ just system-package-qa 0.1.6
 4. Keep Homebrew release updates derived from public GitHub Release
    `oauth-mux.rb` and `SHA256SUMS`, then rerun `just homebrew-qa <version>`
    against the public `jesssullivan/omux` tap.
+5. Require the Homebrew parsed stable version to match the release version
+   before calling a tap update complete.

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -10,13 +10,17 @@ refreshed when release truth, route evidence, or tracker state changes.
 
 - Repo state: `main` is clean against `origin/main`; no open GitHub PRs were
   present in the 2026-05-16 refresh.
-- CI state: the latest checked `main` CI runs were green through run
-  `25930367658`.
+- CI state: the latest checked `main` CI run was green at `25954361661`.
 - Version truth: local/source dogfood is `0.1.7`; public npm, GitHub Release,
   and Homebrew remain `0.1.6`.
-- Installed dogfood: active `oauth-mux` resolves to the user-local binary and
-  active `codex` resolves to the oauth-mux-managed shim; native Codex is still
-  discoverable for pass-through.
+- Installed provenance: PATH can resolve a public package binary or a
+  user-local dogfood binary depending on shell setup. Use `which -a oauth-mux`,
+  `which -a codex`, `oauth-mux version --json`, and `codex preflight` before
+  treating any installed-command run as release evidence.
+- Homebrew truth: the public `0.1.6` tap installs the expected binary, but
+  Homebrew currently parses the formula stable version incorrectly because the
+  generated formula lacks an explicit version. `0.1.7` release proof must catch
+  this class before publication.
 - Codex route truth: `codex-max` currently has four selectable broker-ready
   routes, `session_start_ready:true`, `fallback_ready:true`, and
   `single_route_at_risk:false`.
@@ -85,10 +89,11 @@ not claim to keep them alive.
 
 ## Release And Distribution Posture
 
-Hold `0.1.7` as a release candidate until the truth docs, tracker state,
-negative cassettes, and daemon beta boundary are current. Public install copy
-must continue to say `0.1.6` until npm, GitHub Release, and Homebrew are
-actually published and verified.
+Hold `0.1.7` as a release candidate until release/install parity, tracker
+state, and the daemon beta boundary are current. Negative Codex cassettes remain
+important follow-up proof, but they are not the publication blocker for this
+release tranche. Public install copy must continue to say `0.1.6` until npm,
+GitHub Release, and Homebrew are actually published and verified.
 
 The release lanes remain:
 
@@ -114,6 +119,7 @@ browser is needed; local Playwright is not part of this CLI proof path.
 | Harness session authority bridge | TIN-979 | #191 | Implementation exists, but tracker should be reconciled against current bridge proof. |
 | OTEL-friendly tracing | TIN-1148 | PR #225/#226 lineage | Implemented trace schema should become the standard support-bundle path. |
 | Provider proof beyond Codex | TIN-736 | #68 | Claude next; other agents stay adapter-candidate only. |
+| Website truth refresh | TIN-734 / TIN-925 | external site repo | `omux.xoxd.ai` source lives outside this repo and must be refreshed from the ledger, QA matrix, and install-lane docs. |
 
 ## Acceptance Gates
 
@@ -121,11 +127,14 @@ browser is needed; local Playwright is not part of this CLI proof path.
   `doctor`, `providers list`, `accounts list`, `route explain`,
   `codex preflight`, `broker-session-plan`, `stay-afloat next`,
   `status-latest`, and `daemon status`.
-- Local validation passes: `zig build test`, targeted Codex smokes, and
-  `nix develop --command just check-local`.
+- Local validation passes: `zig build test`, targeted Codex smokes,
+  `nix develop --command just check-local`, and the hybrid `nix flake check`
+  package smoke.
 - Public release validation passes: `just release-proof <version>`, release
   proof workflow, npm dry run/publish workflow as appropriate, Homebrew QA, and
   system package QA.
+- Homebrew release validation proves both installed binary output and
+  `brew info --json=v2` stable version semantics for the public tap formula.
 - Public copy does not claim same-thread continuity, mid-turn recovery,
   unmanaged daemon hot-swap, non-Codex stay-afloat, universal provider support,
   or public `0.1.7` availability before publication.

--- a/docs/qa-handoff-matrix.md
+++ b/docs/qa-handoff-matrix.md
@@ -89,6 +89,10 @@ capability, such as `codex:max-3#codex-max`.
 
 ## Next QA Targets
 
+These targets remain important production hardening work. They should not be
+treated as public claims until captured, but they do not block the package
+parity tranche for `0.1.7`.
+
 1. Publishable cassette for real `usage_limit_reached` response shape.
 2. Live or cassette-backed all-fallbacks-exhausted terminal vector.
 3. Live or cassette-backed tier-insufficient before credited fallback.

--- a/docs/release-install-lanes.md
+++ b/docs/release-install-lanes.md
@@ -1,6 +1,6 @@
 # Release And Install Lanes
 
-Updated: 2026-05-10
+Updated: 2026-05-16
 
 This is the DRY map for installer, package, CI, and local dogfood lanes.
 Detailed historical evidence stays in `docs/install-beta-matrix.md` and
@@ -12,10 +12,10 @@ Detailed historical evidence stays in `docs/install-beta-matrix.md` and
 | --- | --- | --- | --- | --- |
 | Worktree dogfood | `./zig-out/bin/oauth-mux ...` | current checkout | `zig build`, `just check-local` | unreleased behavior only |
 | User-local dogfood | `oauth-mux ...` and managed `codex ...` with PATH resolving to `~/.local/bin` | copied worktree binary plus user-local shim | hash match with `./zig-out/bin/oauth-mux`, version check, preflight check | installed-command dogfood for current checkout |
-| Nix package | `nix build .#` | flake package | `./result/bin/oauth-mux version` | package derivation proof |
+| Nix package | `nix build .#` | flake package | `./result/bin/oauth-mux version`, `nix flake check` smoke | package derivation proof |
 | GitHub Release | downloaded tarball | `dist/out/v*/artifacts` from release workflow | checksum verify and tarball smoke | public raw binary lane |
 | npm | `npm install -g oauth-mux` / `npx oauth-mux` | CI-generated npm tarballs | npm install smoke and `npm view` | public JS package lane |
-| Homebrew | `brew install jesssullivan/omux/oauth-mux` | public tap formula from release checksums | `just homebrew-qa <version>` | public macOS/Linux tap lane |
+| Homebrew | `brew install jesssullivan/omux/oauth-mux` | public tap formula from release checksums | `just homebrew-qa <version>` plus parsed version check | public macOS/Linux tap lane |
 | curl installer | `curl .../install.sh \| sh` | GitHub Release `install.sh` + tarballs | local file URL smoke and public installer smoke | shell installer lane |
 | deb/rpm | system package install | GitHub Release `.deb` / `.rpm` | hosted container install QA | distro package lane |
 
@@ -38,12 +38,20 @@ Detailed historical evidence stays in `docs/install-beta-matrix.md` and
   package versions independently.
 - `just release-proof <version>` is the local release tree proof. It must pass
   before any registry mutation.
+- `nix flake check` is a hybrid package smoke, not the full shell smoke suite.
+  It must prove the flake package runs, reports the source version, and
+  validates no-secret examples.
 - npm publication is CI-only through `.github/workflows/npm-publish.yml`.
   Workstation `npm publish` is unsupported.
+- Release and registry scripts must use an isolated npm cache so root-owned or
+  stale workstation `~/.npm` state cannot affect release proof.
 - Registry dry-runs are non-publishing gates. Use
   `OMUX_REGISTRY_DRY_RUN_CONFIRM=registry-dry-run`.
 - Homebrew and system package checks are package-lane QA. They do not prove
   unreleased worktree behavior unless the package was rebuilt from that tree.
+- Homebrew package QA must check the installed binary and Homebrew's parsed
+  `versions.stable`; a working binary with bad formula metadata is not release
+  parity.
 - For live Codex acceptance, use an installed binary on PATH and preserve the
   status artifact `runtime_identity`, including `binary_source` and
   `binary_sha256`. Repo-local wrapper runs are not acceptance evidence.
@@ -61,7 +69,7 @@ oauth-mux version --json
 oauth-mux codex preflight --profile codex-max --capability codex-max --json
 ```
 
-Expected:
+Expected when testing unreleased behavior:
 
 - `./zig-out/bin/oauth-mux` and `~/.local/bin/oauth-mux` hashes match.
 - `oauth-mux version --json` reports the active executable's
@@ -75,6 +83,12 @@ Expected:
   Codex CLI usage parser.
 - Homebrew may report the same source version while still being a different
   binary hash; treat it as the package lane.
+
+If Homebrew appears before `~/.local/bin` in PATH, use the worktree binary or
+adjust PATH before recording dogfood evidence. The active public Homebrew
+`0.1.6` tap installs the expected binary but has a formula stable-version
+metadata defect; `0.1.7` release proof must reject that defect before
+publication.
 
 On macOS, do not overwrite an existing Mach-O in place for this lane. A direct
 `cp` over `~/.local/bin/oauth-mux` can leave stale taskgated/code-signing state
@@ -104,7 +118,8 @@ DX gates:
 
 - `just check-local` is the single no-network local validation chain;
 - `just release-proof <version>` is the local release validation chain;
-- `nix build .#` proves the flake package for the current checkout.
+- `nix build .#` proves the flake package for the current checkout;
+- `nix flake check` runs the package smoke without replacing `just check-local`.
 
 AX gates:
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -17,6 +17,16 @@ This enters the Nix dev shell and runs:
 - every `examples/*.config.json` through `config validate`
 - synthetic local E2E via `scripts/e2e-local.sh`
 
+Run the flake package smoke separately when changing packaging or release
+surfaces:
+
+```bash
+XDG_CACHE_HOME=/tmp/oauth-mux-nix-cache nix flake check
+```
+
+That check proves the Nix package runs, reports the source version, and validates
+no-secret examples. It is intentionally smaller than `just check`.
+
 The lane-level source of truth for installer, package, and local dogfood
 provenance is `docs/release-install-lanes.md`.
 
@@ -82,9 +92,14 @@ This runs `release-local` and then checks:
 - `SHA256SUMS` against the artifact directory
 - tarball payload names for Unix and Windows targets
 - rendered Homebrew formula placeholders and Ruby syntax when Ruby is present
+- rendered Homebrew formula explicit version metadata
 - local npm install of the matching platform package plus root shim
 - local installer execution against the staged artifact directory
 - non-publishing release handoff generation
+
+The release scripts set an isolated npm cache for packing, dry-run, publish, and
+deprecation operations. A broken workstation `~/.npm` cache must not change
+release proof results.
 
 Generate only the handoff for an already staged tree:
 
@@ -226,13 +241,18 @@ Current release evidence:
   `dry_run=true` for v0.1.6.
 - NPM publish workflow run `25195609579` published v0.1.6 through the CI-only
   SOPS-backed path; `npm view oauth-mux version` reports `0.1.6`.
+- Main CI run `25954361661` completed successfully on 2026-05-16 for the latest
+  checked `main` state before the `0.1.7` release-parity tranche.
 
 ## Before Marking A PR Ready
 
 - `just check` passes.
 - `just release-proof <version>` produces and smoke-checks the release tree.
+- `nix flake check` passes, preferably with an isolated cache such as
+  `XDG_CACHE_HOME=/tmp/oauth-mux-nix-cache` on sandboxed agent hosts.
 - Hosted `System Package Install QA` passes after release assets exist when the
   release changes deb/rpm packaging.
+- Homebrew QA proves both binary output and parsed formula stable version.
 - Hosted PR CI passes.
 - GF lane either passes or is explicitly deferred because of runner/token state.
 - Release notes mention any skipped GF proof.

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,27 @@
 
         checks = {
           build = self.packages.${system}.default;
+          smoke = pkgs.runCommand "oauth-mux-smoke-${version}" {
+            nativeBuildInputs = [ pkgs.jq ];
+          } ''
+            set -eu
+
+            binary="${self.packages.${system}.default}/bin/oauth-mux"
+            test "$($binary version)" = "oauth-mux ${version}"
+            $binary version --json \
+              | jq -e \
+                '.version == "${version}"
+                 and .runtime_identity.binary_path
+                 and .runtime_identity.binary_sha256
+                 and .runtime_identity.binary_sha256_available == true' \
+              >/dev/null
+
+            for cfg in ${./examples}/*.config.json; do
+              OMUX_CONFIG="$cfg" $binary config validate
+            done
+
+            touch "$out"
+          '';
         };
       }
     );

--- a/scripts/homebrew-install-qa.sh
+++ b/scripts/homebrew-install-qa.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 version="${1:-}"
 if [ -z "$version" ] || [ "$version" = "--help" ] || [ "$version" = "-h" ]; then
   cat <<'EOF'
@@ -65,6 +67,7 @@ if [ "$was_tapped" != "1" ]; then
 fi
 
 "$brew_cmd" audit --formula --strict "$formula"
+"$repo_root/scripts/homebrew-version-check.sh" "$version" "$formula"
 
 if [ "$was_installed" = "1" ]; then
   "$brew_cmd" reinstall "$formula"

--- a/scripts/homebrew-version-check.sh
+++ b/scripts/homebrew-version-check.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  cat >&2 <<'EOF'
+Usage: scripts/homebrew-version-check.sh <expected-version> <formula-file-or-ref>
+
+Checks either:
+  - a rendered formula file contains an explicit Homebrew version line, or
+  - a tapped formula reference reports the expected stable version via
+    `brew info --json=v2`.
+EOF
+  exit 2
+fi
+
+expected="$1"
+target="$2"
+
+if [ -f "$target" ]; then
+  if ! grep -Fqx "  version \"$expected\"" "$target"; then
+    printf 'Homebrew formula %s does not contain expected explicit version "%s"\n' "$target" "$expected" >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+brew_cmd="${OMUX_BREW_BIN:-brew}"
+if ! command -v "$brew_cmd" >/dev/null 2>&1; then
+  printf 'required command not found for Homebrew version check: %s\n' "$brew_cmd" >&2
+  exit 1
+fi
+
+info_json="$("$brew_cmd" info --json=v2 "$target")"
+if command -v jq >/dev/null 2>&1; then
+  actual="$(printf '%s\n' "$info_json" | jq -r '.formulae[0].versions.stable')"
+else
+  actual="$(printf '%s\n' "$info_json" | sed -n 's/.*"stable"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+fi
+
+if [ "$actual" != "$expected" ]; then
+  printf 'unexpected Homebrew stable version for %s: got %s, expected %s\n' "$target" "${actual:-<empty>}" "$expected" >&2
+  exit 1
+fi

--- a/scripts/npm-ci-deprecate.sh
+++ b/scripts/npm-ci-deprecate.sh
@@ -75,12 +75,12 @@ EOF
 
 package_exists() {
   local spec="$1"
-  NPM_CONFIG_USERCONFIG="${npmrc:-}" npm view "$spec" version --registry=https://registry.npmjs.org/ >/dev/null 2>&1
+  npm_config_cache="$npm_cache" NPM_CONFIG_USERCONFIG="${npmrc:-}" npm view "$spec" version --registry=https://registry.npmjs.org/ >/dev/null 2>&1
 }
 
 current_deprecation() {
   local spec="$1"
-  NPM_CONFIG_USERCONFIG="${npmrc:-}" npm view "$spec" deprecated --registry=https://registry.npmjs.org/ 2>/dev/null || true
+  npm_config_cache="$npm_cache" NPM_CONFIG_USERCONFIG="${npmrc:-}" npm view "$spec" deprecated --registry=https://registry.npmjs.org/ 2>/dev/null || true
 }
 
 deprecate_one() {
@@ -114,13 +114,16 @@ deprecate_one() {
     return
   fi
 
-  NPM_CONFIG_USERCONFIG="$npmrc" npm deprecate "$spec" "$message" --registry=https://registry.npmjs.org/
+  npm_config_cache="$npm_cache" NPM_CONFIG_USERCONFIG="$npmrc" npm deprecate "$spec" "$message" --registry=https://registry.npmjs.org/
   append "- deprecated: \`${spec}\`"
 }
 
 ensure_ci_boundary
 ensure_confirmed
 require_command npm
+
+npm_cache="${npm_config_cache:-${TMPDIR:-/tmp}/oauth-mux-npm-deprecate-cache}"
+mkdir -p "$npm_cache"
 
 mkdir -p "$handoff_dir"
 
@@ -144,11 +147,13 @@ if [ "$plan_only" = "0" ]; then
   tmp="$(mktemp -d "${TMPDIR:-/tmp}/oauth-mux-npm-deprecate.XXXXXX")"
   trap 'rm -rf "$tmp"' EXIT
   npmrc="$tmp/npmrc"
+  npm_cache="$tmp/npm-cache"
+  mkdir -p "$npm_cache"
   "$repo_root/scripts/resolve-npm-token.sh" --npmrc "$npmrc" >/dev/null
 
   append "## npm identity"
   append
-  npm_user="$(NPM_CONFIG_USERCONFIG="$npmrc" npm whoami --registry=https://registry.npmjs.org/)"
+  npm_user="$(npm_config_cache="$npm_cache" NPM_CONFIG_USERCONFIG="$npmrc" npm whoami --registry=https://registry.npmjs.org/)"
   append "- authenticated as: \`${npm_user}\`"
   append
 fi

--- a/scripts/npm-ci-publish.sh
+++ b/scripts/npm-ci-publish.sh
@@ -89,7 +89,7 @@ EOF
 package_exists() {
   local name="$1"
   local pkg_version="$2"
-  NPM_CONFIG_USERCONFIG="$npmrc" npm view "${name}@${pkg_version}" version >/dev/null 2>&1
+  npm_config_cache="$npm_cache" NPM_CONFIG_USERCONFIG="$npmrc" npm view "${name}@${pkg_version}" version >/dev/null 2>&1
 }
 
 publish_one() {
@@ -122,7 +122,7 @@ publish_one() {
     args+=(--dry-run)
   fi
 
-  NPM_CONFIG_USERCONFIG="$npmrc" npm "${args[@]}"
+  npm_config_cache="$npm_cache" NPM_CONFIG_USERCONFIG="$npmrc" npm "${args[@]}"
   if [ "${OMUX_NPM_PUBLISH_DRY_RUN:-0}" = "1" ]; then
     append "- dry-run OK: \`${name}@${pkg_version}\`"
   else
@@ -167,11 +167,13 @@ else
   tmp="$(mktemp -d "${TMPDIR:-/tmp}/oauth-mux-npm-publish.XXXXXX")"
   trap 'rm -rf "$tmp"' EXIT
   npmrc="$tmp/npmrc"
+  npm_cache="$tmp/npm-cache"
+  mkdir -p "$npm_cache"
   "$repo_root/scripts/resolve-npm-token.sh" --npmrc "$npmrc" >/dev/null
 
   append "## npm identity"
   append
-  npm_user="$(NPM_CONFIG_USERCONFIG="$npmrc" npm whoami --registry=https://registry.npmjs.org/)"
+  npm_user="$(npm_config_cache="$npm_cache" NPM_CONFIG_USERCONFIG="$npmrc" npm whoami --registry=https://registry.npmjs.org/)"
   append "- authenticated as: \`${npm_user}\`"
   if [ "${OMUX_NPM_PUBLISH_DRY_RUN:-0}" = "1" ]; then
     append "- mode: dry-run"

--- a/scripts/registry-dry-run.sh
+++ b/scripts/registry-dry-run.sh
@@ -23,11 +23,15 @@ out_dir="$repo_root/dist/out/v${version}"
 handoff_dir="$out_dir/handoff"
 report="$handoff_dir/registry-dry-run.md"
 tmp_files=()
+tmp_dirs=()
 tmp_taps=()
 
 cleanup() {
   for file in "${tmp_files[@]}"; do
     rm -f "$file"
+  done
+  for dir in "${tmp_dirs[@]}"; do
+    rm -rf "$dir"
   done
   if command -v brew >/dev/null 2>&1; then
     for tap in "${tmp_taps[@]}"; do
@@ -99,23 +103,25 @@ for lane in "${lanes[@]}"; do
     npm)
       require_command npm
       npmrc="$(mktemp)"
+      npm_cache="$(mktemp -d "${TMPDIR:-/tmp}/oauth-mux-npm-cache.XXXXXX")"
       tmp_files+=("$npmrc")
+      tmp_dirs+=("$npm_cache")
       "$repo_root/scripts/resolve-npm-token.sh" --npmrc "$npmrc" >/dev/null
       append "## npm"
       append
-      NPM_CONFIG_USERCONFIG="$npmrc" npm whoami --registry=https://registry.npmjs.org/ >/dev/null
+      npm_config_cache="$npm_cache" NPM_CONFIG_USERCONFIG="$npmrc" npm whoami --registry=https://registry.npmjs.org/ >/dev/null
       for tarball in "$out_dir"/npm-tarballs/*.tgz; do
         name="$(basename "$tarball")"
         publish_log="$(mktemp)"
         tmp_files+=("$publish_log")
-        if NPM_CONFIG_USERCONFIG="$npmrc" npm publish "$tarball" --dry-run --access public ${OMUX_NPM_EXTRA_ARGS:-} >"$publish_log" 2>&1; then
+        if npm_config_cache="$npm_cache" NPM_CONFIG_USERCONFIG="$npmrc" npm publish "$tarball" --dry-run --access public ${OMUX_NPM_EXTRA_ARGS:-} >"$publish_log" 2>&1; then
           append "- dry-run OK: \`npm-tarballs/${name}\`"
           continue
         fi
 
         package_name="${name%-${version}.tgz}"
         if grep -qi 'previously published versions' "$publish_log" &&
-          NPM_CONFIG_USERCONFIG="$npmrc" npm view "${package_name}@${version}" version --registry=https://registry.npmjs.org/ >/dev/null 2>&1; then
+          npm_config_cache="$npm_cache" NPM_CONFIG_USERCONFIG="$npmrc" npm view "${package_name}@${version}" version --registry=https://registry.npmjs.org/ >/dev/null 2>&1; then
           append "- already published OK: \`${package_name}@${version}\`"
           continue
         fi
@@ -159,11 +165,13 @@ for lane in "${lanes[@]}"; do
         cat "$audit_log" >&2
         exit 1
       fi
+      "$repo_root/scripts/homebrew-version-check.sh" "$version" "${tap_name}/oauth-mux"
       append "## homebrew"
       append
       append "- formula copied to tap checkout"
       append "- git diff --check OK"
       append "- ${audit_label} OK via \`${tap_name}/oauth-mux\`"
+      append "- brew info stable version matches \`${version}\`"
       append
       ;;
 

--- a/scripts/release-local.sh
+++ b/scripts/release-local.sh
@@ -122,6 +122,9 @@ chmod 0755 "$root_pkg_dir/bin/codex.js"
 
 if command -v npm >/dev/null 2>&1; then
   printf 'packing npm tarballs...\n'
+  export npm_config_cache="${npm_config_cache:-$work_dir/npm-cache}"
+  export npm_config_update_notifier=false
+  mkdir -p "$npm_config_cache"
   for pkg_json in "$npm_dir"/oauth-mux-{darwin,linux,windows}-*/package.json; do
     npm pack "$(dirname "$pkg_json")" --pack-destination "$npm_tgz_dir" >/dev/null
   done

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -97,10 +97,11 @@ for archive in \
 done
 
 printf 'checking Homebrew formula...\n'
-if grep -q '\${' "$homebrew_formula"; then
+if grep -q -E '\$\{(VERSION|SHA_[A-Z0-9_]+)\}' "$homebrew_formula"; then
   printf 'unrendered placeholder remains in %s\n' "$homebrew_formula" >&2
   exit 1
 fi
+"$repo_root/scripts/homebrew-version-check.sh" "$version" "$homebrew_formula"
 if command -v ruby >/dev/null 2>&1; then
   ruby -c "$homebrew_formula" >/dev/null
 fi

--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -355,7 +355,8 @@ PATH_STDERR="$TMP/path-resolution.stderr"
 PATH_REPORT="$TMP/path-resolution.report"
 mkdir -p "$PATH_STUB_DIR" "$(dirname "$PATH_NDJSON")"
 ln -s "$ROOT/scripts/test-stub-codex.py" "$PATH_STUB_DIR/codex"
-PATH="$PATH_STUB_DIR:$PATH" \
+env -u OMUX_CODEX_BIN \
+  PATH="$PATH_STUB_DIR:$PATH" \
   OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_STATE_DIR="$STATE_DIR" \
   CODEX_HOME="$CANONICAL_SESSION_HOME" \
@@ -474,7 +475,8 @@ NO_PROFILE_NDJSON="$TMP/no-profile/status.ndjson"
 NO_PROFILE_STDERR="$TMP/no-profile.stderr"
 NO_PROFILE_REPORT="$TMP/no-profile.report"
 mkdir -p "$(dirname "$NO_PROFILE_NDJSON")"
-PATH="$PATH_STUB_DIR:$PATH" \
+env -u OMUX_CODEX_BIN \
+  PATH="$PATH_STUB_DIR:$PATH" \
   OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_STATE_DIR="$STATE_DIR" \
   CODEX_HOME="$CANONICAL_SESSION_HOME" \
@@ -500,7 +502,8 @@ DEFAULT_STATUS_DIR="$STATE_DIR/codex/status"
 DEFAULT_STDERR="$TMP/default-status.stderr"
 DEFAULT_REPORT="$TMP/default-status.report"
 rm -rf "$DEFAULT_STATUS_DIR"
-PATH="$PATH_STUB_DIR:$PATH" \
+env -u OMUX_CODEX_BIN \
+  PATH="$PATH_STUB_DIR:$PATH" \
   OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_STATE_DIR="$STATE_DIR" \
   CODEX_HOME="$CANONICAL_SESSION_HOME" \


### PR DESCRIPTION
## Summary

- Add explicit Homebrew formula version metadata plus a helper that verifies both rendered formula files and tapped `brew info --json=v2` stable versions.
- Add a hybrid `nix flake check` package smoke that runs the built binary, checks `version --json`, and validates no-secret example configs.
- Harden release scripts with isolated npm caches and Homebrew version checks across release smoke, registry dry-run, and install QA.
- Keep Codex CLI UX smoke hermetic by unsetting shell-exported `OMUX_CODEX_BIN` for PATH-stub cases.
- Refresh README and release docs around public `0.1.6` vs source `0.1.7`, Homebrew metadata truth, Nix priorities, and current package gates.

## Verification

- `bash -n scripts/homebrew-version-check.sh scripts/release-smoke.sh scripts/registry-dry-run.sh scripts/homebrew-install-qa.sh scripts/check-local.sh scripts/npm-ci-publish.sh scripts/npm-ci-deprecate.sh scripts/release-local.sh scripts/smoke-codex-cli-ux.sh`
- `git diff --check`
- Rendered Homebrew formula helper check for `0.1.7` plus `ruby -c` on the rendered formula
- `XDG_CACHE_HOME=/tmp/oauth-mux-nix-cache nix build .#checks.aarch64-darwin.smoke`
- `XDG_CACHE_HOME=/tmp/oauth-mux-nix-cache nix develop --command just smoke-codex-cli-ux-local`
- `XDG_CACHE_HOME=/tmp/oauth-mux-nix-cache just check`
- `XDG_CACHE_HOME=/tmp/oauth-mux-nix-cache just release-proof 0.1.7`
- `XDG_CACHE_HOME=/tmp/oauth-mux-nix-cache nix flake check`

## Current Public Truth

- npm latest: `0.1.6`
- GitHub latest release: `v0.1.6`
- Homebrew public tap installs keg `0.1.6`, but `formulae[0].versions.stable` currently reports `64-macos`; the new helper rejects that mismatch.
- The `/experimental` Codex settings concern is already tracked by GH #211 and is implemented in the current repo with config passthrough tests/docs.

No raw account identities, tokens, or session ids are included in this PR.