### PR TITLE
Harden broker MCP contract

### DIFF
--- a/docs/spec/broker-mcp-contract-2026-05-03.md
+++ b/docs/spec/broker-mcp-contract-2026-05-03.md
@@ -178,7 +178,21 @@ declared capabilities.
   "surface_version": 1,
   "build": "oauth-mux 0.2.0+broker",
   "transports": ["stdio", "unix"],
-  "capabilities": ["accounts", "quota", "refresh", "events", "policy"]
+  "capabilities": ["accounts", "quota", "refresh", "events", "policy"],
+  "capabilities_detail": {
+    "account_list": true,
+    "account_select": true,
+    "account_swap": true,
+    "credential_materialize": true,
+    "credential_materialize_scope": "adapter_stdio_only",
+    "credential_refresh": false,
+    "quota_observe": true,
+    "quota_status": true,
+    "events_append": false,
+    "events_subscribe": false,
+    "policy_get": true,
+    "policy_request_admission": false
+  }
 }
 ```
 
@@ -220,13 +234,18 @@ Adapter signals "the current account is unusable; give me the next one."
 Broker marks the current account quota-exhausted (or other typed reason),
 selects the next, returns it.
 - Params: `{ "session_id": "...", "current_account": "codex:max-1", "reason": "quota_exhausted", "evidence": { "http_status": 429, "body_class": "usage_limit_reached", "resets_at": 1788000000 } }`
-- Returns: same shape as `account/select`, plus `previous_marked: { "as": "quota_exhausted", "until": 1788000000 }`.
+- Returns: same shape as `account/select`, plus `previous_marked: { "as": "quota_exhausted", "until": 1788000000 }` and explicit claim fields such as `requires_adapter_turn_completion:true`.
 - Errors: `no_account_selectable` with the same typed reasons.
 
 `account/swap` is the load-bearing method. It is what makes
 "`account A` exhausts → `account B` takes over" a single atomic broker
 operation that the adapter requests when its harness shows it the
 exhaustion signal.
+
+`account/swap` itself remains a broker-owned replacement selection. It must
+not emit `claim.level:"next_turn_seamless"` merely because a replacement was
+found. The adapter or proxy promotes to `next_turn_seamless` only after it
+observes the next turn complete against the replacement account.
 
 ### 2.3 Credentials
 

--- a/docs/spec/harness-adapter-pattern-2026-05-03.md
+++ b/docs/spec/harness-adapter-pattern-2026-05-03.md
@@ -194,15 +194,17 @@ per-adapter parsing logic.
 
 ```jsonc
 { "kind": "session_started", "adapter": "codex", "session_id": "...", "selected_account": "codex:max-1", "claim_level": "broker_owned" }
-{ "kind": "account_swap", "from": "...", "to": "...", "reason": "quota_exhausted", "via": "<adapter-specific mechanism>", "claim_level": "next_turn_seamless" }
+{ "kind": "account_swap_selected", "from": "...", "to": "...", "reason": "quota_exhausted", "via": "<adapter-specific mechanism>", "claim_level": "broker_owned" }
+{ "kind": "account_swap_verified", "from": "...", "to": "...", "via": "<adapter-specific mechanism>", "claim_level": "next_turn_seamless" }
 { "kind": "credential_refresh", "account": "...", "trigger": "proactive_exp" | "unauthorized_401", "outcome": "ok" | "failed" }
 { "kind": "quota_observed", "account": "...", "kind_detail": "rate_limited" | "tier_insufficient" | "provider_5xx", "retry_after_s": 12 }
 { "kind": "session_ended", "session_id": "...", "turns": int, "swaps": int, "final_claim_level": "..." }
 ```
 
-The `via` field on `account_swap` is the only adapter-specific freeform
-field; everything else has a fixed enum of allowed values per the broker
-spec.
+The `via` field on swap frames is the only adapter-specific freeform field;
+everything else has a fixed enum of allowed values per the broker spec. A
+replacement selection is not a Level 3 claim; the verified frame appears only
+after the adapter observes a completed turn against the replacement account.
 
 ## When to write a new adapter
 

--- a/scripts/smoke-broker.sh
+++ b/scripts/smoke-broker.sh
@@ -17,7 +17,8 @@
 #   6. quota/observe       — kind=quota_exhausted, resets_at, now_selectable
 #   7. account/select again — proves prior account was actually marked
 #                             non-selectable in the pool
-#   8. account/swap        — full swap chain with claim.level promotion
+#   8. account/swap        — replacement selection without premature
+#                             next_turn_seamless promotion
 #   9. quota/status        — pool snapshot reflects all prior mutations
 #
 # Exit 0 = all assertions pass. Exit non-zero = which step failed.
@@ -41,6 +42,7 @@ fi
 # Tempdir + cleanup
 TMP="$(mktemp -d -t omux-smoke-broker.XXXXXX)"
 trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/state"
 
 # A minimal codex auth.json shape so credential/materialize can resolve
 # fixture token strings. id_token payload encodes plan_type=pro and
@@ -55,6 +57,32 @@ cat >"$TMP/auth.json" <<'EOF'
     "account_id": "acc-smoke-1"
   },
   "auth_mode": "Chatgpt"
+}
+EOF
+
+cat >"$TMP/state/health.json" <<'EOF'
+{
+  "version": 2,
+  "accounts": [
+    {
+      "key": "codex:max-1#codex-max",
+      "liveness": { "state": "live", "availability": "available" },
+      "last_probe_hint_class": "none",
+      "last_probe_decision": "use_this"
+    },
+    {
+      "key": "codex:max-2#codex-max",
+      "liveness": { "state": "live", "availability": "available" },
+      "last_probe_hint_class": "none",
+      "last_probe_decision": "use_this"
+    },
+    {
+      "key": "codex:max-3#codex-max",
+      "liveness": { "state": "live", "availability": "available" },
+      "last_probe_hint_class": "none",
+      "last_probe_decision": "use_this"
+    }
+  ]
 }
 EOF
 
@@ -77,27 +105,22 @@ cat >"$TMP/config.json" <<EOF
 }
 EOF
 
-# Build the JSON-RPC request sequence.
-REQUESTS=$(cat <<'REQ'
-{"jsonrpc":"2.0","id":1,"method":"surface/info"}
-{"jsonrpc":"2.0","id":2,"method":"surface/handshake","params":{"adapter":"smoke","adapter_version":"0","harness_target":"codex","session_pid":1}}
-{"jsonrpc":"2.0","id":3,"method":"account/list","params":{"session_id":"x"}}
-{"jsonrpc":"2.0","id":4,"method":"account/select","params":{"session_id":"x"}}
-{"jsonrpc":"2.0","id":5,"method":"credential/materialize","params":{"session_id":"x","credential_handle":"ch:codex:max-1:0","shape":"chatgpt_auth_tokens"}}
-{"jsonrpc":"2.0","id":6,"method":"quota/observe","params":{"session_id":"x","account":"codex:max-1","kind":"quota_exhausted","http_status":429,"body_class":"usage_limit_reached","resets_at":1788000000}}
-{"jsonrpc":"2.0","id":7,"method":"account/select","params":{"session_id":"x"}}
-{"jsonrpc":"2.0","id":8,"method":"account/swap","params":{"session_id":"x","current_account":"codex:max-2","reason":"quota_exhausted","evidence":{"http_status":429,"resets_at":1788000000}}}
-{"jsonrpc":"2.0","id":9,"method":"quota/status","params":{"session_id":"x"}}
-REQ
-)
+coproc BROKER { OMUX_CONFIG="$TMP/config.json" OMUX_STATE_DIR="$TMP/state" "$BIN" mcp --profile codex-max --capability codex-max 2>"$TMP/stderr.log"; }
+BROKER_OUT=${BROKER[0]}
+BROKER_IN=${BROKER[1]}
 
-# Pipe + capture every response on its own line.
-RESPONSES="$(printf '%s\n' "$REQUESTS" | OMUX_CONFIG="$TMP/config.json" "$BIN" mcp --profile codex-max 2>"$TMP/stderr.log")"
+cleanup_broker() {
+    exec {BROKER_IN}>&- 2>/dev/null || true
+    wait "$BROKER_PID" 2>/dev/null || true
+}
+trap 'cleanup_broker; rm -rf "$TMP"' EXIT
 
-# Helper: pluck the response with the matching id.
-resp_for() {
-    local id=$1
-    printf '%s\n' "$RESPONSES" | jq -c "select(.id==$id)"
+send_rpc() {
+    local payload=$1
+    printf '%s\n' "$payload" >&"$BROKER_IN"
+    local response
+    IFS= read -r response <&"$BROKER_OUT"
+    printf '%s\n' "$response"
 }
 
 assert_eq() {
@@ -110,28 +133,37 @@ assert_eq() {
 }
 
 # 1. surface/info
-r=$(resp_for 1)
+r=$(send_rpc '{"jsonrpc":"2.0","id":1,"method":"surface/info"}')
 assert_eq "surface/info.surface_version" "1" "$(echo "$r" | jq -r .result.surface_version)"
 assert_eq "surface/info.transports[0]"   "stdio" "$(echo "$r" | jq -r .result.transports[0])"
+assert_eq "surface/info.credential_materialize_scope" "adapter_stdio_only" "$(echo "$r" | jq -r .result.capabilities_detail.credential_materialize_scope)"
+
+# 1b. session validation rejects unknown ids before handshake.
+r=$(send_rpc '{"jsonrpc":"2.0","id":10,"method":"account/list","params":{"session_id":"not-real"}}')
+assert_eq "account/list unknown session code" "-32012" "$(echo "$r" | jq -r .error.code)"
 
 # 2. surface/handshake
-r=$(resp_for 2)
+r=$(send_rpc '{"jsonrpc":"2.0","id":2,"method":"surface/handshake","params":{"adapter":"smoke","adapter_version":"0","harness_target":"codex","session_pid":1}}')
 sid_present=$(echo "$r" | jq -r '.result.session_id | length > 0')
 assert_eq "surface/handshake.session_id present" "true" "$sid_present"
 assert_eq "surface/handshake.claim_floor" "broker_owned" "$(echo "$r" | jq -r .result.claim_floor)"
+sid="$(echo "$r" | jq -r .result.session_id)"
 
 # 3. account/list
-r=$(resp_for 3)
+r=$(send_rpc "$(jq -nc --arg sid "$sid" '{jsonrpc:"2.0",id:3,method:"account/list",params:{session_id:$sid,profile:"codex-max",capability:"codex-max"}}')")
 assert_eq "account/list count" "3" "$(echo "$r" | jq -r '.result.accounts | length')"
 assert_eq "account/list[0].id" "codex:max-1" "$(echo "$r" | jq -r .result.accounts[0].id)"
+assert_eq "account/list[0].liveness" "live" "$(echo "$r" | jq -r .result.accounts[0].liveness)"
 
 # 4. account/select picks max-1
-r=$(resp_for 4)
+r=$(send_rpc "$(jq -nc --arg sid "$sid" '{jsonrpc:"2.0",id:4,method:"account/select",params:{session_id:$sid,profile:"codex-max",capability:"codex-max"}}')")
 assert_eq "account/select.account" "codex:max-1" "$(echo "$r" | jq -r .result.account)"
 assert_eq "account/select.claim.level" "broker_owned" "$(echo "$r" | jq -r .result.claim.level)"
+assert_eq "account/select.claim.spare_fallback_ready" "true" "$(echo "$r" | jq -r .result.claim.spare_fallback_ready)"
+handle="$(echo "$r" | jq -r .result.credential_handle)"
 
 # 5. credential/materialize returns the JWT-decoded plan + fedramp
-r=$(resp_for 5)
+r=$(send_rpc "$(jq -nc --arg sid "$sid" --arg handle "$handle" '{jsonrpc:"2.0",id:5,method:"credential/materialize",params:{session_id:$sid,credential_handle:$handle,shape:"chatgpt_auth_tokens"}}')")
 assert_eq "credential/materialize.shape" "chatgpt_auth_tokens" "$(echo "$r" | jq -r .result.shape)"
 assert_eq "credential/materialize.access_token" "AT-smoke-1" "$(echo "$r" | jq -r .result.access_token)"
 assert_eq "credential/materialize.account_id" "acc-smoke-1" "$(echo "$r" | jq -r .result.account_id)"
@@ -139,26 +171,36 @@ assert_eq "credential/materialize.plan_type" "pro" "$(echo "$r" | jq -r .result.
 assert_eq "credential/materialize.fedramp" "true" "$(echo "$r" | jq -r .result.fedramp)"
 
 # 6. quota/observe records exhaustion
-r=$(resp_for 6)
+r=$(send_rpc "$(jq -nc --arg sid "$sid" '{jsonrpc:"2.0",id:6,method:"quota/observe",params:{session_id:$sid,account:"codex:max-1",kind:"quota_exhausted",http_status:429,body_class:"usage_limit_reached",resets_at:1788000000}}')")
 assert_eq "quota/observe.recorded" "true" "$(echo "$r" | jq -r .result.recorded)"
 assert_eq "quota/observe.now_selectable" "false" "$(echo "$r" | jq -r .result.now_selectable)"
 assert_eq "quota/observe.next_eligible_at" "1788000000" "$(echo "$r" | jq -r .result.next_eligible_at)"
 
 # 7. account/select after observe -> picks max-2 (max-1 is exhausted)
-r=$(resp_for 7)
+r=$(send_rpc "$(jq -nc --arg sid "$sid" '{jsonrpc:"2.0",id:7,method:"account/select",params:{session_id:$sid,profile:"codex-max",capability:"codex-max"}}')")
 assert_eq "account/select-post-observe" "codex:max-2" "$(echo "$r" | jq -r .result.account)"
 
-# 8. account/swap on max-2 returns max-3 with next_turn_seamless
-r=$(resp_for 8)
+# 8. account/swap on max-2 returns max-3, but does not self-promote
+# next_turn_seamless until the adapter observes the next turn complete.
+r=$(send_rpc "$(jq -nc --arg sid "$sid" '{jsonrpc:"2.0",id:8,method:"account/swap",params:{session_id:$sid,current_account:"codex:max-2",reason:"quota_exhausted",evidence:{http_status:429,resets_at:1788000000}}}')")
 assert_eq "account/swap.account" "codex:max-3" "$(echo "$r" | jq -r .result.account)"
-assert_eq "account/swap.claim.level" "next_turn_seamless" "$(echo "$r" | jq -r .result.claim.level)"
+assert_eq "account/swap.claim.level" "broker_owned" "$(echo "$r" | jq -r .result.claim.level)"
+assert_eq "account/swap.claim.requires_adapter_turn_completion" "true" "$(echo "$r" | jq -r .result.claim.requires_adapter_turn_completion)"
+assert_eq "account/swap.claim.next_turn_seamless_claimed" "false" "$(echo "$r" | jq -r .result.claim.next_turn_seamless_claimed)"
 assert_eq "account/swap.previous_marked.as" "quota_exhausted" "$(echo "$r" | jq -r .result.previous_marked.as)"
 
 # 9. quota/status reflects two exhausted + one selectable
-r=$(resp_for 9)
+r=$(send_rpc "$(jq -nc --arg sid "$sid" '{jsonrpc:"2.0",id:9,method:"quota/status",params:{session_id:$sid}}')")
 assert_eq "quota/status.selectable_count" "1" "$(echo "$r" | jq -r .result.selectable_count)"
 assert_eq "quota/status.max-1.availability" "quota_exhausted" "$(echo "$r" | jq -r '.result.accounts[] | select(.id=="codex:max-1") | .availability')"
 assert_eq "quota/status.max-3.availability" "available" "$(echo "$r" | jq -r '.result.accounts[] | select(.id=="codex:max-3") | .availability')"
 
+# 10. no selectable replacement returns typed JSON-RPC error data.
+r=$(send_rpc "$(jq -nc --arg sid "$sid" '{jsonrpc:"2.0",id:11,method:"account/swap",params:{session_id:$sid,profile:"codex-max",capability:"codex-max",current_account:"codex:max-3",reason:"quota_exhausted",evidence:{http_status:429,resets_at:1788000000}}}')")
+assert_eq "account/swap-no-replacement.error.code" "-32010" "$(echo "$r" | jq -r .error.code)"
+assert_eq "account/swap-no-replacement.error_name" "no_account_selectable" "$(echo "$r" | jq -r .error.data.error_name)"
+assert_eq "account/swap-no-replacement.selectable_routes" "0" "$(echo "$r" | jq -r .error.data.rejection_summary.selectable_routes)"
+assert_eq "account/swap-no-replacement.first_action" "oauth-mux route explain --profile codex-max --capability codex-max --json" "$(echo "$r" | jq -r .error.data.agent_safe_next_actions[0])"
+
 echo
-echo "smoke-broker: all 22 assertions passed."
+echo "smoke-broker: all assertions passed."

--- a/src/broker/methods.zig
+++ b/src/broker/methods.zig
@@ -23,6 +23,12 @@ pub const DispatchOutcome = union(enum) {
 pub const BrokerErrWithMessage = struct {
     err: types.BrokerError,
     message: []const u8,
+    data: ?std.json.Value = null,
+};
+
+const SessionLookup = union(enum) {
+    ok: []const u8,
+    err: BrokerErrWithMessage,
 };
 
 /// Top-level dispatch by method string.
@@ -76,6 +82,21 @@ fn surfaceInfo(ctx: *Context) DispatchOutcome {
     }
     obj.put("capabilities", .{ .array = caps }) catch return oom();
 
+    var detail = std.json.ObjectMap.init(ctx.allocator);
+    detail.put("account_list", .{ .bool = true }) catch return oom();
+    detail.put("account_select", .{ .bool = true }) catch return oom();
+    detail.put("account_swap", .{ .bool = true }) catch return oom();
+    detail.put("credential_materialize", .{ .bool = true }) catch return oom();
+    detail.put("credential_materialize_scope", .{ .string = "adapter_stdio_only" }) catch return oom();
+    detail.put("credential_refresh", .{ .bool = false }) catch return oom();
+    detail.put("quota_observe", .{ .bool = true }) catch return oom();
+    detail.put("quota_status", .{ .bool = true }) catch return oom();
+    detail.put("events_append", .{ .bool = false }) catch return oom();
+    detail.put("events_subscribe", .{ .bool = false }) catch return oom();
+    detail.put("policy_get", .{ .bool = true }) catch return oom();
+    detail.put("policy_request_admission", .{ .bool = false }) catch return oom();
+    obj.put("capabilities_detail", .{ .object = detail }) catch return oom();
+
     return .{ .ok = .{ .object = obj } };
 }
 
@@ -93,7 +114,7 @@ fn surfaceHandshake(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
     };
 
     const sid = ctx.sessions.newId() catch return oom();
-    defer ctx.allocator.free(sid);
+    defer ctx.sessions.allocator.free(sid);
 
     ctx.sessions.create(.{
         .id = sid,
@@ -122,7 +143,10 @@ fn surfaceHandshake(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
 fn surfaceTeardown(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
     const p = params orelse return invalidParams("missing params");
     if (p != .object) return invalidParams("params must be object");
-    const sid = strField(p.object, "session_id") orelse return invalidParams("missing session_id");
+    const sid = switch (requireSessionId(ctx, p.object)) {
+        .ok => |v| v,
+        .err => |e| return .{ .err = e },
+    };
     _ = ctx.sessions.drop(sid);
 
     var out = std.json.ObjectMap.init(ctx.allocator);
@@ -135,7 +159,10 @@ fn surfaceTeardown(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
 fn accountList(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
     const p = params orelse return invalidParams("missing params");
     if (p != .object) return invalidParams("params must be object");
-    if (strField(p.object, "session_id") == null) return invalidParams("missing session_id");
+    _ = switch (requireSessionId(ctx, p.object)) {
+        .ok => |v| v,
+        .err => |e| return .{ .err = e },
+    };
 
     // Phase 1 scope: profile/capability params are accepted but per-call
     // filtering is not applied here. The pool was already populated for
@@ -171,7 +198,10 @@ fn accountList(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
 fn accountSelect(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
     const p = params orelse return invalidParams("missing params");
     if (p != .object) return invalidParams("params must be object");
-    if (strField(p.object, "session_id") == null) return invalidParams("missing session_id");
+    const sid = switch (requireSessionId(ctx, p.object)) {
+        .ok => |v| v,
+        .err => |e| return .{ .err = e },
+    };
 
     const profile = strField(p.object, "profile");
     const capability = strField(p.object, "capability");
@@ -187,8 +217,12 @@ fn accountSelect(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
         }
     }
 
-    const elected = ctx.pool.elect(profile, capability, excl_buf.items) catch |e| return .{
-        .err = .{ .err = e, .message = "no selectable account" },
+    const elected = ctx.pool.elect(profile, capability, excl_buf.items) catch |e| switch (e) {
+        error.NoAccountSelectable => return noAccountSelectable(ctx, "no selectable account", profile, capability),
+        else => return .{ .err = .{ .err = e, .message = "account election failed" } },
+    };
+    ctx.sessions.setCurrentAccount(sid, elected.id) catch |e| return .{
+        .err = .{ .err = e, .message = "session update failed" },
     };
 
     var out = std.json.ObjectMap.init(ctx.allocator);
@@ -205,7 +239,7 @@ fn accountSelect(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
 
     var claim_obj = std.json.ObjectMap.init(ctx.allocator);
     claim_obj.put("level", .{ .string = "broker_owned" }) catch return oom();
-    claim_obj.put("spare_fallback_ready", .{ .bool = false }) catch return oom();
+    claim_obj.put("spare_fallback_ready", .{ .bool = anotherSelectableExists(ctx.pool, elected.id) }) catch return oom();
     out.put("claim", .{ .object = claim_obj }) catch return oom();
 
     return .{ .ok = .{ .object = out } };
@@ -241,10 +275,15 @@ fn intField(obj: std.json.ObjectMap, key: []const u8) ?i64 {
 fn accountSwap(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
     const p = params orelse return invalidParams("missing params");
     if (p != .object) return invalidParams("params must be object");
-    if (strField(p.object, "session_id") == null) return invalidParams("missing session_id");
+    const sid = switch (requireSessionId(ctx, p.object)) {
+        .ok => |v| v,
+        .err => |e| return .{ .err = e },
+    };
 
     const current = strField(p.object, "current_account") orelse
         return invalidParams("missing current_account");
+    const profile = strField(p.object, "profile");
+    const capability = strField(p.object, "capability");
     const reason_str = strField(p.object, "reason") orelse "quota_exhausted";
     const reason = parseSwapReason(reason_str);
 
@@ -283,8 +322,12 @@ fn accountSwap(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
 
     // Elect a replacement, excluding the current account.
     const exclude = [_][]const u8{current};
-    const elected = ctx.pool.elect(null, null, exclude[0..]) catch |e| return .{
-        .err = .{ .err = e, .message = "no replacement account selectable" },
+    const elected = ctx.pool.elect(profile, capability, exclude[0..]) catch |e| switch (e) {
+        error.NoAccountSelectable => return noAccountSelectable(ctx, "no replacement account selectable", profile, capability),
+        else => return .{ .err = .{ .err = e, .message = "replacement election failed" } },
+    };
+    ctx.sessions.setCurrentAccount(sid, elected.id) catch |e| return .{
+        .err = .{ .err = e, .message = "session update failed" },
     };
 
     // Build response.
@@ -298,8 +341,12 @@ fn accountSwap(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
     out.put("credential_handle", .{ .string = handle }) catch return oom();
 
     var claim_obj = std.json.ObjectMap.init(ctx.allocator);
-    claim_obj.put("level", .{ .string = "next_turn_seamless" }) catch return oom();
+    claim_obj.put("level", .{ .string = "broker_owned" }) catch return oom();
     claim_obj.put("spare_fallback_ready", .{ .bool = anotherSelectableExists(ctx.pool, elected.id) }) catch return oom();
+    claim_obj.put("replacement_selected", .{ .bool = true }) catch return oom();
+    claim_obj.put("requires_adapter_turn_completion", .{ .bool = true }) catch return oom();
+    claim_obj.put("next_turn_seamless_claimed", .{ .bool = false }) catch return oom();
+    claim_obj.put("pending_success_level", .{ .string = "next_turn_seamless" }) catch return oom();
     out.put("claim", .{ .object = claim_obj }) catch return oom();
 
     var prev_obj = std.json.ObjectMap.init(ctx.allocator);
@@ -317,7 +364,7 @@ fn accountSwap(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
 fn anotherSelectableExists(pool: anytype, except_id: []const u8) bool {
     var count: usize = 0;
     for (pool.accounts.items) |a| {
-        if (a.selectable and !std.mem.eql(u8, a.id, except_id)) {
+        if (a.selectable and a.availability == .available and !std.mem.eql(u8, a.id, except_id)) {
             count += 1;
             if (count >= 1) return true;
         }
@@ -331,7 +378,10 @@ fn anotherSelectableExists(pool: anytype, except_id: []const u8) bool {
 fn quotaObserve(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
     const p = params orelse return invalidParams("missing params");
     if (p != .object) return invalidParams("params must be object");
-    if (strField(p.object, "session_id") == null) return invalidParams("missing session_id");
+    _ = switch (requireSessionId(ctx, p.object)) {
+        .ok => |v| v,
+        .err => |e| return .{ .err = e },
+    };
 
     const account = strField(p.object, "account") orelse
         return invalidParams("missing account");
@@ -394,7 +444,10 @@ fn quotaObserve(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
 fn quotaStatus(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
     const p = params orelse return invalidParams("missing params");
     if (p != .object) return invalidParams("params must be object");
-    if (strField(p.object, "session_id") == null) return invalidParams("missing session_id");
+    _ = switch (requireSessionId(ctx, p.object)) {
+        .ok => |v| v,
+        .err => |e| return .{ .err = e },
+    };
 
     var arr = std.json.Array.init(ctx.allocator);
     var selectable_count: usize = 0;
@@ -433,7 +486,10 @@ fn accountIdFromHandle(handle: []const u8) ?[]const u8 {
 fn credentialMaterialize(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
     const p = params orelse return invalidParams("missing params");
     if (p != .object) return invalidParams("params must be object");
-    if (strField(p.object, "session_id") == null) return invalidParams("missing session_id");
+    _ = switch (requireSessionId(ctx, p.object)) {
+        .ok => |v| v,
+        .err => |e| return .{ .err = e },
+    };
 
     const handle = strField(p.object, "credential_handle") orelse
         return invalidParams("missing credential_handle");
@@ -474,7 +530,12 @@ fn credentialMaterialize(ctx: *Context, params: ?std.json.Value) DispatchOutcome
 // ── policy/* ──────────────────────────────────────────────────────────
 
 fn policyGet(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
-    _ = params;
+    const p = params orelse return invalidParams("missing params");
+    if (p != .object) return invalidParams("params must be object");
+    _ = switch (requireSessionId(ctx, p.object)) {
+        .ok => |v| v,
+        .err => |e| return .{ .err = e },
+    };
     var out = std.json.ObjectMap.init(ctx.allocator);
     var budgets = std.json.Array.init(ctx.allocator);
     budgets.append(.{ .string = "free_local" }) catch return oom();
@@ -493,12 +554,115 @@ fn strField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
     return if (v == .string) v.string else null;
 }
 
+fn requireSessionId(ctx: *Context, obj: std.json.ObjectMap) SessionLookup {
+    const sid = strField(obj, "session_id") orelse return .{
+        .err = .{ .err = error.InvalidParams, .message = "missing session_id" },
+    };
+    if (ctx.sessions.getPtr(sid) == null) return .{
+        .err = .{ .err = error.SessionNotFound, .message = "unknown session_id" },
+    };
+    return .{ .ok = sid };
+}
+
 fn invalidParams(msg: []const u8) DispatchOutcome {
     return .{ .err = .{ .err = error.InvalidParams, .message = msg } };
 }
 
 fn oom() DispatchOutcome {
     return .{ .err = .{ .err = error.OutOfMemory, .message = "out of memory" } };
+}
+
+fn noAccountSelectable(
+    ctx: *Context,
+    msg: []const u8,
+    profile: ?[]const u8,
+    capability: ?[]const u8,
+) DispatchOutcome {
+    var summary = std.json.ObjectMap.init(ctx.allocator);
+    var total: i64 = 0;
+    var selectable: i64 = 0;
+    var available: i64 = 0;
+    var quota_exhausted: i64 = 0;
+    var rate_limited: i64 = 0;
+    var dead: i64 = 0;
+    var degraded: i64 = 0;
+    var unknown: i64 = 0;
+    var hidden: i64 = 0;
+
+    for (ctx.pool.accounts.items) |a| {
+        if (!a.selectable and a.liveness == .unknown and a.availability == .available) {
+            hidden += 1;
+            continue;
+        }
+        total += 1;
+        if (a.selectable) selectable += 1;
+        switch (a.availability) {
+            .available => available += 1,
+            .quota_exhausted => quota_exhausted += 1,
+            .rate_limited => rate_limited += 1,
+            .cooldown => rate_limited += 1,
+            .unknown => {},
+        }
+        switch (a.liveness) {
+            .dead => dead += 1,
+            .degraded => degraded += 1,
+            .unknown => unknown += 1,
+            .live => {},
+        }
+    }
+
+    summary.put("total_routes", .{ .integer = total }) catch return oom();
+    summary.put("selectable_routes", .{ .integer = selectable }) catch return oom();
+    summary.put("available_routes", .{ .integer = available }) catch return oom();
+    summary.put("quota_exhausted_routes", .{ .integer = quota_exhausted }) catch return oom();
+    summary.put("rate_limited_routes", .{ .integer = rate_limited }) catch return oom();
+    summary.put("dead_routes", .{ .integer = dead }) catch return oom();
+    summary.put("degraded_routes", .{ .integer = degraded }) catch return oom();
+    summary.put("unknown_routes", .{ .integer = unknown }) catch return oom();
+    summary.put("hidden_routes", .{ .integer = hidden }) catch return oom();
+
+    var data = std.json.ObjectMap.init(ctx.allocator);
+    data.put("error_name", .{ .string = "no_account_selectable" }) catch return oom();
+    if (profile) |p| {
+        data.put("profile", .{ .string = p }) catch return oom();
+    } else {
+        data.put("profile", .{ .null = {} }) catch return oom();
+    }
+    if (capability) |c| {
+        data.put("capability", .{ .string = c }) catch return oom();
+    } else {
+        data.put("capability", .{ .null = {} }) catch return oom();
+    }
+    data.put("rejection_summary", .{ .object = summary }) catch return oom();
+
+    var actions = std.json.Array.init(ctx.allocator);
+    actions.append(.{ .string = routeDiagnosticCommand(ctx.allocator, "route explain", profile, capability) catch return oom() }) catch return oom();
+    actions.append(.{ .string = routeDiagnosticCommand(ctx.allocator, "repair-plan", profile, capability) catch return oom() }) catch return oom();
+    data.put("agent_safe_next_actions", .{ .array = actions }) catch return oom();
+
+    return .{ .err = .{
+        .err = error.NoAccountSelectable,
+        .message = msg,
+        .data = .{ .object = data },
+    } };
+}
+
+fn routeDiagnosticCommand(
+    allocator: std.mem.Allocator,
+    base: []const u8,
+    profile: ?[]const u8,
+    capability: ?[]const u8,
+) ![]const u8 {
+    if (profile) |p| {
+        if (capability) |c| {
+            return std.fmt.allocPrint(allocator, "oauth-mux {s} --profile {s} --capability {s} --json", .{ base, p, c });
+        }
+        return std.fmt.allocPrint(allocator, "oauth-mux {s} --profile {s} --json", .{ base, p });
+    }
+    if (capability) |c| {
+        return std.fmt.allocPrint(allocator, "oauth-mux {s} --capability {s} --json", .{ base, c });
+    }
+    return std.fmt.allocPrint(allocator, "oauth-mux {s} --json", .{base});
 }
 
 test "dispatch surface/info returns object with surface_version=1" {
@@ -596,6 +760,69 @@ test "surface/handshake without adapter returns InvalidParams" {
         .err => |e| try std.testing.expectEqual(error.InvalidParams, e.err),
         else => return error.TestFailed,
     }
+}
+
+test "account methods reject unknown session ids" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var sessions = session_mod.SessionTable.init(arena.allocator());
+    var pool = account_pool_mod.AccountPool.init(arena.allocator());
+    var stderr_buf: [0]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(stderr_buf[0..]);
+    var ctx = Context{
+        .allocator = arena.allocator(),
+        .sessions = &sessions,
+        .pool = &pool,
+        .materializer = null,
+        .log_writer = fbs.writer().any(),
+    };
+
+    var obj = std.json.ObjectMap.init(arena.allocator());
+    try obj.put("session_id", .{ .string = "not-real" });
+    const out = dispatch(&ctx, "account/list", .{ .object = obj });
+    switch (out) {
+        .err => |e| try std.testing.expectEqual(error.SessionNotFound, e.err),
+        .ok => return error.TestFailed,
+    }
+}
+
+test "account/select records current account on the broker session" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    var sessions = session_mod.SessionTable.init(arena.allocator());
+    var pool = account_pool_mod.AccountPool.init(arena.allocator());
+    try pool.add(.{ .id = "codex:max-1", .selectable = true, .liveness = .live, .availability = .available });
+    try pool.add(.{ .id = "codex:max-2", .selectable = true, .liveness = .live, .availability = .available });
+    var stderr_buf: [0]u8 = undefined;
+    var fbs = std.io.fixedBufferStream(stderr_buf[0..]);
+    var ctx = Context{
+        .allocator = arena.allocator(),
+        .sessions = &sessions,
+        .pool = &pool,
+        .materializer = null,
+        .log_writer = fbs.writer().any(),
+    };
+
+    const sid = try sessions.newId();
+    defer sessions.allocator.free(sid);
+    try sessions.create(.{
+        .id = sid,
+        .adapter = "smoke",
+        .adapter_version = "0",
+        .harness_target = "codex",
+        .session_pid = 1,
+        .claim_floor = .broker_owned,
+        .started_at_ms = std.time.milliTimestamp(),
+    });
+
+    var obj = std.json.ObjectMap.init(arena.allocator());
+    try obj.put("session_id", .{ .string = sid });
+    const out = dispatch(&ctx, "account/select", .{ .object = obj });
+    switch (out) {
+        .ok => {},
+        .err => return error.TestFailed,
+    }
+    try std.testing.expectEqualStrings("codex:max-1", sessions.get(sid).?.current_account.?);
 }
 
 test "accountIdFromHandle property: round-trip with 200 random ids" {

--- a/src/broker/server.zig
+++ b/src/broker/server.zig
@@ -148,24 +148,24 @@ pub const Server = struct {
     ) !void {
         _ = self;
         var parsed = std.json.parseFromSlice(std.json.Value, ctx.allocator, line, .{}) catch {
-            try writeError(writer, null, .parse_error, "parse error");
+            try writeError(writer, null, .parse_error, "parse error", null);
             return;
         };
         defer parsed.deinit();
 
         const root = parsed.value;
         if (root != .object) {
-            try writeError(writer, null, .invalid_request, "request must be an object");
+            try writeError(writer, null, .invalid_request, "request must be an object", null);
             return;
         }
 
         const obj = root.object;
         const method_v = obj.get("method") orelse {
-            try writeError(writer, obj.get("id"), .invalid_request, "missing method");
+            try writeError(writer, obj.get("id"), .invalid_request, "missing method", null);
             return;
         };
         if (method_v != .string) {
-            try writeError(writer, obj.get("id"), .invalid_request, "method must be a string");
+            try writeError(writer, obj.get("id"), .invalid_request, "method must be a string", null);
             return;
         }
 
@@ -181,7 +181,7 @@ pub const Server = struct {
             },
             .err => |berr| {
                 const code = ErrorCode.fromBrokerError(berr.err);
-                try writeError(writer, req_id, code, berr.message);
+                try writeError(writer, req_id, code, berr.message, berr.data);
             },
         }
     }
@@ -200,7 +200,7 @@ fn writeOk(writer: anytype, id: std.json.Value, result: std.json.Value) !void {
     try writer.writeByte('\n');
 }
 
-fn writeError(writer: anytype, id: ?std.json.Value, code: ErrorCode, msg: []const u8) !void {
+fn writeError(writer: anytype, id: ?std.json.Value, code: ErrorCode, msg: []const u8, data: ?std.json.Value) !void {
     var sw = std.json.writeStream(writer, .{});
     try sw.beginObject();
     try sw.objectField("jsonrpc");
@@ -213,6 +213,10 @@ fn writeError(writer: anytype, id: ?std.json.Value, code: ErrorCode, msg: []cons
     try sw.write(@intFromEnum(code));
     try sw.objectField("message");
     try sw.write(msg);
+    if (data) |v| {
+        try sw.objectField("data");
+        try sw.write(v);
+    }
     try sw.endObject();
     try sw.endObject();
     try writer.writeByte('\n');

--- a/src/broker/session.zig
+++ b/src/broker/session.zig
@@ -64,11 +64,26 @@ pub const SessionTable = struct {
         owned.adapter = try self.allocator.dupe(u8, s.adapter);
         owned.adapter_version = try self.allocator.dupe(u8, s.adapter_version);
         owned.harness_target = try self.allocator.dupe(u8, s.harness_target);
+        owned.current_account = if (s.current_account) |account|
+            try self.allocator.dupe(u8, account)
+        else
+            null;
         try self.map.put(owned_id, owned);
     }
 
     pub fn get(self: *SessionTable, id: []const u8) ?Session {
         return self.map.get(id);
+    }
+
+    pub fn getPtr(self: *SessionTable, id: []const u8) ?*Session {
+        return self.map.getPtr(id);
+    }
+
+    pub fn setCurrentAccount(self: *SessionTable, id: []const u8, account: []const u8) types.BrokerError!void {
+        const session = self.getPtr(id) orelse return types.BrokerError.SessionNotFound;
+        const owned_account = self.allocator.dupe(u8, account) catch return types.BrokerError.OutOfMemory;
+        if (session.current_account) |old| self.allocator.free(old);
+        session.current_account = owned_account;
     }
 
     pub fn drop(self: *SessionTable, id: []const u8) bool {
@@ -135,4 +150,30 @@ test "SessionTable create/get/drop" {
 
     try std.testing.expect(t.drop(id));
     try std.testing.expect(t.get(id) == null);
+}
+
+test "SessionTable setCurrentAccount replaces owned account state" {
+    var t = SessionTable.init(std.testing.allocator);
+    defer t.deinit();
+
+    const id = try t.newId();
+    defer std.testing.allocator.free(id);
+
+    try t.create(.{
+        .id = id,
+        .adapter = "codex",
+        .adapter_version = "0.1.0",
+        .harness_target = "codex 0.128.0",
+        .session_pid = 1234,
+        .claim_floor = .broker_owned,
+        .started_at_ms = std.time.milliTimestamp(),
+    });
+
+    try t.setCurrentAccount(id, "codex:max-1");
+    try std.testing.expectEqualStrings("codex:max-1", t.get(id).?.current_account.?);
+
+    try t.setCurrentAccount(id, "codex:max-2");
+    try std.testing.expectEqualStrings("codex:max-2", t.get(id).?.current_account.?);
+
+    try std.testing.expectError(types.BrokerError.SessionNotFound, t.setCurrentAccount("missing", "codex:max-3"));
 }

--- a/src/broker_loader.zig
+++ b/src/broker_loader.zig
@@ -79,8 +79,18 @@ pub fn populatePoolFromRouteHealth(
     profile_name: ?[]const u8,
     store: *health_mod.HealthStore,
 ) !void {
+    try populatePoolFromRouteHealthScoped(pool, cfg, profile_name, null, store);
+}
+
+pub fn populatePoolFromRouteHealthScoped(
+    pool: *broker.AccountPool,
+    cfg: config_mod.Config,
+    profile_name: ?[]const u8,
+    capability_name: ?[]const u8,
+    store: *health_mod.HealthStore,
+) !void {
     try populatePool(pool, cfg, profile_name);
-    applyRouteHealth(pool, cfg, profile_name, store);
+    applyRouteHealth(pool, cfg, profile_name, capability_name, store);
 }
 
 pub const CodexAuthRepairSummary = struct {
@@ -142,11 +152,12 @@ fn applyRouteHealth(
     pool: *broker.AccountPool,
     cfg: config_mod.Config,
     profile_name: ?[]const u8,
+    capability_name: ?[]const u8,
     store: *health_mod.HealthStore,
 ) void {
     for (pool.accounts.items) |*entry| {
         if (!entry.selectable) continue;
-        const route_health = routeHealthForPoolAccount(pool.allocator, cfg, profile_name, entry.id, store) orelse {
+        const route_health = routeHealthForPoolAccount(pool.allocator, cfg, profile_name, capability_name, entry.id, store) orelse {
             entry.selectable = false;
             entry.liveness = .unknown;
             entry.availability = .unknown;
@@ -160,6 +171,7 @@ fn routeHealthForPoolAccount(
     allocator: std.mem.Allocator,
     cfg: config_mod.Config,
     profile_name: ?[]const u8,
+    requested_capability: ?[]const u8,
     account_id: []const u8,
     store: *health_mod.HealthStore,
 ) ?health_mod.AccountHealth {
@@ -184,6 +196,9 @@ fn routeHealthForPoolAccount(
                 const head = profile_entry[0..hash];
                 if (!std.mem.eql(u8, head, account_id)) continue;
                 const capability = profile_entry[hash + 1 ..];
+                if (requested_capability) |want| {
+                    if (!std.mem.eql(u8, capability, want)) continue;
+                }
                 const capability_key = health_mod.capabilityKey(provider, account, capability);
                 if (store.accounts.get(capability_key.slice())) |capability_health| {
                     const effective = health_mod.effectiveHealthForRouteSelection(capability_health, now);
@@ -194,6 +209,18 @@ fn routeHealthForPoolAccount(
                     return effective;
                 }
             }
+        }
+    }
+
+    if (requested_capability) |capability| {
+        const capability_key = health_mod.capabilityKey(provider, account, capability);
+        if (store.accounts.get(capability_key.slice())) |capability_health| {
+            const effective = health_mod.effectiveHealthForRouteSelection(capability_health, now);
+            tracePoolHealthNormalization(allocator, provider, account, capability, "capability", capability_health.liveness, effective.liveness);
+            if (accountLivenessBlocksRoute(effective.liveness)) {
+                if (authMaterialRepairHealth(allocator, cfg, provider, account, capability_health)) |repaired| return repaired;
+            }
+            return effective;
         }
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -95,7 +95,10 @@ pub fn main() !void {
             var server = broker.Server.init(allocator);
             defer server.deinit();
 
-            broker_loader.populatePool(&server.pool, parsed.value, mcp_args.profile) catch |e| {
+            var route_health = health_mod.HealthStore.load(allocator, .{});
+            defer route_health.deinit();
+
+            broker_loader.populatePoolFromRouteHealthScoped(&server.pool, parsed.value, mcp_args.profile, mcp_args.capability, &route_health) catch |e| {
                 log.err("mcp: pool populate: {s}", .{@errorName(e)});
                 std.process.exit(types.ExitCode.general_error.int());
             };
@@ -103,10 +106,11 @@ pub fn main() !void {
             var mat_ctx = broker_loader.ChatgptMaterializerCtx{ .cfg = &parsed.value };
             server.setMaterializer(mat_ctx.vtable());
 
-            log.info("mcp: broker surface_version={d} accounts={d} profile={s}", .{
+            log.info("mcp: broker surface_version={d} accounts={d} profile={s} capability={s}", .{
                 broker.SURFACE_VERSION,
                 server.pool.accounts.items.len,
                 mcp_args.profile orelse "(none)",
+                mcp_args.capability orelse "(none)",
             });
 
             server.runStdio() catch |e| {


### PR DESCRIPTION
## Summary

- enforce real broker MCP session ids and track the selected session account
- make `oauth-mux mcp` use route-health-backed pool population with capability scoping
- keep `account/swap` at `broker_owned` until adapter-observed next-turn completion, and return typed `no_account_selectable` error data
- refresh broker/adapter docs and the broker smoke for the stricter contract

Refs #67.

## Validation

- `git diff --check`
- `zig build test`
- `zig build`
- `./scripts/smoke-broker.sh`
- `./scripts/smoke-codex-status-summary.sh`
- `./scripts/smoke-codex-concurrent-sessions.sh`
- `./scripts/smoke-codex-cli-ux.sh`
- `nix develop --command just check-local`

No provider calls; all validation was local/stub/no-spend.