### PR TITLE
Make local dogfood Codex shim opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,13 +153,17 @@ place can leave stale taskgated/code-signing state on the old vnode and produce
 an immediate `SIGKILL` / status `137`.
 
 `just install-local-dogfood` uses that remove-then-copy lane, verifies the
-installed binary hash against `./zig-out/bin/oauth-mux`, and installs a managed
-`codex` shim in the same user-local bin directory. The shim resolves the native
-upstream Codex executable, passes native admin commands through, and enters
-`oauth-mux codex` for managed session commands. It refuses to replace a
-non-oauth-mux `codex` already in that directory unless
-`OMUX_DOGFOOD_REPLACE_CODEX=1` is set. Public packages may carry a managed
-`codex` shim, but installed behavior must still be proven with `version --json`,
+installed binary hash against `./zig-out/bin/oauth-mux`, and leaves the native
+`codex` command unshadowed by default. Use `just install-local-dogfood-shim` or
+set `OMUX_DOGFOOD_INSTALL_CODEX_SHIM=1` only when you intentionally want
+`~/.local/bin/codex` to enter managed Codex sessions through oauth-mux. The shim
+resolves the native upstream Codex executable, passes native admin commands
+through, and enters `oauth-mux codex` for managed session commands. It refuses
+to replace a non-oauth-mux `codex` already in that directory unless
+`OMUX_DOGFOOD_REPLACE_CODEX=1` is set. Use `just uninstall-local-dogfood` to
+remove the local dogfood binary and any oauth-mux-marked `codex` shim without
+touching a native Codex executable. Public packages may carry a managed `codex`
+shim, but installed behavior must still be proven with `version --json`,
 `which -a codex`, and `codex preflight` when you need to distinguish a package
 binary from a worktree dogfood binary.
 

--- a/docs/release-install-lanes.md
+++ b/docs/release-install-lanes.md
@@ -131,10 +131,14 @@ the hash still matches the worktree binary. Re-signing the installed copy is a
 separate repair fallback, but it changes the hash and no longer proves byte
 identity with `./zig-out/bin/oauth-mux`.
 
-The local installer refuses to replace an existing non-oauth-mux
-`~/.local/bin/codex` unless `OMUX_DOGFOOD_REPLACE_CODEX=1` is set. Use
-`OMUX_DOGFOOD_INSTALL_CODEX_SHIM=0` when you need installed-command dogfood for
-`oauth-mux` without shadowing the native `codex` command.
+The local installer installs only `~/.local/bin/oauth-mux` by default and leaves
+the native `codex` command unshadowed. Use
+`OMUX_DOGFOOD_INSTALL_CODEX_SHIM=1` or `just install-local-dogfood-shim` only
+when managed-shim dogfood is the point of the test. The local installer refuses
+to replace an existing non-oauth-mux `~/.local/bin/codex` unless
+`OMUX_DOGFOOD_REPLACE_CODEX=1` is set. Use `just uninstall-local-dogfood` to
+remove the local dogfood binary and any oauth-mux-marked `codex` shim without
+touching a native Codex executable.
 
 ## UX, DX, AX Gates
 

--- a/justfile
+++ b/justfile
@@ -33,6 +33,12 @@ version: build
 install-local-dogfood:
     nix develop --command ./scripts/install-local-dogfood.sh
 
+install-local-dogfood-shim:
+    OMUX_DOGFOOD_INSTALL_CODEX_SHIM=1 nix develop --command ./scripts/install-local-dogfood.sh
+
+uninstall-local-dogfood:
+    ./scripts/uninstall-local-dogfood.sh
+
 status: build
     ./zig-out/bin/oauth-mux status --json
 

--- a/scripts/check-local.sh
+++ b/scripts/check-local.sh
@@ -7,6 +7,7 @@ zig build test
 zig build
 ./zig-out/bin/oauth-mux version --json | jq -e '.version and .runtime_identity.binary_path and .runtime_identity.binary_sha256 and .runtime_identity.path_printed == true' >/dev/null
 bash -n ./scripts/install-local-dogfood.sh
+bash -n ./scripts/uninstall-local-dogfood.sh
 sh -n ./dist/codex-shim.sh
 sh -n ./dist/install.sh
 

--- a/scripts/install-local-dogfood.sh
+++ b/scripts/install-local-dogfood.sh
@@ -5,7 +5,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
 install_dir="${INSTALL_DIR:-$HOME/.local/bin}"
-install_codex_shim="${OMUX_DOGFOOD_INSTALL_CODEX_SHIM:-1}"
+install_codex_shim="${OMUX_DOGFOOD_INSTALL_CODEX_SHIM:-0}"
 replace_existing_codex="${OMUX_DOGFOOD_REPLACE_CODEX:-0}"
 binary_src="$repo_root/zig-out/bin/oauth-mux"
 oauth_mux_target="$install_dir/oauth-mux"
@@ -116,6 +116,8 @@ printf 'oauth-mux sha256: %s\n' "$installed_hash"
 if [ "$install_codex_shim" != "0" ]; then
   printf 'installed managed codex shim: %s\n' "$codex_target"
   printf 'native Codex CLI resolved before install: %s\n' "$native_codex"
+else
+  printf 'skipped managed codex shim: set OMUX_DOGFOOD_INSTALL_CODEX_SHIM=1 to shadow codex for managed-shim dogfood\n'
 fi
 printf 'PATH oauth-mux: %s\n' "$(command -v oauth-mux || true)"
 printf 'PATH codex: %s\n' "$(command -v codex || true)"

--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -376,7 +376,7 @@ else
     exit 1
 fi
 
-echo "smoke-codex-cli-ux: managed codex shim passes native admin commands through"
+echo "smoke-codex-cli-ux: local dogfood install keeps native codex unshadowed by default"
 DOGFOOD_BIN="$TMP/dogfood-bin"
 NATIVE_CODEX="$TMP/native-codex"
 NATIVE_REPORT="$TMP/native-codex.report"
@@ -407,6 +407,21 @@ INSTALL_DIR="$DOGFOOD_BIN" \
   OMUX_DOGFOOD_SKIP_BUILD=1 \
   OMUX_CODEX_BIN="$NATIVE_CODEX" \
   "$ROOT/scripts/install-local-dogfood.sh" >"$TMP/dogfood-install.stdout"
+test -x "$DOGFOOD_BIN/oauth-mux"
+if [[ -e "$DOGFOOD_BIN/codex" ]]; then
+    echo "  ✗ default local dogfood install unexpectedly created a codex shim" >&2
+    cat "$TMP/dogfood-install.stdout" >&2
+    exit 1
+else
+    echo "  ✓ default local dogfood install did not shadow codex"
+fi
+
+echo "smoke-codex-cli-ux: managed codex shim opt-in passes native admin commands through"
+INSTALL_DIR="$DOGFOOD_BIN" \
+  OMUX_DOGFOOD_SKIP_BUILD=1 \
+  OMUX_DOGFOOD_INSTALL_CODEX_SHIM=1 \
+  OMUX_CODEX_BIN="$NATIVE_CODEX" \
+  "$ROOT/scripts/install-local-dogfood.sh" >"$TMP/dogfood-install-shim.stdout"
 
 OMUX_CODEX_BIN="$NATIVE_CODEX" \
   OMUX_NATIVE_CODEX_REPORT="$NATIVE_REPORT" \
@@ -439,6 +454,10 @@ if [[ -e "$TMP/native-xdg/oauth-mux/codex/max-1" ]]; then
 else
     echo "  ✓ shim login did not bootstrap mux account dirs"
 fi
+INSTALL_DIR="$DOGFOOD_BIN" "$ROOT/scripts/uninstall-local-dogfood.sh" >"$TMP/dogfood-uninstall.stdout"
+test ! -e "$DOGFOOD_BIN/oauth-mux"
+test ! -e "$DOGFOOD_BIN/codex"
+echo "  ✓ local dogfood uninstall removed only dogfood-managed files"
 
 LOGIN_STATUS_JSON="$TMP/login-status-all.json"
 LOGIN_STATUS_LEAKS="$TMP/login-status-all.leaks"

--- a/scripts/uninstall-local-dogfood.sh
+++ b/scripts/uninstall-local-dogfood.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+install_dir="${INSTALL_DIR:-$HOME/.local/bin}"
+oauth_mux_target="$install_dir/oauth-mux"
+codex_target="$install_dir/codex"
+
+is_omux_codex_shim() {
+  grep -q 'OMUX_CODEX_SHIM' "$1" 2>/dev/null
+}
+
+removed_any=0
+
+if [ -e "$oauth_mux_target" ]; then
+  rm -f "$oauth_mux_target"
+  printf 'removed oauth-mux dogfood binary: %s\n' "$oauth_mux_target"
+  removed_any=1
+fi
+
+if [ -e "$codex_target" ]; then
+  if is_omux_codex_shim "$codex_target"; then
+    rm -f "$codex_target"
+    printf 'removed managed codex shim: %s\n' "$codex_target"
+    removed_any=1
+  else
+    printf 'left non-oauth-mux codex untouched: %s\n' "$codex_target" >&2
+  fi
+fi
+
+if [ "$removed_any" = "0" ]; then
+  printf 'no oauth-mux dogfood files found in %s\n' "$install_dir"
+fi
+
+printf 'PATH oauth-mux: %s\n' "$(command -v oauth-mux || true)"
+printf 'PATH codex: %s\n' "$(command -v codex || true)"


### PR DESCRIPTION
## Summary
- make local dogfood install leave native `codex` unshadowed by default
- add explicit `just install-local-dogfood-shim` and safe `just uninstall-local-dogfood`
- extend Codex CLI UX smoke coverage for default no-shim install, opt-in shim pass-through, and uninstall cleanup

## Validation
- `git diff --check`
- `bash -n scripts/install-local-dogfood.sh scripts/uninstall-local-dogfood.sh scripts/smoke-codex-cli-ux.sh scripts/check-local.sh && sh -n dist/codex-shim.sh`
- `zig build test`
- `zig build`
- `scripts/smoke-codex-cli-ux.sh`
- `nix develop --command just check-local`

No local Playwright run.
