### PR TITLE
Align managed Codex route election with capability health

### DIFF
--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -45,7 +45,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$TMP/account-A" "$TMP/claude-personal" "$STATE_DIR" "$CANONICAL_SESSION_HOME/sessions/2026/05/06" "$CANONICAL_SESSION_HOME/shell_snapshots"
+mkdir -p "$TMP/account-A" "$TMP/account-B" "$TMP/claude-personal" "$STATE_DIR" "$CANONICAL_SESSION_HOME/sessions/2026/05/06" "$CANONICAL_SESSION_HOME/shell_snapshots"
 touch "$CANONICAL_SESSION_HOME/history.jsonl" "$CANONICAL_SESSION_HOME/session_index.jsonl"
 printf '%s\n' '{"fixture":"resume"}' >"$CANONICAL_SESSION_HOME/sessions/2026/05/06/rollout-managed-good-session.jsonl"
 printf '%s\n' '{"bridge":"preexisting"}' >"$CANONICAL_SESSION_HOME/sessions/omux-session-bridge-smoke.jsonl"
@@ -93,6 +93,9 @@ EOF
 ID_TOKEN="h.eyJodHRwczovL2FwaS5vcGVuYWkuY29tL2F1dGgiOnsiY2hhdGdwdF9wbGFuX3R5cGUiOiJwcm8ifX0.s"
 cat >"$TMP/account-A/auth.json" <<EOF
 {"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"AT-cli-ux-A","refresh_token":"RT-A","account_id":"acc-A-id"},"auth_mode":"Chatgpt"}
+EOF
+cat >"$TMP/account-B/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"AT-cli-ux-B","refresh_token":"RT-B","account_id":"acc-B-id"},"auth_mode":"Chatgpt"}
 EOF
 cat >"$TMP/claude-personal/auth.json" <<EOF
 {"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"AT-cli-ux-claude","refresh_token":"RT-claude","account_id":"acc-claude-id"},"auth_mode":"Chatgpt"}
@@ -280,6 +283,110 @@ run_case top "resume-last" '["resume","--last"]' resume --last
 run_case top "resume-id" '["resume","managed-good-session"]' resume managed-good-session
 run_case top "resume-chooser" '["resume"]' resume
 run_case raw "raw-run" '["resume","--last"]' resume --last
+
+echo "smoke-codex-cli-ux: capability-scoped route election matches broker-session-plan"
+MIXED_CONFIG="$TMP/mixed-capability.config.json"
+MIXED_STATE="$TMP/mixed-capability-state"
+mkdir -p "$MIXED_STATE"
+cat >"$MIXED_CONFIG" <<EOF
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "kind": "codex",
+      "accounts": {
+        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "$TMP/account-A/auth.json" } },
+        "max-2": { "priority": 20, "secret": { "backend": "file", "path": "$TMP/account-B/auth.json" } }
+      }
+    }
+  },
+  "profiles": {
+    "mixed": { "providers": ["codex:max-1#codex-mini", "codex:max-1#codex-max", "codex:max-2#codex-max"] }
+  }
+}
+EOF
+cat >"$MIXED_STATE/health.json" <<'EOF'
+{"version":2,"accounts":[
+  {"key":"codex:max-1#codex-mini","last_probe_source":"capability_probe","last_probe_hint_class":"none","last_probe_decision":"use_this","liveness":{"state":"live","availability":"available"}},
+  {"key":"codex:max-1#codex-max","last_probe_source":"capability_probe","last_probe_hint_class":"quota_exhausted","last_probe_decision":"try_next_account","liveness":{"state":"live","availability":"quota_exhausted","window_resets_at":1999999999}},
+  {"key":"codex:max-2#codex-max","last_probe_source":"capability_probe","last_probe_hint_class":"none","last_probe_decision":"use_this","liveness":{"state":"live","availability":"available"}}
+]}
+EOF
+MIXED_NDJSON="$TMP/mixed-capability/status.ndjson"
+MIXED_STDERR="$TMP/mixed-capability.stderr"
+MIXED_REPORT="$TMP/mixed-capability.report"
+mkdir -p "$(dirname "$MIXED_NDJSON")"
+OMUX_CONFIG="$MIXED_CONFIG" \
+  OMUX_STATE_DIR="$MIXED_STATE" \
+  OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+  CODEX_HOME="$CANONICAL_SESSION_HOME" \
+  OMUX_CODEX_SESSION_HOME="$CANONICAL_SESSION_HOME" \
+  OMUX_CODEX_CONFIG_HOME="$CANONICAL_SESSION_HOME" \
+  OMUX_STUB_CANONICAL_SESSION_HOME="$CANONICAL_SESSION_HOME" \
+  OMUX_STUB_APPEND_SESSION="sessions/2026/05/06/rollout-managed-good-session.jsonl" \
+  OMUX_STUB_CODEX_TURNS=0 \
+  OMUX_STUB_CODEX_REPORT="$MIXED_REPORT" \
+  "$BIN" codex --profile mixed --capability codex-max --json-status-file "$MIXED_NDJSON" resume --last 2>"$MIXED_STDERR"
+assert_grep "mixed capability selected max-2" '"kind":"session_started".*"selected_account":"codex:max-2"' "$MIXED_NDJSON"
+if [[ "$(jq -r .active_account_at_start "$MIXED_REPORT")" == "max-2" ]]; then
+    echo "  ✓ mixed capability launch used the codex-max selectable route"
+else
+    echo "  ✗ mixed capability launch used wrong account" >&2
+    cat "$MIXED_REPORT" >&2
+    exit 1
+fi
+
+PINNED_BLOCKED_NDJSON="$TMP/pinned-blocked/status.ndjson"
+PINNED_BLOCKED_STDERR="$TMP/pinned-blocked.stderr"
+PINNED_BLOCKED_REPORT="$TMP/pinned-blocked.report"
+mkdir -p "$(dirname "$PINNED_BLOCKED_NDJSON")"
+if OMUX_CONFIG="$MIXED_CONFIG" \
+     OMUX_STATE_DIR="$MIXED_STATE" \
+     OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+     CODEX_HOME="$CANONICAL_SESSION_HOME" \
+     OMUX_CODEX_SESSION_HOME="$CANONICAL_SESSION_HOME" \
+     OMUX_CODEX_CONFIG_HOME="$CANONICAL_SESSION_HOME" \
+     OMUX_STUB_CODEX_TURNS=0 \
+     OMUX_STUB_CODEX_REPORT="$PINNED_BLOCKED_REPORT" \
+     "$BIN" codex --profile mixed --capability codex-max --account codex:max-1 --json-status-file "$PINNED_BLOCKED_NDJSON" resume --last 2>"$PINNED_BLOCKED_STDERR"; then
+    echo "  ✗ pinned quota-blocked account unexpectedly launched" >&2
+    exit 1
+fi
+assert_grep "pinned blocked terminal status" '"kind":"session_aborted".*"reason":"no_account_selectable".*"phase":"route_election".*"pre_spawn":true.*"child_spawned":false' "$PINNED_BLOCKED_NDJSON"
+assert_grep "pinned blocked stderr" 'is not selectable for the requested profile/capability' "$PINNED_BLOCKED_STDERR"
+if [[ -e "$PINNED_BLOCKED_REPORT" ]]; then
+    echo "  ✗ pinned quota-blocked account launched stub unexpectedly" >&2
+    cat "$PINNED_BLOCKED_REPORT" >&2
+    exit 1
+else
+    echo "  ✓ pinned quota-blocked account fails before child spawn"
+fi
+
+AMBIGUOUS_NDJSON="$TMP/ambiguous-capability/status.ndjson"
+AMBIGUOUS_STDERR="$TMP/ambiguous-capability.stderr"
+AMBIGUOUS_REPORT="$TMP/ambiguous-capability.report"
+mkdir -p "$(dirname "$AMBIGUOUS_NDJSON")"
+if OMUX_CONFIG="$MIXED_CONFIG" \
+     OMUX_STATE_DIR="$MIXED_STATE" \
+     OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+     CODEX_HOME="$CANONICAL_SESSION_HOME" \
+     OMUX_CODEX_SESSION_HOME="$CANONICAL_SESSION_HOME" \
+     OMUX_CODEX_CONFIG_HOME="$CANONICAL_SESSION_HOME" \
+     OMUX_STUB_CODEX_TURNS=0 \
+     OMUX_STUB_CODEX_REPORT="$AMBIGUOUS_REPORT" \
+     "$BIN" codex --profile mixed --json-status-file "$AMBIGUOUS_NDJSON" resume --last 2>"$AMBIGUOUS_STDERR"; then
+    echo "  ✗ ambiguous mixed-capability profile unexpectedly launched" >&2
+    exit 1
+fi
+assert_grep "ambiguous capability terminal status" '"kind":"session_aborted".*"reason":"no_account_selectable".*"phase":"route_election".*"pre_spawn":true.*"child_spawned":false' "$AMBIGUOUS_NDJSON"
+assert_grep "ambiguous capability stderr" 'pass --capability for managed launch' "$AMBIGUOUS_STDERR"
+if [[ -e "$AMBIGUOUS_REPORT" ]]; then
+    echo "  ✗ ambiguous mixed-capability profile launched stub unexpectedly" >&2
+    cat "$AMBIGUOUS_REPORT" >&2
+    exit 1
+else
+    echo "  ✓ ambiguous mixed-capability profile fails before child spawn"
+fi
 
 echo "smoke-codex-cli-ux: resume chooser missing authority fails before spawn"
 BAD_AUTHORITY_HOME="$TMP/bad-canonical-codex"

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -43,6 +43,7 @@ const wire_proxy = @import("wire_proxy.zig");
 
 pub const RunOptions = struct {
     profile: ?[]const u8 = null,
+    capability: ?[]const u8 = null,
     account: ?[]const u8 = null,
     /// Optional canonical Codex session authority home. Defaults to the
     /// parent CODEX_HOME when set, otherwise ~/.codex.
@@ -489,6 +490,36 @@ fn isCodexAccountId(account_id: []const u8) bool {
     return std.mem.startsWith(u8, account_id, "codex:");
 }
 
+const ManagedCapabilityResolution = union(enum) {
+    none,
+    capability: []const u8,
+    ambiguous,
+};
+
+fn managedRouteCapability(
+    cfg: config_mod.Config,
+    explicit_capability: ?[]const u8,
+    profile_name: ?[]const u8,
+) ManagedCapabilityResolution {
+    if (explicit_capability) |capability| return .{ .capability = capability };
+    const profile = cfg.profiles.map.get(profile_name orelse return .none) orelse return .none;
+
+    var found: ?[]const u8 = null;
+    for (profile.providers) |entry| {
+        const hash = std.mem.indexOfScalar(u8, entry, '#') orelse continue;
+        const head = entry[0..hash];
+        if (!std.mem.startsWith(u8, head, "codex:")) continue;
+        const capability = entry[hash + 1 ..];
+        if (found) |existing| {
+            if (!std.mem.eql(u8, existing, capability)) return .ambiguous;
+        } else {
+            found = capability;
+        }
+    }
+    if (found) |capability| return .{ .capability = capability };
+    return .none;
+}
+
 fn codexAccountLabel(account_id: []const u8) []const u8 {
     const colon = std.mem.indexOfScalar(u8, account_id, ':') orelse return account_id;
     if (colon + 1 >= account_id.len) return account_id;
@@ -631,6 +662,7 @@ fn maybeAutoRevalidateCodexRoutes(
     cfg: config_mod.Config,
     store: *health_mod.HealthStore,
     profile: ?[]const u8,
+    capability_filter: ?[]const u8,
     account_filter: ?[]const u8,
     initial_selectable_routes: usize,
     target_selectable_routes: usize,
@@ -655,8 +687,8 @@ fn maybeAutoRevalidateCodexRoutes(
         candidates.deinit();
     }
 
-    try collectProfileCodexAutoRevalidationRoutes(allocator, cfg, profile, account_filter, &seen, &candidates);
-    try collectHealthCodexAutoRevalidationRoutes(allocator, cfg, store, account_filter, &seen, &candidates);
+    try collectProfileCodexAutoRevalidationRoutes(allocator, cfg, profile, capability_filter, account_filter, &seen, &candidates);
+    try collectHealthCodexAutoRevalidationRoutes(allocator, cfg, store, capability_filter, account_filter, &seen, &candidates);
 
     var summary = AutoRevalidationSummary{ .admitted = true };
     if (candidates.items.len == 0) {
@@ -734,20 +766,21 @@ fn collectProfileCodexAutoRevalidationRoutes(
     allocator: std.mem.Allocator,
     cfg: config_mod.Config,
     profile: ?[]const u8,
+    capability_filter: ?[]const u8,
     account_filter: ?[]const u8,
     seen: *std.StringHashMap(void),
     out: *std.ArrayList(AutoRevalidationRoute),
 ) !void {
     if (profile) |name| {
         if (cfg.profiles.map.get(name)) |profile_cfg| {
-            try collectProfileEntriesForCodexAutoRevalidation(allocator, cfg, profile_cfg.providers, account_filter, seen, out);
+            try collectProfileEntriesForCodexAutoRevalidation(allocator, cfg, profile_cfg.providers, capability_filter, account_filter, seen, out);
         }
         return;
     }
 
     var profiles = cfg.profiles.map.iterator();
     while (profiles.next()) |entry| {
-        try collectProfileEntriesForCodexAutoRevalidation(allocator, cfg, entry.value_ptr.providers, account_filter, seen, out);
+        try collectProfileEntriesForCodexAutoRevalidation(allocator, cfg, entry.value_ptr.providers, capability_filter, account_filter, seen, out);
     }
 }
 
@@ -755,6 +788,7 @@ fn collectProfileEntriesForCodexAutoRevalidation(
     allocator: std.mem.Allocator,
     cfg: config_mod.Config,
     entries: []const []const u8,
+    capability_filter: ?[]const u8,
     account_filter: ?[]const u8,
     seen: *std.StringHashMap(void),
     out: *std.ArrayList(AutoRevalidationRoute),
@@ -764,6 +798,9 @@ fn collectProfileEntriesForCodexAutoRevalidation(
         const parsed = health_mod.parseHealthKey(entry) orelse continue;
         if (!std.mem.eql(u8, parsed.provider, "codex")) continue;
         const capability = parsed.capability orelse continue;
+        if (capability_filter) |filter| {
+            if (!std.mem.eql(u8, filter, capability)) continue;
+        }
         if (account_filter) |filter| {
             if (!codexAccountFilterMatches(filter, parsed.account)) continue;
         }
@@ -776,6 +813,7 @@ fn collectHealthCodexAutoRevalidationRoutes(
     allocator: std.mem.Allocator,
     cfg: config_mod.Config,
     store: *health_mod.HealthStore,
+    capability_filter: ?[]const u8,
     account_filter: ?[]const u8,
     seen: *std.StringHashMap(void),
     out: *std.ArrayList(AutoRevalidationRoute),
@@ -786,6 +824,9 @@ fn collectHealthCodexAutoRevalidationRoutes(
         const parsed = health_mod.parseHealthKey(entry.key_ptr.*) orelse continue;
         if (!std.mem.eql(u8, parsed.provider, "codex")) continue;
         const capability = parsed.capability orelse continue;
+        if (capability_filter) |filter| {
+            if (!std.mem.eql(u8, filter, capability)) continue;
+        }
         if (account_filter) |filter| {
             if (!codexAccountFilterMatches(filter, parsed.account)) continue;
         }
@@ -1040,11 +1081,21 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     };
     defer parsed.deinit();
 
+    const route_capability = switch (managedRouteCapability(parsed.value, opts.capability, opts.profile)) {
+        .capability => |capability| capability,
+        .none => null,
+        .ambiguous => {
+            try stderr.writeAll("oauth-mux codex: profile has multiple Codex capabilities; pass --capability for managed launch\n");
+            try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "no_account_selectable", "route_election", "NoAccountSelectable", session_started_emitted);
+            return RunError.NoAccountSelectable;
+        },
+    };
+
     var server = broker.Server.init(allocator);
     defer server.deinit();
     var route_health = health_mod.HealthStore.load(allocator, .{});
     defer route_health.deinit();
-    broker_loader.populatePoolFromRouteHealth(&server.pool, parsed.value, opts.profile, &route_health) catch {
+    broker_loader.populatePoolFromRouteHealthScoped(&server.pool, parsed.value, opts.profile, route_capability, &route_health) catch {
         try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "pool_populate_failed", "config_health_load", "PoolPopulateFailed", session_started_emitted);
         return RunError.PoolPopulateFailed;
     };
@@ -1059,6 +1110,7 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
             parsed.value,
             &route_health,
             opts.profile,
+            route_capability,
             opts.account,
             initial_selectable_routes,
             target_selectable_routes,
@@ -1068,7 +1120,7 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         if (revalidation.changedRouteHealth()) {
             server.pool.deinit();
             server.pool = broker.AccountPool.init(allocator);
-            broker_loader.populatePoolFromRouteHealth(&server.pool, parsed.value, opts.profile, &route_health) catch {
+            broker_loader.populatePoolFromRouteHealthScoped(&server.pool, parsed.value, opts.profile, route_capability, &route_health) catch {
                 try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "pool_populate_failed", "codex_auto_revalidation", "PoolPopulateFailed", session_started_emitted);
                 return RunError.PoolPopulateFailed;
             };
@@ -1085,12 +1137,19 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
             return RunError.NoAccountSelectable;
         }
         for (server.pool.accounts.items) |a| {
-            if (std.mem.eql(u8, a.id, pin)) break :pin a;
+            if (std.mem.eql(u8, a.id, pin)) {
+                if (!a.selectable or a.availability != .available) {
+                    try stderr.print("oauth-mux codex: --account {s} is not selectable for the requested profile/capability\n", .{pin});
+                    try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "no_account_selectable", "route_election", "NoAccountSelectable", session_started_emitted);
+                    return RunError.NoAccountSelectable;
+                }
+                break :pin a;
+            }
         }
         try stderr.print("oauth-mux codex: --account {s} not in profile\n", .{pin});
         try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "no_account_selectable", "route_election", "NoAccountSelectable", session_started_emitted);
         return RunError.NoAccountSelectable;
-    } else server.pool.elect(opts.profile, null, &.{}) catch |e| switch (e) {
+    } else server.pool.elect(opts.profile, route_capability, &.{}) catch |e| switch (e) {
         broker_types.BrokerError.NoAccountSelectable => {
             try stderr.writeAll("oauth-mux codex: no selectable account in profile\n");
             try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "no_account_selectable", "route_election", "NoAccountSelectable", session_started_emitted);
@@ -2593,11 +2652,53 @@ fn writeConfigOverrideCheckStatus(writer: anytype, check: ConfigOverrideCheck) !
 test "RunOptions defaults" {
     const opts = RunOptions{};
     try std.testing.expect(opts.profile == null);
+    try std.testing.expect(opts.capability == null);
     try std.testing.expect(opts.session_home == null);
     try std.testing.expect(!opts.isolated_session_store);
     try std.testing.expect(!opts.json_status);
     try std.testing.expect(opts.json_status_file == null);
     try std.testing.expectEqual(@as(usize, 0), opts.forward_argv.len);
+}
+
+test "managedRouteCapability infers unique profile capability and rejects ambiguous profiles" {
+    const cfg_json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": { "priority": 20, "secret": { "backend": "file", "path": "/tmp/a" } },
+        \\        "max-2": { "priority": 10, "secret": { "backend": "file", "path": "/tmp/b" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "codex-max": { "providers": ["codex:max-1#codex-max", "codex:max-2#codex-max"] },
+        \\    "mixed": { "providers": ["codex:max-1#codex-mini", "codex:max-2#codex-max"] }
+        \\  }
+        \\}
+    ;
+    var parsed = try config_mod.loadFromBytes(std.testing.allocator, cfg_json);
+    defer parsed.deinit();
+
+    const inferred = managedRouteCapability(parsed.value, null, "codex-max");
+    switch (inferred) {
+        .capability => |capability| try std.testing.expectEqualStrings("codex-max", capability),
+        else => return error.Unexpected,
+    }
+    switch (managedRouteCapability(parsed.value, null, "mixed")) {
+        .ambiguous => {},
+        else => return error.Unexpected,
+    }
+    switch (managedRouteCapability(parsed.value, "codex-mini", "mixed")) {
+        .capability => |capability| try std.testing.expectEqualStrings("codex-mini", capability),
+        else => return error.Unexpected,
+    }
+    switch (managedRouteCapability(parsed.value, null, null)) {
+        .none => {},
+        else => return error.Unexpected,
+    }
 }
 
 test "expandTilde no-op when no tilde" {

--- a/src/broker_loader.zig
+++ b/src/broker_loader.zig
@@ -1144,6 +1144,53 @@ test "populatePoolFromRouteHealth mirrors broker-session-plan route health" {
     }
 }
 
+test "populatePoolFromRouteHealthScoped keeps mixed-profile capabilities isolated" {
+    const cfg_json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "/tmp/a" } },
+        \\        "max-2": { "priority": 20, "secret": { "backend": "file", "path": "/tmp/b" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "mixed": { "providers": ["codex:max-1#codex-mini", "codex:max-1#codex-max", "codex:max-2#codex-max"] }
+        \\  }
+        \\}
+    ;
+    var parsed = try config_mod.loadFromBytes(std.testing.allocator, cfg_json);
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    store.recordCapabilityHttpStatus("codex", "max-1", "codex-max", 429, 7200);
+    const mini = try store.getOrCreate("codex:max-1#codex-mini");
+    mini.liveness = .{ .live = .{ .availability = .available } };
+    mini.last_probe_hint_class = .none;
+    mini.last_probe_decision = .use_this;
+    const max2 = try store.getOrCreate("codex:max-2#codex-max");
+    max2.liveness = .{ .live = .{ .availability = .available } };
+    max2.last_probe_hint_class = .none;
+    max2.last_probe_decision = .use_this;
+
+    var pool = broker.AccountPool.init(std.testing.allocator);
+    defer pool.deinit();
+    try populatePoolFromRouteHealthScoped(&pool, parsed.value, "mixed", "codex-max", &store);
+
+    const elected = try pool.elect("mixed", "codex-max", &.{});
+    try std.testing.expectEqualStrings("codex:max-2", elected.id);
+    for (pool.accounts.items) |entry| {
+        if (std.mem.eql(u8, entry.id, "codex:max-1")) {
+            try std.testing.expect(!entry.selectable);
+            try std.testing.expectEqual(broker.account_pool_mod.Availability.quota_exhausted, entry.availability);
+        }
+    }
+}
+
 test "populatePoolFromRouteHealth lets expired provider degradation yield to capability health" {
     const cfg_json =
         \\{

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -49,6 +49,7 @@ pub const Command = union(enum) {
 
     pub const CodexAdapterArgs = struct {
         profile: ?[]const u8 = null,
+        capability: ?[]const u8 = null,
         account: ?[]const u8 = null,
         session_home: ?[]const u8 = null,
         isolated_session_store: bool = false,
@@ -398,6 +399,9 @@ fn parseCodexAdapter(args: []const []const u8, strict_run: bool) Command {
         } else if ((eql(args[i], "--profile") or eql(args[i], "-p")) and i + 1 < args.len) {
             i += 1;
             result.profile = args[i];
+        } else if (eql(args[i], "--capability") and i + 1 < args.len) {
+            i += 1;
+            result.capability = args[i];
         } else if (eql(args[i], "--account") and i + 1 < args.len) {
             i += 1;
             result.account = args[i];
@@ -1422,7 +1426,7 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\oauth-mux codex — broker-mediated Codex sessions, setup, and probes
         \\
         \\Usage:
-        \\  oauth-mux codex [--profile name] [--account provider:account] [--session-home path] [--isolated-session-store] [--json-status] [--json-status-file path] [-- codex-args...]
+        \\  oauth-mux codex [--profile name] [--capability c] [--account provider:account] [--session-home path] [--isolated-session-store] [--json-status] [--json-status-file path] [-- codex-args...]
         \\  oauth-mux codex resume [id|--last]
         \\  oauth-mux codex run [adapter options] -- [codex-args...]
         \\  oauth-mux setup codex [--accounts a,b,c] [--device|--status-only] [--live]
@@ -2350,11 +2354,12 @@ test "parse mcp broker server profile" {
 }
 
 test "parse codex run adapter args" {
-    const args = [_][]const u8{ "codex", "run", "--profile", "codex-max", "--account", "codex:max-1", "--session-home", "/tmp/codex-sessions", "--isolated-session-store", "--json-status-file", "/tmp/omux-status.ndjson", "--", "--model", "gpt-5.5" };
+    const args = [_][]const u8{ "codex", "run", "--profile", "codex-max", "--capability", "codex-max", "--account", "codex:max-1", "--session-home", "/tmp/codex-sessions", "--isolated-session-store", "--json-status-file", "/tmp/omux-status.ndjson", "--", "--model", "gpt-5.5" };
     const cmd = parse(&args);
     switch (cmd) {
         .codex_adapter => |adapter| {
             try std.testing.expectEqualStrings("codex-max", adapter.profile.?);
+            try std.testing.expectEqualStrings("codex-max", adapter.capability.?);
             try std.testing.expectEqualStrings("codex:max-1", adapter.account.?);
             try std.testing.expectEqualStrings("/tmp/codex-sessions", adapter.session_home.?);
             try std.testing.expect(adapter.isolated_session_store);
@@ -2549,6 +2554,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from config' -a 'validate path' -d 'Config subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex' -a 'resume run setup onboard canary live-qa revalidate-exhausted probe-all preflight managed-plan managed status-latest broker-plan broker-session-plan broker-session-smoke broker-run broker-fallback-drill broker-smoke broker-refresh-smoke broker-401-smoke broker-quota-smoke config-candidate config-merge bootstrap-dirs login login-device login-status login-status-all' -d 'Codex subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex run' -l profile -s p -d 'Profile name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex run' -l capability -d 'Route capability' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex run' -l account -d 'Route account id' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex run' -l session-home -d 'Canonical Codex session authority home' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from codex run' -l isolated-session-store -d 'Use isolated session authority for this run'

--- a/src/main.zig
+++ b/src/main.zig
@@ -65,6 +65,7 @@ pub fn main() !void {
             }
             codex_adapter.run(allocator, .{
                 .profile = adapter_args.profile,
+                .capability = adapter_args.capability,
                 .account = adapter_args.account,
                 .session_home = adapter_args.session_home,
                 .isolated_session_store = adapter_args.isolated_session_store,


### PR DESCRIPTION
## Summary
- add --capability to the broker-mediated Codex adapter path and infer a unique profile capability for existing single-capability profiles
- populate managed Codex pools with capability-scoped route health so launch selection matches broker-session-plan
- reject pinned accounts that are present but not selectable, and refuse ambiguous mixed-capability profiles before spawning Codex
- extend CLI UX smoke coverage for mixed codex-mini/codex-max profiles and pinned quota-blocked accounts

## Validation
- git diff --check
- zig build test
- zig build
- scripts/smoke-codex-cli-ux.sh
- scripts/smoke-codex-status-summary.sh
- scripts/smoke-codex-concurrent-sessions.sh
- scripts/smoke-broker.sh
- nix develop --command just check-local

No local Playwright run.