### PR TITLE
[codex] Harden Codex proxy stream disconnect handling

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,7 +10,7 @@ on:
       version:
         description: "Version to stage and publish"
         required: false
-        default: "0.1.0"
+        default: "0.1.9"
         type: string
       dry_run:
         description: "Run npm publish --dry-run instead of publishing"

--- a/.github/workflows/registry-dry-run.yml
+++ b/.github/workflows/registry-dry-run.yml
@@ -10,7 +10,7 @@ on:
       version:
         description: "Version to stage and dry-run"
         required: false
-        default: "0.1.0"
+        default: "0.1.9"
         type: string
       lanes:
         description: "Comma-separated lanes: plan,github,npm,homebrew,system"

--- a/.github/workflows/release-proof.yml
+++ b/.github/workflows/release-proof.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: "Release version to stage and smoke-test"
         required: false
-        default: "0.1.0"
+        default: "0.1.9"
         type: string
 
 permissions:

--- a/.github/workflows/system-package-install-qa.yml
+++ b/.github/workflows/system-package-install-qa.yml
@@ -13,7 +13,7 @@ on:
       version:
         description: "Published version to install from GitHub Release assets"
         required: false
-        default: "0.1.6"
+        default: "0.1.9"
         type: string
       expect_codex_shim:
         description: "Require published deb/rpm packages to include /usr/bin/codex"
@@ -40,7 +40,7 @@ jobs:
           set -euo pipefail
           version="${{ github.event.inputs.version }}"
           if [ -z "$version" ]; then
-            version="0.1.6"
+            version="0.1.9"
           fi
           if [ "${{ github.event.inputs.expect_codex_shim }}" = "true" ]; then
             export OMUX_EXPECT_CODEX_SHIM=1

--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@ diagnostic infrastructure. They are not product success.
 
 ## Current Truth
 
-Public install lanes are versioned by channel. GitHub Release assets, npm root
-and platform packages, the curl installer, and published deb/rpm assets last
-resolved to `0.1.7` in the public parity sweep. The public Homebrew tap now
-serves `0.1.9`. The current source tree also tightens install parity after a
-2026-05-18 finding that the public Homebrew `codex` shim routed native admin
-commands such as `codex --version` through oauth-mux route election. Homebrew
-must remain binary-only by default: `brew install jesssullivan/omux/oauth-mux`
-installs `oauth-mux` and must not install or link a managed `codex` shim.
+Public install lanes are versioned by channel. The current verified release is
+`0.1.9`: GitHub Release assets exist, npm root and platform packages resolve,
+the curl installer and deb/rpm assets are attached to the release, and the
+public Homebrew tap reports stable `0.1.9`. The 2026-05-18/19 install-parity
+work fixed a package-lane bug where a public Homebrew `codex` shim routed
+native admin commands such as `codex --version` through oauth-mux route
+election. Homebrew remains binary-only by default:
+`brew install jesssullivan/omux/oauth-mux` installs `oauth-mux` and must not
+install or link a managed `codex` shim.
 
 What works today:
 
@@ -230,7 +231,7 @@ oauth-mux codex preflight --profile codex-max --capability codex-max --json
 
 See `docs/tracing.md` for the trace schema and redaction contract.
 
-Those inspection commands do not spend provider calls. In the `0.1.7` release,
+Those inspection commands do not spend provider calls. In the current release,
 managed Codex launch/resume and admitted stay-afloat execution may spend
 provider calls only to revalidate expired Codex quota/rate windows before route
 election. Live probes, broad revalidation, and non-Codex provider-spend paths

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -65,10 +65,10 @@ The public Homebrew tap is `Jesssullivan/homebrew-omux`, documented in
 infrastructure, not public adoption copy.
 The DRY release/install lane contract is `docs/release-install-lanes.md`; keep
 new UX/DX/AX installer copy aligned with that file rather than duplicating
-package-state tables here. As of the 2026-05-17 package-parity refresh, public
-GitHub Release, npm, Homebrew, curl installer, and system package lanes resolve
-to `0.1.7`. Package-lane QA proves installability and metadata, not live
-provider handoff behavior.
+package-state tables here. As of the 2026-05-20 release-hygiene refresh, public
+GitHub Release, npm, Homebrew, curl installer assets, and system package assets
+resolve to `0.1.9`. Package-lane QA proves installability and metadata, not
+live provider handoff behavior.
 
 When validating unreleased source behavior, install or invoke the worktree build
 deliberately and record provenance:

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -1,6 +1,6 @@
 # Productionization Ledger
 
-Updated: 2026-05-19
+Updated: 2026-05-20
 
 This ledger is the short operator map for oauth-mux productionization. It is
 subordinate to the broker contract and Codex adapter contract, and it should be
@@ -8,37 +8,45 @@ refreshed when release truth, route evidence, or tracker state changes.
 
 ## Current Snapshot
 
-- Repo state: `main` is clean against `origin/main` after the product-guardrail
-  and dogfood process fanout snapshot merge.
-- CI state: GitHub Actions is the live source for the latest run. The
-  2026-05-17 refresh verified the `v0.1.7` release workflow, npm publish
-  workflow, and hosted system-package install QA.
-- Version truth: public npm, GitHub Release, curl installer, and deb/rpm lanes
-  last resolved to `0.1.7` in the public parity sweep. The public Homebrew tap
-  now advertises `0.1.9`, but the 2026-05-18/19 shim investigation found a
-  package-lane ownership bug: the Homebrew formula must not install or link a
-  managed `codex` shim by default.
-- Installed provenance: PATH can resolve a public package binary or a
-  user-local dogfood binary depending on shell setup. Use `which -a oauth-mux`,
-  `which -a codex`, `oauth-mux version --json`, and `codex preflight` before
-  treating any installed-command run as release evidence.
+- Repo state: `main` matches `origin/main` at `f05a44f`; local worktrees may
+  carry focused BrokenPipe/network-blip WIP until that regression fix is landed.
+- CI state: GitHub Actions is the live source for the latest run. The latest
+  observed `main` run for `f05a44f` succeeded on 2026-05-19. Release workflow
+  `26012676776`, registry dry-run `26012836911`, and npm publish
+  `26013003383` verified the `v0.1.9` release lane on 2026-05-18.
+- Version truth: public npm, GitHub Release, curl installer assets, deb/rpm
+  assets, and the public Homebrew tap resolve to `0.1.9`; this was rechecked on
+  2026-05-21. The 2026-05-18/19 shim investigation fixed a package-lane
+  ownership bug: the Homebrew formula must not install or link a managed
+  `codex` shim by default.
+- Installed provenance: PATH currently resolves user-local
+  `/Users/jess/.local/bin/oauth-mux` before Homebrew. Use
+  `which -a oauth-mux`, `which -a codex`, `oauth-mux version --json`, and
+  `codex preflight` before treating any installed-command run as release
+  evidence.
 - Homebrew truth: the public `jesssullivan/omux` tap advertises `oauth-mux
-  0.1.9`. Homebrew should be treated as a binary-only package lane: QA must
-  prove `brew install jesssullivan/omux/oauth-mux` installs `oauth-mux`, does
-  not install an `OMUX_CODEX_SHIM`, and leaves native `codex` command
-  resolution unchanged.
-- Codex route truth: refresh before every live test. The latest 2026-05-17
-  22:24 EDT installed Homebrew `0.1.7` no-spend snapshot is `not_afloat`:
-  all four named `codex-max` routes are runtime-ready and broker-ready but
-  blocked as `unrecorded`. The next step is spend-confirmed route-health
-  repair/probe, not managed resume.
+  0.1.9` and the local linked keg is `0.1.9`. Homebrew is a binary-only package
+  lane by default: QA must prove
+  `brew install jesssullivan/omux/oauth-mux` installs `oauth-mux`, does not
+  install an `OMUX_CODEX_SHIM`, and leaves native `codex` command resolution
+  unchanged.
+- Codex route truth: the 2026-05-21 02:57 UTC post-repair no-spend refresh used
+  user-local `oauth-mux 0.1.9`. All four named `codex-max` route stores are
+  runtime-ready and broker-ready. `codex:max-3#codex-max` is selected and
+  selectable; `max-4` is a live selectable fallback; `max-1` and `max-2` remain
+  blocked as `unrecorded`. Current state is `session_start_ready:true`,
+  `fallback_ready:true`, `single_route_at_risk:false`. The next live cassette
+  run still needs a just-in-time no-spend refresh plus explicit operator
+  approval for provider-spend capture.
 - Latest local status truth: `oauth-mux codex status-latest --json` currently
-  reports `brokered_without_fallback` from a rolling local artifact. This
-  does not supersede the preserved quota-handoff proof; status artifacts must be
-  refreshed before being used in public claims.
+  reports `brokered_without_fallback` from a rolling local artifact. This is
+  stale relative to current route truth and does not supersede the preserved
+  quota-handoff proof; status artifacts must be refreshed before being used in
+  public claims.
 - Daemon truth: `oauth-mux daemon status --json` still reports
-  `contract:"experimental_socket_stub"` and `hosts_stay_afloat:false`; any
-  stale foreground tick snapshot is observational only. The beta daemon lane
+  `status:"not_running"`, `contract:"experimental_socket_stub"`, and
+  `hosts_stay_afloat:false`; its foreground tick snapshot is observational only
+  even when fresh and showing `afloat_with_spare_fallback`. The beta daemon lane
   must host the same foreground tick engine and must not claim unmanaged
   hot-swap.
 - Codex shim truth: package/user-local installs can make future bare `codex`
@@ -113,16 +121,25 @@ boundary, quota signal, failure signal, wire interception, process topology, and
 session authority. Until then, they may consume oauth-mux diagnostics or future
 MCP repair prompts, but oauth-mux must not claim to keep them alive.
 
+## Active Plan
+
+The current testable workstream plan lives at
+`docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md`. It prioritizes
+the BrokenPipe regression fix, no-spend route/process truth refresh, real Codex
+wire cassettes, release hygiene, tracker reconciliation, then later sidecar and
+non-Codex provider work.
+
 ## Release And Distribution Posture
 
-`0.1.7` version availability is complete for the public install lanes, but
-package parity is not complete until the shared Codex shim fix ships and the
-package lanes prove native admin pass-through. Negative Codex cassettes,
-broader adapter proof, and daemon beta truth remain follow-up work. Windows
-managed-`codex` parity is intentionally assigned to the npm wrapper lane rather
-than raw tarballs until a native Windows operator need is proven. Future public
-install copy must avoid claiming a version or lane behavior until that version
-is actually published and verified.
+`0.1.9` version availability is complete for the public install lanes checked
+again on 2026-05-21: GitHub Release `v0.1.9` is published and non-draft,
+npm `latest` is `0.1.9`, Homebrew stable/linked keg is `0.1.9`, and curl
+installer plus deb/rpm assets are attached to the release. Negative Codex
+cassettes, broader adapter proof, and daemon beta truth remain follow-up work.
+Windows managed-`codex` parity is intentionally assigned to the npm wrapper
+lane rather than raw tarballs until a native Windows operator need is proven.
+Future public install copy must avoid claiming a version or lane behavior until
+that version is actually published and verified.
 
 The release lanes remain:
 
@@ -145,11 +162,11 @@ browser is needed; local Playwright is not part of this CLI proof path.
 | Codex next-turn broker switch | TIN-916 | #131 | Closed for the proven managed Codex live handoff. Remaining negative/permutation work lives in #212/#176; same-thread, mid-turn, and unmanaged daemon behavior remain separate non-claims. |
 | Upstream Codex usage-limit hook | TIN-939 | #164 | Draft proposal written; use it to request a first-class external-auth usage-limit handoff hook while keeping oauth-mux claims scoped to proven managed-proxy behavior. |
 | Live Codex account-swap acceptance | TIN-951 | #177 | Done for managed Codex; strongest preserved proof is `docs/evidence/codex-engineered-quota-handoff-20260509/`. |
-| Wire cassette coverage | TIN-950 | #176 | Needed before treating negative permutations as stable release proof. |
+| Wire cassette coverage | TIN-950 | #176 | Still needed before treating negative permutations as stable release proof. Linear currently marks TIN-950 Done while GitHub #176 remains open; reconcile only after real cassette acceptance or an explicit tracker correction. |
 | Harness session authority bridge | TIN-979 | #191 | Closed for Codex: managed auth/config overlays bridge canonical session authority, `state_5.sqlite*`, and root config while rejecting silent session-store import/copy. Future cross-harness authority work stays under #67/#68. |
 | Codex session-store portability | TIN-936 | #161 | Policy is explicit: canonical bridge is supported; silent route-local session import/copy is rejected until a separate confirmed import command exists. |
 | OTEL-friendly tracing | TIN-1148 | PR #225/#226 lineage | Implemented trace schema should become the standard support-bundle path. |
-| Package parity and install lanes | TIN-1255 | #252 | `0.1.7` is published and verified across GitHub Release, npm, Homebrew, curl, and deb/rpm package lanes. |
+| Package parity and install lanes | TIN-1255 | #252 | `0.1.9` is published and verified across GitHub Release, npm, Homebrew, curl installer assets, and deb/rpm release assets. |
 | Home Manager and Windows shim parity | not assigned | #257 | Home Manager source lane is implemented with opt-in shim; Windows raw tarballs stay binary-only and npm is the managed-shim lane. |
 | Provider proof beyond Codex | TIN-736 | #68 | Claude next; other agents stay adapter-candidate only. |
 | Website truth refresh | TIN-734 / TIN-925 | external site repo | `omux.xoxd.ai` source lives outside this repo and must be refreshed from the ledger, QA matrix, and install-lane docs. |

--- a/docs/qa-handoff-matrix.md
+++ b/docs/qa-handoff-matrix.md
@@ -102,32 +102,34 @@ publishable evidence for those same negative shapes.
   `docs/evidence/codex-engineered-quota-handoff-20260509/`.
 - Current no-spend route truth is volatile and must be refreshed before each
   live session. The 2026-05-17 22:24 EDT installed Homebrew `0.1.7` snapshot is
-  `not_afloat` for `codex-max`: all four named routes are runtime-ready and
-  broker-ready, but route liveness is `unrecorded`.
-- `oauth-mux codex preflight --profile codex-max --capability codex-max --json`
-  reports `routes_total:4`, `selectable_routes:0`,
-  `blocked_route_reasons:[unrecorded(4)]`, `session_start_ready:false`, and
-  `fallback_ready:false` in that snapshot.
-- No user-mediated login handoff is pending in that snapshot. The next action is
-  a spend-confirmed route-health repair/probe, such as the preflight-reported
-  `oauth-mux stay-afloat --once --execute --profile codex-max --capability
-  codex-max --json`, or a targeted `oauth-mux probe --provider codex --account
-  max-N --capability codex-max --json` after operator quota UI review.
+  historical evidence, not current route truth; it was `not_afloat` for
+  `codex-max` with all four named routes runtime-ready and broker-ready but
+  route liveness `unrecorded`.
+- The 2026-05-20 17:01 UTC no-spend refresh improved that to one selectable
+  route (`max-3`) but still had no spare fallback; treat it as historical
+  single-route-risk evidence.
+- The 2026-05-21 02:57 UTC post-repair no-spend refresh used user-local
+  `oauth-mux 0.1.9`: `codex:max-3#codex-max` is selected, `max-4` is a live
+  selectable fallback, and `max-1` / `max-2` remain runtime/broker ready but
+  blocked as `unrecorded`.
+- Current resilience from that refresh is `session_start_ready:true`,
+  `fallback_ready:true`, `single_route_at_risk:false`. Refresh immediately
+  before any provider-spend run; do not treat this paragraph as future-proof.
 - `oauth-mux codex status-latest --json` currently reports
-  `brokered_without_fallback` from a rolling local artifact. This does not
-  supersede the preserved quota handoff proof above; refresh this command
-  before copying current-state claims into public release notes or tracker
-  comments.
+  `brokered_without_fallback` from a rolling local artifact. This is stale
+  relative to route truth and does not supersede the preserved quota handoff
+  proof above; refresh this command before copying current-state claims into
+  public release notes or tracker comments.
 - `oauth-mux daemon status --json` currently reports no hosted stay-afloat
-  loop. Its stale foreground tick snapshot must not override current preflight
-  or route-explain truth.
+  loop. Its foreground tick snapshot is observational only and must not be cited
+  as daemon-hosted continuity proof.
 
 ## Next Multi-Account Session
 
-Start from an installed `0.1.7` binary and record provenance before any
-spend-confirmed test. As of the 2026-05-17 package-parity refresh, bare
-`oauth-mux` resolves the public Homebrew `0.1.7` package first on the operator
-machine; use `oauth-mux version --json` to distinguish that package binary from
+Start from the current installed `0.1.9` binary, or an explicitly installed
+dogfood binary, and record provenance before any spend-confirmed test. As of
+the 2026-05-20 release-hygiene refresh, public package lanes resolve to
+`0.1.9`; use `oauth-mux version --json` to distinguish that package binary from
 `~/.local/bin/oauth-mux` or `./zig-out/bin/oauth-mux` worktree dogfood hashes.
 
 No-spend opening sequence:
@@ -147,27 +149,31 @@ Current matrix entry:
 | Route | Current state | Session role |
 | --- | --- | --- |
 | `codex:max-1#codex-max` | blocked, `unrecorded`; runtime ready; `probe_needed` | route-health repair candidate |
-| `codex:max-2#codex-max` | blocked, `unrecorded`; runtime ready; `probe_needed` | prior engineered primary; route-health repair candidate |
-| `codex:max-3#codex-max` | blocked, `unrecorded`; runtime ready; `probe_needed` | prior engineered fallback; route-health repair candidate |
-| `codex:max-4#codex-max` | blocked, `unrecorded`; runtime ready; `probe_needed` | reset-repair / route-health repair candidate |
+| `codex:max-2#codex-max` | blocked, `unrecorded`; runtime ready; `probe_needed` | route-health repair candidate |
+| `codex:max-3#codex-max` | selectable, live; selected | current primary |
+| `codex:max-4#codex-max` | selectable, live | current spare fallback |
 
-Do not start the next managed live session from this state. `oauth-mux codex
-resume` should wait until route-health repair makes at least one primary and
-one fallback selectable. Otherwise the expected outcome is a typed
-`NoAccountSelectable` refusal, not quota-handoff evidence.
+Do not start provider-spend cassette or negative-matrix work from memory. Rerun
+the no-spend opener first and verify `session_start_ready:true`,
+`fallback_ready:true`, and `single_route_at_risk:false`; then proceed only with
+explicit operator approval for the provider-spend capture. If the just-in-time
+refresh falls back to single-route risk, pause and repair/probe before treating
+the run as release-grade evidence.
 
 Spend-confirmed activation sequence:
 
-1. Refresh private quota UI for the four route labels and pick the least risky
-   primary/fallback pair.
-2. With explicit operator consent, run the smallest targeted provider probe(s)
-   needed to make one primary and one fallback selectable.
+1. Refresh private quota UI for the four route labels and confirm the current
+   `max-3` / `max-4` primary-fallback pair is still the least risky pair.
+2. With explicit operator consent, run only the smallest targeted provider
+   probe(s) needed to restore spare fallback if the no-spend opener regresses;
+   optionally probe `max-1` / `max-2` only when additional redundancy is worth
+   the provider spend.
 3. If a targeted probe reports auth failure, run only the labeled
    `oauth-mux codex login-device max-N` handoff for that route, then rerun the
    no-spend opener and a spend-confirmed probe only if still needed.
-4. Once `session_start_ready:true` and `fallback_ready:true` are restored, run
-   the chosen negative/live permutation through installed `oauth-mux`, not a
-   repo-local binary.
+4. Once `session_start_ready:true` and `fallback_ready:true` are reconfirmed,
+   run the chosen negative/live permutation through the intended installed
+   `oauth-mux` binary and record provenance.
 
 Next spend-confirmed permutations should prefer negative coverage over another
 happy-path quota proof: all-fallbacks-exhausted, tier-insufficient
@@ -177,8 +183,9 @@ false-positive guards.
 ## Next QA Targets
 
 These targets remain important production hardening work. They should not be
-treated as public claims until captured, but they do not block the package
-parity tranche for `0.1.7`.
+treated as public claims until captured. They do not block current package
+parity, but they do block stronger Codex negative-matrix and release-proof
+claims.
 
 1. Publishable cassette for real `usage_limit_reached` response shape.
 2. Publishable provider cassette or live all-fallbacks-exhausted terminal

--- a/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
+++ b/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
@@ -1,0 +1,356 @@
+# oauth-mux Operational Hardening Plan
+Date: 2026-05-20
+Status: active plan and testable todo list; subordinate to `AGENTS.md`,
+`docs/spec/broker-mcp-contract-2026-05-03.md`,
+`docs/spec/codex-adapter-contract-2026-05-03.md`, and
+`docs/spec/harness-session-authority-bridge-2026-05-05.md`.
+
+## Purpose
+
+Turn the May 20 BrokenPipe / Codex operations review into completion-metric
+workstreams. The product anchor remains managed harness continuity:
+`oauth-mux codex` must keep the active managed Codex session usable when auth,
+quota, tier, or local runtime state changes. Restart, supervised relaunch, and
+prepared fallback remain diagnostic infrastructure, not the success claim.
+
+## Current Verified State
+
+- Local checkout: feature branch `jess/brokenpipe-network-blip-reliability`
+  based on `main` at `f05a44f`. Slice A is locally committed as `5bd36b3`
+  (`fix: classify codex stream disconnects`); Slice B docs/release hygiene is
+  separate WIP.
+- GitHub read-only refresh at 2026-05-21 17:22 UTC: no open PRs, no GitHub
+  Discussions, and open issues are `#67`, `#68`, `#163`, `#176`, and `#212`.
+  Latest observed `main` CI run for `f05a44f` is `26085487311` and succeeded on
+  2026-05-19.
+- Linear: `TIN-1517` and `TIN-1518` are Done. `TIN-950` is marked Done, but
+  GitHub `#176` is still open for real Codex wire cassettes; treat that as a
+  tracker hygiene mismatch until reconciled. `TIN-1079` is Backlog, `TIN-938`
+  is Todo, and `TIN-736` is In Progress.
+- Release truth: source version is `0.1.9`; GitHub Release `v0.1.9` is
+  published, not draft/prerelease, with installer, npm, Homebrew, tarball,
+  deb/rpm, and checksum assets; `npm view oauth-mux version dist-tags --json`
+  reports `latest:0.1.9`; the public Homebrew tap reports stable and linked keg
+  `0.1.9`.
+- CI truth: latest observed `main` Actions run for `f05a44f` completed
+  successfully on 2026-05-19.
+- Current route truth from the 2026-05-21 02:57 UTC post-repair no-spend
+  refresh: active binary is user-local `oauth-mux 0.1.9`; native Codex resolves
+  outside oauth-mux; `codex:max-3#codex-max` is selected; `max-4` is a live
+  selectable fallback; `max-1` and `max-2` remain runtime/broker ready but
+  blocked as `unrecorded`.
+- Local validation at 2026-05-21 03:20 UTC: `just check-local` passed with the
+  BrokenPipe/client-disconnect regression, upstream partial-stream
+  interruption regression, managed Codex smokes, and cassette replay smokes.
+
+## Workstream 1 - BrokenPipe And Network-Blip Reliability
+
+Priority: P0 now. Keep this as the next small PR.
+
+Completion metric:
+
+- Downstream Codex/client socket closes are classified as `client_disconnected`,
+  not as provider degradation.
+- Downstream close emits a redacted `proxy_client_disconnected` trace/status
+  event and does not write degraded route health.
+- Upstream/provider interruption is classified separately as
+  `upstream_interrupted`, records provider-degraded evidence, and does not
+  retry a same-turn request after a partial `200` stream has reached Codex.
+- Upstream short-body EOF with `Content-Length` mismatch is treated as
+  provider interruption, not successful route health.
+- Benign close errors such as `BrokenPipe` / `ConnectionResetByPeer` do not
+  bubble up as noisy `proxy: serveOne: BrokenPipe` operator failures.
+- The regression is locked by a CI-safe smoke that reproduces client-close and
+  upstream-interrupted paths without provider traffic.
+
+Test commands:
+
+```bash
+python3 -m py_compile scripts/test-stub-codex.py scripts/test-stub-upstream.py
+bash -n scripts/smoke-codex-provider-degraded.sh
+just smoke-codex-provider-degraded-local
+just test
+just check-local
+git diff --check
+```
+
+Todo:
+
+- [x] Split streamed proxy outcome into client-disconnect versus upstream
+  interruption paths.
+- [x] Add no-spend stub coverage for downstream disconnects and provider
+  degraded upstream interruption.
+- [x] Add a CI-safe smoke for partial upstream `200` interruption that proves
+  no same-turn retry after partial delivery and records provider-degraded route
+  health.
+- [x] Suppress benign proxy thread close noise while preserving real upstream
+  diagnostics.
+- [ ] Land the WIP as a small focused PR before starting live cassette or
+  provider-spend work.
+
+## Workstream 2 - No-Spend Route And Process Truth Refresh
+
+Priority: P0 before any live Codex spend, cassette capture, or tracker claim.
+
+Completion metric:
+
+- The exact `oauth-mux` and `codex` binaries under test are recorded.
+- Route election, fallback readiness, daemon state, status artifact verdict,
+  and shell/PATH provenance agree or explicitly document disagreement.
+- The refresh does not read token files, mutate credential stores, run upstream
+  login, or spend provider calls.
+- Any process-fanout concern is backed by fresh redacted snapshot output, not
+  by stale memory/process impressions.
+
+No-spend command set:
+
+```bash
+which -a oauth-mux
+which -a codex
+oauth-mux version --json
+oauth-mux doctor runtime --profile codex-max --capability codex-max --json
+oauth-mux accounts list --provider codex --json
+oauth-mux route explain --profile codex-max --capability codex-max --json
+oauth-mux codex preflight --profile codex-max --capability codex-max --json
+oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json
+oauth-mux codex status-latest --json
+oauth-mux daemon status --json
+python3 scripts/dogfood-process-snapshot.py
+```
+
+Todo:
+
+- [x] Run the no-spend command set immediately after Workstream 1 is landed or
+  intentionally before any live run.
+- [x] Preserve a redacted summary under `docs/evidence/` only if it adds new
+  proof value; otherwise keep it as operator scratch.
+- [x] Block cassette/live work while the 2026-05-20 17:01 UTC snapshot showed
+  `single_route_at_risk:true`.
+- [x] Re-run no-spend route truth after spend-confirmed route-health repair.
+- [ ] Re-run route truth immediately before cassette capture and verify
+  `single_route_at_risk:false` still holds.
+
+2026-05-20 17:01 UTC no-spend refresh:
+
+- Active installed binary is public Homebrew `oauth-mux 0.1.9`; native Codex
+  resolves outside oauth-mux and is not an oauth-mux shim.
+- Runtime doctor is clean for the four named `codex-max` route stores.
+- `codex:max-3#codex-max` is selected and selectable.
+- `codex:max-1`, `codex:max-2`, and `codex:max-4` are runtime/broker ready but
+  blocked as `unrecorded`; each needs an explicit spend-provider probe before
+  it can be used as fallback evidence.
+- `session_start_ready:true`, `fallback_ready:false`,
+  `single_route_at_risk:true`.
+- `codex status-latest` reports `brokered_without_fallback` from a rolling
+  local artifact, with 160 `200` proxy turns and no quota handoff.
+- `daemon status` is `not_running`; its stay-afloat snapshot is stale and must
+  not override current preflight/route-explain truth.
+- Process fanout snapshot is observational only: 8 agent trees, 6 oauth-mux
+  processes, 13 Codex processes, 5 accumulated sessions, 6 duplicate helper
+  groups, 4 orphan listener candidates, and no heap leak proven from a single
+  snapshot.
+Historical gate from this snapshot: do not start real cassette or
+spend-confirmed live work until spare fallback capacity is restored or the
+operator intentionally accepts a single-route-at-risk run.
+
+2026-05-21 02:57 UTC post-repair no-spend refresh:
+
+- Active binary is user-local `oauth-mux 0.1.9` at
+  `/Users/jess/.local/bin/oauth-mux`; Homebrew `0.1.9` remains installed as a
+  second candidate. Native Codex still resolves outside oauth-mux and is not an
+  oauth-mux shim.
+- Runtime doctor remains clean for the four named `codex-max` route stores.
+- `codex:max-3#codex-max` is selected and selectable.
+- `codex:max-4#codex-max` is now a live selectable fallback.
+- `codex:max-1#codex-max` and `codex:max-2#codex-max` remain runtime/broker
+  ready but blocked as `unrecorded`; they still need explicit spend-provider
+  probes before being counted as additional fallback evidence.
+- `session_start_ready:true`, `fallback_ready:true`,
+  `single_route_at_risk:false`.
+- `broker-session-plan` reports prepared fallback only:
+  `same_turn_quota_recovery:false`, `same_thread_quota_recovery:false`,
+  `current_process_hotswap:false`, and `unmanaged_tui_hotswap:false`.
+- `codex status-latest` still reports `brokered_without_fallback` from a
+  rolling local artifact with 224 `200` proxy turns and no quota handoff; it is
+  stale relative to route truth and must not be used as fallback-readiness
+  proof.
+- `daemon status` is still `not_running`,
+  `contract:"experimental_socket_stub"`, `hosts_stay_afloat:false`; its fresh
+  foreground tick snapshot shows `afloat_with_spare_fallback` but remains
+  observational and is not daemon-hosted continuity proof.
+- Current gate: cassette capture may proceed only after a just-in-time no-spend
+  route refresh reconfirms the spare fallback and the operator explicitly
+  approves any live provider-spend capture.
+
+## Workstream 3 - Real Codex Wire Cassettes
+
+Priority: P0 after Workstreams 1 and 2.
+
+Completion metric:
+
+- GitHub `#176` is the active public tracker for real Codex wire cassettes even
+  while Linear `TIN-950` is Done.
+- Capture preserves SSE streaming shape rather than flattening the behavior
+  under test.
+- Each captured fixture pins profile, capability, selected account label,
+  route-health state, Codex CLI/build identity, and reset-window normalization.
+- Non-turn probe traffic is filtered out or explicitly marked as setup noise.
+- Raw captures stay out of git. Only scrubbed, fixture-sized JSON with reviewed
+  token/account/session/path redaction may be committed.
+- Replay failure is diagnostic (`no_cassette_match`, shape drift, or typed
+  rejection), not a silent green.
+
+Test commands:
+
+```bash
+just smoke-codex-cassette-replay-local
+just smoke-codex-cassette-all-exhausted-local
+just check-local
+git diff --check
+```
+
+Todo:
+
+- [ ] Prepare the tracker reconciliation note for `TIN-950` versus `#176`;
+  do not post it without explicit operator approval.
+- [ ] Re-run no-spend route truth immediately before capture.
+- [ ] Capture at least one normal `200` Codex turn with streaming preserved.
+- [ ] Capture or explicitly record not-observed status for `401`,
+  `usage_limit_reached`, `usage_not_included`, and all-fallbacks-exhausted.
+- [ ] Add one scrubbed real-shape replay fixture and wire it into CI-safe
+  cassette smoke coverage.
+
+## Workstream 4 - Release, Docs, And Workflow Hygiene
+
+Priority: P0/P1 mixed; low risk and can proceed while Workstream 1 is being
+prepared.
+
+Completion metric:
+
+- Current-state docs describe `0.1.9` as the latest verified release truth.
+- Historical docs may keep older versions only when clearly framed as
+  historical evidence.
+- Manual workflow defaults use the current project version or are deliberately
+  documented as historical cleanup targets.
+- Release lane docs keep Homebrew binary-only by default and keep managed
+  Codex shim behavior opt-in where required.
+
+Test commands:
+
+```bash
+scripts/project-version.sh
+gh release view v0.1.9 --json tagName,publishedAt,url
+npm view oauth-mux version
+brew info --json=v2 jesssullivan/omux/oauth-mux | jq -r '.formulae[0].versions.stable'
+rg -n "0\\.1\\.[0-8]" README.md docs/productionization-ledger.md docs/adoption.md docs/qa-handoff-matrix.md .github/workflows
+git diff --check
+```
+
+Todo:
+
+- [x] Update current-state docs and workflow defaults from stale `0.1.7` /
+  `0.1.6` / `0.1.0` wording to `0.1.9` where the text is not historical.
+- [x] Keep `docs/install-beta-matrix.md` and old release-runbook entries as
+  historical evidence unless a fresh parity sweep replaces them.
+- [x] Add a short pointer from the productionization ledger to this plan.
+- [x] When running the stale-version search, confirm remaining older-version
+  hits are explicitly historical, such as the 2026-05-17 no-spend snapshot or
+  the `0.1.1` npm deprecation cleanup workflow.
+
+## Workstream 5 - Tracker Hygiene
+
+Priority: P1 after local facts are current.
+
+Completion metric:
+
+- GitHub issues, Linear tickets, and repo docs tell the same story about what
+  is proven, what remains open, and what is only diagnostic infrastructure.
+- No discussion or tracker comment is posted from this plan without explicit
+  operator approval.
+- The `TIN-950` Done / `#176` open mismatch is resolved by either reopening or
+  clarifying Linear, or by closing `#176` only after real cassette acceptance is
+  actually complete.
+
+Todo:
+
+- [x] Draft tracker update text locally for `#176`, `#212`, `#67`, `#68`, and
+  `#163`.
+- [x] Re-check GitHub open issues/open PRs and Linear ticket states read-only.
+- [ ] Ask before posting or changing Linear/GitHub state.
+- [ ] Keep `#163` and `#68` scoped as later work, not blockers for the
+  BrokenPipe/cassette path.
+
+Local draft: `docs/tracker-updates/2026-05-20/README.md`.
+
+## Workstream 6 - Codex Remote App-Server Sidecar
+
+Priority: later this week after Workstreams 1-3 are stable.
+
+Completion metric:
+
+- A no-spend sidecar smoke proves loopback transport, remote auth token
+  handling, connection ordering, and TUI attachment without live provider
+  calls.
+- The prototype records whether `thread/start`, `thread/list`,
+  `thread/resume`, `account/read`, and error/rate-limit surfaces are observable
+  enough for managed interactive UX.
+- Docs state whether the sidecar can become the managed TUI path or remains
+  experimental.
+
+Todo:
+
+- [ ] Keep `TIN-938` / GitHub `#163` scoped to no-spend connection smoke first.
+- [ ] Do not claim managed interactive UX or live sidecar spend proof until a
+  separate explicit acceptance run exists.
+
+## Workstream 7 - Non-Codex Provider Proof
+
+Priority: later this week / secondary until Codex reference adapter hardening is
+stable.
+
+Completion metric:
+
+- One non-Codex provider has fixture-backed positive and negative proof through
+  the provider-authoring checklist.
+- The provider support matrix distinguishes schema-modeled, no-spend proven,
+  fixture-backed, and live-proven states.
+- No non-Codex stay-afloat, background daemon, or universal provider claim is
+  made before live adapter proof.
+
+Todo:
+
+- [ ] Keep `TIN-736` / GitHub `#68` open and secondary.
+- [ ] Pick the next provider by narrowest no-spend truth surface; likely Claude
+  auth-status first, then MCP/Figma/Linear only when official auth/failure
+  boundaries are pinned.
+- [ ] Add fixtures and docs before any public support copy is upgraded.
+
+## Execution Order
+
+Recommended landing slices:
+
+- Slice A, focused reliability PR: `src/adapters/codex/main.zig`,
+  `src/adapters/codex/wire_proxy.zig`, `scripts/test-stub-codex.py`,
+  `scripts/test-stub-upstream.py`, and
+  `scripts/smoke-codex-provider-degraded.sh`. Completion metric is Workstream 1
+  green with `just check-local` and `git diff --check`. Local commit:
+  `5bd36b3 fix: classify codex stream disconnects`.
+- Slice B, docs and release hygiene PR: workflow default-version updates,
+  README/adoption/QA/ledger refreshes, this plan, and local tracker drafts.
+  Completion metric is stale-version search showing only historical older
+  versions plus `git diff --check`.
+- Slice C, real cassette PR: starts only after Slice A lands and a just-in-time
+  no-spend route refresh confirms spare fallback. Requires explicit operator
+  approval for any provider-spend capture.
+- Slice D, later sidecar/provider work: Workstreams 6 and 7 remain secondary
+  until the Codex reference adapter has the BrokenPipe and cassette evidence
+  stabilized.
+
+1. Land Workstream 1 as a focused BrokenPipe reliability PR.
+2. Refresh Workstream 2 no-spend route/process truth.
+3. Run Workstream 3 real cassette capture and replay hardening.
+4. Keep Workstream 4 hygiene moving in small docs/workflow patches.
+5. Reconcile tracker state after the facts are refreshed.
+6. Start Workstream 6 sidecar no-spend prototype later this week.
+7. Start Workstream 7 non-Codex provider proof only after Codex evidence is
+   stable enough to be the reference path.

--- a/docs/tracker-updates/2026-05-20/README.md
+++ b/docs/tracker-updates/2026-05-20/README.md
@@ -1,0 +1,116 @@
+# Tracker Update Drafts - 2026-05-20
+
+Status: local drafts only. Do not post to GitHub or Linear without explicit
+operator approval.
+
+## Shared Current Truth
+
+- BrokenPipe/network-blip regression work is locally implemented and verified.
+  Downstream Codex/client socket closes are now distinct from upstream provider
+  interruptions in the managed Codex proxy path. Upstream partial `200` streams
+  that EOF before the promised `Content-Length` are treated as provider
+  interruption, not successful route health.
+- Local gates passed, refreshed at 2026-05-21 03:20 UTC:
+  `python3 -m py_compile` for Codex stubs, `bash -n` for the provider-degraded
+  smoke, `just smoke-codex-provider-degraded-local`, `just test`,
+  `just check-local`, and `git diff --check`.
+- Current installed no-spend route truth from the 2026-05-21 02:57 UTC
+  post-repair refresh: active binary is user-local `oauth-mux 0.1.9`; native
+  Codex resolves outside oauth-mux; four `codex-max` route stores are
+  runtime/broker ready; `codex:max-3` is selected; `max-4` is a live selectable
+  fallback; `max-1` and `max-2` remain blocked as `unrecorded`.
+- Current resilience is `session_start_ready:true`, `fallback_ready:true`,
+  `single_route_at_risk:false`.
+- Current cassette/live gate: a real cassette capture can proceed only after a
+  just-in-time no-spend refresh reconfirms spare fallback capacity and the
+  operator explicitly approves any live provider-spend capture.
+- Daemon remains non-production: `status:"not_running"`,
+  `contract:"experimental_socket_stub"`, `hosts_stay_afloat:false`; foreground
+  tick snapshots are observational only even when fresh.
+
+## GitHub #176 / Linear TIN-950 - Real Codex Wire Cassettes
+
+Draft:
+
+> 2026-05-20 local update, not a closure claim:
+>
+> The BrokenPipe/network-blip regression is now covered locally: downstream
+> Codex/client disconnects are classified as `proxy_client_disconnected` and do
+> not poison route health or same-turn retry, while upstream/provider
+> interruptions remain provider-degraded evidence and do not retry after a
+> partial stream reaches Codex. The regression also covers short `Content-Length`
+> EOF on a partial upstream `200`, so that does not persist false successful
+> route health. Local gates are green, including
+> `just smoke-codex-provider-degraded-local`, `just test`, and
+> `just check-local`.
+>
+> Real cassette capture is still open. The 2026-05-21 post-repair no-spend
+> refresh shows user-local `oauth-mux 0.1.9`, `codex:max-3` selected, and
+> `max-4` available as a live selectable fallback. `max-1` and `max-2` remain
+> `unrecorded`. Current resilience is `fallback_ready:true` and
+> `single_route_at_risk:false`, but the next cassette attempt should still do a
+> just-in-time no-spend refresh and get explicit operator approval for any live
+> provider-spend capture.
+>
+> Tracker hygiene note: Linear `TIN-950` is marked Done, but this GitHub issue
+> remains the active public gate for real Codex wire cassette acceptance. Treat
+> that as a mismatch until a real scrubbed cassette fixture lands or Linear is
+> clarified.
+
+Completion metric before closing:
+
+- At least one scrubbed real Codex `200` streaming cassette is committed.
+- `usage_limit_reached`, `usage_not_included`, `401`, and all-fallbacks
+  exhausted are captured or explicitly marked not observed.
+- Replay smoke fails diagnostically on shape drift and is included in CI-safe
+  local validation.
+
+## GitHub #212 / Linear TIN-1079 - Codex Quota Matrix
+
+Draft:
+
+> 2026-05-21 post-repair no-spend refresh: `codex:max-3#codex-max` is selected
+> and `max-4` is a live selectable fallback. `max-1` and `max-2` are
+> runtime/broker ready but still blocked as `unrecorded`, so the profile is
+> afloat with one spare fallback:
+> `session_start_ready:true`, `fallback_ready:true`,
+> `single_route_at_risk:false`.
+>
+> This means the negative permutation matrix can move out of the single-route
+> risk block, but release-grade evidence still requires a just-in-time no-spend
+> refresh and explicit approval for provider-spend cases. API-credit
+> false-positive, all-fallbacks-exhausted, tier-insufficient, and reset-window
+> repair remain the priority negative permutations.
+
+## GitHub #67 - Broker Daemon And Adapter Contract
+
+Draft:
+
+> BrokenPipe/network-blip hardening improves the managed Codex broker-owned
+> proxy path without expanding daemon claims. Downstream client disconnects no
+> longer look like provider degradation, and upstream stream interruptions are
+> recorded as provider-degraded without retrying after partial delivery.
+>
+> Daemon truth remains unchanged: current `daemon status` is not running,
+> experimental socket stub only, and `hosts_stay_afloat:false`. Foreground tick
+> snapshots must not be cited as unmanaged daemon hot-swap evidence.
+
+## GitHub #163 / Linear TIN-938 - Codex Remote App-Server Sidecar
+
+Draft:
+
+> Keep this queued behind the BrokenPipe/cassette path. The first acceptable
+> next step is still a no-spend sidecar smoke proving loopback transport,
+> remote auth token handling, connection ordering, and TUI attachment. No live
+> sidecar spend proof or managed interactive UX claim should be made until a
+> separate acceptance run exists.
+
+## GitHub #68 / Linear TIN-736 - Provider Proof Beyond Codex
+
+Draft:
+
+> Keep non-Codex proof secondary until the Codex reference adapter has stable
+> negative/cassette evidence. The next non-Codex provider should be admitted by
+> the provider-authoring checklist with fixture-backed positive and negative
+> proof. No non-Codex stay-afloat, background daemon, or universal provider
+> claim should be made from schema-modeled support alone.

--- a/scripts/smoke-codex-provider-degraded.sh
+++ b/scripts/smoke-codex-provider-degraded.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
-# Provider-degraded smoke: 5xx responses are provider failures, not credential
-# failures. The proxy should retry a selectable fallback before Codex sees the
-# 5xx, and should pass through a no-fallback provider 5xx without emitting the
-# route-repair no-account body.
+# Provider-degraded and stream-disconnect smoke: 5xx responses are provider
+# failures, not credential failures. The proxy should retry a selectable
+# fallback before Codex sees the 5xx, pass through a no-fallback provider 5xx
+# without emitting the route-repair no-account body, and treat downstream Codex
+# socket closes as local client disconnects rather than provider degradation.
+# Upstream interruptions after partial stream delivery should be recorded as
+# provider-degraded evidence, but must not trigger same-turn retry.
 
 set -euo pipefail
 
@@ -30,6 +33,10 @@ cleanup() {
             wait "$pid" 2>/dev/null || true
         fi
     done
+    if [[ "${OMUX_KEEP_SMOKE_TMP:-0}" == "1" ]]; then
+        echo "smoke-codex-provider-degraded: kept temp dir $TMP" >&2
+        return
+    fi
     rm -rf "$TMP"
 }
 trap cleanup EXIT
@@ -337,9 +344,112 @@ PY
     fi
 }
 
+run_upstream_interrupted_case() {
+    local case_dir="$TMP/upstream-interrupted"
+    local portfile="$case_dir/upstream.port"
+    local ndjson="$case_dir/adapter.ndjson"
+    local adapter_stderr="$case_dir/adapter.stderr"
+    local stub_report="$case_dir/stub-codex.report"
+    local trace_file="$case_dir/trace.ndjson"
+    mkdir -p "$case_dir"
+    write_one_account_fixture "$case_dir"
+
+    OMUX_STUB_PORT=0 \
+      OMUX_STUB_PORTFILE="$portfile" \
+      OMUX_STUB_OK_BEFORE_429=99 \
+      OMUX_STUB_200_BODY_REPEAT=4096 \
+      OMUX_STUB_TRUNCATE_200_AFTER_BYTES=128 \
+      python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$case_dir/upstream.stderr" &
+    local upstream_pid=$!
+    UPSTREAM_PIDS+=("$upstream_pid")
+    wait_for_port "$portfile"
+    local upstream_port
+    upstream_port="$(cat "$portfile" | tr -d '[:space:]')"
+    echo "smoke-codex-provider-degraded: upstream-interrupted stub pid=$upstream_pid port=$upstream_port"
+
+    OMUX_CONFIG="$case_dir/oauth-mux.config.json" \
+      OMUX_STATE_DIR="$case_dir/state" \
+      OMUX_UPSTREAM_HOST="127.0.0.1:$upstream_port" \
+      OMUX_UPSTREAM_SCHEME="http" \
+      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_TRACE=1 \
+      OMUX_TRACE_FILE="$trace_file" \
+      OMUX_STUB_CODEX_TURNS=1 \
+      OMUX_STUB_CODEX_REPORT="$stub_report" \
+      "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$ndjson" 2>"$adapter_stderr" || {
+        echo "adapter exited nonzero in upstream-interrupted case" >&2
+        cat "$ndjson" >&2 || true
+        cat "$adapter_stderr" >&2 || true
+        exit 1
+    }
+
+    echo "smoke-codex-provider-degraded: upstream-interrupted assertions"
+    jq -e 'select(.kind == "proxy_stream_interrupted" and .account == "codex:max-1" and .status == 200 and .bytes_streamed > 0 and .delivered_to_codex == true and .retry_attempted == false)' "$ndjson" >/dev/null
+    echo "  ✓ upstream partial stream classified as interrupted"
+    assert_no_grep "partial upstream stream did not same-turn retry" '"kind":"proxy_provider_same_turn_retry"|"kind":"proxy_same_turn_retry"|"kind":"proxy_provider_retry_unavailable"' "$ndjson"
+    jq -e 'select(.name == "codex.proxy.upstream_failure" and .attributes.path_kind == "responses" and .attributes.raw_account_id_printed == false)' "$trace_file" >/dev/null
+    echo "  ✓ trace captured interrupted upstream stream"
+    jq -e '[.turns[] | select(.status == 200 and (.body_head | contains("response.created")))] | length == 1' "$stub_report" >/dev/null
+    echo "  ✓ stub-codex saw partial 200 stream"
+    jq -e '[.accounts[] | select(.key == "codex:max-1#codex-max" and .last_probe_hint_class == "provider_degraded")] | length == 1' "$case_dir/state/health.json" >/dev/null
+    echo "  ✓ interrupted upstream stream recorded provider-degraded route health"
+}
+
+run_client_disconnect_case() {
+    local case_dir="$TMP/client-disconnect"
+    local portfile="$case_dir/upstream.port"
+    local ndjson="$case_dir/adapter.ndjson"
+    local adapter_stderr="$case_dir/adapter.stderr"
+    local stub_report="$case_dir/stub-codex.report"
+    local trace_file="$case_dir/trace.ndjson"
+    mkdir -p "$case_dir"
+    write_one_account_fixture "$case_dir"
+
+    OMUX_STUB_PORT=0 \
+      OMUX_STUB_PORTFILE="$portfile" \
+      OMUX_STUB_OK_BEFORE_429=99 \
+      OMUX_STUB_200_BODY_REPEAT=4096 \
+      python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$case_dir/upstream.stderr" &
+    local upstream_pid=$!
+    UPSTREAM_PIDS+=("$upstream_pid")
+    wait_for_port "$portfile"
+    local upstream_port
+    upstream_port="$(cat "$portfile" | tr -d '[:space:]')"
+    echo "smoke-codex-provider-degraded: client-disconnect stub pid=$upstream_pid port=$upstream_port"
+
+    OMUX_CONFIG="$case_dir/oauth-mux.config.json" \
+      OMUX_STATE_DIR="$case_dir/state" \
+      OMUX_UPSTREAM_HOST="127.0.0.1:$upstream_port" \
+      OMUX_UPSTREAM_SCHEME="http" \
+      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_TRACE=1 \
+      OMUX_TRACE_FILE="$trace_file" \
+      OMUX_STUB_CODEX_TURNS=1 \
+      OMUX_STUB_CODEX_DISCONNECT_TURNS=0 \
+      OMUX_STUB_CODEX_REPORT="$stub_report" \
+      "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$ndjson" 2>"$adapter_stderr" || {
+        echo "adapter exited nonzero in client-disconnect case" >&2
+        cat "$ndjson" >&2 || true
+        cat "$adapter_stderr" >&2 || true
+        exit 1
+    }
+
+    echo "smoke-codex-provider-degraded: client-disconnect assertions"
+    assert_grep "downstream close classified as client disconnect" '"kind":"proxy_client_disconnected".*"account":"codex:max-1".*"status":200.*"retry_attempted":false' "$ndjson"
+    assert_no_grep "downstream close did not record upstream failure" '"kind":"proxy_upstream_failed"' "$ndjson"
+    assert_no_grep "downstream close did not same-turn retry" '"kind":"proxy_provider_same_turn_retry"|"kind":"proxy_same_turn_retry"|"kind":"proxy_provider_retry_unavailable"' "$ndjson"
+    assert_no_grep "adapter stderr suppresses benign proxy close" 'proxy: serveOne: (BrokenPipe|ConnectionResetByPeer|EndOfStream)' "$adapter_stderr"
+    jq -e '[.turns[] | select(.status == 0 and (.body_head | contains("client_disconnected_before_response")))] | length == 1' "$stub_report" >/dev/null
+    echo "  ✓ stub-codex intentionally closed the turn socket"
+    jq -e '[.accounts[] | select(.last_probe_hint_class == "provider_degraded")] | length == 0' "$case_dir/state/health.json" >/dev/null
+    echo "  ✓ route health was not polluted by downstream disconnect"
+}
+
 run_fallback_case
 run_no_fallback_case
 run_transport_failure_case
+run_upstream_interrupted_case
+run_client_disconnect_case
 
 echo
 echo "smoke-codex-provider-degraded: all assertions passed."

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -37,6 +37,9 @@ Env (set by the smoke harness):
                             Codex persisting refreshed ChatGPT tokens in the
                             managed overlay.
   OMUX_STUB_CODEX_TURN_DELAY_MS — optional delay between turns (default 50).
+  OMUX_STUB_CODEX_DISCONNECT_TURNS — optional comma-separated turn indexes that
+                            should send the request then close the proxy socket
+                            before reading the streamed response.
   The report records argv after the stub binary so CLI forwarding smokes can
   assert `oauth-mux codex ...` command shape without provider traffic.
 """
@@ -47,6 +50,8 @@ import http.client
 import json
 import os
 import re
+import socket
+import struct
 import sys
 import time
 from pathlib import Path
@@ -106,6 +111,44 @@ def _auth_token_for_turn(turn: int) -> str | None:
     return tokens[min(turn, len(tokens) - 1)]
 
 
+def _disconnect_turns() -> set[int]:
+    raw = os.environ.get("OMUX_STUB_CODEX_DISCONNECT_TURNS", "")
+    turns: set[int] = set()
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        turns.add(int(part))
+    return turns
+
+
+def _request_parts(proxy_url: str, body: bytes, turn: int) -> tuple[str, bytes]:
+    m = re.match(r"http://([^/]+)(/.*)$", proxy_url)
+    if not m:
+        print(f"stub-codex: cannot parse base_url={proxy_url}", file=sys.stderr)
+        sys.exit(2)
+    netloc, prefix = m.group(1), m.group(2)
+    headers = [
+        f"POST {prefix}/responses HTTP/1.1",
+        f"Host: {netloc}",
+        "Content-Type: application/json",
+        "User-Agent: stub-codex/0",
+        "x-codex-turn-state: stub-turn-state-v1",
+        "x-codex-installation-id: stub-install-1",
+        "OpenAI-Beta: responses_websockets=2026-02-06",
+        f"Content-Length: {len(body)}",
+        "Connection: close",
+    ]
+    account_id = os.environ.get("OMUX_STUB_CODEX_CHATGPT_ACCOUNT_ID")
+    auth_token = _auth_token_for_turn(turn)
+    if account_id:
+        headers.append(f"ChatGPT-Account-ID: {account_id}")
+    if auth_token:
+        headers.append(f"Authorization: Bearer {auth_token}")
+    request = ("\r\n".join(headers) + "\r\n\r\n").encode("utf-8") + body
+    return netloc, request
+
+
 def _post(proxy_url: str, body: bytes, turn: int) -> tuple[int, str]:
     # base_url is like http://127.0.0.1:NNNN/backend-api/codex
     # We want to POST to that prefix + /responses.
@@ -139,6 +182,19 @@ def _post(proxy_url: str, body: bytes, turn: int) -> tuple[int, str]:
         return resp.status, resp.read().decode("utf-8", errors="replace")
     finally:
         conn.close()
+
+
+def _post_and_disconnect(proxy_url: str, body: bytes, turn: int) -> tuple[int, str]:
+    netloc, request = _request_parts(proxy_url, body, turn)
+    host, port_s = netloc.rsplit(":", 1)
+    sock = socket.create_connection((host, int(port_s)), timeout=15)
+    try:
+        sock.sendall(request)
+        linger = struct.pack("ii", 1, 0)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, linger)
+    finally:
+        sock.close()
+    return 0, "client_disconnected_before_response"
 
 
 def _session_bridge_report(codex_home: Path) -> dict:
@@ -231,12 +287,13 @@ def main() -> int:
     )
 
     turn_results: list[dict] = []
+    disconnect_turns = _disconnect_turns()
     for i in range(turns):
-        status, body = _post(
-            proxy_url,
-            json.dumps({"input": f"stub turn {i}"}).encode("utf-8"),
-            i,
-        )
+        payload = json.dumps({"input": f"stub turn {i}"}).encode("utf-8")
+        if i in disconnect_turns:
+            status, body = _post_and_disconnect(proxy_url, payload, i)
+        else:
+            status, body = _post(proxy_url, payload, i)
         turn_results.append({"turn": i, "status": status, "body_head": body[:120]})
         print(f"stub-codex: turn {i} -> {status}", file=sys.stderr, flush=True)
         time.sleep(turn_delay_ms / 1000)

--- a/scripts/test-stub-upstream.py
+++ b/scripts/test-stub-upstream.py
@@ -15,6 +15,13 @@ Behavior (configurable via env):
                             for ANY GIVEN account-id (default 2)
   OMUX_STUB_LOGFILE   — path to append per-request JSON log lines
                         (default /tmp/omux-stub-upstream.log)
+  OMUX_STUB_200_BODY_REPEAT — repeat the tiny SSE 200 response this many
+                        times (default 1). Used by disconnect smokes to
+                        force multiple streamed proxy writes.
+  OMUX_STUB_TRUNCATE_200_AFTER_BYTES — if positive, send only this many bytes
+                        of a 200 response body, then reset the connection.
+                        Used to model upstream network interruption after a
+                        partial streaming response reached the proxy.
 
 Per request:
   - Logs a JSON line with: ts, path, method, account_id (from
@@ -48,6 +55,8 @@ import hashlib
 import http.server
 import json
 import os
+import socket
+import struct
 import sys
 import time
 from pathlib import Path
@@ -58,6 +67,8 @@ PORT = int(os.environ.get("OMUX_STUB_PORT", "0"))
 PORTFILE = Path(os.environ.get("OMUX_STUB_PORTFILE", "/tmp/omux-stub-upstream.port"))
 OK_BEFORE_429 = int(os.environ.get("OMUX_STUB_OK_BEFORE_429", "2"))
 LOGFILE = Path(os.environ.get("OMUX_STUB_LOGFILE", "/tmp/omux-stub-upstream.log"))
+BODY_REPEAT = int(os.environ.get("OMUX_STUB_200_BODY_REPEAT", "1"))
+TRUNCATE_200_AFTER_BYTES = int(os.environ.get("OMUX_STUB_TRUNCATE_200_AFTER_BYTES", "0"))
 
 # OMUX_STUB_429_TYPE chooses what the stub returns once an account
 # crosses OK_BEFORE_429:
@@ -164,6 +175,7 @@ class StubHandler(http.server.BaseHTTPRequestHandler):
                 "event: response.completed\n"
                 'data: {"type":"response.completed","response":{"id":"resp-stub","output":[]}}\n\n'
             )
+            body = body * max(1, BODY_REPEAT)
             return 200, {"_text": body, "_ct": "text/event-stream"}
         # 429 path. Body shape selected by OMUX_STUB_429_TYPE so the
         # harness can drive the swap-eligible (usage_limit_reached)
@@ -209,6 +221,31 @@ class StubHandler(http.server.BaseHTTPRequestHandler):
             payload = json.dumps(body).encode("utf-8")
             ct = "application/json"
 
+        if status == 200 and TRUNCATE_200_AFTER_BYTES > 0 and TRUNCATE_200_AFTER_BYTES < len(payload):
+            self.send_response(status)
+            self.send_header("Content-Type", ct)
+            self.send_header("Content-Length", str(len(payload)))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.write(payload[:TRUNCATE_200_AFTER_BYTES])
+            self.wfile.flush()
+            try:
+                linger = struct.pack("ii", 1, 0)
+                self.connection.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, linger)
+            except OSError:
+                pass
+            self.close_connection = True
+            _log({
+                "path": path,
+                "method": self.command,
+                "account_id": self._account_id(),
+                "auth_prefix": self._auth_prefix(),
+                "status_returned": status,
+                "response_classification": "ok_truncated",
+                "bytes_written": TRUNCATE_200_AFTER_BYTES,
+            })
+            return
+
         self.send_response(status)
         self.send_header("Content-Type", ct)
         self.send_header("Content-Length", str(len(payload)))
@@ -241,6 +278,8 @@ def main() -> int:
     print(f"stub-upstream: portfile={PORTFILE}", file=sys.stderr, flush=True)
     print(f"stub-upstream: logfile={LOGFILE}", file=sys.stderr, flush=True)
     print(f"stub-upstream: ok_before_429={OK_BEFORE_429} per account", file=sys.stderr, flush=True)
+    print(f"stub-upstream: 200_body_repeat={BODY_REPEAT}", file=sys.stderr, flush=True)
+    print(f"stub-upstream: truncate_200_after_bytes={TRUNCATE_200_AFTER_BYTES}", file=sys.stderr, flush=True)
     print(f"stub-upstream: 429_type={ERROR_TYPE}", file=sys.stderr, flush=True)
     if ALWAYS_STATUS:
         print(f"stub-upstream: always_status={ALWAYS_STATUS} (overrides classification)", file=sys.stderr, flush=True)

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -1552,11 +1552,25 @@ fn proxyThreadMain(p: *wire_proxy.Proxy, shutdown: *std.atomic.Value(bool)) void
         p.serveOne() catch |e| {
             // Server error or accept failure; if shutting down, exit.
             if (shutdown.load(.acquire)) return;
+            if (isBenignProxyConnectionClose(e)) continue;
             std.debug.print("proxy: serveOne: {s}\n", .{@errorName(e)});
             // Continue serving; transient errors should not kill the
             // proxy mid-session.
         };
     }
+}
+
+fn isBenignProxyConnectionClose(err: anyerror) bool {
+    return err == error.BrokenPipe or
+        err == error.ConnectionResetByPeer or
+        err == error.EndOfStream;
+}
+
+test "proxy thread suppresses expected localhost connection close errors" {
+    try std.testing.expect(isBenignProxyConnectionClose(error.BrokenPipe));
+    try std.testing.expect(isBenignProxyConnectionClose(error.ConnectionResetByPeer));
+    try std.testing.expect(isBenignProxyConnectionClose(error.EndOfStream));
+    try std.testing.expect(!isBenignProxyConnectionClose(error.Unexpected));
 }
 
 /// Open a TCP connection to the proxy and immediately close it. This

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -380,6 +380,39 @@ pub const Proxy = struct {
                 continue;
             };
 
+            if (status_and_class.stream_outcome.kind == .client_disconnected) {
+                self.logEvent("proxy_client_disconnected", .{
+                    .account = elected.id,
+                    .method = req.method,
+                    .path_kind = pathKind(req.path),
+                    .status = status_and_class.status,
+                    .err = status_and_class.stream_outcome.err orelse "client_disconnected",
+                    .bytes_streamed = status_and_class.stream_outcome.bytes_streamed,
+                    .retry_attempted = false,
+                });
+                final_account = elected.id;
+                break;
+            }
+
+            if (status_and_class.stream_outcome.kind == .upstream_interrupted) {
+                const err_name = status_and_class.stream_outcome.err orelse "stream_interrupted";
+                appendRejection(a, &rejections, elected.id, .provider_degraded, err_name) catch {};
+                self.logEvent("proxy_stream_interrupted", .{
+                    .account = elected.id,
+                    .method = req.method,
+                    .path_kind = pathKind(req.path),
+                    .status = status_and_class.status,
+                    .err = err_name,
+                    .bytes_streamed = status_and_class.stream_outcome.bytes_streamed,
+                    .delivered_to_codex = true,
+                    .retry_attempted = false,
+                });
+                self.traceUpstreamFailure(req, elected.id, err_name);
+                self.recordDurableRouteState(elected.id, .provider_degraded, 503, 60);
+                final_account = elected.id;
+                break;
+            }
+
             // ── 5. Apply classification + log ──────────────────────
             self.applyClassification(elected.id, status_and_class.classification) catch |err| {
                 self.logEvent("proxy_apply_classification_failed", .{ .account = elected.id, .err = @errorName(err) });
@@ -1168,6 +1201,18 @@ const BufferedResponse = struct {
     body: []const u8,
 };
 
+const StreamOutcomeKind = enum {
+    complete,
+    client_disconnected,
+    upstream_interrupted,
+};
+
+const StreamOutcome = struct {
+    kind: StreamOutcomeKind = .complete,
+    err: ?[]const u8 = null,
+    bytes_streamed: usize = 0,
+};
+
 const StatusAndClassification = struct {
     status: u16,
     classification: Classification,
@@ -1178,6 +1223,7 @@ const StatusAndClassification = struct {
     /// false if it was buffered for classification/retry or never
     /// arrived (early failure).
     streamed: bool,
+    stream_outcome: StreamOutcome = .{},
     /// Present when the response was buffered and has not yet been written to
     /// Codex. The caller may retry first, then write this only if recovery is
     /// unavailable or the retry also fails with a buffered response.
@@ -1256,8 +1302,13 @@ fn forwardAndStream(
     }
 
     const classification = classify(a, status_u16, &.{});
-    try writeStreamedResponse(client_writer, http_req.response, http_req.reader());
-    return .{ .status = status_u16, .classification = classification, .streamed = true };
+    const stream_outcome = writeStreamedResponse(client_writer, http_req.response, http_req.reader());
+    return .{
+        .status = status_u16,
+        .classification = classification,
+        .streamed = true,
+        .stream_outcome = stream_outcome,
+    };
 }
 
 fn pathKind(path: []const u8) []const u8 {
@@ -1586,20 +1637,60 @@ fn writeStreamedResponse(
     writer: anytype,
     response: std.http.Client.Response,
     upstream_reader: anytype,
-) !void {
-    try writer.print("HTTP/1.1 {d} \r\n", .{@intFromEnum(response.status)});
-    try writeForwardingResponseHeaders(writer, response);
-    try writer.writeAll("Connection: close\r\n\r\n");
+) StreamOutcome {
+    writer.print("HTTP/1.1 {d} \r\n", .{@intFromEnum(response.status)}) catch |err| {
+        return .{ .kind = .client_disconnected, .err = @errorName(err) };
+    };
+    writeForwardingResponseHeaders(writer, response) catch |err| {
+        return .{ .kind = .client_disconnected, .err = @errorName(err) };
+    };
+    writer.writeAll("Connection: close\r\n\r\n") catch |err| {
+        return .{ .kind = .client_disconnected, .err = @errorName(err) };
+    };
 
+    return pumpStreamBody(writer, upstream_reader, response.content_length);
+}
+
+fn shortReadOutcome(bytes_streamed: usize, expected_content_length: ?u64) ?StreamOutcome {
+    const expected = expected_content_length orelse return null;
+    const streamed: u64 = @intCast(bytes_streamed);
+    if (streamed >= expected) return null;
+    return .{
+        .kind = .upstream_interrupted,
+        .err = "ShortRead",
+        .bytes_streamed = bytes_streamed,
+    };
+}
+
+fn pumpStreamBody(writer: anytype, upstream_reader: anytype, expected_content_length: ?u64) StreamOutcome {
     var buf: [64 * 1024]u8 = undefined;
+    var bytes_streamed: usize = 0;
     while (true) {
         const n = upstream_reader.read(&buf) catch |err| switch (err) {
-            error.EndOfStream => break,
-            else => return err,
+            error.EndOfStream => {
+                if (shortReadOutcome(bytes_streamed, expected_content_length)) |outcome| return outcome;
+                break;
+            },
+            else => return .{
+                .kind = .upstream_interrupted,
+                .err = @errorName(err),
+                .bytes_streamed = bytes_streamed,
+            },
         };
-        if (n == 0) break;
-        try writer.writeAll(buf[0..n]);
+        if (n == 0) {
+            if (shortReadOutcome(bytes_streamed, expected_content_length)) |outcome| return outcome;
+            break;
+        }
+        writer.writeAll(buf[0..n]) catch |err| {
+            return .{
+                .kind = .client_disconnected,
+                .err = @errorName(err),
+                .bytes_streamed = bytes_streamed,
+            };
+        };
+        bytes_streamed += n;
     }
+    return .{ .kind = .complete, .bytes_streamed = bytes_streamed };
 }
 
 // ── Tests ────────────────────────────────────────────────────────────
@@ -1622,6 +1713,83 @@ test "pathKind redacts Codex endpoint paths into stable classes" {
     try std.testing.expectEqualStrings("memories_trace_summarize", pathKind("/backend-api/codex/memories/trace_summarize"));
     try std.testing.expectEqualStrings("codex_other", pathKind("/backend-api/codex/unknown/shape"));
     try std.testing.expectEqualStrings("unknown", pathKind("/not-codex"));
+}
+
+const TestSinkWriter = struct {
+    bytes: usize = 0,
+    fail: bool = false,
+
+    const Error = error{BrokenPipe};
+    const Writer = std.io.Writer(*TestSinkWriter, Error, write);
+
+    fn writer(self: *TestSinkWriter) Writer {
+        return .{ .context = self };
+    }
+
+    fn write(self: *TestSinkWriter, bytes: []const u8) Error!usize {
+        if (self.fail) return error.BrokenPipe;
+        self.bytes += bytes.len;
+        return bytes.len;
+    }
+};
+
+const TestChunkReader = struct {
+    chunk: []const u8,
+    emitted: bool = false,
+    fail_after_chunk: bool = false,
+
+    const Error = error{ EndOfStream, ConnectionResetByPeer };
+    const Reader = std.io.Reader(*TestChunkReader, Error, read);
+
+    fn reader(self: *TestChunkReader) Reader {
+        return .{ .context = self };
+    }
+
+    fn read(self: *TestChunkReader, buf: []u8) Error!usize {
+        if (self.emitted) {
+            if (self.fail_after_chunk) return error.ConnectionResetByPeer;
+            return error.EndOfStream;
+        }
+        self.emitted = true;
+        const n = @min(buf.len, self.chunk.len);
+        @memcpy(buf[0..n], self.chunk[0..n]);
+        return n;
+    }
+};
+
+test "stream body BrokenPipe is classified as downstream disconnect" {
+    var writer = TestSinkWriter{ .fail = true };
+    var reader = TestChunkReader{ .chunk = "data" };
+
+    const outcome = pumpStreamBody(writer.writer(), reader.reader(), null);
+
+    try std.testing.expectEqual(StreamOutcomeKind.client_disconnected, outcome.kind);
+    try std.testing.expectEqualStrings("BrokenPipe", outcome.err.?);
+    try std.testing.expectEqual(@as(usize, 0), outcome.bytes_streamed);
+}
+
+test "stream body upstream read failure is classified without retrying partial response" {
+    var writer = TestSinkWriter{};
+    var reader = TestChunkReader{ .chunk = "data", .fail_after_chunk = true };
+
+    const outcome = pumpStreamBody(writer.writer(), reader.reader(), null);
+
+    try std.testing.expectEqual(StreamOutcomeKind.upstream_interrupted, outcome.kind);
+    try std.testing.expectEqualStrings("ConnectionResetByPeer", outcome.err.?);
+    try std.testing.expectEqual(@as(usize, 4), outcome.bytes_streamed);
+    try std.testing.expectEqual(@as(usize, 4), writer.bytes);
+}
+
+test "stream body short Content-Length EOF is classified as upstream interrupted" {
+    var writer = TestSinkWriter{};
+    var reader = TestChunkReader{ .chunk = "data" };
+
+    const outcome = pumpStreamBody(writer.writer(), reader.reader(), 8);
+
+    try std.testing.expectEqual(StreamOutcomeKind.upstream_interrupted, outcome.kind);
+    try std.testing.expectEqualStrings("ShortRead", outcome.err.?);
+    try std.testing.expectEqual(@as(usize, 4), outcome.bytes_streamed);
+    try std.testing.expectEqual(@as(usize, 4), writer.bytes);
 }
 
 test "classifyHttpErrorBody identifies Cloudflare 400 without exposing body" {


### PR DESCRIPTION
## Summary

This PR hardens the managed Codex wire proxy against network-blip and local client-disconnect failure modes observed during dogfood.

Primary reliability slice:
- classify downstream Codex/client socket closes as `client_disconnected`
- avoid provider-degraded route-health writes for local client disconnects
- classify upstream partial-stream interruptions separately as `upstream_interrupted`
- treat short `Content-Length` EOF after partial `200` delivery as provider-degraded evidence
- suppress noisy benign proxy thread close errors such as `BrokenPipe`, `ConnectionResetByPeer`, and `EndOfStream`

Supporting hygiene slice:
- record the operational hardening plan and local tracker drafts
- refresh release/docs/workflow truth to `0.1.9`
- pin current route truth: `max-3` selected, `max-4` spare fallback, `max-1/max-2` still `unrecorded`

## Root Cause

The proxy previously collapsed downstream client closes and upstream/provider interruptions into one failure path. A downstream disconnect could surface as noisy `proxy: serveOne: BrokenPipe`, while a partial upstream `200` stream could be treated as successful route health even when the provider connection ended before the promised body was delivered.

## Validation

- `zig fmt --check src/adapters/codex/main.zig src/adapters/codex/wire_proxy.zig`
- `python3 -m py_compile scripts/test-stub-codex.py scripts/test-stub-upstream.py`
- `bash -n scripts/smoke-codex-provider-degraded.sh`
- `just smoke-codex-provider-degraded-local`
- `just test`
- `just check-local`
- `git diff --check`

## Notes

No GitHub issue or Linear ticket comments were posted from the local tracker drafts. Real Codex cassette capture remains blocked on a just-in-time no-spend route refresh and explicit provider-spend approval.
