### PR TITLE
Truth negative Codex matrix coverage

### DIFF
--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -10,7 +10,7 @@ refreshed when release truth, route evidence, or tracker state changes.
 
 - Repo state: `main` is clean against `origin/main`; no open GitHub PRs were
   present in the 2026-05-16 refresh.
-- CI state: the latest checked `main` CI run was green at `25974342238`.
+- CI state: the latest checked `main` CI run was green at `25974613776`.
 - Version truth: local/source dogfood is `0.1.7`; public npm, GitHub Release,
   and Homebrew remain `0.1.6`.
 - Installed provenance: PATH can resolve a public package binary or a

--- a/docs/qa-handoff-matrix.md
+++ b/docs/qa-handoff-matrix.md
@@ -54,8 +54,9 @@ capability, such as `codex:max-3#codex-max`.
 | Labeled reauth | `oauth-mux codex login-device <account>` | action says `user_handoff`, route label named, no raw identity | live operator flow |
 | Auth fallback | selected route 401, fallback 200 | `proxy_auth_same_turn_retry`, `auth_health_observed quota_claim:false` | live and smoke evidence |
 | Quota handoff | selected route `usage_limit_reached`, fallback 200 | `proxy_turn 429`, durable quota evidence, `proxy_same_turn_retry`, fallback `200` | live-proven for managed Codex |
-| All fallbacks unavailable | every candidate rejected | `quota_handoff_failed_no_account_selectable` with redacted vector | synthetic; live/cassette target |
-| Tier before fallback | B returns `usage_not_included`, C succeeds | B marked `tier_insufficient`, C selected | synthetic; live/cassette target |
+| All fallbacks unavailable | every candidate rejected | `quota_handoff_failed_no_account_selectable` with redacted vector | synthetic covered; live/cassette target |
+| Tier selected-route classification | selected route returns `usage_not_included` | route marked `tier_insufficient`; no quota classification or same-turn quota retry | synthetic covered; live/cassette target |
+| Tier before fallback election | already-tier-blocked B precedes credited C in route pool | B is not elected; C selected | route-state matrix target |
 | Reset-window repair | quota window expires | no-spend state becomes stale; confirmed revalidation repairs only with provider evidence | live target |
 | API-credit false positive | subscription quota exhausted but API credits exist | Codex subscription route stays quota-blocked | live target |
 | Child signal | Codex child killed/stopped | `session_aborted` with `term_kind`, `term_code`, `signal_name` | status regression added |
@@ -69,6 +70,26 @@ capability, such as `codex:max-3#codex-max`.
 | Cassette replay | none after capture | real wire-shape regression without provider calls | scrubbed `usage_limit_reached`, 401, tier/rate captures |
 | Live no-spend | no provider spend | installed binary route truth and runtime state | `route explain`, `doctor runtime`, `status-latest` |
 | Live spend-confirmed | yes | provider-originated quota/auth/tier truth | `probe-all`, `revalidate-exhausted`, managed Codex dogfood |
+
+## Coverage Reality
+
+`just check-local` already includes synthetic smokes for the two highest-value
+negative Codex UX lanes:
+
+- `scripts/smoke-codex-all-exhausted.sh` covers the all-fallbacks terminal
+  vector, typed `503` repair body, redaction, and stable managed child PID.
+- `scripts/smoke-codex-tier-insufficient.sh` covers
+  `usage_not_included -> tier_insufficient`, no quota misclassification, and no
+  same-turn quota retry.
+- `scripts/e2e-local.sh` covers expired quota windows staying blocked as
+  `revalidation_needed` until spend-confirmed provider revalidation.
+- `scripts/smoke-codex-status-summary.sh` keeps the Python and native
+  `status-latest` oracles aligned on quota-handoff success and terminal
+  no-account-selectable failure shapes.
+
+The remaining gap is not "no test exists"; it is provider-originated,
+publishable evidence for those same negative shapes, plus a generated
+route-state matrix that enumerates blocked accounts across 1-4 account pools.
 
 ## Current Codex Truth
 
@@ -115,8 +136,9 @@ Current matrix entry:
 | `codex:max-4#codex-max` | selectable, `available` | fallback / reset-repair target |
 
 Next spend-confirmed permutations should prefer negative coverage over another
-happy-path quota proof: all-fallbacks-exhausted, tier-insufficient before
-fallback success, reset-window repair, and API-credit false-positive guards.
+happy-path quota proof: all-fallbacks-exhausted, tier-insufficient
+classification plus later-election skip, reset-window repair, and API-credit
+false-positive guards.
 
 ## Next QA Targets
 
@@ -126,7 +148,8 @@ parity tranche for `0.1.7`.
 
 1. Publishable cassette for real `usage_limit_reached` response shape.
 2. Live or cassette-backed all-fallbacks-exhausted terminal vector.
-3. Live or cassette-backed tier-insufficient before credited fallback.
+3. Live or cassette-backed tier-insufficient classification, then route
+   election that skips the tier-blocked route before a credited fallback.
 4. Reset-window repair after quota reset with no manual health reset.
 5. API-credit false-positive guard for subscription-backed Codex.
 6. Beta daemon status/handoff mediation proof that preserves the foreground

--- a/docs/spec/codex-productionization-todo-2026-05-09.md
+++ b/docs/spec/codex-productionization-todo-2026-05-09.md
@@ -113,24 +113,36 @@ Not proven:
     `codex:max-3`; raw identities remain private operator state.
 - [ ] Run the exhausted ChatGPT quota plus extra API credits permutation and
   verify API credits do not falsely make a subscription-backed Codex route
-  selectable.
-- [ ] Run all-fallbacks-exhausted live or cassette-backed proof and verify the
-  terminal event is `quota_handoff_failed_no_account_selectable` with a
-  complete redacted rejection vector.
+  selectable. No synthetic substitute currently proves this because it depends
+  on a real account with separate API-credit and subscription-quota signals.
+- [ ] Run provider-originated all-fallbacks-exhausted live or cassette-backed
+  proof and verify the terminal event is
+  `quota_handoff_failed_no_account_selectable` with a
+  complete redacted rejection vector. The synthetic managed-run regression is
+  already covered by `scripts/smoke-codex-all-exhausted.sh` and is part of
+  `just check-local`; the remaining gap is real wire/live evidence.
 - [ ] Run reset-window repair proof: exhausted route stays blocked until reset
-  or spend-gated revalidation evidence repairs it.
+  or spend-gated revalidation evidence repairs it. Synthetic stale-window
+  routing is already covered in `scripts/e2e-local.sh`; the remaining gap is
+  a live reset-window repair without manually clearing health.
 
 ## P0 Test Hardening
 
-- [ ] Add deterministic route-state tests for 1-4 account pools covering `200`,
-  `401`, `429 usage_limit_reached`, generic `429`, `usage_not_included`,
-  materialization failure, and network failure.
-- [ ] Assert no attempted, auth-dead, quota-exhausted, rate-limited,
-  tier-insufficient, or credential-unavailable account is elected in the same
-  request.
-- [ ] Assert quota evidence is recorded before retry.
-- [ ] Assert terminal no-fallback evidence includes every rejected candidate and
-  redacts sensitive fields.
+- [x] Assert terminal no-fallback evidence includes every rejected candidate and
+  redacts sensitive fields in the synthetic all-fallbacks managed-run smoke and
+  supporting unit coverage.
+- [x] Assert `usage_not_included` is `tier_insufficient`, not quota, and does
+  not trigger a same-turn quota retry.
+- [x] Assert expired quota reset windows remain blocked as
+  `revalidation_needed` until provider revalidation.
+- [ ] Add a deterministic route-state matrix for 1-4 account pools covering
+  `200`, `401`, `429 usage_limit_reached`, generic `429`,
+  `usage_not_included`, materialization failure, and network failure.
+- [ ] In that matrix, assert no attempted, auth-dead, quota-exhausted,
+  rate-limited, tier-insufficient, or credential-unavailable account is elected
+  in the same request.
+- [ ] Assert quota evidence is recorded before retry in a small unit or cassette
+  replay that does not depend on timing or status-line ordering.
 - [ ] Add cassette replay for the redacted real `usage_limit_reached` shape from
   the 2026-05-08 proof when a publishable cassette is available.
 

--- a/docs/spec/test-and-coverage-review-2026-05-05.md
+++ b/docs/spec/test-and-coverage-review-2026-05-05.md
@@ -1,12 +1,12 @@
 # Test, Coverage, Architecture, and Story Review
 Date: 2026-05-05
-Status: current-main assessment; not a product contract.
+Status: historical current-main assessment; not a product contract.
 
 Anchor: `docs/spec/broker-mcp-contract-2026-05-03.md`.
 Codex adapter contract: `docs/spec/codex-adapter-contract-2026-05-03.md`.
 
 This review replaces the stale quarry-branch assessment from
-`<local-quarry-worktree>`. It describes current `main` through
+`<local-quarry-worktree>`. It describes the 2026-05-05 `main` state through
 `9cdf5a3` (`Add Codex dogfood status monitor helper (#209)`), after
 route-health truthing, Codex quarry smokes, expired-quota revalidation state,
 restart-claim demotion, managed resume UX work, request-framing fixes,
@@ -14,7 +14,8 @@ same-account child-refresh preservation, auth fallback chain summarization,
 managed auth-health recording, and dogfood-9's live auth-continuity event
 followed by failed live quota handoff. It is superseded for current Codex
 quota-handoff evidence by
-`docs/spec/codex-live-quota-handoff-evidence-2026-05-08.md`.
+`docs/spec/codex-live-quota-handoff-evidence-2026-05-08.md`, and for current
+route/test matrix truth by `docs/qa-handoff-matrix.md`.
 
 ## Product Bar
 


### PR DESCRIPTION
## Summary
- separate synthetic-covered Codex negative lanes from live/cassette gaps
- split tier-insufficient behavior into selected-route classification and later route-election skip targets
- refresh the productionization ledger with the latest verified main CI run

## Verification
- git diff --check
- just test