### PR TITLE
release: stage 0.1.9 homebrew audit fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ root and platform packages, the public Homebrew tap, the curl installer, and
 published deb/rpm assets. The current source tree also tightens install parity
 after a 2026-05-18 finding that the public Homebrew `codex` shim routed native
 admin commands such as `codex --version` through oauth-mux route election.
-Source `0.1.8` is the shim-parity patch release candidate.
+Source `0.1.9` is the package-lane patch release candidate after `0.1.8`
+exposed Homebrew formula audit drift before registry/tap publication.
 
 What works today:
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .oauth_mux,
-    .version = "0.1.8",
+    .version = "0.1.9",
     .fingerprint = 0x21c445132f61984e,
     .minimum_zig_version = "0.14.0",
     .paths = .{

--- a/dist/homebrew/oauth-mux.rb
+++ b/dist/homebrew/oauth-mux.rb
@@ -1,8 +1,8 @@
 class OauthMux < Formula
   desc "OAuth fallback muxing for AI harness subscriptions"
   homepage "https://omux.xoxd.ai"
-  license "MIT"
   version "${VERSION}"
+  license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?

--- a/dist/npm/package.json
+++ b/dist/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth-mux",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "OAuth fallback muxing for AI harness subscriptions",
   "license": "MIT",
   "repository": "Jesssullivan/oauth-mux",
@@ -17,11 +17,11 @@
     "postinstall": "node install.js"
   },
   "optionalDependencies": {
-    "oauth-mux-darwin-arm64": "0.1.8",
-    "oauth-mux-darwin-x64": "0.1.8",
-    "oauth-mux-linux-arm64": "0.1.8",
-    "oauth-mux-linux-x64": "0.1.8",
-    "oauth-mux-windows-arm64": "0.1.8",
-    "oauth-mux-windows-x64": "0.1.8"
+    "oauth-mux-darwin-arm64": "0.1.9",
+    "oauth-mux-darwin-x64": "0.1.9",
+    "oauth-mux-linux-arm64": "0.1.9",
+    "oauth-mux-linux-x64": "0.1.9",
+    "oauth-mux-windows-arm64": "0.1.9",
+    "oauth-mux-windows-x64": "0.1.9"
   }
 }

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -16,8 +16,9 @@ refreshed when release truth, route evidence, or tracker state changes.
 - Version truth: public npm, GitHub Release, Homebrew, curl installer, and
   deb/rpm lanes resolve to `0.1.7`, but the 2026-05-18 shim investigation found
   a package-lane QA gap: public Homebrew `0.1.7` routes native admin commands
-  such as `codex --version` through `oauth-mux codex`. Source `0.1.8` is the
-  shim-parity patch release candidate.
+  such as `codex --version` through `oauth-mux codex`. GitHub Release `0.1.8`
+  exists, but registry/tap publication is targeting source `0.1.9` after the
+  Homebrew dry-run caught formula audit drift.
 - Installed provenance: PATH can resolve a public package binary or a
   user-local dogfood binary depending on shell setup. Use `which -a oauth-mux`,
   `which -a codex`, `oauth-mux version --json`, and `codex preflight` before

--- a/docs/release-install-lanes.md
+++ b/docs/release-install-lanes.md
@@ -45,8 +45,8 @@ The 2026-05-18 investigation found that public Homebrew `0.1.7` installed a
 `codex` shim that always entered `oauth-mux codex`, so `codex --version` and
 `codex login` could hit route election and fail with `NoAccountSelectable`.
 That was package-lane drift, not a route-health issue. The current source tree
-fixes the release templates and adds package smokes so the next release can
-prove this behavior before publication.
+fixes the release templates and adds package smokes so the `0.1.9` package
+release can prove this behavior before publication.
 
 ## CI/CD Surfaces
 

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -108,6 +108,12 @@ if grep -q -E '\$\{(VERSION|SHA_[A-Z0-9_]+)\}' "$homebrew_formula"; then
   printf 'unrendered placeholder remains in %s\n' "$homebrew_formula" >&2
   exit 1
 fi
+version_line="$(awk '/^[[:space:]]+version / { print NR; exit }' "$homebrew_formula")"
+license_line="$(awk '/^[[:space:]]+license / { print NR; exit }' "$homebrew_formula")"
+if [ -z "${version_line:-}" ] || [ -z "${license_line:-}" ] || [ "$version_line" -ge "$license_line" ]; then
+  printf 'Homebrew formula must put version before license for brew audit compatibility: %s\n' "$homebrew_formula" >&2
+  exit 1
+fi
 "$repo_root/scripts/homebrew-version-check.sh" "$version" "$homebrew_formula"
 if command -v ruby >/dev/null 2>&1; then
   ruby -c "$homebrew_formula" >/dev/null


### PR DESCRIPTION
## Summary

Stages `0.1.9` as the package-lane patch release candidate after the `0.1.8` GitHub Release exposed a Homebrew formula audit failure before registry/tap publication.

## Why

The `0.1.8` registry dry-run passed release proof but failed the Homebrew lane because `brew audit --strict` now requires the explicit `version` line before `license`. Rather than hand-editing the tap and drifting from source, this fixes the release template and adds a local release-smoke guard so future release proofs catch the ordering before any public release/tap work.

## Changes

- Reorder the Homebrew formula template to put `version` before `license`.
- Add a release-smoke guard for Homebrew `version`/`license` ordering.
- Bump source/package metadata to `0.1.9`.
- Update README and release truth docs to mark `0.1.9` as the registry/tap target after the `0.1.8` dry-run finding.

## Validation

- `just test`
- `git diff --check`
- `just release-proof 0.1.9`
- `nix flake check`
