### PR TITLE
Timebox GloriousFlywheel cache-first commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,31 @@ jobs:
             test -n "${ATTIC_SERVER:-}"
             test -n "${ATTIC_CACHE:-}"
             test -n "${NIX_CONFIG:-}"
-            nix develop --command just check-local
+
+            run_with_timeout() {
+              local label="$1"
+              local duration="$2"
+              shift 2
+
+              if ! command -v timeout >/dev/null 2>&1; then
+                echo "::warning::GNU timeout is unavailable; running ${label} without an inner timeout"
+                "$@"
+                return
+              fi
+
+              set +e
+              timeout --foreground "${duration}" "$@"
+              local status=$?
+              set -e
+
+              if [ "${status}" -eq 124 ]; then
+                echo "::error::${label} timed out after ${duration}"
+              fi
+
+              return "${status}"
+            }
+
+            run_with_timeout "GloriousFlywheel cache-first validation" "${OMUX_GF_CHECK_TIMEOUT:-25m}" nix develop --command just check-local
 
       - name: Record skipped cache-first validation
         if: steps.gf.outputs.enabled != 'true'

--- a/.github/workflows/release-proof.yml
+++ b/.github/workflows/release-proof.yml
@@ -59,7 +59,31 @@ jobs:
             test -n "${ATTIC_SERVER:-}"
             test -n "${ATTIC_CACHE:-}"
             test -n "${NIX_CONFIG:-}"
-            nix develop --command just release-proof-local "${{ inputs.version }}"
+
+            run_with_timeout() {
+              local label="$1"
+              local duration="$2"
+              shift 2
+
+              if ! command -v timeout >/dev/null 2>&1; then
+                echo "::warning::GNU timeout is unavailable; running ${label} without an inner timeout"
+                "$@"
+                return
+              fi
+
+              set +e
+              timeout --foreground "${duration}" "$@"
+              local status=$?
+              set -e
+
+              if [ "${status}" -eq 124 ]; then
+                echo "::error::${label} timed out after ${duration}"
+              fi
+
+              return "${status}"
+            }
+
+            run_with_timeout "GloriousFlywheel release proof" "${OMUX_GF_RELEASE_PROOF_TIMEOUT:-40m}" nix develop --command just release-proof-local "${{ inputs.version }}"
 
       - name: Record skipped release proof
         if: steps.gf.outputs.enabled != 'true'

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -213,6 +213,11 @@ The normal CI workflow has a GloriousFlywheel cache-first lane on
 If `GF_ACTIONS_TOKEN` is absent, CI records a token-gated skip instead of
 claiming a cache-first proof.
 
+oauth-mux wraps the private action command with an inner timeout so runner or
+cache stalls fail with an explicit step diagnostic before the outer workflow
+timeout. CI uses `OMUX_GF_CHECK_TIMEOUT` with a default of `25m`; the manual
+release proof uses `OMUX_GF_RELEASE_PROOF_TIMEOUT` with a default of `40m`.
+
 During known lab or runner outages, do not block release staging on a queued
 `tinyland-nix` job alone. Use these signals together:
 


### PR DESCRIPTION
## Summary

- add an inner timeout wrapper around the GloriousFlywheel cache-first CI command
- add the same inner timeout around the manual GloriousFlywheel release proof command
- document the GF timeout knobs in the release runbook

## Validation

- git diff --check
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }; puts "yaml ok"' .github/workflows/ci.yml .github/workflows/release-proof.yml\n- nix develop --command just check-local\n\n## Notes\n\nNo local Playwright run. This keeps the private GF action honest when the underlying runner/cache command wedges: the oauth-mux command now emits an explicit timeout error before the outer workflow timeout.