### PR TITLE
docs: refresh 0.1.7 package parity truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,10 @@ diagnostic infrastructure. They are not product success.
 
 ## Current Truth
 
-Source and local dogfood are `0.1.7` candidate. Public npm, GitHub Release, and
-Homebrew install lanes still publish `0.1.6`.
-The current public Homebrew tap installs the `0.1.6` binary, but its formula
-metadata can parse the stable version incorrectly; the `0.1.7` release gate now
-checks Homebrew's parsed version explicitly.
+Public install lanes now resolve to `0.1.7`: GitHub Release assets, npm root
+and platform packages, the public Homebrew tap, the curl installer, and
+published deb/rpm assets have all passed package-lane QA. Homebrew QA now checks
+both the installed binary and Homebrew's parsed `versions.stable` metadata.
 
 What works today:
 
@@ -103,7 +102,7 @@ ladder diagrams.
 
 ## Install
 
-Public install lanes currently resolve to `0.1.6`:
+Public install lanes currently resolve to `0.1.7`:
 
 ```bash
 npm install -g oauth-mux
@@ -111,7 +110,7 @@ npm install -g oauth-mux
 brew install jesssullivan/omux/oauth-mux
 ```
 
-Local `0.1.7` candidate dogfood should keep provenance explicit:
+Unreleased source dogfood should keep provenance explicit:
 
 ```bash
 just install-local-dogfood
@@ -150,8 +149,10 @@ installed binary hash against `./zig-out/bin/oauth-mux`, and installs a managed
 `codex` shim in the same user-local bin directory. The shim resolves the native
 upstream Codex executable, passes it through `OMUX_CODEX_BIN`, and then enters
 `oauth-mux codex`. It refuses to replace a non-oauth-mux `codex` already in that
-directory unless `OMUX_DOGFOOD_REPLACE_CODEX=1` is set. Public package channels
-do not carry that shim until `0.1.7` is published.
+directory unless `OMUX_DOGFOOD_REPLACE_CODEX=1` is set. Public npm and Homebrew
+package lanes also carry the managed `codex` shim; use `version --json` and
+`codex preflight` when you need to distinguish a package binary from a worktree
+dogfood binary.
 
 ## Usage
 
@@ -193,7 +194,7 @@ oauth-mux codex preflight --profile codex-max --capability codex-max --json
 
 See `docs/tracing.md` for the trace schema and redaction contract.
 
-Those inspection commands do not spend provider calls. In the `0.1.7` candidate,
+Those inspection commands do not spend provider calls. In the `0.1.7` release,
 managed Codex launch/resume and admitted stay-afloat execution may spend
 provider calls only to revalidate expired Codex quota/rate windows before route
 election. Live probes, broad revalidation, and non-Codex provider-spend paths

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -65,12 +65,10 @@ The public Homebrew tap is `Jesssullivan/homebrew-omux`, documented in
 infrastructure, not public adoption copy.
 The DRY release/install lane contract is `docs/release-install-lanes.md`; keep
 new UX/DX/AX installer copy aligned with that file rather than duplicating
-package-state tables here.
-As of the `0.1.7` release-candidate tranche, public packages still resolve to
-`0.1.6`; the public Homebrew tap also has a formula metadata defect where the
-installed binary is correct but `brew info --json=v2` does not report a stable
-version of `0.1.6`. Do not promote `0.1.7` install copy until npm, GitHub
-Release, Homebrew, and system package verification have all passed.
+package-state tables here. As of the 2026-05-17 package-parity refresh, public
+GitHub Release, npm, Homebrew, curl installer, and system package lanes resolve
+to `0.1.7`. Package-lane QA proves installability and metadata, not live
+provider handoff behavior.
 
 When validating unreleased source behavior, install or invoke the worktree build
 deliberately and record provenance:

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -1,6 +1,6 @@
 # Install Beta Matrix
 
-Updated: 2026-05-16
+Updated: 2026-05-17
 
 This matrix tracks clean-install proof for the public adoption surfaces. It is
 operator evidence, not a credential runbook: do not paste OAuth stores, `.env`
@@ -13,17 +13,17 @@ The lane contract and current operator rules live in
 
 | Surface | Version | Host | Source | Result | Caveat |
 | --- | --- | --- | --- | --- | --- |
-| npm global install | 0.1.6 | macOS arm64 | public npm registry | Pass | Public registry reports `oauth-mux@0.1.6` plus all six platform packages. |
-| npm one-shot | 0.1.6 | macOS arm64 | public npm registry | Pass | `npx -y oauth-mux@0.1.6 version` returns `oauth-mux 0.1.6`. |
-| user-local dogfood install | 0.1.7 candidate | macOS arm64 | current worktree copied to `~/.local/bin` | Pass | Remove the old installed file before copying; `./zig-out/bin/oauth-mux` and `~/.local/bin/oauth-mux` hashes match. Use this lane for unreleased installed-command dogfood. |
-| Nix package | 0.1.7 candidate | macOS arm64 | source flake | Candidate | `nix eval .#packages.aarch64-darwin.default.version` reports `0.1.7`; `nix flake check` now includes a package smoke gate. |
-| GitHub release tarball | 0.1.6 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Release workflow `25195318899` published all tarballs, packages, checksums, formula, and installer. |
-| `curl | sh` installer | 0.1.6 | macOS arm64 and `../lab` | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass | Default installer repo is canonical; no `REPO=...` override needed. |
-| Homebrew formula | 0.1.6 | macOS arm64 + hosted Ubuntu dry-run | public `jesssullivan/omux` tap | Binary pass, metadata defect | Installed binary reports `oauth-mux 0.1.6`, but `brew info --json=v2` currently parses the stable formula version incorrectly. `0.1.7` release proof must reject this. |
-| deb package | 0.1.6 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25195456319` installed package and ran `/usr/bin/oauth-mux version`. |
-| rpm package | 0.1.6 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25195456319` installed package and ran `/usr/bin/oauth-mux version`. |
-| Codex route dogfood | 0.1.7 candidate | macOS arm64 | installed user-local binary | Pass with four selectable routes | Current 2026-05-16 no-spend truth: `codex-max` has four selectable broker-ready routes, `session_start_ready:true`, `fallback_ready:true`, and `single_route_at_risk:false`. Public package channels remain `0.1.6`. |
-| lab dogfood | 0.1.6 | macOS arm64 | public npm one-shot | Pass | Installed `oauth-mux doctor --json` reports `ok: true` against local config/state. |
+| npm global install | 0.1.7 | macOS arm64 | public npm registry | Pass | Public registry reports `oauth-mux@0.1.7` plus all six platform packages; temp-prefix global install returns `oauth-mux 0.1.7`. |
+| npm one-shot | 0.1.7 | macOS arm64 | public npm registry | Pass | `npx -y oauth-mux@0.1.7 version` returns `oauth-mux 0.1.7`; `doctor --json` reports `ok:true`. |
+| user-local dogfood install | source checkout | macOS arm64 | current worktree copied to `~/.local/bin` | Pass | Remove the old installed file before copying; `./zig-out/bin/oauth-mux` and `~/.local/bin/oauth-mux` hashes match. Use this lane only for unreleased installed-command dogfood. |
+| Nix package | 0.1.7 | macOS arm64 | source flake | Pass | `nix eval .#packages.aarch64-darwin.default.version` reports `0.1.7`; `nix flake check` includes a package smoke gate. |
+| GitHub release tarball | 0.1.7 | macOS arm64 | public `Jesssullivan/oauth-mux` release asset | Pass | Release workflow `25980203233` published all tarballs, packages, checksums, formula, installer, and handoff files. |
+| `curl | sh` installer | 0.1.7 | macOS arm64 | public `Jesssullivan/oauth-mux` `install.sh` asset | Pass | Public installer installed `oauth-mux 0.1.7`; installed binary SHA-256 was `42197206aab61c615eb1544acc74630529ba261a792229bf794381044b504cad`. |
+| Homebrew formula | 0.1.7 | macOS arm64 | public `jesssullivan/omux` tap | Pass | Public tap PR `Jesssullivan/homebrew-omux#1` updated the formula from the GitHub Release asset; clean QA installed `oauth-mux 0.1.7` and `brew info --json=v2` reports stable `0.1.7`. |
+| deb package | 0.1.7 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25980333371` installed package and ran `/usr/bin/oauth-mux version`. |
+| rpm package | 0.1.7 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25980333371` installed package and ran `/usr/bin/oauth-mux version`. |
+| Codex route dogfood | 0.1.7 | macOS arm64 | installed binary | Pass with four selectable routes | Current 2026-05-16 no-spend truth: `codex-max` has four selectable broker-ready routes, `session_start_ready:true`, `fallback_ready:true`, and `single_route_at_risk:false`. |
+| lab dogfood | 0.1.7 | macOS arm64 | public npm one-shot | Pass | Public `npx` run reports `oauth-mux 0.1.7` and `doctor --json` reports `ok:true` against local config/state. |
 | first-run source e2e | main | macOS arm64 | source checkout | Pass | `just first-run-e2e` runs with temporary HOME/XDG roots and proves no-config `init --codex-max`, JSON diagnostics, runtime diagnostics, redacted report, no-spend route explanation/select refusal, and non-mutating Codex help. |
 
 ## Evidence Commands
@@ -33,7 +33,7 @@ npm clean install:
 ```bash
 tmp="$(mktemp -d)"
 npm_config_cache="$tmp/cache" \
-  npm install --prefix "$tmp/app" --install-strategy=shallow oauth-mux@0.1.6 \
+  npm install --prefix "$tmp/app" --install-strategy=shallow oauth-mux@0.1.7 \
   --ignore-scripts=false --no-audit --no-fund
 "$tmp/app/node_modules/.bin/oauth-mux" version
 rm -rf "$tmp"
@@ -42,7 +42,7 @@ rm -rf "$tmp"
 Expected output includes:
 
 ```text
-oauth-mux 0.1.6
+oauth-mux 0.1.7
 ```
 
 Raw release tarball:
@@ -50,9 +50,9 @@ Raw release tarball:
 ```bash
 tmp="$(mktemp -d)"
 curl -fsSL -o "$tmp/oauth-mux-aarch64-macos.tar.gz" \
-  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.6/oauth-mux-aarch64-macos.tar.gz
+  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.7/oauth-mux-aarch64-macos.tar.gz
 curl -fsSL -o "$tmp/SHA256SUMS" \
-  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.6/SHA256SUMS
+  https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.7/SHA256SUMS
 (cd "$tmp" && shasum -a 256 -c --ignore-missing SHA256SUMS)
 tar -xzf "$tmp/oauth-mux-aarch64-macos.tar.gz" -C "$tmp"
 "$tmp/oauth-mux" version
@@ -63,16 +63,16 @@ Expected output includes:
 
 ```text
 oauth-mux-aarch64-macos.tar.gz: OK
-oauth-mux 0.1.6
+oauth-mux 0.1.7
 ```
 
-Public installer for v0.1.6:
+Public installer for v0.1.7:
 
 ```bash
 tmp="$(mktemp -d)"
-VERSION=0.1.6 \
+VERSION=0.1.7 \
 INSTALL_DIR="$tmp/bin" \
-  sh -c 'curl -fsSL https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.6/install.sh | sh'
+  sh -c 'curl -fsSL https://github.com/Jesssullivan/oauth-mux/releases/download/v0.1.7/install.sh | sh'
 "$tmp/bin/oauth-mux" version
 rm -rf "$tmp"
 ```
@@ -80,30 +80,30 @@ rm -rf "$tmp"
 Expected output includes:
 
 ```text
-oauth-mux 0.1.6
+oauth-mux 0.1.7
 ```
 
 Homebrew tap install:
 
 ```bash
-just homebrew-qa 0.1.6
+just homebrew-qa 0.1.7
 ```
 
 Expected output includes:
 
 ```text
-Homebrew install QA passed for oauth-mux 0.1.6 via jesssullivan/omux/oauth-mux
+Homebrew install QA passed for oauth-mux 0.1.7 via jesssullivan/omux/oauth-mux
 ```
 
-Current public `0.1.6` caveat:
+Homebrew metadata check:
 
 ```bash
 brew info jesssullivan/omux/oauth-mux --json=v2
 ```
 
-The installed keg is `0.1.6`, but the formula's parsed
-`formulae[0].versions.stable` is not `0.1.6`. Treat that as a release metadata
-defect, not as proof that the binary failed.
+For the current public tap, both the installed keg and
+`formulae[0].versions.stable` report `0.1.7`. Treat a future mismatch as a
+release metadata defect even if the binary itself runs.
 
 First-run source e2e:
 
@@ -123,7 +123,7 @@ first-run e2e passed
 To keep the formula installed after dogfood QA:
 
 ```bash
-OMUX_HOMEBREW_KEEP_INSTALLED=1 OMUX_HOMEBREW_KEEP_TAP=1 just homebrew-qa 0.1.6
+OMUX_HOMEBREW_KEEP_INSTALLED=1 OMUX_HOMEBREW_KEEP_TAP=1 just homebrew-qa 0.1.7
 ```
 
 To include the starter Codex canary from the installed Homebrew binary:
@@ -136,7 +136,7 @@ OMUX_HOMEBREW_KEEP_TAP=1 \
 OMUX_HOMEBREW_CODEX_CANARY=1 \
 OMUX_HOMEBREW_CODEX_LIVE=1 \
 OMUX_LIVE_QA_CONFIRM=spend-real-calls \
-  just homebrew-qa 0.1.6
+  just homebrew-qa 0.1.7
 ```
 
 Latest local Homebrew dogfood proof:
@@ -148,11 +148,13 @@ brew tap jesssullivan/omux https://github.com/Jesssullivan/homebrew-omux.git: pa
 brew install jesssullivan/omux/oauth-mux: pass
 brew audit --formula --strict jesssullivan/omux/oauth-mux: pass
 brew test jesssullivan/omux/oauth-mux: pass
-/opt/homebrew/bin/oauth-mux version: oauth-mux 0.1.6
+/opt/homebrew/bin/oauth-mux version: oauth-mux 0.1.7
 /opt/homebrew/bin/oauth-mux doctor --json: ok
 Public tap repository: `Jesssullivan/homebrew-omux`, default branch `main`.
-Hosted registry dry-run `25199131583`: pass, checked out public tap and passed
-the Homebrew lane.
+Public tap PR `Jesssullivan/homebrew-omux#1`: merged at `43c32ce`.
+Clean local QA installed from `https://github.com/Jesssullivan/homebrew-omux.git`
+and passed audit, parsed stable-version check, install, test, `version`, and
+`doctor --json`.
 ```
 
 Latest private/staged Homebrew proof:
@@ -167,16 +169,15 @@ brew test tinyland/tools/oauth-mux: pass
 Production tap PR `tinyland-inc/homebrew-tools#4` merged at `f3016e3`.
 ```
 
-Latest public npm dogfood proof, historical 2026-05-01 snapshot:
+Latest public npm dogfood proof, 2026-05-17 snapshot:
 
 ```text
-npm publish workflow run 25195609579: pass
-npm view oauth-mux version: 0.1.6
-npx -y oauth-mux@0.1.6 version: oauth-mux 0.1.6
-npx -y oauth-mux@0.1.6 doctor --json: ok
-npx -y oauth-mux@0.1.6 route select --profile codex-max --capability codex-max --json:
-  selected: codex:max-2#codex-max
-  max-1#codex-max: quota_exhausted reset@1777987200
+npm publish workflow run 25980468974: pass
+npm view oauth-mux@0.1.7 version: 0.1.7
+npm view oauth-mux-<platform>@0.1.7 version: 0.1.7 for all six platform packages
+temp-prefix npm install oauth-mux@0.1.7: oauth-mux 0.1.7
+npx -y oauth-mux@0.1.7 version: oauth-mux 0.1.7
+npx -y oauth-mux@0.1.7 doctor --json: ok
 ```
 
 Current paid-cohort route truth is tracked in `docs/qa-handoff-matrix.md`.
@@ -186,20 +187,20 @@ time-sensitive account availability into this install matrix.
 System package install QA after GitHub Release publication:
 
 ```bash
-gh workflow run system-package-install-qa.yml -f version=0.1.6
+gh workflow run system-package-install-qa.yml -f version=0.1.7
 ```
 
 Latest hosted proof:
 
 ```text
-System Package Install QA run 25195456319: pass
-job 73874903526: deb/rpm install from published release assets
+System Package Install QA run 25980333371: pass
+job 76367854350: deb/rpm install from published release assets
 ```
 
 Local reproduction on a host with healthy Docker:
 
 ```bash
-just system-package-qa 0.1.6
+just system-package-qa 0.1.7
 ```
 
 ## Next Proof

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -1,6 +1,6 @@
 # Productionization Ledger
 
-Updated: 2026-05-16
+Updated: 2026-05-17
 
 This ledger is the short operator map for oauth-mux productionization. It is
 subordinate to the broker contract and Codex adapter contract, and it should be
@@ -8,21 +8,20 @@ refreshed when release truth, route evidence, or tracker state changes.
 
 ## Current Snapshot
 
-- Repo state: `main` is clean against `origin/main`; no open GitHub PRs were
-  present in the 2026-05-16 refresh.
+- Repo state: `main` is clean against `origin/main` after the `0.1.7`
+  package-parity refresh.
 - CI state: GitHub Actions is the live source for the latest run. The
-  2026-05-16 refresh verified green PR and post-merge `main` checks; do not
-  treat a run id copied into docs as current release proof.
-- Version truth: local/source dogfood is `0.1.7`; public npm, GitHub Release,
-  and Homebrew remain `0.1.6`.
+  2026-05-17 refresh verified the `v0.1.7` release workflow, npm publish
+  workflow, and hosted system-package install QA.
+- Version truth: public npm, GitHub Release, Homebrew, curl installer, and
+  deb/rpm lanes now resolve to `0.1.7`.
 - Installed provenance: PATH can resolve a public package binary or a
   user-local dogfood binary depending on shell setup. Use `which -a oauth-mux`,
   `which -a codex`, `oauth-mux version --json`, and `codex preflight` before
   treating any installed-command run as release evidence.
-- Homebrew truth: the public `0.1.6` tap installs the expected binary, but
-  Homebrew currently parses the formula stable version incorrectly because the
-  generated formula lacks an explicit version. `0.1.7` release proof must catch
-  this class before publication.
+- Homebrew truth: the public `jesssullivan/omux` tap installs `oauth-mux
+  0.1.7`, includes the managed `codex` shim, and `brew info --json=v2`
+  reports stable version `0.1.7`.
 - Codex route truth: `codex-max` currently has four selectable broker-ready
   routes, `session_start_ready:true`, `fallback_ready:true`, and
   `single_route_at_risk:false`.
@@ -92,11 +91,11 @@ not claim to keep them alive.
 
 ## Release And Distribution Posture
 
-Hold `0.1.7` as a release candidate until release/install parity, tracker
-state, and the daemon beta boundary are current. Negative Codex cassettes remain
-important follow-up proof, but they are not the publication blocker for this
-release tranche. Public install copy must continue to say `0.1.6` until npm,
-GitHub Release, and Homebrew are actually published and verified.
+`0.1.7` package parity is complete for the public install lanes. Negative Codex
+cassettes, broader adapter proof, and daemon beta truth remain important
+follow-up work, but they are no longer publication blockers for this release
+tranche. Future public install copy must still avoid naming a version until
+that version is actually published and verified.
 
 The release lanes remain:
 
@@ -121,6 +120,7 @@ browser is needed; local Playwright is not part of this CLI proof path.
 | Wire cassette coverage | TIN-950 | #176 | Needed before treating negative permutations as stable release proof. |
 | Harness session authority bridge | TIN-979 | #191 | Implementation exists, but tracker should be reconciled against current bridge proof. |
 | OTEL-friendly tracing | TIN-1148 | PR #225/#226 lineage | Implemented trace schema should become the standard support-bundle path. |
+| Package parity and install lanes | TIN-1255 | #252 | `0.1.7` is published and verified across GitHub Release, npm, Homebrew, curl, and deb/rpm package lanes. |
 | Provider proof beyond Codex | TIN-736 | #68 | Claude next; other agents stay adapter-candidate only. |
 | Website truth refresh | TIN-734 / TIN-925 | external site repo | `omux.xoxd.ai` source lives outside this repo and must be refreshed from the ledger, QA matrix, and install-lane docs. |
 
@@ -140,4 +140,4 @@ browser is needed; local Playwright is not part of this CLI proof path.
   `brew info --json=v2` stable version semantics for the public tap formula.
 - Public copy does not claim same-thread continuity, mid-turn recovery,
   unmanaged daemon hot-swap, non-Codex stay-afloat, universal provider support,
-  or public `0.1.7` availability before publication.
+  or future package availability before publication.

--- a/docs/qa-handoff-matrix.md
+++ b/docs/qa-handoff-matrix.md
@@ -114,19 +114,19 @@ publishable evidence for those same negative shapes.
 
 ## Next Multi-Account Session
 
-Start from the user-local `0.1.7` dogfood binary unless PATH is fixed to put
-that binary first. As of the 2026-05-16 local post-merge refresh, bare
-`oauth-mux` resolves Homebrew `0.1.6` first, while
-`~/.local/bin/oauth-mux` and `./zig-out/bin/oauth-mux` have matching `0.1.7`
-hashes.
+Start from an installed `0.1.7` binary and record provenance before any
+spend-confirmed test. As of the 2026-05-17 package-parity refresh, bare
+`oauth-mux` resolves the public Homebrew `0.1.7` package first on the operator
+machine; use `oauth-mux version --json` to distinguish that package binary from
+`~/.local/bin/oauth-mux` or `./zig-out/bin/oauth-mux` worktree dogfood hashes.
 
 No-spend opening sequence:
 
 ```bash
-~/.local/bin/oauth-mux version --json
-~/.local/bin/oauth-mux codex preflight --profile codex-max --capability codex-max --json
-~/.local/bin/oauth-mux route explain --profile codex-max --capability codex-max --json
-~/.local/bin/oauth-mux codex status-latest --json
+oauth-mux version --json
+oauth-mux codex preflight --profile codex-max --capability codex-max --json
+oauth-mux route explain --profile codex-max --capability codex-max --json
+oauth-mux codex status-latest --json
 ```
 
 Current matrix entry:

--- a/docs/release-install-lanes.md
+++ b/docs/release-install-lanes.md
@@ -1,6 +1,6 @@
 # Release And Install Lanes
 
-Updated: 2026-05-16
+Updated: 2026-05-17
 
 This is the DRY map for installer, package, CI, and local dogfood lanes.
 Detailed historical evidence stays in `docs/install-beta-matrix.md` and
@@ -85,10 +85,10 @@ Expected when testing unreleased behavior:
   binary hash; treat it as the package lane.
 
 If Homebrew appears before `~/.local/bin` in PATH, use the worktree binary or
-adjust PATH before recording dogfood evidence. The active public Homebrew
-`0.1.6` tap installs the expected binary but has a formula stable-version
-metadata defect; `0.1.7` release proof must reject that defect before
-publication.
+adjust PATH before recording unreleased dogfood evidence. The active public
+Homebrew tap now resolves `0.1.7` and passes both installed-binary and
+`brew info --json=v2` stable-version checks, but it is still a package binary,
+not worktree proof.
 
 On macOS, do not overwrite an existing Mach-O in place for this lane. A direct
 `cp` over `~/.local/bin/oauth-mux` can leave stale taskgated/code-signing state

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -243,6 +243,23 @@ Current release evidence:
   SOPS-backed path; `npm view oauth-mux version` reports `0.1.6`.
 - Main CI run `25954361661` completed successfully on 2026-05-16 for the latest
   checked `main` state before the `0.1.7` release-parity tranche.
+- Hosted GloriousFlywheel release proof run `25979637380` passed for `0.1.7`.
+- Hosted registry dry-run run `25979761165` passed for `0.1.7` lanes
+  `plan,github,system`.
+- Release workflow run `25980203233` published the latest `v0.1.7` GitHub
+  Release assets from commit `6838db5`.
+- System Package Install QA run `25980333371` passed for published `0.1.7`
+  `.deb` and `.rpm` assets.
+- NPM publish dry-run `25980347239` passed for all seven `0.1.7` packages, then
+  NPM publish run `25980468974` published all seven packages with provenance
+  disabled for the private-source release path.
+- Public npm verification confirms `oauth-mux@0.1.7` and all six platform
+  packages resolve; temp-prefix npm install and `npx -y oauth-mux@0.1.7`
+  both return `oauth-mux 0.1.7`.
+- Public Homebrew tap PR `Jesssullivan/homebrew-omux#1` updated the formula
+  from the `v0.1.7` GitHub Release asset and merged at `43c32ce`; clean
+  public tap QA passed with installed binary `oauth-mux 0.1.7` and parsed
+  stable version `0.1.7`.
 
 ## Before Marking A PR Ready
 

--- a/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
+++ b/docs/spec/dogfood-e2e-oauth-flow-plan-2026-04-30.md
@@ -33,13 +33,13 @@ Install surfaces:
 
 | Surface | Current proof |
 | --- | --- |
-| npm global install | `oauth-mux@0.1.6` installs from the public npm registry and returns `oauth-mux 0.1.6`. |
-| npm one-shot | `npx -y oauth-mux@0.1.6 version` passed from `../lab`. |
-| GitHub Release tarball | v0.1.6 macOS arm64 tarball verifies against `SHA256SUMS` and runs. |
-| curl installer | v0.1.6 installer downloads public release assets, verifies checksums, and runs on macOS and `../lab`. |
-| Homebrew | `just homebrew-qa 0.1.6` installs from public `jesssullivan/omux`, runs `brew audit`, `brew test`, `version`, and `doctor --json`. The private `tinyland/tools` tap remains a staged internal lane. |
-| deb/rpm | Hosted System Package Install QA run `25195456319` installed published v0.1.6 `.deb` and `.rpm` assets in Debian/Rocky containers. |
-| lab dogfood | Public npm one-shot `oauth-mux@0.1.6` reports healthy `doctor --json` against the local config/state. |
+| npm global install | `oauth-mux@0.1.7` installs from the public npm registry and returns `oauth-mux 0.1.7`. |
+| npm one-shot | `npx -y oauth-mux@0.1.7 version` passes; `doctor --json` reports `ok:true`. |
+| GitHub Release tarball | v0.1.7 macOS arm64 tarball verifies against `SHA256SUMS` and runs. |
+| curl installer | v0.1.7 installer downloads public release assets, verifies checksums, and runs on macOS. |
+| Homebrew | `just homebrew-qa 0.1.7` installs from public `jesssullivan/omux`, runs `brew audit`, parsed stable-version check, `brew test`, `version`, and `doctor --json`. The private `tinyland/tools` tap remains a staged internal lane. |
+| deb/rpm | Hosted System Package Install QA run `25980333371` installed published v0.1.7 `.deb` and `.rpm` assets in Debian/Rocky containers. |
+| lab dogfood | Public npm one-shot `oauth-mux@0.1.7` reports healthy `doctor --json` against the local config/state. |
 
 OAuth and muxing surfaces:
 
@@ -79,7 +79,7 @@ These are the adoption blockers that should stay visible:
    stdin, and env references need explicit e2e proof before public copy implies
    they are equally dogfooded.
 
-5. Homebrew is public-tap proven for v0.1.6, but release automation still needs
+5. Homebrew is public-tap proven for v0.1.7, and release automation still needs
    to keep future formula updates derived from public GitHub Release assets.
    The public tap is `Jesssullivan/homebrew-omux`; the private Tinyland tap is
    staging infrastructure.

--- a/docs/spec/homebrew-public-lane-decision-2026-05-01.md
+++ b/docs/spec/homebrew-public-lane-decision-2026-05-01.md
@@ -33,6 +33,8 @@ avoiding any claim that this is Homebrew core.
   test, `oauth-mux version`, and `oauth-mux doctor --json`.
 - `Jesssullivan/homebrew-omux` now exists as the public tap, with default
   branch `main`.
+- The public `jesssullivan/omux` tap installs `oauth-mux 0.1.7` and
+  `brew info --json=v2` reports stable version `0.1.7`.
 - The release workflow already emits `oauth-mux.rb` and `SHA256SUMS` from the
   public GitHub Release tree.
 
@@ -56,6 +58,18 @@ Result:
 
 ```text
 Homebrew install QA passed for oauth-mux 0.1.6 via jesssullivan/omux/oauth-mux
+```
+
+On 2026-05-17, public tap PR `Jesssullivan/homebrew-omux#1` updated the formula
+from the published `oauth-mux` v0.1.7 GitHub Release formula asset and merged at
+`43c32ce`. Clean local QA removed the previous install/tap, tapped the public
+repo, ran strict audit, checked Homebrew's parsed stable version, installed,
+ran `brew test`, checked `oauth-mux version`, and ran `oauth-mux doctor --json`.
+
+Result:
+
+```text
+Homebrew install QA passed for oauth-mux 0.1.7 via jesssullivan/omux/oauth-mux
 ```
 
 ## Rationale
@@ -132,5 +146,6 @@ Close `#66` / `TIN-858` only after:
 4. `docs/adoption.md`, `docs/install-beta-matrix.md`, the website, and release
    notes use the public tap wording.
 
-Items 1-3 have clean-local v0.1.6 proof as of 2026-05-01. Item 4 remains the
-cross-repo alignment gate.
+Items 1-4 have repo-doc clean-local v0.1.7 proof as of 2026-05-17. The website
+still needs a separate source refresh if its copy names a specific older
+version.

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -11,7 +11,7 @@ auth-broker proof `TIN-913` / GitHub `#125`.
 
 ## Baseline
 
-`oauth-mux` v0.1.6 is published and dogfooded for the Codex route-selection
+`oauth-mux` v0.1.7 is published and dogfooded for the Codex route-selection
 path. The release has public GitHub assets, npm `latest`, `curl | sh`,
 deb/rpm assets, and a public Jess-owned Homebrew tap. The remaining adoption
 risks are no longer general release mechanics. They are specific product
@@ -43,11 +43,16 @@ same-thread continuity semantics, mid-turn streaming recovery, unmanaged
 bare-`codex` daemon handoff, non-Codex harnesses, and the remaining auth/quota
 permutations as open proof lanes.
 
+Supersession note, 2026-05-17: `v0.1.7` package parity is live. GitHub Release,
+npm, curl installer, Homebrew public tap, and deb/rpm package QA resolve to
+`0.1.7`. This updates distribution truth only; it does not add new live
+provider handoff claims beyond the preserved Codex evidence above.
+
 ## Public Issue Map
 
 | Facet | Public GitHub issue | Linear tracking | Current posture |
 | --- | --- | --- | --- |
-| Homebrew distribution | `#66` | `TIN-858`, related to `TIN-737` | Public Jess-owned tap exists and clean local install QA passes; Tinyland tap remains private/staged. Live website copy was rechecked on 2026-05-03 and now uses the public `jesssullivan/omux` tap. |
+| Homebrew distribution | `#66` | `TIN-858`, related to `TIN-737` | Public Jess-owned tap exists and clean local install QA passes for `0.1.7`; Tinyland tap remains private/staged. Live website copy was rechecked on 2026-05-03 and used the public `jesssullivan/omux` tap, but site copy should be refreshed against the 2026-05-17 package-parity truth. |
 | Stay-afloat daemon | `#67` | `TIN-738`, `TIN-859`, `TIN-860`, `TIN-866`, `TIN-867`, `TIN-897`, `TIN-898`, `TIN-940` | Foreground/agent-safe stay-afloat is shipped; production background daemon is not. Socket daemon is explicitly non-product plumbing. The active claim matrix lives in `docs/daemon-boundary.md`; managed Codex launch/resume and broker-owned app-server sessions are scoped proof surfaces. Supervised child capture is diagnostic only, not a product claim level. |
 | Provider expansion | `#68` | `TIN-736`, `TIN-861`, `TIN-862`, `TIN-863`, `TIN-876`, `TIN-877`, `TIN-878`, `TIN-879` | Managed Codex route selection, broker-owned sessions, and installed `oauth-mux codex resume` quota handoff are live-proven for scoped commands, including the 2026-05-09 engineered handoff. Same-thread semantics, unmanaged daemon handoff, and non-Codex proof remain capability-level or still need operator proof. |
 | Paid multi-account proof | `#67`, `#68` | `TIN-892`, `TIN-893`, `TIN-894`, `TIN-895`, `TIN-896` | Codex has a four-route paid cohort. Dogfood-9 proved managed auth-continuity and failed-quota truth. The 2026-05-08 installed-runtime artifacts proved managed load/resume quota handoff from `codex:default` to `codex:max-2`; the 2026-05-09 engineered artifact proved managed-session quota handoff from `codex:max-2` to `codex:max-3` after successful primary traffic. Claude, Figma, same-thread semantics, unmanaged daemon handoff, and long-window soak evidence remain separate gates. |
@@ -57,7 +62,7 @@ permutations as open proof lanes.
 Current truth:
 
 - `brew tap jesssullivan/omux https://github.com/Jesssullivan/homebrew-omux.git`
-  plus `brew install jesssullivan/omux/oauth-mux` installs v0.1.6 from the
+  plus `brew install jesssullivan/omux/oauth-mux` installs v0.1.7 from the
   public tap.
 - The public tap is `Jesssullivan/homebrew-omux`, default branch `main`.
 - `tinyland-inc/homebrew-tools` still exists and remains private/staged


### PR DESCRIPTION
Updates README and release/install docs after public 0.1.7 package parity was verified.\n\nEvidence reflected:\n- GitHub Release v0.1.7 is latest\n- npm root + six platform packages resolve and install at 0.1.7\n- public Homebrew tap installs 0.1.7 and reports stable 0.1.7\n- curl installer installs 0.1.7\n- hosted deb/rpm install QA passed\n\nNo new live provider handoff claims are added.