### PR TITLE
release: stage 0.1.8 shim parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ root and platform packages, the public Homebrew tap, the curl installer, and
 published deb/rpm assets. The current source tree also tightens install parity
 after a 2026-05-18 finding that the public Homebrew `codex` shim routed native
 admin commands such as `codex --version` through oauth-mux route election.
+Source `0.1.8` is the shim-parity patch release candidate.
 
 What works today:
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .oauth_mux,
-    .version = "0.1.7",
+    .version = "0.1.8",
     .fingerprint = 0x21c445132f61984e,
     .minimum_zig_version = "0.14.0",
     .paths = .{

--- a/dist/npm/package.json
+++ b/dist/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth-mux",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "OAuth fallback muxing for AI harness subscriptions",
   "license": "MIT",
   "repository": "Jesssullivan/oauth-mux",
@@ -17,11 +17,11 @@
     "postinstall": "node install.js"
   },
   "optionalDependencies": {
-    "oauth-mux-darwin-arm64": "0.1.7",
-    "oauth-mux-darwin-x64": "0.1.7",
-    "oauth-mux-linux-arm64": "0.1.7",
-    "oauth-mux-linux-x64": "0.1.7",
-    "oauth-mux-windows-arm64": "0.1.7",
-    "oauth-mux-windows-x64": "0.1.7"
+    "oauth-mux-darwin-arm64": "0.1.8",
+    "oauth-mux-darwin-x64": "0.1.8",
+    "oauth-mux-linux-arm64": "0.1.8",
+    "oauth-mux-linux-x64": "0.1.8",
+    "oauth-mux-windows-arm64": "0.1.8",
+    "oauth-mux-windows-x64": "0.1.8"
   }
 }

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -16,7 +16,8 @@ refreshed when release truth, route evidence, or tracker state changes.
 - Version truth: public npm, GitHub Release, Homebrew, curl installer, and
   deb/rpm lanes resolve to `0.1.7`, but the 2026-05-18 shim investigation found
   a package-lane QA gap: public Homebrew `0.1.7` routes native admin commands
-  such as `codex --version` through `oauth-mux codex`.
+  such as `codex --version` through `oauth-mux codex`. Source `0.1.8` is the
+  shim-parity patch release candidate.
 - Installed provenance: PATH can resolve a public package binary or a
   user-local dogfood binary depending on shell setup. Use `which -a oauth-mux`,
   `which -a codex`, `oauth-mux version --json`, and `codex preflight` before


### PR DESCRIPTION
## Summary

Stages `0.1.8` as a shim-parity patch release candidate for the install-lane bug fixed in #256.

This keeps public claims scoped correctly: source/tree truth is now `0.1.8` staged for release, while published package lanes remain `0.1.7` until the release is cut and verified.

## Why

Public Homebrew `0.1.7` can route native Codex admin commands such as `codex --version` and `codex login` through `oauth-mux codex`, which can fail route election with `NoAccountSelectable`. The shared shim fix is already merged; this PR stages the patch version needed to publish that fix.

## Changes

- Bump Zig package version to `0.1.8`.
- Bump npm root and platform package dependency versions to `0.1.8`.
- Update README and productionization ledger to call `0.1.8` a source patch release candidate, not a published-lane fact.

## Validation

- `just test`
- `git diff --check`
- `just release-proof 0.1.8`
- `nix flake check`
