### PR TITLE
TIN-1518: add product guardrail and dogfood process snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,41 @@ commit message, or PR description frames any of those as "the success" or
 "the fallback if seamless mux is hard," it is wrong by construction;
 delete and re-anchor on the broker contract.
 
+## Product Guardrail
+
+oauth-mux is a harness continuity layer, not a general auth diagnostics
+toolkit. The product is:
+
+> Install oauth-mux, enroll the engineer's agent accounts, run
+> `oauth-mux <harness>`, and keep that harness usable when auth, quota, tier,
+> or local runtime state changes, with little to no extra user interaction.
+
+Treat work as core only when it directly improves one of these surfaces:
+
+- `oauth-mux codex` as the reference managed harness flow.
+- Account enrollment and route-health truth across multiple engineer identities.
+- Managed in-session quota/rate/auth/tier handoff.
+- Native-feeling UX for install, preflight, login/pass-through, resume, status,
+  and repair.
+- Redacted no-spend AX so agents can inspect state and request safe next actions
+  without reading tokens or spending provider calls.
+- A reusable harness adapter contract for future Claude, OpenCode, and other
+  harness integrations.
+
+Broker MCP methods, daemon status, route diagnostics, trace flags, cassette
+capture, packaging, and website/docs updates are support infrastructure. They
+matter only when they make the managed harness experience more reliable, easier
+to repair, safer for agents, or easier to generalize into the next real harness
+adapter.
+
+Defer or contain work that primarily chases universal provider support, hidden
+daemon dependency, unmanaged harness hot-swap, same-thread provider continuity,
+mid-turn streaming recovery, or broad adapter claims without live proof.
+
+Feature-creep test: if a change does not make `oauth-mux codex` more reliable,
+easier to install, easier to repair, easier for agents to inspect safely, or
+easier to generalize into the next harness adapter, it is probably out of scope.
+
 ## Source of Truth Hierarchy
 
 1. This file (AGENTS.md)

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ Keep the claim ladder tied to evidence:
   adapter strategy, daemon beta boundary, release posture, and tracker map.
 - `docs/release-install-lanes.md`: public package lanes versus local dogfood
   lanes.
+- `docs/dogfood-process-fanout.md`: no-spend agent process topology snapshots
+  and cleanup rules for suspected helper fanout or RSS growth.
 - `docs/lifecycle.md`: application lifecycle, managed Codex flow, agent-safe
   control plane, and claim levels.
 - `docs/spec/in-agent-reauth-handoff-contract-2026-05-14.md`: agent/MCP

--- a/docs/dogfood-process-fanout.md
+++ b/docs/dogfood-process-fanout.md
@@ -1,0 +1,126 @@
+# Dogfood Process Fanout Runbook
+
+Status: observational support diagnostic. This is not a stay-afloat claim.
+
+Use this runbook when Codex/Claude dogfood feels persistently slow, duplicated,
+or memory-heavy and you need to distinguish normal accumulated sessions from
+orphan helper fanout or a suspected RSS leak.
+
+The snapshot path is no-spend and non-mutating:
+
+- it does not call provider APIs;
+- it does not mutate oauth-mux config, route health, or credential stores;
+- it does not kill processes;
+- it does not sleep in the foreground;
+- it does not prove a heap leak from a single sample.
+
+## Snapshot
+
+Write a redacted Markdown and JSON snapshot:
+
+```bash
+just dogfood-process-snapshot
+```
+
+For Codex Max dogfood labeling:
+
+```bash
+just codex-max-process-snapshot
+```
+
+For machine-readable output on stdout:
+
+```bash
+just dogfood-process-snapshot-json
+```
+
+The report groups visible Codex, Claude, and oauth-mux process trees and records:
+
+- parent PID / PPID;
+- elapsed time;
+- instantaneous CPU percent from `ps`;
+- RSS in KiB and MiB;
+- helper child count;
+- listening TCP ports visible through `lsof`;
+- duplicate helper command groups;
+- helper/listener processes that are not inside a visible agent tree.
+
+Commands, temp paths, home paths, and common bearer/token spellings are redacted.
+The script intentionally does not read process environments.
+
+## Bounded Comparison
+
+To compare two snapshots without running a foreground wait:
+
+```bash
+python3 scripts/dogfood-process-snapshot.py --out dist/dogfood/process --tag baseline
+python3 scripts/dogfood-process-snapshot.py --out dist/dogfood/process --tag current
+python3 scripts/dogfood-process-snapshot.py \
+  --compare dist/dogfood/process/process-snapshot-BASELINE.json \
+            dist/dogfood/process/process-snapshot-CURRENT.json
+```
+
+For a delayed follow-up, schedule the wait in a detached background process:
+
+```bash
+python3 scripts/dogfood-process-snapshot.py \
+  --out dist/dogfood/process \
+  --tag baseline \
+  --schedule-followup-seconds 300
+```
+
+That command returns after scheduling the follow-up. The background follow-up
+writes a second snapshot and a comparison artifact in the same output directory.
+
+Default RSS growth suspicion requires both:
+
+- at least 64 MiB same-PID RSS growth;
+- at least 25 percent same-PID RSS growth.
+
+Treat the result as `suspected_rss_growth`, not a proven heap leak, until the
+same process keeps growing across repeated samples without an active workload
+explanation.
+
+## Classification
+
+Use these labels when filing follow-up evidence:
+
+- `accumulated_sessions`: old Codex/Claude parent processes are still active.
+- `orphan_helper_fanout`: helper/listener processes are visible outside a known
+  agent tree.
+- `duplicate_helper_spawn`: repeated helper command signatures are visible.
+- `suspected_rss_growth`: same PID crosses the configured growth threshold.
+- `stable_or_session_churn`: processes are stable, appeared, or disappeared
+  without same-PID growth.
+
+## Cleanup Rules
+
+No automation should kill processes from this report.
+
+Leave sessions alone when:
+
+- the shell or agent session is active;
+- a check, deploy, smoke, or live dogfood command is running;
+- the owner or workspace is unclear.
+
+Close manually only after confirming the session is idle or obsolete. If a
+helper appears orphaned, collect a second snapshot first so the follow-up can
+show whether it persists outside a parent session.
+
+If cleanup is needed, ask the operator which PID or parent session to close.
+Then use the normal shell/session exit path first. Use `kill` only with explicit
+operator approval and a PID list copied from the latest snapshot.
+
+## What This Does Not Prove
+
+This diagnostic does not prove:
+
+- unmanaged Codex hot-swap;
+- same-thread provider continuity;
+- daemon-owned stay-afloat;
+- provider health or route selection correctness;
+- a heap leak from one process sample.
+
+Use `oauth-mux codex status-latest --json`, `codex preflight`, route diagnostics,
+and managed status artifacts for route/session truth. Use this runbook only for
+agent process topology and resource evidence.

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -96,6 +96,9 @@ AX:
 - Agents must not read token files, run upstream login, spend provider calls, or
   mutate credential stores without explicit consent.
 - Trace and status artifacts are support material only after redaction review.
+- Agent process fanout evidence lives in `docs/dogfood-process-fanout.md` and
+  `scripts/dogfood-process-snapshot.py`; it is observational only and must not
+  kill processes, spend provider calls, or be cited as route-selection proof.
 
 ## Adapter Strategy
 
@@ -160,6 +163,8 @@ browser is needed; local Playwright is not part of this CLI proof path.
 - Local validation passes: `zig build test`, targeted Codex smokes,
   `nix develop --command just check-local`, and the hybrid `nix flake check`
   package smoke.
+- Dogfood process/memory concerns are backed by at least two redacted
+  `dogfood-process-snapshot` artifacts before being called leaks.
 - Public release validation passes: `just release-proof <version>`, release
   proof workflow, npm dry run/publish workflow as appropriate, Homebrew QA, and
   system package QA.

--- a/justfile
+++ b/justfile
@@ -93,6 +93,15 @@ paid-cohort-soak-snapshot: build
 
 codex-max-soak-snapshot: paid-cohort-soak-snapshot
 
+dogfood-process-snapshot OUT="dist/dogfood/process":
+    python3 ./scripts/dogfood-process-snapshot.py --out {{OUT}}
+
+dogfood-process-snapshot-json:
+    python3 ./scripts/dogfood-process-snapshot.py --json
+
+codex-max-process-snapshot OUT="dist/dogfood/process":
+    python3 ./scripts/dogfood-process-snapshot.py --out {{OUT}} --tag codex-max
+
 codex-max-live-qa: build
     OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux codex live-qa
 

--- a/scripts/check-local.sh
+++ b/scripts/check-local.sh
@@ -8,6 +8,7 @@ zig build
 ./zig-out/bin/oauth-mux version --json | jq -e '.version and .runtime_identity.binary_path and .runtime_identity.binary_sha256 and .runtime_identity.path_printed == true' >/dev/null
 bash -n ./scripts/install-local-dogfood.sh
 bash -n ./scripts/uninstall-local-dogfood.sh
+python3 -m py_compile ./scripts/dogfood-process-snapshot.py
 sh -n ./dist/codex-shim.sh
 sh -n ./dist/install.sh
 
@@ -19,6 +20,7 @@ done
 ./scripts/first-run-e2e.sh
 ./scripts/stay-afloat-wrapper-doc-smoke.sh
 ./scripts/smoke-trace.sh
+./scripts/smoke-dogfood-process-snapshot.sh
 ./scripts/smoke-broker.sh
 ./scripts/smoke-broker-claude.sh
 ./scripts/smoke-codex-cli-ux.sh

--- a/scripts/dogfood-process-snapshot.py
+++ b/scripts/dogfood-process-snapshot.py
@@ -1,0 +1,759 @@
+#!/usr/bin/env python3
+"""No-spend agent process fanout snapshot for oauth-mux dogfood sessions."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+AGENT_NAMES = {"codex", "claude", "claude-code", "claude_code"}
+ROOT_NAMES = AGENT_NAMES | {"oauth-mux"}
+HELPER_RE = re.compile(
+    r"(mcp|figma-console|serena|language-server|node|npm|npx|bun|uvx|"
+    r"playwright|puppeteer|chrome-devtools)",
+    re.IGNORECASE,
+)
+SECRET_REDACTIONS = [
+    (re.compile(r"(?i)(authorization:\s*bearer\s+)[^\s'\"]+"), r"\1<redacted>"),
+    (re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+"), r"\1<redacted>"),
+    (re.compile(r"(?i)((?:access|refresh|id)_token[=:\s]+)[^\s,'\"]+"), r"\1<redacted>"),
+    (re.compile(r"(?i)((?:api[_-]?key|token)[=:\s]+)[^\s,'\"]+"), r"\1<redacted>"),
+]
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def redact(value: str) -> str:
+    result = value
+    for pattern, replacement in SECRET_REDACTIONS:
+        result = pattern.sub(replacement, result)
+    home = os.environ.get("HOME")
+    if home:
+        result = result.replace(home, "~")
+    tmpdir = os.environ.get("TMPDIR")
+    if tmpdir:
+        result = result.replace(tmpdir.rstrip("/"), "<tmp>")
+    result = re.sub(r"/private/tmp/[^\s'\"]+", "<tmp>", result)
+    result = re.sub(r"/tmp/[^\s'\"]+", "<tmp>", result)
+    result = re.sub(r"/private/var/folders/[^\s'\"]+", "<tmp>", result)
+    result = re.sub(r"/var/folders/[^\s'\"]+", "<tmp>", result)
+    return result
+
+
+def run_command(argv: list[str]) -> tuple[int, str, str]:
+    try:
+        proc = subprocess.run(argv, check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        return proc.returncode, proc.stdout, proc.stderr
+    except FileNotFoundError as exc:
+        return 127, "", str(exc)
+
+
+def command_name(command: str) -> str:
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        parts = command.split()
+    if not parts:
+        return ""
+    return os.path.basename(parts[0])
+
+
+def parse_etime(value: str) -> int | None:
+    # ps etime formats: [[dd-]hh:]mm:ss
+    try:
+        days = 0
+        rest = value
+        if "-" in rest:
+            day_s, rest = rest.split("-", 1)
+            days = int(day_s)
+        parts = [int(part) for part in rest.split(":")]
+        if len(parts) == 2:
+            hours = 0
+            minutes, seconds = parts
+        elif len(parts) == 3:
+            hours, minutes, seconds = parts
+        else:
+            return None
+        return (((days * 24) + hours) * 60 + minutes) * 60 + seconds
+    except ValueError:
+        return None
+
+
+def parse_ps() -> tuple[list[dict[str, Any]], list[str]]:
+    code, stdout, stderr = run_command(["ps", "-axo", "pid=,ppid=,pcpu=,rss=,etime=,command="])
+    warnings: list[str] = []
+    if code != 0:
+        warnings.append(f"ps failed with status {code}: {redact(stderr.strip())}")
+        return [], warnings
+
+    rows: list[dict[str, Any]] = []
+    this_pid = os.getpid()
+    for line in stdout.splitlines():
+        parts = line.strip().split(None, 5)
+        if len(parts) < 6:
+            continue
+        pid_s, ppid_s, cpu_s, rss_s, etime_s, command = parts
+        try:
+            pid = int(pid_s)
+            ppid = int(ppid_s)
+            cpu = float(cpu_s)
+            rss_kib = int(rss_s)
+        except ValueError:
+            continue
+        if pid == this_pid:
+            continue
+        rows.append(
+            {
+                "pid": pid,
+                "ppid": ppid,
+                "command_name": command_name(command),
+                "command": redact(command),
+                "cpu_pct": cpu,
+                "rss_kib": rss_kib,
+                "rss_mib": round(rss_kib / 1024, 1),
+                "elapsed": etime_s,
+                "elapsed_seconds": parse_etime(etime_s),
+            }
+        )
+    return rows, warnings
+
+
+def parse_lsof() -> tuple[dict[int, list[str]], list[str]]:
+    code, stdout, stderr = run_command(["lsof", "-nP", "-iTCP", "-sTCP:LISTEN", "-F", "pcn"])
+    warnings: list[str] = []
+    listeners: dict[int, list[str]] = {}
+    if code != 0:
+        message = stderr.strip() or "no listening TCP processes visible"
+        warnings.append(f"lsof listen scan unavailable: {redact(message)}")
+        return listeners, warnings
+
+    current_pid: int | None = None
+    for line in stdout.splitlines():
+        if not line:
+            continue
+        tag = line[0]
+        value = line[1:]
+        if tag == "p":
+            try:
+                current_pid = int(value)
+            except ValueError:
+                current_pid = None
+        elif tag == "n" and current_pid is not None:
+            listeners.setdefault(current_pid, []).append(redact(value))
+    return listeners, warnings
+
+
+def is_agent_process(proc: dict[str, Any]) -> bool:
+    name = proc["command_name"].lower()
+    if name in AGENT_NAMES:
+        return True
+    command = proc["command"].lower()
+    return any(f"/{agent}" in command or f" {agent} " in command for agent in AGENT_NAMES)
+
+
+def is_helper_process(proc: dict[str, Any]) -> bool:
+    return bool(HELPER_RE.search(proc["command"]))
+
+
+def is_root_process(proc: dict[str, Any]) -> bool:
+    name = proc["command_name"].lower()
+    if name in ROOT_NAMES:
+        return True
+    command = proc["command"].lower()
+    return any(f"/{root}" in command or f" {root} " in command for root in ROOT_NAMES)
+
+
+def is_oauth_mux_process(proc: dict[str, Any]) -> bool:
+    command = proc["command"].lower()
+    return proc["command_name"].lower() == "oauth-mux" or "/oauth-mux" in command or " oauth-mux " in command
+
+
+def is_codex_process(proc: dict[str, Any]) -> bool:
+    command = proc["command"].lower()
+    return proc["command_name"].lower() == "codex" or "/codex" in command or " codex " in command
+
+
+def is_claude_process(proc: dict[str, Any]) -> bool:
+    command = proc["command"].lower()
+    return proc["command_name"].lower() in {"claude", "claude-code", "claude_code"} or " claude" in command
+
+
+def descendants(pid: int, children: dict[int, list[int]]) -> list[int]:
+    result: list[int] = []
+    stack = list(children.get(pid, []))
+    while stack:
+        child = stack.pop()
+        result.append(child)
+        stack.extend(children.get(child, []))
+    return result
+
+
+def has_ancestor(
+    pid: int,
+    by_pid: dict[int, dict[str, Any]],
+    predicate: Any,
+) -> bool:
+    current = by_pid.get(pid)
+    seen: set[int] = set()
+    while current is not None:
+        ppid = current["ppid"]
+        if ppid in seen:
+            return False
+        seen.add(ppid)
+        parent = by_pid.get(ppid)
+        if parent is None:
+            return False
+        if predicate(parent):
+            return True
+        current = parent
+    return False
+
+
+def depth_first_tree(pid: int, children: dict[int, list[int]], by_pid: dict[int, dict[str, Any]], depth: int = 0) -> list[dict[str, Any]]:
+    proc = by_pid.get(pid)
+    if proc is None:
+        return []
+    node = dict(proc)
+    node["depth"] = depth
+    rows = [node]
+    for child in sorted(children.get(pid, [])):
+        rows.extend(depth_first_tree(child, children, by_pid, depth + 1))
+    return rows
+
+
+def listener_ports(names: list[str]) -> list[str]:
+    ports: list[str] = []
+    for name in names:
+        match = re.search(r":(\d+)(?:\s|\(|$)", name)
+        if match:
+            ports.append(match.group(1))
+    return ports
+
+
+def build_snapshot(args: argparse.Namespace) -> dict[str, Any]:
+    processes, ps_warnings = parse_ps()
+    listeners, lsof_warnings = parse_lsof()
+    warnings = ps_warnings + lsof_warnings
+
+    by_pid = {proc["pid"]: proc for proc in processes}
+    children: dict[int, list[int]] = {}
+    for proc in processes:
+        children.setdefault(proc["ppid"], []).append(proc["pid"])
+
+    for pid, proc in by_pid.items():
+        proc["listeners"] = listeners.get(pid, [])
+        proc["listener_ports"] = listener_ports(proc["listeners"])
+        proc["is_agent"] = is_agent_process(proc)
+        proc["is_helper"] = is_helper_process(proc)
+        proc["is_oauth_mux"] = is_oauth_mux_process(proc)
+        proc["is_codex"] = is_codex_process(proc)
+        proc["is_claude"] = is_claude_process(proc)
+        proc["role"] = "oauth_mux_parent" if proc["is_oauth_mux"] else "agent_parent" if proc["is_agent"] else "helper" if proc["is_helper"] else "other"
+
+    root_candidates = {proc["pid"] for proc in processes if is_root_process(proc)}
+    nested_roots = set()
+    for pid in root_candidates:
+        nested_roots.update(set(descendants(pid, children)).intersection(root_candidates))
+    root_pids = sorted(root_candidates - nested_roots)
+
+    for pid, proc in by_pid.items():
+        if proc["is_codex"] and has_ancestor(pid, by_pid, is_oauth_mux_process):
+            proc["role"] = "managed_codex_child"
+        elif proc["is_codex"]:
+            proc["role"] = "native_codex"
+        elif proc["is_claude"]:
+            proc["role"] = "native_claude"
+
+    trees: list[dict[str, Any]] = []
+    covered: set[int] = set()
+    for root_pid in root_pids:
+        tree_rows = depth_first_tree(root_pid, children, by_pid)
+        tree_pids = {row["pid"] for row in tree_rows}
+        covered.update(tree_pids)
+        helper_count = sum(1 for row in tree_rows if row["is_helper"])
+        root = by_pid[root_pid]
+        tree_listeners = [
+            {"pid": row["pid"], "command_name": row["command_name"], "listeners": row["listeners"]}
+            for row in tree_rows
+            if row["listeners"]
+        ]
+        trees.append(
+            {
+                "root": root,
+                "child_count": max(len(tree_rows) - 1, 0),
+                "helper_count": helper_count,
+                "total_rss_kib": sum(row["rss_kib"] for row in tree_rows),
+                "total_rss_mib": round(sum(row["rss_kib"] for row in tree_rows) / 1024, 1),
+                "total_cpu_pct": round(sum(row["cpu_pct"] for row in tree_rows), 1),
+                "listeners": tree_listeners,
+                "processes": tree_rows,
+            }
+        )
+
+    orphan_listener_candidates = []
+    for pid, names in sorted(listeners.items()):
+        proc = by_pid.get(pid)
+        if proc is None or pid in covered:
+            continue
+        if proc["is_helper"] or HELPER_RE.search(" ".join(names)):
+            orphan_listener_candidates.append(
+                {
+                    "pid": pid,
+                    "ppid": proc["ppid"],
+                    "command_name": proc["command_name"],
+                    "role": proc["role"],
+                    "command": proc["command"],
+                    "rss_kib": proc["rss_kib"],
+                    "rss_mib": proc["rss_mib"],
+                    "cpu_pct": proc["cpu_pct"],
+                    "elapsed": proc["elapsed"],
+                    "elapsed_seconds": proc["elapsed_seconds"],
+                    "listeners": names,
+                    "listener_ports": listener_ports(names),
+                }
+            )
+
+    helper_groups: dict[str, list[dict[str, Any]]] = {}
+    for proc in processes:
+        if not proc["is_helper"]:
+            continue
+        signature = proc["command_name"] or proc["command"].split(" ", 1)[0]
+        if signature in {"sh", "bash", "zsh"}:
+            signature = proc["command"][:120]
+        helper_groups.setdefault(signature, []).append(proc)
+    duplicate_helper_groups = [
+        {
+            "signature": signature,
+            "count": len(group),
+            "pids": [proc["pid"] for proc in group],
+            "total_rss_mib": round(sum(proc["rss_kib"] for proc in group) / 1024, 1),
+        }
+        for signature, group in sorted(helper_groups.items())
+        if len(group) > 1
+    ]
+
+    accumulated_sessions = [
+        {
+            "pid": tree["root"]["pid"],
+            "command_name": tree["root"]["command_name"],
+            "elapsed": tree["root"]["elapsed"],
+            "elapsed_seconds": tree["root"]["elapsed_seconds"],
+            "rss_mib": tree["root"]["rss_mib"],
+            "cpu_pct": tree["root"]["cpu_pct"],
+        }
+        for tree in trees
+        if (tree["root"]["elapsed_seconds"] or 0) >= args.accumulated_seconds
+    ]
+    oauth_mux_processes = [proc for proc in processes if proc["is_oauth_mux"]]
+    codex_processes = [proc for proc in processes if proc["is_codex"]]
+    claude_processes = [proc for proc in processes if proc["is_claude"]]
+    managed_codex_children = [proc for proc in codex_processes if proc["role"] == "managed_codex_child"]
+    unmanaged_codex_processes = [proc for proc in codex_processes if proc["role"] == "native_codex"]
+    process_summary = {
+        "oauth_mux_processes": len(oauth_mux_processes),
+        "codex_processes": len(codex_processes),
+        "claude_processes": len(claude_processes),
+        "managed_codex_children": len(managed_codex_children),
+        "unmanaged_codex_processes": len(unmanaged_codex_processes),
+        "ambiguous_processes": len(orphan_listener_candidates),
+    }
+
+    return {
+        "kind": "dogfood_process_snapshot",
+        "mode": "agent_process_fanout_snapshot",
+        "schema_version": 1,
+        "collected_at": utc_now(),
+        "host": os.uname().nodename,
+        "pid": os.getpid(),
+        "scope": "agent_process_fanout",
+        "spends_provider_calls": False,
+        "no_provider_spend": True,
+        "mutates_user_config": False,
+        "mutates_route_health": False,
+        "mutates_processes": False,
+        "kills_processes": False,
+        "sleeps": False,
+        "foreground_sleep": False,
+        "tag": args.tag,
+        "thresholds": {
+            "accumulated_seconds": args.accumulated_seconds,
+            "rss_growth_kib": args.rss_growth_kib,
+            "rss_growth_pct": args.rss_growth_pct,
+        },
+        "summary": {
+            "process_count": len(processes),
+            "agent_tree_count": len(trees),
+            "orphan_listener_candidate_count": len(orphan_listener_candidates),
+            "duplicate_helper_group_count": len(duplicate_helper_groups),
+            "accumulated_session_count": len(accumulated_sessions),
+            "heap_leak_proven": False,
+            "heap_leak_evidence": "single snapshot only; compare two snapshots before calling this a leak",
+        },
+        "process_summary": process_summary,
+        "claim": {
+            "current_process_hotswap": False,
+            "unmanaged_tui_hotswap": False,
+            "per_request_muxing": False,
+        },
+        "agent_trees": trees,
+        "orphan_listener_candidates": orphan_listener_candidates,
+        "duplicate_helper_groups": duplicate_helper_groups,
+        "accumulated_sessions": accumulated_sessions,
+        "safe_cleanup": {
+            "automation_may_kill": False,
+            "requires_operator_approval": True,
+            "guidance": [
+                "Do not kill active Codex or Claude sessions from this report.",
+                "Close old shells or agent sessions manually when their work is complete.",
+                "Only collect a leak bug after repeated snapshots show unexplained RSS growth for the same PID.",
+            ],
+        },
+        "warnings": warnings,
+    }
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def compare_snapshots(base: dict[str, Any], current: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    base_procs: dict[int, dict[str, Any]] = {}
+    for tree in base.get("agent_trees", []):
+        for proc in tree.get("processes", []):
+            base_procs[int(proc["pid"])] = proc
+    for proc in base.get("orphan_listener_candidates", []):
+        base_procs[int(proc["pid"])] = proc
+
+    current_procs: dict[int, dict[str, Any]] = {}
+    for tree in current.get("agent_trees", []):
+        for proc in tree.get("processes", []):
+            current_procs[int(proc["pid"])] = proc
+    for proc in current.get("orphan_listener_candidates", []):
+        current_procs[int(proc["pid"])] = proc
+
+    stable: list[dict[str, Any]] = []
+    growth: list[dict[str, Any]] = []
+    disappeared: list[dict[str, Any]] = []
+    appeared: list[dict[str, Any]] = []
+
+    for pid, before in sorted(base_procs.items()):
+        after = current_procs.get(pid)
+        if after is None:
+            disappeared.append({"pid": pid, "command_name": before.get("command_name"), "before_elapsed": before.get("elapsed")})
+            continue
+        rss_delta = int(after["rss_kib"]) - int(before["rss_kib"])
+        before_rss = max(int(before["rss_kib"]), 1)
+        pct = (rss_delta / before_rss) * 100
+        row = {
+            "pid": pid,
+            "command_name": after.get("command_name"),
+            "rss_delta_kib": rss_delta,
+            "rss_delta_mib": round(rss_delta / 1024, 1),
+            "rss_delta_pct": round(pct, 1),
+            "before_rss_mib": before.get("rss_mib"),
+            "after_rss_mib": after.get("rss_mib"),
+            "before_elapsed": before.get("elapsed"),
+            "after_elapsed": after.get("elapsed"),
+            "command": after.get("command"),
+        }
+        if rss_delta >= args.rss_growth_kib and pct >= args.rss_growth_pct:
+            growth.append(row)
+        else:
+            stable.append(row)
+
+    for pid, after in sorted(current_procs.items()):
+        if pid not in base_procs:
+            appeared.append({"pid": pid, "command_name": after.get("command_name"), "rss_mib": after.get("rss_mib"), "elapsed": after.get("elapsed")})
+
+    return {
+        "kind": "dogfood_process_snapshot_comparison",
+        "mode": "agent_process_fanout_comparison",
+        "schema_version": 1,
+        "compared_at": utc_now(),
+        "spends_provider_calls": False,
+        "mutates_user_config": False,
+        "mutates_route_health": False,
+        "mutates_processes": False,
+        "kills_processes": False,
+        "sleeps": False,
+        "foreground_sleep": False,
+        "baseline_collected_at": base.get("collected_at"),
+        "current_collected_at": current.get("collected_at"),
+        "thresholds": {
+            "rss_growth_kib": args.rss_growth_kib,
+            "rss_growth_pct": args.rss_growth_pct,
+        },
+        "summary": {
+            "same_pid_count": len(stable) + len(growth),
+            "suspected_rss_growth_count": len(growth),
+            "stable_or_explained_count": len(stable),
+            "appeared_count": len(appeared),
+            "disappeared_count": len(disappeared),
+            "heap_leak_proven": False,
+            "classification": "suspected_rss_growth" if growth else "stable_or_session_churn",
+        },
+        "suspected_rss_growth": growth,
+        "stable_or_explained": stable,
+        "appeared": appeared,
+        "disappeared": disappeared,
+        "safe_cleanup": {
+            "automation_may_kill": False,
+            "requires_operator_approval": True,
+        },
+    }
+
+
+def render_snapshot_md(snapshot: dict[str, Any]) -> str:
+    lines = [
+        "# Dogfood Process Fanout Snapshot",
+        "",
+        f"Collected: {snapshot['collected_at']}",
+        f"Host: {snapshot['host']}",
+        "",
+        "This report is observational only. It does not spend provider calls, mutate oauth-mux state, sleep in the foreground, or kill processes.",
+        "",
+        "## Summary",
+        "",
+    ]
+    for key, value in snapshot["summary"].items():
+        lines.append(f"- `{key}`: {value}")
+    lines.append("")
+    lines.append("## Process Summary")
+    lines.append("")
+    for key, value in snapshot["process_summary"].items():
+        lines.append(f"- `{key}`: {value}")
+    if snapshot.get("warnings"):
+        lines.extend(["", "## Warnings", ""])
+        lines.extend(f"- {warning}" for warning in snapshot["warnings"])
+
+    lines.extend(["", "## Agent Process Trees", ""])
+    if not snapshot["agent_trees"]:
+        lines.append("No Codex or Claude parent processes were visible to this user.")
+    for tree in snapshot["agent_trees"]:
+        root = tree["root"]
+        lines.extend(
+            [
+                f"### `{root['command_name']}` pid `{root['pid']}`",
+                "",
+                f"- elapsed: `{root['elapsed']}`",
+                f"- root RSS: `{root['rss_mib']} MiB`",
+                f"- tree RSS: `{tree['total_rss_mib']} MiB`",
+                f"- tree CPU: `{tree['total_cpu_pct']}%`",
+                f"- child count: `{tree['child_count']}`",
+                f"- helper count: `{tree['helper_count']}`",
+                "",
+                "| depth | pid | ppid | role | cpu | rss MiB | elapsed | listeners | command |",
+                "| ---: | ---: | ---: | --- | ---: | ---: | --- | --- | --- |",
+            ]
+        )
+        for proc in tree["processes"]:
+            listeners = ", ".join(proc["listener_ports"]) if proc["listener_ports"] else ""
+            command = proc["command"].replace("|", "\\|")
+            lines.append(
+                f"| {proc['depth']} | {proc['pid']} | {proc['ppid']} | `{proc['role']}` | {proc['cpu_pct']} | "
+                f"{proc['rss_mib']} | {proc['elapsed']} | {listeners} | `{command}` |"
+            )
+        lines.append("")
+
+    lines.extend(["## Orphan Listener Candidates", ""])
+    if not snapshot["orphan_listener_candidates"]:
+        lines.append("No helper/listener candidates were visible outside the agent trees.")
+    else:
+        lines.append("| pid | ppid | role | cpu | rss MiB | elapsed | listeners | command |")
+        lines.append("| ---: | ---: | --- | ---: | ---: | --- | --- | --- |")
+        for proc in snapshot["orphan_listener_candidates"]:
+            listeners = ", ".join(proc["listener_ports"]) if proc["listener_ports"] else ", ".join(proc["listeners"])
+            command = proc["command"].replace("|", "\\|")
+            lines.append(
+                f"| {proc['pid']} | {proc['ppid']} | `{proc.get('role', 'helper')}` | {proc['cpu_pct']} | {proc['rss_mib']} | "
+                f"{proc['elapsed']} | {listeners} | `{command}` |"
+            )
+
+    lines.extend(["", "## Duplicate Helper Groups", ""])
+    if not snapshot["duplicate_helper_groups"]:
+        lines.append("No duplicate helper groups were detected by command signature.")
+    else:
+        for group in snapshot["duplicate_helper_groups"]:
+            lines.append(
+                f"- `{group['signature']}`: {group['count']} processes, "
+                f"{group['total_rss_mib']} MiB total RSS, pids `{group['pids']}`"
+            )
+
+    lines.extend(
+        [
+            "",
+            "## Safe Cleanup Rules",
+            "",
+            "- Do not kill processes from this report automatically.",
+            "- Leave active shells/sessions alone while work is in progress.",
+            "- Close old shells or agent sessions manually after confirming they are idle.",
+            "- File a real leak bug only after repeated snapshots show unexplained RSS growth for the same PID.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_comparison_md(comparison: dict[str, Any]) -> str:
+    lines = [
+        "# Dogfood Process Fanout Comparison",
+        "",
+        f"Compared: {comparison['compared_at']}",
+        f"Baseline: {comparison.get('baseline_collected_at')}",
+        f"Current: {comparison.get('current_collected_at')}",
+        "",
+        "## Summary",
+        "",
+    ]
+    for key, value in comparison["summary"].items():
+        lines.append(f"- `{key}`: {value}")
+
+    lines.extend(["", "## Suspected RSS Growth", ""])
+    if not comparison["suspected_rss_growth"]:
+        lines.append("No same-PID RSS growth crossed the configured threshold.")
+    else:
+        lines.append("| pid | command | delta MiB | delta % | before | after |")
+        lines.append("| ---: | --- | ---: | ---: | ---: | ---: |")
+        for row in comparison["suspected_rss_growth"]:
+            lines.append(
+                f"| {row['pid']} | `{row['command_name']}` | {row['rss_delta_mib']} | "
+                f"{row['rss_delta_pct']} | {row['before_rss_mib']} | {row['after_rss_mib']} |"
+            )
+
+    lines.extend(["", "## Session Churn", ""])
+    lines.append(f"- appeared: `{comparison['summary']['appeared_count']}`")
+    lines.append(f"- disappeared: `{comparison['summary']['disappeared_count']}`")
+    lines.extend(["", "Automation still must not kill any listed process without explicit operator approval.", ""])
+    return "\n".join(lines)
+
+
+def write_artifacts(payload: dict[str, Any], markdown: str, out_dir: Path, prefix: str) -> tuple[Path, Path]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    tag = payload.get("tag")
+    suffix = f"-{tag}" if tag else ""
+    json_path = out_dir / f"{prefix}-{stamp}{suffix}.json"
+    md_path = out_dir / f"{prefix}-{stamp}{suffix}.md"
+    json_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    md_path.write_text(markdown, encoding="utf-8")
+    return json_path, md_path
+
+
+def schedule_followup(args: argparse.Namespace, baseline_path: Path, out_dir: Path) -> int:
+    log_path = out_dir / f"process-followup-{dt.datetime.now(dt.timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.log"
+    cmd = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        "--followup-after-seconds",
+        str(args.schedule_followup_seconds),
+        "--followup-baseline",
+        str(baseline_path),
+        "--out",
+        str(out_dir),
+        "--tag",
+        "followup",
+        "--rss-growth-kib",
+        str(args.rss_growth_kib),
+        "--rss-growth-pct",
+        str(args.rss_growth_pct),
+    ]
+    log = log_path.open("ab")
+    proc = subprocess.Popen(cmd, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+    return proc.pid
+
+
+def followup_mode(args: argparse.Namespace) -> int:
+    # This sleep is intentionally in a detached/background follow-up process.
+    time.sleep(args.followup_after_seconds)
+    snapshot = build_snapshot(args)
+    markdown = render_snapshot_md(snapshot)
+    out_dir = Path(args.out)
+    current_json, current_md = write_artifacts(snapshot, markdown, out_dir, "process-snapshot")
+    baseline = load_json(Path(args.followup_baseline))
+    comparison = compare_snapshots(baseline, snapshot, args)
+    comp_md = render_comparison_md(comparison)
+    comp_json, comp_md_path = write_artifacts(comparison, comp_md, out_dir, "process-comparison")
+    print(f"follow-up snapshot: {current_json}")
+    print(f"follow-up report:   {current_md}")
+    print(f"comparison json:    {comp_json}")
+    print(f"comparison report:  {comp_md_path}")
+    return 0
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="print JSON to stdout instead of Markdown")
+    parser.add_argument("--out", help="write JSON and Markdown artifacts to this directory")
+    parser.add_argument("--tag", help="short label to add to written artifact names")
+    parser.add_argument("--compare", nargs=2, metavar=("BASELINE_JSON", "CURRENT_JSON"), help="compare two snapshot JSON files")
+    parser.add_argument("--schedule-followup-seconds", type=int, help="after writing --out artifacts, schedule a background follow-up snapshot")
+    parser.add_argument("--accumulated-seconds", type=int, default=4 * 60 * 60, help="elapsed time threshold for accumulated-session classification")
+    parser.add_argument("--rss-growth-kib", type=int, default=64 * 1024, help="minimum same-PID RSS growth for comparison suspicion")
+    parser.add_argument("--rss-growth-pct", type=float, default=25.0, help="minimum same-PID RSS percent growth for comparison suspicion")
+    parser.add_argument("--followup-after-seconds", type=int, help=argparse.SUPPRESS)
+    parser.add_argument("--followup-baseline", help=argparse.SUPPRESS)
+    args = parser.parse_args(argv)
+    if args.schedule_followup_seconds is not None and args.schedule_followup_seconds <= 0:
+        parser.error("--schedule-followup-seconds must be positive")
+    if args.schedule_followup_seconds is not None and not args.out:
+        parser.error("--schedule-followup-seconds requires --out")
+    if args.followup_after_seconds is not None and not args.followup_baseline:
+        parser.error("--followup-after-seconds requires --followup-baseline")
+    return args
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+
+    if args.followup_after_seconds is not None:
+        return followup_mode(args)
+
+    if args.compare:
+        baseline = load_json(Path(args.compare[0]))
+        current = load_json(Path(args.compare[1]))
+        payload = compare_snapshots(baseline, current, args)
+        markdown = render_comparison_md(payload)
+        prefix = "process-comparison"
+    else:
+        payload = build_snapshot(args)
+        markdown = render_snapshot_md(payload)
+        prefix = "process-snapshot"
+
+    written_json: Path | None = None
+    if args.out:
+        written_json, written_md = write_artifacts(payload, markdown, Path(args.out), prefix)
+        print(f"wrote json:   {written_json}", file=sys.stderr)
+        print(f"wrote report: {written_md}", file=sys.stderr)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(markdown)
+
+    if args.schedule_followup_seconds is not None:
+        assert written_json is not None
+        pid = schedule_followup(args, written_json, Path(args.out))
+        print(
+            f"scheduled background follow-up pid {pid} after {args.schedule_followup_seconds}s; "
+            "no foreground sleep is running",
+            file=sys.stderr,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/smoke-dogfood-process-snapshot.sh
+++ b/scripts/smoke-dogfood-process-snapshot.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d -t omux-process-snapshot.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+python3 "$ROOT/scripts/dogfood-process-snapshot.py" --json >"$TMP/snapshot.json"
+
+jq -e '
+  .kind == "dogfood_process_snapshot"
+  and .schema_version == 1
+  and .spends_provider_calls == false
+  and .mutates_user_config == false
+  and .mutates_route_health == false
+  and .mutates_processes == false
+  and .kills_processes == false
+  and .sleeps == false
+  and .foreground_sleep == false
+  and .safe_cleanup.automation_may_kill == false
+  and .safe_cleanup.requires_operator_approval == true
+  and (.process_summary.oauth_mux_processes | type == "number")
+  and (.agent_trees | type == "array")
+  and (.orphan_listener_candidates | type == "array")
+  and (.duplicate_helper_groups | type == "array")
+' "$TMP/snapshot.json" >/dev/null
+
+python3 "$ROOT/scripts/dogfood-process-snapshot.py" \
+  --compare "$TMP/snapshot.json" "$TMP/snapshot.json" \
+  --json >"$TMP/comparison.json"
+
+jq -e '
+  .kind == "dogfood_process_snapshot_comparison"
+  and .spends_provider_calls == false
+  and .mutates_user_config == false
+  and .mutates_route_health == false
+  and .kills_processes == false
+  and .sleeps == false
+  and .foreground_sleep == false
+  and .safe_cleanup.automation_may_kill == false
+  and .summary.suspected_rss_growth_count == 0
+' "$TMP/comparison.json" >/dev/null
+
+python3 "$ROOT/scripts/dogfood-process-snapshot.py" --out "$TMP/out" --tag smoke >/dev/null
+test -n "$(find "$TMP/out" -name 'process-snapshot-*-smoke.json' -print -quit)"
+test -n "$(find "$TMP/out" -name 'process-snapshot-*-smoke.md' -print -quit)"
+
+echo "smoke-dogfood-process-snapshot: all assertions passed."


### PR DESCRIPTION
## Summary

- Add the AGENTS.md product guardrail: oauth-mux is a harness continuity layer, with a concrete feature-creep test for future work.
- Add a no-spend dogfood process fanout snapshot script that groups visible Codex, Claude, and oauth-mux process trees with RSS/CPU/listener evidence.
- Add JSON/Markdown artifact output, same-PID comparison mode, and optional detached follow-up scheduling without foreground sleep.
- Add just targets, a check-local smoke, and a runbook with explicit manual cleanup rules.

Linear: TIN-1518

## Validation

- git diff --check
- python3 -m py_compile ./scripts/dogfood-process-snapshot.py
- ./scripts/smoke-dogfood-process-snapshot.sh
- nix develop --command just check-local

## Dogfood Snapshot Note

A live no-spend snapshot after the local check saw zero oauth-mux processes, eight unmanaged/native Codex processes, five long-running Codex sessions, and duplicate helper groups. The diagnostic intentionally treats this as accumulated process topology evidence, not a proven heap leak from one sample.