### PR TITLE
Add Home Manager shim parity lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ npm install -g oauth-mux
 brew install jesssullivan/omux/oauth-mux
 ```
 
+Nix users can choose the binary-only package or the managed-shim package:
+
+```bash
+nix build .#oauth-mux
+nix build .#withCodexShim
+```
+
+Home Manager users should import `inputs.oauth-mux.homeManagerModules.default`.
+The module installs only `oauth-mux` by default; set
+`programs.oauth-mux.codexShim.enable = true` to intentionally put the managed
+`codex` shim on PATH. See `docs/home-manager.md`.
+
 Unreleased source dogfood should keep provenance explicit:
 
 ```bash

--- a/docs/home-manager.md
+++ b/docs/home-manager.md
@@ -1,0 +1,60 @@
+# Home Manager Lane
+
+Updated: 2026-05-18
+
+oauth-mux exposes a Home Manager module from the flake:
+
+```nix
+inputs.oauth-mux.url = "github:Jesssullivan/oauth-mux";
+```
+
+Then import the module in your Home Manager configuration:
+
+```nix
+{
+  imports = [
+    inputs.oauth-mux.homeManagerModules.default
+  ];
+
+  programs.oauth-mux.enable = true;
+}
+```
+
+By default this installs only the `oauth-mux` binary. It does not install a
+`codex` command, so it does not unexpectedly shadow an upstream Codex CLI that
+is already on PATH.
+
+To intentionally install the managed Codex shim:
+
+```nix
+{
+  imports = [
+    inputs.oauth-mux.homeManagerModules.default
+  ];
+
+  programs.oauth-mux = {
+    enable = true;
+    codexShim.enable = true;
+  };
+}
+```
+
+With `codexShim.enable = true`, the Home Manager profile installs the same
+managed `codex` shim as the Nix package. Native admin commands such as
+`codex --version`, `codex login`, `codex logout`, `codex auth`, and `codex mcp`
+pass through to the native upstream Codex CLI. Managed session commands such as
+`codex resume` enter `oauth-mux codex` only when PATH resolves this shim.
+
+The module chooses between two flake packages:
+
+- `packages.<system>.oauth-mux`: binary-only package, no `codex` shim.
+- `packages.<system>.withCodexShim`: `oauth-mux` plus the managed `codex` shim.
+
+Smoke the lane from the repo with:
+
+```bash
+just home-manager-smoke
+```
+
+That smoke builds both package variants and verifies that the shimmed package
+passes native `codex --version` through to a native Codex stub.

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -45,6 +45,11 @@ refreshed when release truth, route evidence, or tracker state changes.
   commands enter `oauth-mux codex` when PATH resolves the shim, but that is not
   a global stay-afloat daemon and does not protect direct native Codex binaries
   or already-running unmanaged sessions.
+- Nix/Home Manager truth: source now exposes a binary-only
+  `packages.<system>.oauth-mux` package, the existing shimmed
+  `packages.<system>.withCodexShim` / default package, and a Home Manager module
+  that defaults to binary-only unless `programs.oauth-mux.codexShim.enable =
+  true`.
 
 ## Feature Ledger
 
@@ -56,6 +61,7 @@ refreshed when release truth, route evidence, or tracker state changes.
 | Config/TOML preservation | Implemented | Root-partitioned Codex config passthrough keeps user settings, MCP servers, profiles, model defaults, approval/sandbox policy, and non-managed provider definitions. |
 | Experimental Codex settings injection | Implemented | Defaults can be injected without treating user config as disposable. |
 | Native Codex shim pass-through | Implemented in source, release pending | Admin/login/help/version paths bypass route election and exec native Codex. The 2026-05-18 package-lane fix must ship before public Homebrew/curl claims use this as installed truth. |
+| Home Manager lane | Implemented in source | Module defaults to binary-only install; managed `codex` shim is explicit opt-in. |
 | Route-health recovery | Implemented | Transient provider degradation can recover after retry windows without becoming permanent auth death. |
 | Redacted diagnostics and tracing | Implemented | JSON diagnostics and `OMUX_TRACE=1` support route/session/auth/runtime debugging without token, raw account id, session id, or path leakage. |
 | Agent-safe reauth mediation | Contracted, partial surfaces | CLI JSON exposes consent/action fields and safe handoff-plan commands for upstream-owned login surfaces; future MCP tools must mirror CLI semantics. |
@@ -107,20 +113,21 @@ not claim to keep them alive.
 `0.1.7` version availability is complete for the public install lanes, but
 package parity is not complete until the shared Codex shim fix ships and the
 package lanes prove native admin pass-through. Negative Codex cassettes,
-broader adapter proof, Home Manager packaging, Windows raw-tarball shim parity,
-and daemon beta truth remain follow-up work. Future public install copy must
-avoid claiming a version or lane behavior until that version is actually
-published and verified.
+broader adapter proof, and daemon beta truth remain follow-up work. Windows
+managed-`codex` parity is intentionally assigned to the npm wrapper lane rather
+than raw tarballs until a native Windows operator need is proven. Future public
+install copy must avoid claiming a version or lane behavior until that version
+is actually published and verified.
 
 The release lanes remain:
 
 - worktree dogfood;
 - user-local dogfood;
 - Nix package;
-- GitHub Release tarballs and installer;
 - npm;
 - Homebrew;
-- deb/rpm packages.
+- deb/rpm packages;
+- Home Manager.
 
 Remote/browser validation should use the repo's remote execution lane when a
 browser is needed; local Playwright is not part of this CLI proof path.
@@ -136,6 +143,7 @@ browser is needed; local Playwright is not part of this CLI proof path.
 | Harness session authority bridge | TIN-979 | #191 | Implementation exists, but tracker should be reconciled against current bridge proof. |
 | OTEL-friendly tracing | TIN-1148 | PR #225/#226 lineage | Implemented trace schema should become the standard support-bundle path. |
 | Package parity and install lanes | TIN-1255 | #252 | `0.1.7` is published and verified across GitHub Release, npm, Homebrew, curl, and deb/rpm package lanes. |
+| Home Manager and Windows shim parity | not assigned | #257 | Home Manager source lane is implemented with opt-in shim; Windows raw tarballs stay binary-only and npm is the managed-shim lane. |
 | Provider proof beyond Codex | TIN-736 | #68 | Claude next; other agents stay adapter-candidate only. |
 | Website truth refresh | TIN-734 / TIN-925 | external site repo | `omux.xoxd.ai` source lives outside this repo and must be refreshed from the ledger, QA matrix, and install-lane docs. |
 

--- a/docs/release-install-lanes.md
+++ b/docs/release-install-lanes.md
@@ -18,7 +18,7 @@ Detailed historical evidence stays in `docs/install-beta-matrix.md` and
 | Homebrew | `brew install jesssullivan/omux/oauth-mux` | public tap formula from release checksums | `just homebrew-qa <version>`, formula test shim pass-through, parsed version check | public macOS/Linux tap lane |
 | curl installer | `curl .../install.sh \| sh` | GitHub Release `install.sh` + tarballs | local file URL binary+shim smoke and public installer smoke | shell installer lane |
 | deb/rpm | system package install | GitHub Release `.deb` / `.rpm` | hosted container install QA for `/usr/bin/oauth-mux`; set `OMUX_EXPECT_CODEX_SHIM=1` for releases that should include `/usr/bin/codex` | distro package lane |
-| Home Manager | not yet published | future Nix module wrapping the flake package | not implemented | planned Nix user-profile lane |
+| Home Manager | `programs.oauth-mux.enable = true` | flake Home Manager module | `just home-manager-smoke` package-variant smoke | Nix user-profile lane with opt-in Codex shim |
 
 ## Codex Shim Contract
 
@@ -37,9 +37,23 @@ Every install lane that puts `codex` on PATH must preserve this behavior:
   generated deb/rpm packages.
 - npm uses `dist/npm/bin/codex.js`, which must match the same admin
   pass-through contract even though it is a JS wrapper.
-- Windows raw tarballs currently ship only `oauth-mux.exe`; managed `codex`
-  command parity on Windows is covered by the npm wrapper, not by a standalone
-  raw-tarball shim.
+- Windows raw tarballs currently ship only `oauth-mux.exe`. The 2026-05-18
+  decision is that managed `codex` command parity on Windows is covered by the
+  npm JS wrapper, not by a standalone raw-tarball `.cmd` or PowerShell shim,
+  until a native Windows operator need is proven.
+
+## Home Manager
+
+The flake exposes `homeManagerModules.default`. The Home Manager lane is safer
+than the default Nix package lane by default:
+
+- `programs.oauth-mux.enable = true` installs only the binary-only
+  `packages.<system>.oauth-mux` package.
+- `programs.oauth-mux.codexShim.enable = true` explicitly opts into
+  `packages.<system>.withCodexShim`, which puts the managed `codex` shim on
+  PATH.
+
+See `docs/home-manager.md` for the module snippet and local smoke command.
 
 The 2026-05-18 investigation found that public Homebrew `0.1.7` installed a
 `codex` shim that always entered `oauth-mux codex`, so `codex --version` and

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,53 @@
   };
 
   outputs = { self, nixpkgs, flake-utils, zig-overlay }:
-    flake-utils.lib.eachDefaultSystem (system:
+    let
+      homeModule = { config, lib, pkgs, ... }:
+        let
+          cfg = config.programs.oauth-mux;
+          system = pkgs.stdenv.hostPlatform.system;
+          packageSet = self.packages.${system};
+        in
+        {
+          options.programs.oauth-mux = {
+            enable = lib.mkEnableOption "oauth-mux";
+
+            package = lib.mkOption {
+              type = lib.types.package;
+              default =
+                if cfg.codexShim.enable
+                then packageSet.withCodexShim
+                else packageSet.oauth-mux;
+              defaultText = lib.literalExpression ''
+                if config.programs.oauth-mux.codexShim.enable
+                then inputs.oauth-mux.packages.''${pkgs.stdenv.hostPlatform.system}.withCodexShim
+                else inputs.oauth-mux.packages.''${pkgs.stdenv.hostPlatform.system}.oauth-mux
+              '';
+              description = ''
+                oauth-mux package installed into the user profile.
+              '';
+            };
+
+            codexShim.enable = lib.mkOption {
+              type = lib.types.bool;
+              default = false;
+              description = ''
+                Install the managed Codex shim as `codex`. This is opt-in so
+                Home Manager users do not unexpectedly shadow an existing
+                upstream Codex CLI in their profile.
+              '';
+            };
+          };
+
+          config = lib.mkIf cfg.enable {
+            home.packages = [ cfg.package ];
+          };
+        };
+    in
+    {
+      homeModules.default = homeModule;
+      homeManagerModules.default = homeModule;
+    } // flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
           inherit system;
@@ -22,11 +68,9 @@
               (map (line: builtins.match ".*\\.version[[:space:]]*=[[:space:]]*\"([^\"]+)\".*" line) lines);
           in
           builtins.head (builtins.head matches);
-      in
-      {
-        packages = {
-          default = pkgs.stdenvNoCC.mkDerivation {
-            pname = "oauth-mux";
+        mkPackage = { installCodexShim }:
+          pkgs.stdenvNoCC.mkDerivation {
+            pname = if installCodexShim then "oauth-mux-with-codex-shim" else "oauth-mux";
             inherit version;
             src = ./.;
 
@@ -43,9 +87,12 @@
                 --release=safe \
                 --prefix "$out" \
                 -Doptimize=ReleaseSafe
+            '' + pkgs.lib.optionalString installCodexShim ''
               cp dist/codex-shim.sh "$out/bin/codex"
               chmod 0755 "$out/bin/codex"
             '';
+
+            passthru.codexShim = installCodexShim;
 
             meta = with pkgs.lib; {
               description = "OAuth fallback muxing for AI harness subscriptions";
@@ -54,6 +101,12 @@
               mainProgram = "oauth-mux";
             };
           };
+      in
+      {
+        packages = rec {
+          oauth-mux = mkPackage { installCodexShim = false; };
+          withCodexShim = mkPackage { installCodexShim = true; };
+          default = withCodexShim;
         };
 
         devShells.default = pkgs.mkShell {
@@ -66,6 +119,15 @@
 
         checks = {
           build = self.packages.${system}.default;
+          binary-only = pkgs.runCommand "oauth-mux-binary-only-smoke-${version}" { } ''
+            set -eu
+
+            binary="${self.packages.${system}.oauth-mux}/bin/oauth-mux"
+            test "$($binary version)" = "oauth-mux ${version}"
+            test ! -e "${self.packages.${system}.oauth-mux}/bin/codex"
+
+            touch "$out"
+          '';
           smoke = pkgs.runCommand "oauth-mux-smoke-${version}" {
             nativeBuildInputs = [ pkgs.jq ];
           } ''

--- a/justfile
+++ b/justfile
@@ -177,6 +177,9 @@ nix-build:
 nix-check:
     nix flake check
 
+home-manager-smoke:
+    ./scripts/smoke-home-manager-lane.sh
+
 # ── Validation ──
 
 check:

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -64,6 +64,15 @@ archive_contains() {
   tar -tzf "$archive" | awk -v expected="$expected" '$0 == expected { found = 1 } END { exit found ? 0 : 1 }'
 }
 
+archive_not_contains() {
+  local archive="$1"
+  local unexpected="$2"
+  if tar -tzf "$archive" | awk -v unexpected="$unexpected" '$0 == unexpected { found = 1 } END { exit found ? 0 : 1 }'; then
+    printf 'unexpected file in archive %s: %s\n' "$archive" "$unexpected" >&2
+    exit 1
+  fi
+}
+
 printf 'checking release tree: %s\n' "$out_dir"
 if [ ! -d "$out_dir" ]; then
   printf 'release output does not exist: %s\n' "$out_dir" >&2
@@ -101,6 +110,9 @@ for archive in \
   oauth-mux-x86_64-windows.tar.gz \
   oauth-mux-aarch64-windows.tar.gz; do
   archive_contains "$artifacts_dir/$archive" 'oauth-mux.exe'
+  archive_not_contains "$artifacts_dir/$archive" 'codex'
+  archive_not_contains "$artifacts_dir/$archive" 'codex.cmd'
+  archive_not_contains "$artifacts_dir/$archive" 'codex.ps1'
 done
 
 printf 'checking Homebrew formula...\n'

--- a/scripts/smoke-home-manager-lane.sh
+++ b/scripts/smoke-home-manager-lane.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if ! command -v nix >/dev/null 2>&1; then
+  printf 'missing required command for Home Manager lane smoke: nix\n' >&2
+  exit 1
+fi
+
+binary_only="$(nix build --no-link --print-out-paths .#oauth-mux)"
+with_shim="$(nix build --no-link --print-out-paths .#withCodexShim)"
+
+test -x "$binary_only/bin/oauth-mux"
+test ! -e "$binary_only/bin/codex"
+
+test -x "$with_shim/bin/oauth-mux"
+test -x "$with_shim/bin/codex"
+grep -q OMUX_CODEX_SHIM "$with_shim/bin/codex"
+
+native_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$native_dir"
+}
+trap cleanup EXIT
+
+native_codex="$native_dir/codex"
+cat >"$native_codex" <<'EOF'
+#!/bin/sh
+case "$1" in
+  --version) echo "native-codex-stub 0.0.0" ;;
+  *) echo "native-codex-stub" ;;
+esac
+EOF
+chmod 0755 "$native_codex"
+
+OMUX_CODEX_BIN="$native_codex" "$with_shim/bin/codex" --version \
+  | grep -qx "native-codex-stub 0.0.0"
+
+module_pnames="$(nix eval --impure --raw --expr "
+let
+  flake = builtins.getFlake \"path:$repo_root\";
+  system = builtins.currentSystem;
+  pkgs = import flake.inputs.nixpkgs {
+    inherit system;
+    overlays = [ flake.inputs.zig-overlay.overlays.default ];
+  };
+  lib = pkgs.lib;
+  base = { lib, ... }: {
+    options.home.packages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [];
+    };
+  };
+  eval = module:
+    (lib.evalModules {
+      specialArgs = { inherit pkgs; };
+      modules = [ base flake.homeManagerModules.default module ];
+    }).config.home.packages;
+  binaryOnly = builtins.head (eval ({ ... }: { programs.oauth-mux.enable = true; }));
+  withShimPackage = builtins.head (eval ({ ... }: {
+    programs.oauth-mux.enable = true;
+    programs.oauth-mux.codexShim.enable = true;
+  }));
+in binaryOnly.pname + \" \" + withShimPackage.pname
+")"
+test "$module_pnames" = "oauth-mux oauth-mux-with-codex-shim"
+
+nix flake show --json . >/dev/null
+
+printf 'Home Manager lane smoke passed\n'


### PR DESCRIPTION
## Summary

- add binary-only and managed-shim Nix package variants
- add Home Manager module with binary-only default and explicit Codex shim opt-in
- document the Home Manager lane and Windows raw-tarball decision
- add a Home Manager lane smoke and a release-smoke guard that Windows raw tarballs stay binary-only

## Validation

- `git diff --check`
- `bash -n scripts/smoke-home-manager-lane.sh scripts/release-smoke.sh scripts/install-local-dogfood.sh scripts/uninstall-local-dogfood.sh`
- `sh -n dist/codex-shim.sh dist/install.sh`
- `./scripts/smoke-home-manager-lane.sh`
- `nix flake check`
- `nix eval` module checks for both `homeModules.default` and `homeManagerModules.default`
- `zig build test`
- `./scripts/smoke-codex-cli-ux.sh`

## Notes

- `./scripts/release-smoke.sh 0.1.8` reached the new Windows archive assertions, then failed on the already-known 0.1.8 Homebrew formula-order defect. Current-source release proof should be run on a fresh 0.1.9 release tree.
- No live auth, provider spend, or local Playwright was run.
