### PR TITLE
Prepare 0.1.10 provenance and dogfood release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,7 +10,7 @@ on:
       version:
         description: "Version to stage and publish"
         required: false
-        default: "0.1.9"
+        default: "0.1.10"
         type: string
       dry_run:
         description: "Run npm publish --dry-run instead of publishing"

--- a/.github/workflows/registry-dry-run.yml
+++ b/.github/workflows/registry-dry-run.yml
@@ -10,7 +10,7 @@ on:
       version:
         description: "Version to stage and dry-run"
         required: false
-        default: "0.1.9"
+        default: "0.1.10"
         type: string
       lanes:
         description: "Comma-separated lanes: plan,github,npm,homebrew,system"

--- a/.github/workflows/release-proof.yml
+++ b/.github/workflows/release-proof.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: "Release version to stage and smoke-test"
         required: false
-        default: "0.1.9"
+        default: "0.1.10"
         type: string
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -150,10 +150,10 @@ oauth-mux codex preflight --profile codex-max --capability codex-max --json
 If `which -a oauth-mux` resolves Homebrew before the user-local dogfood binary,
 adjust PATH or invoke `./zig-out/bin/oauth-mux` directly for source-tree proof.
 
-`version --json` prints the active executable path classification and SHA-256
-under `runtime_identity`. Use it when public packages and local dogfood have
-nearby version strings and you need machine-readable proof of the exact binary
-that will run.
+`version --json` prints the active executable path classification, SHA-256, and
+compiled `build_id` under `runtime_identity`. Use it when public packages and
+local dogfood have nearby version strings and you need machine-readable proof of
+the exact binary that will run.
 
 `codex preflight` prints the active `oauth-mux` path, all visible `oauth-mux`
 and `codex` PATH candidates, whether active `codex` is the managed oauth-mux
@@ -190,6 +190,8 @@ touching a native Codex executable. Public packages may carry a managed `codex`
 shim, but installed behavior must still be proven with `version --json`,
 `which -a codex`, and `codex preflight` when you need to distinguish a package
 binary from a worktree dogfood binary.
+The installer warns if the copied user-local binary is still shadowed by a
+Homebrew or other PATH entry.
 
 ## Usage
 

--- a/build.zig
+++ b/build.zig
@@ -6,8 +6,11 @@ pub fn build(b: *std.Build) void {
     const project_version = readProjectVersion(b) catch |err| {
         std.debug.panic("failed to read project version from build.zig.zon: {s}", .{@errorName(err)});
     };
+    const project_build_id = b.option([]const u8, "build-id", "Build provenance id") orelse
+        readBuildId(b, project_version);
     const build_options = b.addOptions();
     build_options.addOption([]const u8, "version", project_version);
+    build_options.addOption([]const u8, "build_id", project_build_id);
 
     const exe = b.addExecutable(.{
         .name = "oauth-mux",
@@ -77,4 +80,36 @@ fn readProjectVersion(b: *std.Build) ![]const u8 {
     const after_first_quote = after_marker[first_quote + 1 ..];
     const second_quote = std.mem.indexOfScalar(u8, after_first_quote, '"') orelse return error.ProjectVersionMissing;
     return try b.allocator.dupe(u8, after_first_quote[0..second_quote]);
+}
+
+fn readBuildId(b: *std.Build, project_version: []const u8) []const u8 {
+    const env_build_id = std.process.getEnvVarOwned(b.allocator, "OMUX_BUILD_ID") catch null;
+    if (env_build_id) |value| {
+        if (std.mem.trim(u8, value, " \t\r\n").len != 0) return value;
+        b.allocator.free(value);
+    }
+
+    const result = std.process.Child.run(.{
+        .allocator = b.allocator,
+        .argv = &.{ "git", "describe", "--tags", "--dirty", "--always" },
+    }) catch return project_version;
+    defer b.allocator.free(result.stderr);
+
+    if (result.term != .Exited or result.term.Exited != 0) {
+        b.allocator.free(result.stdout);
+        return project_version;
+    }
+
+    const trimmed = std.mem.trim(u8, result.stdout, " \t\r\n");
+    if (trimmed.len == 0) {
+        b.allocator.free(result.stdout);
+        return project_version;
+    }
+
+    const build_id = b.allocator.dupe(u8, trimmed) catch {
+        b.allocator.free(result.stdout);
+        return project_version;
+    };
+    b.allocator.free(result.stdout);
+    return build_id;
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .oauth_mux,
-    .version = "0.1.9",
+    .version = "0.1.10",
     .fingerprint = 0x21c445132f61984e,
     .minimum_zig_version = "0.14.0",
     .paths = .{

--- a/dist/npm/package.json
+++ b/dist/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth-mux",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "OAuth fallback muxing for AI harness subscriptions",
   "license": "MIT",
   "repository": "Jesssullivan/oauth-mux",
@@ -17,11 +17,11 @@
     "postinstall": "node install.js"
   },
   "optionalDependencies": {
-    "oauth-mux-darwin-arm64": "0.1.9",
-    "oauth-mux-darwin-x64": "0.1.9",
-    "oauth-mux-linux-arm64": "0.1.9",
-    "oauth-mux-linux-x64": "0.1.9",
-    "oauth-mux-windows-arm64": "0.1.9",
-    "oauth-mux-windows-x64": "0.1.9"
+    "oauth-mux-darwin-arm64": "0.1.10",
+    "oauth-mux-darwin-x64": "0.1.10",
+    "oauth-mux-linux-arm64": "0.1.10",
+    "oauth-mux-linux-x64": "0.1.10",
+    "oauth-mux-windows-arm64": "0.1.10",
+    "oauth-mux-windows-x64": "0.1.10"
   }
 }

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -1,6 +1,6 @@
 # Productionization Ledger
 
-Updated: 2026-05-20
+Updated: 2026-05-25
 
 This ledger is the short operator map for oauth-mux productionization. It is
 subordinate to the broker contract and Codex adapter contract, and it should be
@@ -8,22 +8,24 @@ refreshed when release truth, route evidence, or tracker state changes.
 
 ## Current Snapshot
 
-- Repo state: `main` matches `origin/main` at `f05a44f`; local worktrees may
-  carry focused BrokenPipe/network-blip WIP until that regression fix is landed.
-- CI state: GitHub Actions is the live source for the latest run. The latest
-  observed `main` run for `f05a44f` succeeded on 2026-05-19. Release workflow
-  `26012676776`, registry dry-run `26012836911`, and npm publish
-  `26013003383` verified the `v0.1.9` release lane on 2026-05-18.
+- Repo state: `main` matches `origin/main` at `3de6e17`, including the
+  BrokenPipe/client-disconnect hardening from PR #279.
+- CI state: GitHub Actions is the live source for the latest run. Release
+  workflow `26012676776`, registry dry-run `26012836911`, and npm publish
+  `26013003383` verified the `v0.1.9` release lane on 2026-05-18. Any
+  installed public `0.1.9` package predates PRs #260-#279 unless its binary hash
+  is explicitly proven otherwise.
 - Version truth: public npm, GitHub Release, curl installer assets, deb/rpm
   assets, and the public Homebrew tap resolve to `0.1.9`; this was rechecked on
   2026-05-21. The 2026-05-18/19 shim investigation fixed a package-lane
   ownership bug: the Homebrew formula must not install or link a managed
   `codex` shim by default.
-- Installed provenance: PATH currently resolves user-local
-  `/Users/jess/.local/bin/oauth-mux` before Homebrew. Use
-  `which -a oauth-mux`, `which -a codex`, `oauth-mux version --json`, and
+- Installed provenance: PATH may resolve Homebrew before user-local dogfood.
+  Use `which -a oauth-mux`, `which -a codex`, `oauth-mux version --json`, and
   `codex preflight` before treating any installed-command run as release
-  evidence.
+  evidence. `version --json` must be checked for both binary SHA-256 and
+  `runtime_identity.build_id`; source builds after this update report a git
+  describe-style build id such as `v0.1.9-19-g3de6e17`.
 - Homebrew truth: the public `jesssullivan/omux` tap advertises `oauth-mux
   0.1.9` and the local linked keg is `0.1.9`. Homebrew is a binary-only package
   lane by default: QA must prove
@@ -70,7 +72,7 @@ refreshed when release truth, route evidence, or tracker state changes.
 | Experimental Codex settings injection | Implemented | Defaults can be injected without treating user config as disposable. |
 | Native Codex shim pass-through | Implemented in source, release pending | Admin/login/help/version paths bypass route election and exec native Codex. The 2026-05-18 package-lane fix must ship before public Homebrew/curl claims use this as installed truth. |
 | Home Manager lane | Implemented in source | Module defaults to binary-only install; managed `codex` shim is explicit opt-in. |
-| Route-health recovery | Implemented | Transient provider degradation can recover after retry windows without becoming permanent auth death. |
+| Route-health recovery | Implemented | Transient provider degradation can recover after retry windows without becoming permanent auth death. Source after PR #279 also separates downstream client disconnects from upstream/provider failures so client `BrokenPipe` does not poison route health. |
 | Redacted diagnostics and tracing | Implemented | JSON diagnostics and `OMUX_TRACE=1` support route/session/auth/runtime debugging without token, raw account id, session id, or path leakage. |
 | Agent-safe reauth mediation | Contracted, partial surfaces | CLI JSON exposes consent/action fields and safe handoff-plan commands for upstream-owned login surfaces; future MCP tools must mirror CLI semantics. |
 | Beta daemon | Experimental | Foreground tick engine and daemon-hosted beta may mediate status/handoffs; not a hidden dependency and not unmanaged hot-swap. |
@@ -124,10 +126,12 @@ MCP repair prompts, but oauth-mux must not claim to keep them alive.
 ## Active Plan
 
 The current testable workstream plan lives at
-`docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md`. It prioritizes
-the BrokenPipe regression fix, no-spend route/process truth refresh, real Codex
-wire cassettes, release hygiene, tracker reconciliation, then later sidecar and
-non-Codex provider work.
+`docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md`. The BrokenPipe
+regression fix is landed in source; the immediate operational risk is stale
+installed package/dogfood provenance. Next work should prioritize installed
+build-id proof, package parity/release hygiene, no-spend route/process truth
+refresh, real Codex wire cassettes, tracker reconciliation, then later sidecar
+and non-Codex provider work.
 
 ## Release And Distribution Posture
 

--- a/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
+++ b/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
@@ -15,25 +15,20 @@ prepared fallback remain diagnostic infrastructure, not the success claim.
 
 ## Current Verified State
 
-- Local checkout: feature branch `jess/brokenpipe-network-blip-reliability`
-  based on `main` at `f05a44f`. Slice A is locally committed as `5bd36b3`
-  (`fix: classify codex stream disconnects`); Slice B docs/release hygiene is
-  separate WIP.
-- GitHub read-only refresh at 2026-05-21 17:22 UTC: no open PRs, no GitHub
-  Discussions, and open issues are `#67`, `#68`, `#163`, `#176`, and `#212`.
-  Latest observed `main` CI run for `f05a44f` is `26085487311` and succeeded on
-  2026-05-19.
+- Local checkout: `main` is at `3de6e17`, where PR #279 landed the
+  BrokenPipe/client-disconnect reliability slice.
+- GitHub read-only refresh at 2026-05-25: no open PRs, no GitHub Discussions,
+  and open issues are `#67`, `#68`, `#163`, `#176`, and `#212`.
 - Linear: `TIN-1517` and `TIN-1518` are Done. `TIN-950` is marked Done, but
   GitHub `#176` is still open for real Codex wire cassettes; treat that as a
   tracker hygiene mismatch until reconciled. `TIN-1079` is Backlog, `TIN-938`
   is Todo, and `TIN-736` is In Progress.
-- Release truth: source version is `0.1.9`; GitHub Release `v0.1.9` is
-  published, not draft/prerelease, with installer, npm, Homebrew, tarball,
-  deb/rpm, and checksum assets; `npm view oauth-mux version dist-tags --json`
-  reports `latest:0.1.9`; the public Homebrew tap reports stable and linked keg
-  `0.1.9`.
-- CI truth: latest observed `main` Actions run for `f05a44f` completed
-  successfully on 2026-05-19.
+- Release truth: public GitHub Release `v0.1.9` is published, not
+  draft/prerelease, with installer, npm, Homebrew, tarball, deb/rpm, and
+  checksum assets; `npm view oauth-mux version dist-tags --json` reports
+  `latest:0.1.9`; the public Homebrew tap reports stable and linked keg
+  `0.1.9`. Source is staged for `0.1.10` so the next package lane can carry the
+  post-`0.1.9` Codex hardening.
 - Current route truth from the 2026-05-21 02:57 UTC post-repair no-spend
   refresh: active binary is user-local `oauth-mux 0.1.9`; native Codex resolves
   outside oauth-mux; `codex:max-3#codex-max` is selected; `max-4` is a live
@@ -42,6 +37,8 @@ prepared fallback remain diagnostic infrastructure, not the success claim.
 - Local validation at 2026-05-21 03:20 UTC: `just check-local` passed with the
   BrokenPipe/client-disconnect regression, upstream partial-stream
   interruption regression, managed Codex smokes, and cassette replay smokes.
+  On 2026-05-25, dogfood logs showed the public/Homebrew `0.1.9` binary still
+  lacks that fix because it predates PR #279.
 
 ## Workstream 1 - BrokenPipe And Network-Blip Reliability
 
@@ -85,8 +82,10 @@ Todo:
   health.
 - [x] Suppress benign proxy thread close noise while preserving real upstream
   diagnostics.
-- [ ] Land the WIP as a small focused PR before starting live cassette or
-  provider-spend work.
+- [x] Land the WIP as a small focused PR before starting live cassette or
+  provider-spend work. Landed as PR #279.
+- [ ] Publish or install a build that contains PR #279 before treating
+  installed `oauth-mux codex resume` dogfood as fixed.
 
 ## Workstream 2 - No-Spend Route And Process Truth Refresh
 
@@ -227,7 +226,8 @@ prepared.
 
 Completion metric:
 
-- Current-state docs describe `0.1.9` as the latest verified release truth.
+- Current-state docs describe `0.1.9` as the latest verified public release
+  truth and `0.1.10` as the next staged source/package version until published.
 - Historical docs may keep older versions only when clearly framed as
   historical evidence.
 - Manual workflow defaults use the current project version or are deliberately
@@ -253,6 +253,8 @@ Todo:
 - [x] Keep `docs/install-beta-matrix.md` and old release-runbook entries as
   historical evidence unless a fresh parity sweep replaces them.
 - [x] Add a short pointer from the productionization ledger to this plan.
+- [x] Stage `0.1.10` source/release metadata for the post-`0.1.9` BrokenPipe
+  and install-provenance fixes.
 - [x] When running the stale-version search, confirm remaining older-version
   hits are explicitly historical, such as the 2026-05-17 no-spend snapshot or
   the `0.1.1` npm deprecation cleanup workflow.

--- a/scripts/install-local-dogfood.sh
+++ b/scripts/install-local-dogfood.sh
@@ -119,5 +119,11 @@ if [ "$install_codex_shim" != "0" ]; then
 else
   printf 'skipped managed codex shim: set OMUX_DOGFOOD_INSTALL_CODEX_SHIM=1 to shadow codex for managed-shim dogfood\n'
 fi
-printf 'PATH oauth-mux: %s\n' "$(command -v oauth-mux || true)"
-printf 'PATH codex: %s\n' "$(command -v codex || true)"
+path_oauth_mux="$(command -v oauth-mux || true)"
+path_codex="$(command -v codex || true)"
+printf 'PATH oauth-mux: %s\n' "$path_oauth_mux"
+if [ -n "$path_oauth_mux" ] && [ "$(real_path "$path_oauth_mux")" != "$(real_path "$oauth_mux_target")" ]; then
+  printf 'warning: installed dogfood oauth-mux is shadowed on PATH by %s\n' "$path_oauth_mux" >&2
+  printf 'warning: put %s before that directory or invoke %s directly for source dogfood\n' "$install_dir" "$oauth_mux_target" >&2
+fi
+printf 'PATH codex: %s\n' "$path_codex"

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -1246,7 +1246,7 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     }
 
     if (emit_status) {
-        const runtime_identity = try runtime_mod.oauthMuxRuntimeIdentity(allocator, cli.version);
+        const runtime_identity = try runtime_mod.oauthMuxRuntimeIdentity(allocator, cli.version, cli.build_id);
         defer runtime_identity.deinit(allocator);
         const command_spelling = try getEnvOwnedOrDefault(allocator, "OMUX_COMMAND_SPELLING", "oauth-mux codex");
         defer allocator.free(command_spelling);

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -3,6 +3,7 @@ const types = @import("types.zig");
 const build_options = @import("build_options");
 
 pub const version = build_options.version;
+pub const build_id = build_options.build_id;
 
 pub const Command = union(enum) {
     exec: ExecArgs,

--- a/src/main.zig
+++ b/src/main.zig
@@ -311,7 +311,7 @@ pub fn main() !void {
 }
 
 fn writeVersionJson(allocator: std.mem.Allocator, writer: anytype) !void {
-    const identity = try runtime_mod.oauthMuxRuntimeIdentity(allocator, cli.version);
+    const identity = try runtime_mod.oauthMuxRuntimeIdentity(allocator, cli.version, cli.build_id);
     defer identity.deinit(allocator);
 
     try writer.writeAll("{\"version\":");

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -45,14 +45,14 @@ pub const OauthMuxRuntimeIdentity = struct {
     }
 };
 
-pub fn oauthMuxRuntimeIdentity(allocator: std.mem.Allocator, version: []const u8) !OauthMuxRuntimeIdentity {
+pub fn oauthMuxRuntimeIdentity(allocator: std.mem.Allocator, version: []const u8, default_build_id: []const u8) !OauthMuxRuntimeIdentity {
     const binary_path = std.fs.selfExePathAlloc(allocator) catch try allocator.dupe(u8, "unknown");
     errdefer allocator.free(binary_path);
 
     const binary_sha256 = hashFileSha256Hex(allocator, binary_path) catch null;
     errdefer if (binary_sha256) |sha| allocator.free(sha);
 
-    const build_id = std.process.getEnvVarOwned(allocator, "OMUX_BUILD_ID") catch try allocator.dupe(u8, version);
+    const build_id = try allocator.dupe(u8, default_build_id);
     errdefer allocator.free(build_id);
 
     return .{


### PR DESCRIPTION
## Summary
- stage source/release metadata for 0.1.10 so post-0.1.9 Codex hardening can ship to package lanes
- compile a git-derived build_id into version --json and managed Codex runtime_identity
- warn when local dogfood installs are shadowed by Homebrew or another PATH entry
- update current productionization docs for the #279 BrokenPipe fix and stale installed 0.1.9 boundary

## Root cause from dogfood logs
The live Homebrew 0.1.9 binary predates #279. It classified Codex/client BrokenPipe disconnects as provider_degraded, briefly marking both selectable Codex routes unavailable and producing false NoAccountSelectable. Source/main already has the stream-disconnect fix; this PR makes installed provenance and the next release lane unambiguous.

## Validation
- scripts/project-version.sh
- bash -n scripts/install-local-dogfood.sh
- bash -n scripts/smoke-codex-provider-degraded.sh
- git diff --check
- zig build test
- zig build && ./scripts/smoke-codex-provider-degraded.sh
- just check-local
- OMUX_DOGFOOD_SKIP_BUILD=1 ./scripts/install-local-dogfood.sh
- /Users/jess/.local/bin/oauth-mux version --json
- /Users/jess/.local/bin/oauth-mux codex preflight --profile codex-max --capability codex-max --json

No provider calls were used.