### PR TITLE
Make Homebrew formula codex-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ diagnostic infrastructure. They are not product success.
 
 ## Current Truth
 
-Public install lanes currently resolve to `0.1.7`: GitHub Release assets, npm
-root and platform packages, the public Homebrew tap, the curl installer, and
-published deb/rpm assets. The current source tree also tightens install parity
-after a 2026-05-18 finding that the public Homebrew `codex` shim routed native
-admin commands such as `codex --version` through oauth-mux route election.
-Source `0.1.9` is the package-lane patch release candidate after `0.1.8`
-exposed Homebrew formula audit drift before registry/tap publication.
+Public install lanes are versioned by channel. GitHub Release assets, npm root
+and platform packages, the curl installer, and published deb/rpm assets last
+resolved to `0.1.7` in the public parity sweep. The public Homebrew tap now
+serves `0.1.9`. The current source tree also tightens install parity after a
+2026-05-18 finding that the public Homebrew `codex` shim routed native admin
+commands such as `codex --version` through oauth-mux route election. Homebrew
+must remain binary-only by default: `brew install jesssullivan/omux/oauth-mux`
+installs `oauth-mux` and must not install or link a managed `codex` shim.
 
 What works today:
 
@@ -110,13 +111,17 @@ ladder diagrams.
 
 ## Install
 
-Public install lanes currently resolve to `0.1.7`:
+Public install lanes:
 
 ```bash
 npm install -g oauth-mux
 # or
 brew install jesssullivan/omux/oauth-mux
 ```
+
+The Homebrew formula is intentionally binary-only. It should not change
+`command -v codex`; use the explicit local, npm, Nix, or future opt-in package
+shim lanes when testing managed bare-`codex` behavior.
 
 Nix users can choose the binary-only package or the managed-shim package:
 

--- a/dist/homebrew/oauth-mux.rb
+++ b/dist/homebrew/oauth-mux.rb
@@ -1,7 +1,6 @@
 class OauthMux < Formula
   desc "OAuth fallback muxing for AI harness subscriptions"
   homepage "https://omux.xoxd.ai"
-  version "${VERSION}"
   license "MIT"
 
   on_macos do
@@ -26,21 +25,10 @@ class OauthMux < Formula
 
   def install
     bin.install "oauth-mux"
-    bin.install "codex"
   end
 
   test do
     assert_match "oauth-mux", shell_output("#{bin}/oauth-mux version")
-    assert_match "OMUX_CODEX_SHIM", shell_output("grep OMUX_CODEX_SHIM #{bin}/codex")
-    native = testpath/"native-codex"
-    native.write <<~EOS
-      #!/bin/sh
-      case "$1" in
-        --version) echo "native-codex-stub 0.0.0" ;;
-        *) echo "native-codex-stub" ;;
-      esac
-    EOS
-    chmod 0755, native
-    assert_match "native-codex-stub 0.0.0", shell_output("OMUX_CODEX_BIN=#{native} #{bin}/codex --version")
+    system "test", "!", "-e", "#{bin}/codex"
   end
 end

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -1,6 +1,6 @@
 # Productionization Ledger
 
-Updated: 2026-05-18
+Updated: 2026-05-19
 
 This ledger is the short operator map for oauth-mux productionization. It is
 subordinate to the broker contract and Codex adapter contract, and it should be
@@ -8,25 +8,25 @@ refreshed when release truth, route evidence, or tracker state changes.
 
 ## Current Snapshot
 
-- Repo state: `main` is clean against `origin/main` after the `0.1.7`
-  package-parity refresh.
+- Repo state: `main` is clean against `origin/main` after the product-guardrail
+  and dogfood process fanout snapshot merge.
 - CI state: GitHub Actions is the live source for the latest run. The
   2026-05-17 refresh verified the `v0.1.7` release workflow, npm publish
   workflow, and hosted system-package install QA.
-- Version truth: public npm, GitHub Release, Homebrew, curl installer, and
-  deb/rpm lanes resolve to `0.1.7`, but the 2026-05-18 shim investigation found
-  a package-lane QA gap: public Homebrew `0.1.7` routes native admin commands
-  such as `codex --version` through `oauth-mux codex`. GitHub Release `0.1.8`
-  exists, but registry/tap publication is targeting source `0.1.9` after the
-  Homebrew dry-run caught formula audit drift.
+- Version truth: public npm, GitHub Release, curl installer, and deb/rpm lanes
+  last resolved to `0.1.7` in the public parity sweep. The public Homebrew tap
+  now advertises `0.1.9`, but the 2026-05-18/19 shim investigation found a
+  package-lane ownership bug: the Homebrew formula must not install or link a
+  managed `codex` shim by default.
 - Installed provenance: PATH can resolve a public package binary or a
   user-local dogfood binary depending on shell setup. Use `which -a oauth-mux`,
   `which -a codex`, `oauth-mux version --json`, and `codex preflight` before
   treating any installed-command run as release evidence.
-- Homebrew truth: the public `jesssullivan/omux` tap installs `oauth-mux
-  0.1.7`, includes a managed `codex` shim, and `brew info --json=v2`
-  reports stable version `0.1.7`; the current public shim still needs the
-  admin pass-through fix from this source tree.
+- Homebrew truth: the public `jesssullivan/omux` tap advertises `oauth-mux
+  0.1.9`. Homebrew should be treated as a binary-only package lane: QA must
+  prove `brew install jesssullivan/omux/oauth-mux` installs `oauth-mux`, does
+  not install an `OMUX_CODEX_SHIM`, and leaves native `codex` command
+  resolution unchanged.
 - Codex route truth: refresh before every live test. The latest 2026-05-17
   22:24 EDT installed Homebrew `0.1.7` no-spend snapshot is `not_afloat`:
   all four named `codex-max` routes are runtime-ready and broker-ready but

--- a/docs/release-install-lanes.md
+++ b/docs/release-install-lanes.md
@@ -15,7 +15,7 @@ Detailed historical evidence stays in `docs/install-beta-matrix.md` and
 | Nix package | `nix build .#` | flake package plus shared POSIX shim | `./result/bin/oauth-mux version`, `nix flake check` binary+shim smoke | package derivation proof |
 | GitHub Release | downloaded tarball | `dist/out/v*/artifacts` from release workflow | checksum verify, tarball binary+shim smoke | public raw binary lane |
 | npm | `npm install -g oauth-mux` / `npx oauth-mux` | CI-generated npm tarballs plus JS `codex` shim | npm install smoke, shim pass-through smoke, and `npm view` | public JS package lane |
-| Homebrew | `brew install jesssullivan/omux/oauth-mux` | public tap formula from release checksums | `just homebrew-qa <version>`, formula test shim pass-through, parsed version check | public macOS/Linux tap lane |
+| Homebrew | `brew install jesssullivan/omux/oauth-mux` | public tap formula from release checksums | `just homebrew-qa <version>`, formula test proves no `codex` install, parsed version check | public macOS/Linux tap lane |
 | curl installer | `curl .../install.sh \| sh` | GitHub Release `install.sh` + tarballs | local file URL binary+shim smoke and public installer smoke | shell installer lane |
 | deb/rpm | system package install | GitHub Release `.deb` / `.rpm` | hosted container install QA for `/usr/bin/oauth-mux`; set `OMUX_EXPECT_CODEX_SHIM=1` for releases that should include `/usr/bin/codex` | distro package lane |
 | Home Manager | `programs.oauth-mux.enable = true` | flake Home Manager module | `just home-manager-smoke` package-variant smoke | Nix user-profile lane with opt-in Codex shim |
@@ -32,9 +32,12 @@ Every install lane that puts `codex` on PATH must preserve this behavior:
   `oauth-mux codex` only when PATH resolves the oauth-mux shim.
 - The shim discovers native Codex via `OMUX_CODEX_BIN` first, then PATH,
   skipping other files marked `OMUX_CODEX_SHIM`.
-- POSIX lanes use the single shared source `dist/codex-shim.sh`: user-local
-  dogfood, GitHub Release tarballs, curl installer, Homebrew, Nix, and
-  generated deb/rpm packages.
+- POSIX shim-bearing lanes use the single shared source `dist/codex-shim.sh`:
+  user-local dogfood, GitHub Release tarballs, curl installer, opt-in Nix /
+  Home Manager packages, and generated deb/rpm packages.
+- Homebrew is intentionally binary-only for PATH ownership: the formula installs
+  `oauth-mux` but must not install or link `codex`. A managed Codex shim for
+  Homebrew users must be an explicit opt-in lane, not the default formula.
 - npm uses `dist/npm/bin/codex.js`, which must match the same admin
   pass-through contract even though it is a JS wrapper.
 - Windows raw tarballs currently ship only `oauth-mux.exe`. The 2026-05-18
@@ -59,8 +62,8 @@ The 2026-05-18 investigation found that public Homebrew `0.1.7` installed a
 `codex` shim that always entered `oauth-mux codex`, so `codex --version` and
 `codex login` could hit route election and fail with `NoAccountSelectable`.
 That was package-lane drift, not a route-health issue. The current source tree
-fixes the release templates and adds package smokes so the `0.1.9` package
-release can prove this behavior before publication.
+fixes the release templates and adds package smokes so Homebrew proves native
+Codex command resolution is unchanged by `brew install jesssullivan/omux/oauth-mux`.
 
 ## CI/CD Surfaces
 
@@ -95,8 +98,12 @@ release can prove this behavior before publication.
 - Homebrew package QA must check the installed binary and Homebrew's parsed
   `versions.stable`; a working binary with bad formula metadata is not release
   parity.
-- Package QA must check the managed `codex` shim's admin pass-through behavior
-  with a native Codex stub. A binary version check alone is not sufficient.
+- Homebrew package QA must prove the formula does not install `codex`, does not
+  link an `OMUX_CODEX_SHIM` into the Homebrew prefix, and leaves `command -v
+  codex` unchanged from before install.
+- Shim-bearing package QA must check the managed `codex` shim's admin
+  pass-through behavior with a native Codex stub. A binary version check alone
+  is not sufficient.
 - For live Codex acceptance, use an installed binary on PATH and preserve the
   status artifact `runtime_identity`, including `binary_source` and
   `binary_sha256`. Repo-local wrapper runs are not acceptance evidence.
@@ -114,7 +121,7 @@ oauth-mux version --json
 oauth-mux codex preflight --profile codex-max --capability codex-max --json
 ```
 
-Expected when testing unreleased behavior:
+Expected when testing unreleased managed-shim behavior:
 
 - `./zig-out/bin/oauth-mux` and `~/.local/bin/oauth-mux` hashes match.
 - `oauth-mux version --json` reports the active executable's
@@ -123,7 +130,7 @@ Expected when testing unreleased behavior:
 - `which -a oauth-mux` resolves `~/.local/bin/oauth-mux` before Homebrew when
   testing unreleased behavior.
 - `which -a codex` resolves `~/.local/bin/codex` before the native upstream
-  Codex CLI when testing managed Codex behavior.
+  Codex CLI only when testing the explicit managed-shim lane.
 - `oauth-mux codex preflight --json` is handled by oauth-mux, not by the native
   Codex CLI usage parser.
 - Homebrew may report the same source version while still being a different
@@ -131,10 +138,9 @@ Expected when testing unreleased behavior:
 
 If Homebrew appears before `~/.local/bin` in PATH, use the worktree binary or
 adjust PATH before recording unreleased dogfood evidence. The active public
-Homebrew tap now resolves `0.1.7` and passes both installed-binary and
-`brew info --json=v2` stable-version checks, but it is still a package binary,
-not worktree proof, and those older checks did not prove native Codex admin
-pass-through.
+Homebrew is a package binary, not worktree proof. It must not shadow native
+Codex by default; use `which -a codex` before and after Homebrew QA to verify
+the `codex` executable owner did not change.
 
 On macOS, do not overwrite an existing Mach-O in place for this lane. A direct
 `cp` over `~/.local/bin/oauth-mux` can leave stale taskgated/code-signing state

--- a/scripts/homebrew-install-qa.sh
+++ b/scripts/homebrew-install-qa.sh
@@ -8,8 +8,9 @@ if [ -z "$version" ] || [ "$version" = "--help" ] || [ "$version" = "-h" ]; then
   cat <<'EOF'
 Usage: scripts/homebrew-install-qa.sh <version>
 
-Installs oauth-mux from the configured Homebrew tap, runs brew audit/test, and
-verifies the installed binary version.
+Installs oauth-mux from the configured Homebrew tap, runs brew audit/test,
+verifies the installed binary version, and proves the formula does not shadow
+native Codex with an oauth-mux shim.
 
 Environment:
   OMUX_HOMEBREW_TAP_NAME       Homebrew tap name. Default: jesssullivan/omux
@@ -37,13 +38,19 @@ require_command() {
 
 require_command "$brew_cmd"
 
+resolve_command() {
+  command -v "$1" 2>/dev/null || true
+}
+
+codex_before="$(resolve_command codex)"
+
 was_tapped=0
 if "$brew_cmd" tap | grep -Fxq "$tap_name"; then
   was_tapped=1
 fi
 
 was_installed=0
-if "$brew_cmd" list --versions oauth-mux >/dev/null 2>&1; then
+if [ -n "$("$brew_cmd" list --versions "$formula" 2>/dev/null)" ]; then
   was_installed=1
 fi
 
@@ -52,7 +59,7 @@ keep_tap="${OMUX_HOMEBREW_KEEP_TAP:-$was_tapped}"
 
 cleanup() {
   if [ "$keep_installed" != "1" ] && [ "$was_installed" != "1" ]; then
-    "$brew_cmd" uninstall oauth-mux >/dev/null 2>&1 || true
+    "$brew_cmd" uninstall "$formula" >/dev/null 2>&1 || true
   fi
   if [ "$keep_tap" != "1" ] && [ "$was_tapped" != "1" ]; then
     "$brew_cmd" untap "$tap_name" >/dev/null 2>&1 || true
@@ -77,7 +84,7 @@ fi
 
 "$brew_cmd" test "$formula"
 
-prefix="$("$brew_cmd" --prefix oauth-mux)"
+prefix="$("$brew_cmd" --prefix "$formula")"
 bin="$prefix/bin/oauth-mux"
 if [ ! -x "$bin" ]; then
   printf 'installed binary not executable: %s\n' "$bin" >&2
@@ -92,6 +99,24 @@ if [ "$actual" != "$expected" ]; then
 fi
 
 "$bin" doctor --json >/dev/null
+
+if [ -e "$prefix/bin/codex" ]; then
+  printf 'Homebrew oauth-mux formula must not install a formula-local codex shim: %s\n' "$prefix/bin/codex" >&2
+  exit 1
+fi
+
+brew_prefix="$("$brew_cmd" --prefix)"
+homebrew_codex="$brew_prefix/bin/codex"
+if [ -e "$homebrew_codex" ] && grep -q 'OMUX_CODEX_SHIM' "$homebrew_codex" 2>/dev/null; then
+  printf 'Homebrew oauth-mux formula must not link OMUX_CODEX_SHIM into PATH: %s\n' "$homebrew_codex" >&2
+  exit 1
+fi
+
+codex_after="$(resolve_command codex)"
+if [ "$codex_before" != "$codex_after" ]; then
+  printf 'Homebrew oauth-mux install changed codex resolution: before=%s after=%s\n' "${codex_before:-<not found>}" "${codex_after:-<not found>}" >&2
+  exit 1
+fi
 
 if [ "${OMUX_HOMEBREW_CODEX_CANARY:-0}" = "1" ]; then
   canary_args=(codex canary)

--- a/scripts/homebrew-version-check.sh
+++ b/scripts/homebrew-version-check.sh
@@ -6,7 +6,8 @@ if [ "$#" -ne 2 ]; then
 Usage: scripts/homebrew-version-check.sh <expected-version> <formula-file-or-ref>
 
 Checks either:
-  - a rendered formula file contains an explicit Homebrew version line, or
+  - a rendered formula file contains an explicit Homebrew version line or a
+    release URL from which Homebrew can infer the expected stable version, or
   - a tapped formula reference reports the expected stable version via
     `brew info --json=v2`.
 EOF
@@ -17,11 +18,20 @@ expected="$1"
 target="$2"
 
 if [ -f "$target" ]; then
-  if ! grep -Fqx "  version \"$expected\"" "$target"; then
-    printf 'Homebrew formula %s does not contain expected explicit version "%s"\n' "$target" "$expected" >&2
-    exit 1
+  if grep -Fqx "  version \"$expected\"" "$target"; then
+    exit 0
   fi
-  exit 0
+  inferred="$(
+    sed -n 's|.*releases/download/v\([^/"]*\)/.*|\1|p' "$target" |
+      sort -u |
+      tr '\n' ' ' |
+      sed 's/[[:space:]]*$//'
+  )"
+  if [ "$inferred" = "$expected" ]; then
+    exit 0
+  fi
+  printf 'Homebrew formula %s does not expose expected stable version "%s" (inferred: %s)\n' "$target" "$expected" "${inferred:-<none>}" >&2
+  exit 1
 fi
 
 brew_cmd="${OMUX_BREW_BIN:-brew}"

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -120,13 +120,24 @@ if grep -q -E '\$\{(VERSION|SHA_[A-Z0-9_]+)\}' "$homebrew_formula"; then
   printf 'unrendered placeholder remains in %s\n' "$homebrew_formula" >&2
   exit 1
 fi
-version_line="$(awk '/^[[:space:]]+version / { print NR; exit }' "$homebrew_formula")"
+if grep -q '^[[:space:]]*version ' "$homebrew_formula"; then
+  printf 'Homebrew formula must not declare a redundant explicit version; Homebrew should infer it from release URLs: %s\n' "$homebrew_formula" >&2
+  exit 1
+fi
 license_line="$(awk '/^[[:space:]]+license / { print NR; exit }' "$homebrew_formula")"
-if [ -z "${version_line:-}" ] || [ -z "${license_line:-}" ] || [ "$version_line" -ge "$license_line" ]; then
-  printf 'Homebrew formula must put version before license for brew audit compatibility: %s\n' "$homebrew_formula" >&2
+if [ -z "${license_line:-}" ]; then
+  printf 'Homebrew formula missing license line: %s\n' "$homebrew_formula" >&2
   exit 1
 fi
 "$repo_root/scripts/homebrew-version-check.sh" "$version" "$homebrew_formula"
+if grep -q 'bin.install "codex"' "$homebrew_formula"; then
+  printf 'Homebrew formula must not install codex; shim lanes must be opt-in outside Brew: %s\n' "$homebrew_formula" >&2
+  exit 1
+fi
+if ! grep -q 'system "test", "!", "-e", "#{bin}/codex"' "$homebrew_formula"; then
+  printf 'Homebrew formula test must prove codex is not installed by oauth-mux: %s\n' "$homebrew_formula" >&2
+  exit 1
+fi
 if command -v ruby >/dev/null 2>&1; then
   ruby -c "$homebrew_formula" >/dev/null
 fi


### PR DESCRIPTION
## Summary

- Make the generated Homebrew formula install only `oauth-mux`, not the managed `codex` shim.
- Update Homebrew QA to use fully-qualified formula names, prove no formula-local `codex`, reject linked `OMUX_CODEX_SHIM`, and assert `command -v codex` is unchanged after install.
- Update release smoke/version checks for Homebrew-inferred stable versions and binary-only Homebrew ownership.
- Document Homebrew as a binary-only package lane; shim-bearing lanes remain explicit opt-in outside default Brew install.

## Validation

- git diff --check
- bash -n scripts/homebrew-install-qa.sh scripts/homebrew-version-check.sh scripts/release-smoke.sh
- ruby -c dist/homebrew/oauth-mux.rb
- rendered-template homebrew-version-check for 0.1.9
- brew audit --formula --strict jesssullivan/omux/oauth-mux
- OMUX_HOMEBREW_KEEP_INSTALLED=1 OMUX_HOMEBREW_KEEP_TAP=1 scripts/homebrew-install-qa.sh 0.1.9
- nix develop --command just check-local

## Notes

`nix develop --command just release-proof-local 0.1.9` was attempted, but `zig build release` sat idle for roughly ten minutes with no compiler children and was terminated. I am not claiming that gate here. The targeted Homebrew package proof passed and kept `oauth-mux 0.1.9` installed from Brew while leaving native `codex` on the Nix path.