### PR TITLE
Guard local release proof on constrained hosts

### DIFF
--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -79,6 +79,22 @@ The Nix dev shell supplies Zig, Just, Node/npm, and nfpm, so `just release-local
 is the reproducible proof path. Running `scripts/release-local.sh` directly will
 still skip npm or deb/rpm output if those host tools are absent.
 
+`release-local` performs a host-resource preflight before deleting or staging
+`dist/out/v<version>`. By default it requires at least 12 GiB free on the repo
+filesystem. On hosts with less than 12 GiB RAM, it constrains Zig release
+compilation with `-j2` unless `OMUX_RELEASE_ZIG_JOBS` is already set. This is
+intentional: the six-target ReleaseSafe graph can look like a shell hang on
+low-disk, memory-compressed dogfood machines.
+
+Useful overrides:
+
+- `OMUX_RELEASE_PREFLIGHT_ONLY=1 scripts/release-local.sh <version>` checks the
+  host without mutating release output.
+- `OMUX_RELEASE_ALLOW_LOW_DISK=1` continues despite the disk warning.
+- `OMUX_RELEASE_MIN_FREE_KIB=<kib>` changes the free-space threshold.
+- `OMUX_RELEASE_ZIG_JOBS=<n>` sets Zig release concurrency explicitly.
+- `OMUX_RELEASE_SKIP_PREFLIGHT=1` disables the host-resource guard.
+
 Run the full build-plus-smoke proof:
 
 ```bash

--- a/scripts/check-local.sh
+++ b/scripts/check-local.sh
@@ -8,6 +8,9 @@ zig build
 ./zig-out/bin/oauth-mux version --json | jq -e '.version and .runtime_identity.binary_path and .runtime_identity.binary_sha256 and .runtime_identity.path_printed == true' >/dev/null
 bash -n ./scripts/install-local-dogfood.sh
 bash -n ./scripts/uninstall-local-dogfood.sh
+bash -n ./scripts/release-local.sh
+bash -n ./scripts/release-smoke.sh
+bash -n ./scripts/release-handoff.sh
 python3 -m py_compile ./scripts/dogfood-process-snapshot.py
 sh -n ./dist/codex-shim.sh
 sh -n ./dist/install.sh

--- a/scripts/release-local.sh
+++ b/scripts/release-local.sh
@@ -21,6 +21,58 @@ homebrew_dir="$out_dir/homebrew"
 nfpm_dir="$out_dir/nfpm"
 work_dir="$out_dir/work"
 
+format_kib_as_gib() {
+  awk "BEGIN { printf \"%.1f\", $1 / 1048576 }"
+}
+
+host_memory_bytes() {
+  if command -v sysctl >/dev/null 2>&1; then
+    sysctl -n hw.memsize 2>/dev/null && return 0
+  fi
+  if [ -r /proc/meminfo ]; then
+    awk '/^MemTotal:/ { printf "%.0f\n", $2 * 1024; exit }' /proc/meminfo
+    return 0
+  fi
+  return 1
+}
+
+release_host_preflight() {
+  if [ "${OMUX_RELEASE_SKIP_PREFLIGHT:-0}" = "1" ]; then
+    printf 'warning: skipping release host preflight because OMUX_RELEASE_SKIP_PREFLIGHT=1\n' >&2
+    return
+  fi
+
+  local free_kib min_free_kib
+  free_kib="$(df -Pk "$repo_root" | awk 'NR == 2 { print $4 }')"
+  min_free_kib="${OMUX_RELEASE_MIN_FREE_KIB:-12582912}"
+  if [ -n "$free_kib" ] && [ "$free_kib" -lt "$min_free_kib" ]; then
+    if [ "${OMUX_RELEASE_ALLOW_LOW_DISK:-0}" != "1" ]; then
+      printf 'release host preflight failed: only %s GiB free at %s; need at least %s GiB for local release proof\n' \
+        "$(format_kib_as_gib "$free_kib")" "$repo_root" "$(format_kib_as_gib "$min_free_kib")" >&2
+      printf 'free disk space, use remote CI/RBE release proof, or set OMUX_RELEASE_ALLOW_LOW_DISK=1 to continue anyway\n' >&2
+      exit 2
+    fi
+    printf 'warning: continuing with only %s GiB free because OMUX_RELEASE_ALLOW_LOW_DISK=1\n' \
+      "$(format_kib_as_gib "$free_kib")" >&2
+  fi
+
+  local mem_bytes low_mem_bytes
+  low_mem_bytes=$((12 * 1024 * 1024 * 1024))
+  mem_bytes="$(host_memory_bytes 2>/dev/null || true)"
+  if [ -n "$mem_bytes" ] && [ "$mem_bytes" -lt "$low_mem_bytes" ] && [ -z "${OMUX_RELEASE_ZIG_JOBS:-}" ]; then
+    OMUX_RELEASE_ZIG_JOBS=2
+    export OMUX_RELEASE_ZIG_JOBS
+    printf 'release host preflight: detected less than 12 GiB RAM; using zig -j%s for local release proof\n' \
+      "$OMUX_RELEASE_ZIG_JOBS" >&2
+  fi
+}
+
+release_host_preflight
+if [ "${OMUX_RELEASE_PREFLIGHT_ONLY:-0}" = "1" ]; then
+  printf 'release host preflight passed\n'
+  exit 0
+fi
+
 rm -rf "$out_dir"
 mkdir -p "$artifacts_dir" "$npm_dir" "$npm_tgz_dir" "$homebrew_dir" "$nfpm_dir" "$work_dir"
 
@@ -87,7 +139,12 @@ EOF
 }
 
 printf 'building release binaries...\n'
-zig build release
+zig_release_args=(build release --summary all)
+if [ -n "${OMUX_RELEASE_ZIG_JOBS:-}" ]; then
+  zig_release_args+=("-j${OMUX_RELEASE_ZIG_JOBS}")
+fi
+printf 'running: zig %s\n' "${zig_release_args[*]}"
+zig "${zig_release_args[@]}"
 
 package_binary "x86_64-linux" "oauth-mux-x86_64-linux" "oauth-mux-linux-x64" "linux" "x64" "oauth-mux"
 package_binary "aarch64-linux" "oauth-mux-aarch64-linux" "oauth-mux-linux-arm64" "linux" "arm64" "oauth-mux"


### PR DESCRIPTION
## Summary
- add a release-local host-resource preflight before mutating staged release output
- fail clearly when local release proof has too little free disk, with explicit override knobs
- constrain Zig release concurrency on sub-12 GiB hosts unless OMUX_RELEASE_ZIG_JOBS is set
- include release shell scripts in check-local syntax validation and document the operator controls

## Validation
- git diff --check
- bash -n scripts/release-local.sh scripts/release-smoke.sh scripts/release-handoff.sh scripts/check-local.sh
- OMUX_RELEASE_PREFLIGHT_ONLY=1 scripts/release-local.sh 0.1.9 exits 2 on this low-disk host with a clear diagnostic
- OMUX_RELEASE_PREFLIGHT_ONLY=1 OMUX_RELEASE_ALLOW_LOW_DISK=1 scripts/release-local.sh 0.1.9 passes and selects zig -j2
- nix develop --command just check-local

No local Playwright run.