### PR TITLE
Tighten broker discovery truth

### DIFF
--- a/docs/spec/broker-mcp-contract-2026-05-03.md
+++ b/docs/spec/broker-mcp-contract-2026-05-03.md
@@ -127,9 +127,11 @@ The broker exposes its surface as **MCP server methods over stdio**. JSON-RPC
 3. The protocol is versioned and auditable. A Codex protocol drift won't
    silently break adapters that were correctly speaking the broker contract.
 
-Concretely: the broker process can be invoked as
-`oauth-mux mcp` for stdio MCP clients, and as a long-lived daemon for
-adapter children. Both speak the same method surface.
+Concretely: the broker process can be invoked as `oauth-mux mcp` for stdio MCP
+clients today. A future daemon/unix transport must speak the same method
+surface before it is advertised as a broker host; the current daemon socket
+remains experimental status/control plumbing and must not be treated as the
+broker MCP transport.
 
 ### 1.3 The user-facing entrypoints become the adapters
 
@@ -177,8 +179,14 @@ declared capabilities.
 {
   "surface_version": 1,
   "build": "oauth-mux 0.2.0+broker",
-  "transports": ["stdio", "unix"],
-  "capabilities": ["accounts", "quota", "refresh", "events", "policy"],
+  "transports": ["stdio"],
+  "transport_detail": {
+    "stdio_broker": true,
+    "unix_broker": false,
+    "daemon_socket_contract": "experimental_socket_stub",
+    "daemon_hosts_broker": false
+  },
+  "capabilities": ["accounts", "quota", "credentials", "policy"],
   "capabilities_detail": {
     "account_list": true,
     "account_select": true,
@@ -431,8 +439,11 @@ JSON entirely; restart is not a claim, it is a non-event.
 bare `codex`.
 **Deliverables:**
 - `oauth-mux mcp` exposes `surface/info`, `surface/handshake`,
-  `account/list`, `account/select`, `credential/materialize`, `events/*`,
-  `policy/get`. Stdio transport only.
+  `account/list`, `account/select`, `account/swap`,
+  `credential/materialize`, `quota/observe`, `quota/status`, and
+  `policy/get`. Stdio transport only. `credential/refresh`, `events/*`,
+  and policy admission return typed not-implemented responses until later
+  slices wire those capabilities.
 - `oauth-mux codex` adapter: spawns `codex app-server --listen stdio://`,
   drives the JSON-RPC, renders a thin terminal pass-through, materializes
   one selected account's tokens via the broker.

--- a/scripts/smoke-broker.sh
+++ b/scripts/smoke-broker.sh
@@ -136,7 +136,14 @@ assert_eq() {
 r=$(send_rpc '{"jsonrpc":"2.0","id":1,"method":"surface/info"}')
 assert_eq "surface/info.surface_version" "1" "$(echo "$r" | jq -r .result.surface_version)"
 assert_eq "surface/info.transports[0]"   "stdio" "$(echo "$r" | jq -r .result.transports[0])"
+assert_eq "surface/info.transports length" "1" "$(echo "$r" | jq -r '.result.transports | length')"
+assert_eq "surface/info.unix_broker" "false" "$(echo "$r" | jq -r .result.transport_detail.unix_broker)"
+assert_eq "surface/info.daemon_hosts_broker" "false" "$(echo "$r" | jq -r .result.transport_detail.daemon_hosts_broker)"
+assert_eq "surface/info.no refresh capability overclaim" "false" "$(echo "$r" | jq -r '.result.capabilities | index("refresh") != null')"
+assert_eq "surface/info.no events capability overclaim" "false" "$(echo "$r" | jq -r '.result.capabilities | index("events") != null')"
 assert_eq "surface/info.credential_materialize_scope" "adapter_stdio_only" "$(echo "$r" | jq -r .result.capabilities_detail.credential_materialize_scope)"
+assert_eq "surface/info.credential_refresh disabled" "false" "$(echo "$r" | jq -r .result.capabilities_detail.credential_refresh)"
+assert_eq "surface/info.events_append disabled" "false" "$(echo "$r" | jq -r .result.capabilities_detail.events_append)"
 
 # 1b. session validation rejects unknown ids before handshake.
 r=$(send_rpc '{"jsonrpc":"2.0","id":10,"method":"account/list","params":{"session_id":"not-real"}}')

--- a/src/broker/methods.zig
+++ b/src/broker/methods.zig
@@ -73,11 +73,17 @@ fn surfaceInfo(ctx: *Context) DispatchOutcome {
 
     var transports = std.json.Array.init(ctx.allocator);
     transports.append(.{ .string = "stdio" }) catch return oom();
-    transports.append(.{ .string = "unix" }) catch return oom();
     obj.put("transports", .{ .array = transports }) catch return oom();
 
+    var transport_detail = std.json.ObjectMap.init(ctx.allocator);
+    transport_detail.put("stdio_broker", .{ .bool = true }) catch return oom();
+    transport_detail.put("unix_broker", .{ .bool = false }) catch return oom();
+    transport_detail.put("daemon_socket_contract", .{ .string = "experimental_socket_stub" }) catch return oom();
+    transport_detail.put("daemon_hosts_broker", .{ .bool = false }) catch return oom();
+    obj.put("transport_detail", .{ .object = transport_detail }) catch return oom();
+
     var caps = std.json.Array.init(ctx.allocator);
-    inline for (.{ "accounts", "quota", "refresh", "events", "policy" }) |c| {
+    inline for (.{ "accounts", "quota", "credentials", "policy" }) |c| {
         caps.append(.{ .string = c }) catch return oom();
     }
     obj.put("capabilities", .{ .array = caps }) catch return oom();
@@ -693,6 +699,33 @@ test "dispatch surface/info returns object with surface_version=1" {
             const sv = v.object.get("surface_version") orelse return error.TestFailed;
             try std.testing.expect(sv == .integer);
             try std.testing.expectEqual(@as(i64, 1), sv.integer);
+
+            const transports = v.object.get("transports") orelse return error.TestFailed;
+            try std.testing.expect(transports == .array);
+            try std.testing.expectEqual(@as(usize, 1), transports.array.items.len);
+            try std.testing.expectEqualStrings("stdio", transports.array.items[0].string);
+
+            const transport_detail = v.object.get("transport_detail") orelse return error.TestFailed;
+            try std.testing.expect(transport_detail == .object);
+            try std.testing.expectEqual(false, transport_detail.object.get("unix_broker").?.bool);
+            try std.testing.expectEqual(false, transport_detail.object.get("daemon_hosts_broker").?.bool);
+            try std.testing.expectEqualStrings(
+                "experimental_socket_stub",
+                transport_detail.object.get("daemon_socket_contract").?.string,
+            );
+
+            const caps = v.object.get("capabilities") orelse return error.TestFailed;
+            try std.testing.expect(caps == .array);
+            for (caps.array.items) |cap| {
+                try std.testing.expect(cap == .string);
+                try std.testing.expect(!std.mem.eql(u8, cap.string, "refresh"));
+                try std.testing.expect(!std.mem.eql(u8, cap.string, "events"));
+            }
+            const detail = v.object.get("capabilities_detail") orelse return error.TestFailed;
+            try std.testing.expect(detail == .object);
+            try std.testing.expectEqual(false, detail.object.get("credential_refresh").?.bool);
+            try std.testing.expectEqual(false, detail.object.get("events_append").?.bool);
+            try std.testing.expectEqual(false, detail.object.get("events_subscribe").?.bool);
         },
         .err => return error.TestFailed,
     }


### PR DESCRIPTION
## Summary

- make `surface/info` advertise only the currently implemented stdio broker transport
- add `transport_detail` so adapters can see the daemon socket is still `experimental_socket_stub` and not a broker MCP host
- remove top-level refresh/events capability overclaims while keeping disabled detail fields for typed discovery
- update the broker contract and broker smoke assertions

## Validation

- `git diff --check`
- `zig build test`
- `zig build && ./scripts/smoke-broker.sh`
- `nix develop --command just check-local`

Part of #67.