### PR TITLE
Require explicit Homebrew formula version

### DIFF
--- a/dist/homebrew/oauth-mux.rb
+++ b/dist/homebrew/oauth-mux.rb
@@ -2,6 +2,7 @@ class OauthMux < Formula
   desc "OAuth fallback muxing for AI harness subscriptions"
   homepage "https://omux.xoxd.ai"
   license "MIT"
+  version "${VERSION}"
 
   on_macos do
     if Hardware::CPU.arm?

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -8,30 +8,34 @@ refreshed when release truth, route evidence, or tracker state changes.
 
 ## Current Snapshot
 
-- Repo state: `main` matches `origin/main` at `3de6e17`, including the
-  BrokenPipe/client-disconnect hardening from PR #279.
+- Repo state: `main` matches `origin/main` at `42b103c`, including the
+  BrokenPipe/client-disconnect hardening from PR #279 and the 0.1.10
+  provenance/release preparation from PR #280.
 - CI state: GitHub Actions is the live source for the latest run. Release
   workflow `26012676776`, registry dry-run `26012836911`, and npm publish
   `26013003383` verified the `v0.1.9` release lane on 2026-05-18. Any
   installed public `0.1.9` package predates PRs #260-#279 unless its binary hash
   is explicitly proven otherwise.
-- Version truth: public npm, GitHub Release, curl installer assets, deb/rpm
-  assets, and the public Homebrew tap resolve to `0.1.9`; this was rechecked on
-  2026-05-21. The 2026-05-18/19 shim investigation fixed a package-lane
-  ownership bug: the Homebrew formula must not install or link a managed
-  `codex` shim by default.
+- Version truth: GitHub Release, curl installer assets, deb/rpm assets, and the
+  public Homebrew tap resolve to `0.1.10`; this was rechecked on 2026-05-25.
+  npm `latest` is still `0.1.9` because the CI npm lane currently lacks usable
+  npm auth and fails `npm whoami` with 401. The 2026-05-18/19 shim
+  investigation fixed a package-lane ownership bug: the Homebrew formula must
+  not install or link a managed `codex` shim by default.
 - Installed provenance: PATH may resolve Homebrew before user-local dogfood.
   Use `which -a oauth-mux`, `which -a codex`, `oauth-mux version --json`, and
   `codex preflight` before treating any installed-command run as release
   evidence. `version --json` must be checked for both binary SHA-256 and
   `runtime_identity.build_id`; source builds after this update report a git
-  describe-style build id such as `v0.1.9-19-g3de6e17`.
+  describe-style build id, while tagged releases report the exact tag such as
+  `v0.1.10`.
 - Homebrew truth: the public `jesssullivan/omux` tap advertises `oauth-mux
-  0.1.9` and the local linked keg is `0.1.9`. Homebrew is a binary-only package
-  lane by default: QA must prove
+  0.1.10` and the local linked keg is `0.1.10`. Homebrew is a binary-only
+  package lane by default: QA must prove
   `brew install jesssullivan/omux/oauth-mux` installs `oauth-mux`, does not
   install an `OMUX_CODEX_SHIM`, and leaves native `codex` command resolution
-  unchanged.
+  unchanged. The formula must declare explicit version metadata because Linux
+  Homebrew can infer `64-linux` from the x86_64 Linux tarball name.
 - Codex route truth: the 2026-05-21 02:57 UTC post-repair no-spend refresh used
   user-local `oauth-mux 0.1.9`. All four named `codex-max` route stores are
   runtime-ready and broker-ready. `codex:max-3#codex-max` is selected and
@@ -135,10 +139,12 @@ and non-Codex provider work.
 
 ## Release And Distribution Posture
 
-`0.1.9` version availability is complete for the public install lanes checked
-again on 2026-05-21: GitHub Release `v0.1.9` is published and non-draft,
-npm `latest` is `0.1.9`, Homebrew stable/linked keg is `0.1.9`, and curl
-installer plus deb/rpm assets are attached to the release. Negative Codex
+`0.1.10` version availability is complete for GitHub Release, curl installer,
+deb/rpm assets, and Homebrew as of 2026-05-25: GitHub Release `v0.1.10` is
+published and non-draft, Homebrew stable/linked keg is `0.1.10`, and hosted
+system package install QA passed for the published `.deb` / `.rpm` assets. npm
+publication remains blocked on npm auth; npm `latest` still reports `0.1.9`.
+Negative Codex
 cassettes, broader adapter proof, and daemon beta truth remain follow-up work.
 Windows managed-`codex` parity is intentionally assigned to the npm wrapper
 lane rather than raw tarballs until a native Windows operator need is proven.

--- a/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
+++ b/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
@@ -15,25 +15,24 @@ prepared fallback remain diagnostic infrastructure, not the success claim.
 
 ## Current Verified State
 
-- Local checkout: `main` is at `3de6e17`, where PR #279 landed the
-  BrokenPipe/client-disconnect reliability slice.
+- Local checkout: `main` is at `42b103c`, where PR #279 landed the
+  BrokenPipe/client-disconnect reliability slice and PR #280 prepared the
+  0.1.10 provenance/release lane.
 - GitHub read-only refresh at 2026-05-25: no open PRs, no GitHub Discussions,
   and open issues are `#67`, `#68`, `#163`, `#176`, and `#212`.
 - Linear: `TIN-1517` and `TIN-1518` are Done. `TIN-950` is marked Done, but
   GitHub `#176` is still open for real Codex wire cassettes; treat that as a
   tracker hygiene mismatch until reconciled. `TIN-1079` is Backlog, `TIN-938`
   is Todo, and `TIN-736` is In Progress.
-- Release truth: public GitHub Release `v0.1.9` is published, not
-  draft/prerelease, with installer, npm, Homebrew, tarball, deb/rpm, and
-  checksum assets; `npm view oauth-mux version dist-tags --json` reports
-  `latest:0.1.9`; the public Homebrew tap reports stable and linked keg
-  `0.1.9`. Source is staged for `0.1.10` so the next package lane can carry the
-  post-`0.1.9` Codex hardening.
-- Current route truth from the 2026-05-21 02:57 UTC post-repair no-spend
-  refresh: active binary is user-local `oauth-mux 0.1.9`; native Codex resolves
-  outside oauth-mux; `codex:max-3#codex-max` is selected; `max-4` is a live
-  selectable fallback; `max-1` and `max-2` remain runtime/broker ready but
-  blocked as `unrecorded`.
+- Release truth: public GitHub Release `v0.1.10` is published, not
+  draft/prerelease, with installer, Homebrew, tarball, deb/rpm, and checksum
+  assets; the public Homebrew tap reports stable and linked keg `0.1.10`.
+  `npm view oauth-mux version` still reports `0.1.9` because the CI npm lane
+  currently lacks usable npm auth and fails `npm whoami` with 401.
+- Current route truth from the 2026-05-25 refresh: active bare binary is
+  Homebrew `oauth-mux 0.1.10`; native Codex resolves outside oauth-mux;
+  `codex:max-3#codex-max` is selected; `max-4` is a live selectable fallback;
+  `max-1` and `max-2` remain runtime/broker ready but blocked as `unrecorded`.
 - Local validation at 2026-05-21 03:20 UTC: `just check-local` passed with the
   BrokenPipe/client-disconnect regression, upstream partial-stream
   interruption regression, managed Codex smokes, and cassette replay smokes.
@@ -255,6 +254,8 @@ Todo:
 - [x] Add a short pointer from the productionization ledger to this plan.
 - [x] Stage `0.1.10` source/release metadata for the post-`0.1.9` BrokenPipe
   and install-provenance fixes.
+- [x] Publish `v0.1.10` GitHub Release assets and update the public Homebrew tap
+  to `0.1.10`; npm remains blocked on CI npm auth.
 - [x] When running the stale-version search, confirm remaining older-version
   hits are explicitly historical, such as the 2026-05-17 no-spend snapshot or
   the `0.1.1` npm deprecation cleanup workflow.

--- a/scripts/homebrew-version-check.sh
+++ b/scripts/homebrew-version-check.sh
@@ -6,8 +6,8 @@ if [ "$#" -ne 2 ]; then
 Usage: scripts/homebrew-version-check.sh <expected-version> <formula-file-or-ref>
 
 Checks either:
-  - a rendered formula file contains an explicit Homebrew version line or a
-    release URL from which Homebrew can infer the expected stable version, or
+  - a rendered formula file contains an explicit Homebrew version line, or a
+    legacy release URL from which Homebrew can infer the expected stable version, or
   - a tapped formula reference reports the expected stable version via
     `brew info --json=v2`.
 EOF

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -120,8 +120,8 @@ if grep -q -E '\$\{(VERSION|SHA_[A-Z0-9_]+)\}' "$homebrew_formula"; then
   printf 'unrendered placeholder remains in %s\n' "$homebrew_formula" >&2
   exit 1
 fi
-if grep -q '^[[:space:]]*version ' "$homebrew_formula"; then
-  printf 'Homebrew formula must not declare a redundant explicit version; Homebrew should infer it from release URLs: %s\n' "$homebrew_formula" >&2
+if ! grep -Fqx "  version \"$version\"" "$homebrew_formula"; then
+  printf 'Homebrew formula must declare explicit version "%s" so Linux Homebrew does not infer a platform suffix: %s\n' "$version" "$homebrew_formula" >&2
   exit 1
 fi
 license_line="$(awk '/^[[:space:]]+license / { print NR; exit }' "$homebrew_formula")"


### PR DESCRIPTION
Homebrew on Linux can infer the stable version as a platform suffix from `oauth-mux-x86_64-linux.tar.gz` unless the formula declares explicit version metadata. This makes the generated formula declare the release version and updates release smoke to require it.\n\nAlso refreshes the productionization ledger with the v0.1.10 release/Homebrew truth and the current npm-auth blocker.\n\nValidation:\n- rendered formula syntax and version check\n- bash -n scripts/release-smoke.sh scripts/homebrew-version-check.sh scripts/release-local.sh\n- git diff --check\n- just release-proof 0.1.10\n- just check-local