### PR TITLE
Close proven Codex tracker states

### DIFF
--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -137,11 +137,11 @@ browser is needed; local Playwright is not part of this CLI proof path.
 | Theme | Linear | GitHub | Current stance |
 | --- | --- | --- | --- |
 | Broker daemon and adapter contract | TIN-738 | #67 | Anchor remains open until daemon beta and second-adapter validation are honest. |
-| Codex next-turn broker switch | TIN-916 | #131 | Managed Codex handoff is proven; keep remaining negative/permutation work distinct from same-thread or mid-turn claims. |
+| Codex next-turn broker switch | TIN-916 | #131 | Closed for the proven managed Codex live handoff. Remaining negative/permutation work lives in #212/#176; same-thread, mid-turn, and unmanaged daemon behavior remain separate non-claims. |
 | Upstream Codex usage-limit hook | TIN-939 | #164 | Draft proposal written; use it to request a first-class external-auth usage-limit handoff hook while keeping oauth-mux claims scoped to proven managed-proxy behavior. |
 | Live Codex account-swap acceptance | TIN-951 | #177 | Done for managed Codex; strongest preserved proof is `docs/evidence/codex-engineered-quota-handoff-20260509/`. |
 | Wire cassette coverage | TIN-950 | #176 | Needed before treating negative permutations as stable release proof. |
-| Harness session authority bridge | TIN-979 | #191 | Implementation exists, but tracker should be reconciled against current bridge proof. |
+| Harness session authority bridge | TIN-979 | #191 | Closed for Codex: managed auth/config overlays bridge canonical session authority, `state_5.sqlite*`, and root config while rejecting silent session-store import/copy. Future cross-harness authority work stays under #67/#68. |
 | Codex session-store portability | TIN-936 | #161 | Policy is explicit: canonical bridge is supported; silent route-local session import/copy is rejected until a separate confirmed import command exists. |
 | OTEL-friendly tracing | TIN-1148 | PR #225/#226 lineage | Implemented trace schema should become the standard support-bundle path. |
 | Package parity and install lanes | TIN-1255 | #252 | `0.1.7` is published and verified across GitHub Release, npm, Homebrew, curl, and deb/rpm package lanes. |

--- a/docs/spec/codex-productionization-todo-2026-05-09.md
+++ b/docs/spec/codex-productionization-todo-2026-05-09.md
@@ -192,4 +192,7 @@ Not proven:
   public-copy changes.
 - [ ] Split product/code changes and website proof-copy changes into separate
   commits or PRs when publishing.
-- [ ] Do not close TIN-951/#177 or TIN-916/#131 from synthetic tests alone.
+- [x] Close TIN-951/#177 and TIN-916/#131 only from live evidence, not
+  synthetic tests alone. #177 closed from the managed Codex live account-swap
+  acceptance; #131 closed from the May 9 engineered managed-session quota
+  handoff proof, with remaining negative/permutation lanes tracked separately.

--- a/docs/spec/test-and-coverage-review-2026-05-05.md
+++ b/docs/spec/test-and-coverage-review-2026-05-05.md
@@ -76,8 +76,11 @@ Later in the same artifact, `codex:max-4` returned provider-originated
 `429 usage_limit_reached` / `quota_exhausted`, and oauth-mux reported
 `proxy_same_turn_retry_unavailable` / `NoAccountSelectable` instead of
 substituting another credited account. The correct summarizer verdict is
-`quota_handoff_failed`; this keeps TIN-916 / GitHub #131 and TIN-951 /
-GitHub #177 open.
+`quota_handoff_failed`; at the time, this kept TIN-916 / GitHub #131 and
+TIN-951 / GitHub #177 open. Later May 8 and May 9 installed-runtime evidence
+superseded that state for the managed Codex handoff claim; same-thread,
+mid-turn streaming, unmanaged-daemon, non-Codex, and negative/permutation
+lanes remain separate proof surfaces.
 
 ## 2026-05-08 Managed Load Quota Handoff
 


### PR DESCRIPTION
## Summary

- mark the Codex next-turn broker switch tracker as closed for the proven managed live handoff
- mark the Codex session-authority bridge tracker as closed for the proven Codex scope
- keep remaining negative/permutation, cassette, daemon, same-thread, and non-Codex work routed to the existing open trackers

## Validation

- `git diff --check`

## Boundaries

This is docs/tracker truthing only. It does not add new provider evidence or claim same-thread continuity, mid-turn streaming recovery, unmanaged daemon hot-swap, or non-Codex stay-afloat.