### PR TITLE
Fix Codex cassette text replay fidelity

### DIFF
--- a/docs/spec/codex-wire-evidence-2026-05-03.md
+++ b/docs/spec/codex-wire-evidence-2026-05-03.md
@@ -27,7 +27,7 @@ TIN-950 adds the capture/replay tooling only:
   summarizes endpoint/status coverage, extracts 429 quota shapes, and
   fails on obvious secret-like values before a capture is promoted.
 - `scripts/test-cassette-upstream.py` replays reviewed capture JSON by
-  `(method, path)`.
+  `(method, path)`, ignoring query strings for route matching.
 - `just smoke-codex-cassette-replay` proves the replayer on a tiny
   synthetic cassette without provider traffic.
 - `just smoke-codex-capture-review` pins the offline reviewer: scrubbed
@@ -67,7 +67,11 @@ evidence:
 4. Manually inspect the fixture-sized JSON selected for promotion.
    The reviewer catches obvious token/JWT/API-key strings; it is not a
    formal proof that all account-identifying material is gone.
-5. Commit only scrubbed per-flow JSON. Do not commit
+5. Textual non-JSON responses such as `text/event-stream` may include
+   `body_text` so the cassette replayer can serve realistic SSE frames.
+   Keep only reviewed, fixture-sized text bodies and remove prompt,
+   transcript, or account-identifying content before promotion.
+6. Commit only scrubbed per-flow JSON. Do not commit
    `captures/**/flows.binary`.
 
 ## 1. Endpoints Observed

--- a/scripts/codex-wire-addon.py
+++ b/scripts/codex-wire-addon.py
@@ -15,6 +15,9 @@ Redactions:
   - Body fields tokens.access_token / refresh_token / id_token: replace
     with sha256(value)[:10] (so swap-correctness can be argued from the
     capture without leaking material)
+  - Textual non-JSON response bodies such as text/event-stream are kept
+    as body_text for replay fidelity and must be manually reviewed before
+    fixture promotion.
 """
 
 from __future__ import annotations
@@ -48,6 +51,12 @@ HASH_REDACT_KEYS = {
     "accountId",
     "account_id",
 }
+
+TEXTUAL_CONTENT_TYPES = (
+    "text/event-stream",
+    "text/plain",
+    "application/x-ndjson",
+)
 
 
 def _hash10(s: str) -> str:
@@ -91,11 +100,28 @@ def _redact_obj(node: Any) -> Any:
     return node
 
 
-def _safe_json(b: bytes) -> Any:
+def _is_textual_content_type(content_type: str) -> bool:
+    low = content_type.split(";", 1)[0].strip().lower()
+    if low in TEXTUAL_CONTENT_TYPES:
+        return True
+    if low.endswith("+json"):
+        return True
+    return False
+
+
+def _safe_body(b: bytes, content_type: str) -> Any:
     try:
         return json.loads(b.decode("utf-8"))
     except Exception:
-        return {"__non_json__": True, "len": len(b), "head_hex": b[:64].hex()}
+        out: dict[str, Any] = {
+            "__non_json__": True,
+            "len": len(b),
+            "head_hex": b[:64].hex(),
+        }
+        if b and _is_textual_content_type(content_type):
+            out["text_encoding"] = "utf-8"
+            out["body_text"] = b.decode("utf-8", "replace")
+        return out
 
 
 class CodexWireAddon:
@@ -138,8 +164,14 @@ class CodexWireAddon:
         req_headers = [(k, _redact_header(k, v)) for k, v in flow.request.headers.items()]
         resp_headers = [(k, _redact_header(k, v)) for k, v in flow.response.headers.items()]
 
-        req_body = _redact_obj(_safe_json(flow.request.raw_content or b""))
-        resp_body = _redact_obj(_safe_json(flow.response.raw_content or b""))
+        req_body = _redact_obj(_safe_body(
+            flow.request.raw_content or b"",
+            flow.request.headers.get("content-type", ""),
+        ))
+        resp_body = _redact_obj(_safe_body(
+            flow.response.raw_content or b"",
+            flow.response.headers.get("content-type", ""),
+        ))
 
         record = {
             "captured_at": time.time(),

--- a/scripts/smoke-codex-capture-review.sh
+++ b/scripts/smoke-codex-capture-review.sh
@@ -40,6 +40,36 @@ cat >"$CAP/00001-POST-backend-api_codex_responses.json" <<'JSON'
 }
 JSON
 
+cat >"$CAP/00002-POST-backend-api_codex_responses.json" <<'JSON'
+{
+  "captured_at": 1788000000.5,
+  "host": "chatgpt.com",
+  "scheme": "https",
+  "method": "POST",
+  "path": "/backend-api/codex/responses?captured=query",
+  "request": {
+    "headers": [
+      ["Authorization", "Bearer abcdef-<0123456789>"],
+      ["ChatGPT-Account-ID", "acct-a-<abcdef0123>"]
+    ],
+    "body": {"model": "gpt-5.5"}
+  },
+  "response": {
+    "status": 200,
+    "reason": "OK",
+    "headers": [["content-type", "text/event-stream"]],
+    "body": {
+      "__non_json__": true,
+      "len": 62,
+      "head_hex": "6576656e743a20726573706f6e73652e636f6d706c657465640a646174613a207b2274797065223a22726573706f6e73652e636f6d706c65746564227d0a0a",
+      "text_encoding": "utf-8",
+      "body_text": "event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n"
+    }
+  },
+  "timing_ms": 24
+}
+JSON
+
 python3 "$ROOT/scripts/review-codex-wire-capture.py" "$TMP/codex-wire-synth" --json >"$TMP/summary.json"
 
 python3 - "$TMP/summary.json" <<'PY'
@@ -47,8 +77,9 @@ import json
 import sys
 summary = json.load(open(sys.argv[1]))
 assert summary["ok"] is True, summary
-assert summary["flow_count"] == 1, summary
-assert summary["path_counts"]["responses"] == 1, summary
+assert summary["flow_count"] == 2, summary
+assert summary["path_counts"]["responses"] == 2, summary
+assert summary["status_counts"]["200"] == 1, summary
 assert summary["status_counts"]["429"] == 1, summary
 shape = summary["quota_shapes"][0]
 assert shape["error_type"] == "usage_limit_reached", shape
@@ -56,7 +87,7 @@ assert shape["has_resets_at"] is True, shape
 assert shape["plan_type"] == "pro", shape
 PY
 
-cat >"$CAP/00002-POST-secret-leak.json" <<'JSON'
+cat >"$CAP/00003-POST-secret-leak.json" <<'JSON'
 {
   "captured_at": 1788000001.0,
   "host": "chatgpt.com",
@@ -73,7 +104,13 @@ cat >"$CAP/00002-POST-secret-leak.json" <<'JSON'
     "status": 200,
     "reason": "OK",
     "headers": [],
-    "body": {}
+    "body": {
+      "__non_json__": true,
+      "len": 55,
+      "head_hex": "6576656e743a20726573706f6e73652e636f6d706c657465640a",
+      "text_encoding": "utf-8",
+      "body_text": "event: leak\ndata: Bearer live-token-value-that-should-never-be-promoted\n\n"
+    }
   },
   "timing_ms": 1
 }

--- a/scripts/smoke-codex-cassette-replay.sh
+++ b/scripts/smoke-codex-cassette-replay.sh
@@ -39,13 +39,15 @@ import sys
 
 d = pathlib.Path(sys.argv[1])
 
+ok_body = 'event: response.completed\ndata: {"type":"response.completed"}\n\n'
+
 flows = [
     {
         "captured_at": 1788000000.001,
         "host": "chatgpt.com",
         "scheme": "https",
         "method": "POST",
-        "path": "/backend-api/codex/responses",
+        "path": "/backend-api/codex/responses?captured=query",
         "request": {
             "headers": [
                 ["Authorization", "Bearer synth-<redacted>"],
@@ -57,7 +59,13 @@ flows = [
             "status": 200,
             "reason": "OK",
             "headers": [["Content-Type", "text/event-stream"]],
-            "body": "event: response.completed\ndata: {\"type\":\"response.completed\"}\n\n",
+            "body": {
+                "__non_json__": True,
+                "len": len(ok_body.encode("utf-8")),
+                "head_hex": ok_body.encode("utf-8")[:64].hex(),
+                "text_encoding": "utf-8",
+                "body_text": ok_body,
+            },
         },
         "timing_ms": 12,
     },

--- a/scripts/test-cassette-upstream.py
+++ b/scripts/test-cassette-upstream.py
@@ -34,8 +34,8 @@ matching what `codex-wire-addon.py` writes. Each file:
     }
 
 Replay strategy: match incoming requests to captures by
-(method, path) tuple. If multiple captures match the same key,
-cycle through them in capture-time order so a session that
+(method, path-without-query) tuple. If multiple captures match the
+same key, cycle through them in capture-time order so a session that
 captured "200, 200, 429" can be replayed in the same sequence.
 
 Env (matching test-stub-upstream.py for harness compatibility):
@@ -49,6 +49,10 @@ Failure modes:
     {"error":"no_cassette_match","method":...,"path":...}
   - Cassette dir is empty: server starts but every request errors
     (the harness should treat this as a setup failure)
+
+Textual non-JSON captures may include response.body.body_text; those
+bytes are replayed directly so reviewed text/event-stream cassettes
+exercise the same parser path as real Codex SSE responses.
 
 This script does NOT generate cassettes. Use
 `scripts/capture-codex-wire.sh proxy` for that. Once captures
@@ -65,6 +69,7 @@ import sys
 import time
 from collections import defaultdict
 from pathlib import Path
+from urllib.parse import urlsplit
 
 
 CASSETTE_DIR = os.environ.get("OMUX_CASSETTE_DIR")
@@ -79,6 +84,11 @@ def _log(record: dict) -> None:
         f.write(json.dumps(record) + "\n")
 
 
+def _normalize_path(path: str) -> str:
+    split = urlsplit(path or "/")
+    return split.path or "/"
+
+
 def _load_cassettes(d: Path) -> dict[tuple[str, str], list[dict]]:
     """Load all flow JSON files; group by (method, path); sort by ts."""
     by_key: dict[tuple[str, str], list[dict]] = defaultdict(list)
@@ -90,11 +100,18 @@ def _load_cassettes(d: Path) -> dict[tuple[str, str], list[dict]]:
         except Exception as e:
             print(f"cassette: skipping malformed {f.name}: {e}", file=sys.stderr)
             continue
-        key = (flow.get("method", "GET"), flow.get("path", "/"))
+        key = (flow.get("method", "GET"), _normalize_path(flow.get("path", "/")))
         by_key[key].append(flow)
     for k in by_key:
         by_key[k].sort(key=lambda f: f.get("captured_at", 0))
     return by_key
+
+
+def _header_value(headers: list, target: str) -> str | None:
+    for name, value in headers:
+        if str(name).lower() == target.lower():
+            return str(value)
+    return None
 
 
 # Per-key replay cursor. Each (method, path) advances independently;
@@ -115,10 +132,7 @@ class CassetteHandler(http.server.BaseHTTPRequestHandler):
         return b""
 
     def _serve(self) -> None:
-        path = self.path
-        # Strip query string for matching
-        if "?" in path:
-            path = path.split("?", 1)[0]
+        path = _normalize_path(self.path)
         body_in = self._read_body()
         _ = body_in
 
@@ -132,25 +146,31 @@ class CassetteHandler(http.server.BaseHTTPRequestHandler):
         CURSORS[key] += 1
         flow = flows[cursor]
         resp = flow.get("response", {})
+        headers = resp.get("headers") or []
         status = resp.get("status", 200)
         body_obj = resp.get("body")
+        captured_ct = _header_value(headers, "content-type")
         if isinstance(body_obj, str):
             payload = body_obj.encode("utf-8")
-            ct = "text/plain"
+            ct = captured_ct or "text/plain"
         elif isinstance(body_obj, dict) and body_obj.get("__non_json__"):
-            # Non-JSON original; we have head_hex but not full bytes.
-            # For replay we send a minimal body of the same length.
-            payload = b"\x00" * body_obj.get("len", 0)
-            ct = "application/octet-stream"
+            if isinstance(body_obj.get("body_text"), str):
+                payload = body_obj["body_text"].encode(body_obj.get("text_encoding", "utf-8"))
+                ct = captured_ct or "text/plain"
+            else:
+                # Legacy non-JSON captures have head_hex but not full bytes.
+                # For replay we send a minimal body of the same length.
+                payload = b"\x00" * body_obj.get("len", 0)
+                ct = captured_ct or "application/octet-stream"
         else:
             payload = json.dumps(body_obj or {}).encode("utf-8")
-            ct = "application/json"
+            ct = captured_ct or "application/json"
 
         self.send_response(status)
         # Replay headers verbatim except framing-related ones we control
-        for name, value in resp.get("headers", []):
-            n = name.lower()
-            if n in ("content-length", "transfer-encoding", "connection", "keep-alive"):
+        for name, value in headers:
+            n = str(name).lower()
+            if n in ("content-length", "content-type", "transfer-encoding", "connection", "keep-alive"):
                 continue
             self.send_header(name, value)
         self.send_header("Content-Type", ct)


### PR DESCRIPTION
## Summary

- preserve reviewed textual non-JSON Codex capture bodies, including SSE, as body_text
- replay captured query-string paths by normalized route path and preserve captured content type
- extend cassette replay and capture-review smokes to cover real-capture-shaped SSE bodies and leak detection inside body_text

## Validation

- git diff --check
- python3 -m py_compile scripts/codex-wire-addon.py scripts/test-cassette-upstream.py scripts/review-codex-wire-capture.py
- zig build test
- scripts/smoke-codex-cassette-replay.sh
- scripts/smoke-codex-capture-review.sh
- scripts/smoke-codex-cassette-all-exhausted.sh
- nix develop --command just check-local

Refs #176