### PR TITLE
docs: refresh next Codex matrix truth

### DIFF
--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -10,7 +10,7 @@ refreshed when release truth, route evidence, or tracker state changes.
 
 - Repo state: `main` is clean against `origin/main`; no open GitHub PRs were
   present in the 2026-05-16 refresh.
-- CI state: the latest checked `main` CI run was green at `25954361661`.
+- CI state: the latest checked `main` CI run was green at `25974342238`.
 - Version truth: local/source dogfood is `0.1.7`; public npm, GitHub Release,
   and Homebrew remain `0.1.6`.
 - Installed provenance: PATH can resolve a public package binary or a
@@ -25,8 +25,9 @@ refreshed when release truth, route evidence, or tracker state changes.
   routes, `session_start_ready:true`, `fallback_ready:true`, and
   `single_route_at_risk:false`.
 - Latest local status truth: `oauth-mux codex status-latest --json` currently
-  reports `successful_live_quota_handoff`; status artifacts are rolling local
-  evidence and must be refreshed before being used in public claims.
+  reports `auth_fallback_sequence_observed` from a rolling local artifact. This
+  does not supersede the preserved quota-handoff proof; status artifacts must be
+  refreshed before being used in public claims.
 - Daemon truth: `oauth-mux daemon status --json` still reports
   `contract:"experimental_socket_stub"`; the beta daemon lane must host the
   same foreground tick engine and must not claim unmanaged hot-swap.
@@ -113,8 +114,8 @@ browser is needed; local Playwright is not part of this CLI proof path.
 | Theme | Linear | GitHub | Current stance |
 | --- | --- | --- | --- |
 | Broker daemon and adapter contract | TIN-738 | #67 | Anchor remains open until daemon beta and second-adapter validation are honest. |
-| Codex next-turn broker switch | TIN-916 | #131 | Codex is the reference path; keep evidence distinct from same-thread or mid-turn claims. |
-| Live Codex account-swap acceptance | TIN-951 | #177 | Spend-confirmed only; requires selected route plus spare fallback and redacted artifacts. |
+| Codex next-turn broker switch | TIN-916 | #131 | Managed Codex handoff is proven; keep remaining negative/permutation work distinct from same-thread or mid-turn claims. |
+| Live Codex account-swap acceptance | TIN-951 | #177 | Done for managed Codex; strongest preserved proof is `docs/evidence/codex-engineered-quota-handoff-20260509/`. |
 | Wire cassette coverage | TIN-950 | #176 | Needed before treating negative permutations as stable release proof. |
 | Harness session authority bridge | TIN-979 | #191 | Implementation exists, but tracker should be reconciled against current bridge proof. |
 | OTEL-friendly tracing | TIN-1148 | PR #225/#226 lineage | Implemented trace schema should become the standard support-bundle path. |

--- a/docs/qa-handoff-matrix.md
+++ b/docs/qa-handoff-matrix.md
@@ -83,9 +83,40 @@ capability, such as `codex:max-3#codex-max`.
   reports `session_start_ready:true`, `fallback_ready:true`, and
   `single_route_at_risk:false`.
 - `oauth-mux codex status-latest --json` currently reports
-  `successful_live_quota_handoff`. Status artifacts are rolling local evidence;
-  refresh this command before copying current-state claims into public release
-  notes or tracker comments.
+  `auth_fallback_sequence_observed` from the latest rolling local artifact.
+  This does not supersede the preserved quota handoff proof above; refresh this
+  command before copying current-state claims into public release notes or
+  tracker comments.
+
+## Next Multi-Account Session
+
+Start from the user-local `0.1.7` dogfood binary unless PATH is fixed to put
+that binary first. As of the 2026-05-16 local post-merge refresh, bare
+`oauth-mux` resolves Homebrew `0.1.6` first, while
+`~/.local/bin/oauth-mux` and `./zig-out/bin/oauth-mux` have matching `0.1.7`
+hashes.
+
+No-spend opening sequence:
+
+```bash
+~/.local/bin/oauth-mux version --json
+~/.local/bin/oauth-mux codex preflight --profile codex-max --capability codex-max --json
+~/.local/bin/oauth-mux route explain --profile codex-max --capability codex-max --json
+~/.local/bin/oauth-mux codex status-latest --json
+```
+
+Current matrix entry:
+
+| Route | Current state | Session role |
+| --- | --- | --- |
+| `codex:max-1#codex-max` | selectable, `available`, selected | primary candidate |
+| `codex:max-2#codex-max` | selectable, `available` | fallback / prior engineered primary |
+| `codex:max-3#codex-max` | selectable, `available` | fallback / prior engineered fallback |
+| `codex:max-4#codex-max` | selectable, `available` | fallback / reset-repair target |
+
+Next spend-confirmed permutations should prefer negative coverage over another
+happy-path quota proof: all-fallbacks-exhausted, tier-insufficient before
+fallback success, reset-window repair, and API-credit false-positive guards.
 
 ## Next QA Targets
 


### PR DESCRIPTION
## Summary

- Refresh the productionization ledger after PR #245 and main CI `25974342238`.
- Correct latest rolling `status-latest` truth to `auth_fallback_sequence_observed` while keeping the preserved engineered quota handoff as the headline proof.
- Add the next multi-account session opener to the QA handoff matrix, including the PATH caveat that bare `oauth-mux` currently resolves Homebrew `0.1.6` before the user-local `0.1.7` dogfood binary.
- Record current redacted `codex-max` route shape: `max-1` selected and all four routes selectable/available.

## Verification

- `~/.local/bin/oauth-mux version --json` reports `0.1.7` user-local dogfood.
- `./zig-out/bin/oauth-mux version --json` reports matching `0.1.7` repo-local hash.
- `~/.local/bin/oauth-mux codex preflight --profile codex-max --capability codex-max --json` reports `session_start_ready:true`, `fallback_ready:true`, `single_route_at_risk:false`.
- `~/.local/bin/oauth-mux route explain --profile codex-max --capability codex-max --json` reports `max-1` selected and three selectable fallbacks.
- `~/.local/bin/oauth-mux codex status-latest --json` reports `auth_fallback_sequence_observed`.
- `git diff --check`.

No raw account identities, tokens, credential paths, or session ids are added.