### PR TITLE
Fix Homebrew audit order and dogfood truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,11 @@ diagnostic infrastructure. They are not product success.
 ## Current Truth
 
 Public install lanes are versioned by channel. The current verified release is
-`0.1.9`: GitHub Release assets exist, npm root and platform packages resolve,
-the curl installer and deb/rpm assets are attached to the release, and the
-public Homebrew tap reports stable `0.1.9`. The 2026-05-18/19 install-parity
-work fixed a package-lane bug where a public Homebrew `codex` shim routed
-native admin commands such as `codex --version` through oauth-mux route
-election. Homebrew remains binary-only by default:
+`0.1.10` for GitHub Release, curl installer, deb/rpm assets, and Homebrew.
+The npm package lane still reports `0.1.9` until CI npm auth is repaired. The
+2026-05-18/19 install-parity work fixed a package-lane bug where a public
+Homebrew `codex` shim routed native admin commands such as `codex --version`
+through oauth-mux route election. Homebrew remains binary-only by default:
 `brew install jesssullivan/omux/oauth-mux` installs `oauth-mux` and must not
 install or link a managed `codex` shim.
 
@@ -35,8 +34,8 @@ What works today:
 
 - Managed Codex launch and resume through `oauth-mux codex` and
   `oauth-mux codex resume`.
-- Current source/user-local dogfood and next package artifacts include a
-  `codex` shim, so a future bare `codex` command is managed only when PATH
+- Current source/user-local dogfood and the npm wrapper lane can include a
+  managed `codex` shim, so a bare `codex` command is managed only when PATH
   resolves that shim. Admin commands such as `codex login` and
   `codex --version` must pass through to native Codex. Direct native Codex
   binaries and already-running native sessions are not globally protected.

--- a/dist/homebrew/oauth-mux.rb
+++ b/dist/homebrew/oauth-mux.rb
@@ -1,8 +1,8 @@
 class OauthMux < Formula
   desc "OAuth fallback muxing for AI harness subscriptions"
   homepage "https://omux.xoxd.ai"
-  license "MIT"
   version "${VERSION}"
+  license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -8,14 +8,15 @@ refreshed when release truth, route evidence, or tracker state changes.
 
 ## Current Snapshot
 
-- Repo state: `main` matches `origin/main` at `42b103c`, including the
-  BrokenPipe/client-disconnect hardening from PR #279 and the 0.1.10
-  provenance/release preparation from PR #280.
-- CI state: GitHub Actions is the live source for the latest run. Release
-  workflow `26012676776`, registry dry-run `26012836911`, and npm publish
-  `26013003383` verified the `v0.1.9` release lane on 2026-05-18. Any
-  installed public `0.1.9` package predates PRs #260-#279 unless its binary hash
-  is explicitly proven otherwise.
+- Repo state: `main` matches `origin/main` at `33133e3`, including the
+  BrokenPipe/client-disconnect hardening from PR #279, the 0.1.10
+  provenance/release preparation from PR #280, and the explicit Homebrew
+  formula-version guard from PR #281.
+- CI state: GitHub Actions is the live source for the latest run. Main CI for
+  PR #281 completed green on 2026-05-25. Release workflow `26408682726`
+  published `v0.1.10`; system package install QA `26409604539` passed against
+  the published deb/rpm assets. npm dry-run/publish remains blocked by npm auth
+  and returns `npm whoami` 401.
 - Version truth: GitHub Release, curl installer assets, deb/rpm assets, and the
   public Homebrew tap resolve to `0.1.10`; this was rechecked on 2026-05-25.
   npm `latest` is still `0.1.9` because the CI npm lane currently lacks usable
@@ -36,14 +37,15 @@ refreshed when release truth, route evidence, or tracker state changes.
   install an `OMUX_CODEX_SHIM`, and leaves native `codex` command resolution
   unchanged. The formula must declare explicit version metadata because Linux
   Homebrew can infer `64-linux` from the x86_64 Linux tarball name.
-- Codex route truth: the 2026-05-21 02:57 UTC post-repair no-spend refresh used
-  user-local `oauth-mux 0.1.9`. All four named `codex-max` route stores are
-  runtime-ready and broker-ready. `codex:max-3#codex-max` is selected and
-  selectable; `max-4` is a live selectable fallback; `max-1` and `max-2` remain
-  blocked as `unrecorded`. Current state is `session_start_ready:true`,
-  `fallback_ready:true`, `single_route_at_risk:false`. The next live cassette
-  run still needs a just-in-time no-spend refresh plus explicit operator
-  approval for provider-spend capture.
+- Codex route truth: the 2026-05-25 dogfood refresh uses Homebrew
+  `oauth-mux 0.1.10` and native Codex `0.132.0`. Explicit capability probes
+  proved `codex:max-1#codex-max` and `codex:max-2#codex-max` available, so
+  current preflight reports `session_start_ready:true`, `fallback_ready:true`,
+  and `single_route_at_risk:false`. `codex:max-3#codex-max` is quota-exhausted
+  until reset. An extant managed resume process is still running from
+  `/opt/homebrew/Cellar/oauth-mux/0.1.9.reinstall/bin/oauth-mux`; its status
+  artifact continues to show pre-0.1.10 `BrokenPipe` provider-degraded events
+  and can re-poison `max-4` until that old process exits or is restarted.
 - Latest local status truth: `oauth-mux codex status-latest --json` currently
   reports `brokered_without_fallback` from a rolling local artifact. This is
   stale relative to current route truth and does not supersede the preserved

--- a/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
+++ b/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
@@ -15,9 +15,10 @@ prepared fallback remain diagnostic infrastructure, not the success claim.
 
 ## Current Verified State
 
-- Local checkout: `main` is at `42b103c`, where PR #279 landed the
-  BrokenPipe/client-disconnect reliability slice and PR #280 prepared the
-  0.1.10 provenance/release lane.
+- Local checkout: `main` is at `33133e3`, where PR #279 landed the
+  BrokenPipe/client-disconnect reliability slice, PR #280 prepared the
+  0.1.10 provenance/release lane, and PR #281 required explicit Homebrew
+  formula version metadata.
 - GitHub read-only refresh at 2026-05-25: no open PRs, no GitHub Discussions,
   and open issues are `#67`, `#68`, `#163`, `#176`, and `#212`.
 - Linear: `TIN-1517` and `TIN-1518` are Done. `TIN-950` is marked Done, but
@@ -31,8 +32,10 @@ prepared fallback remain diagnostic infrastructure, not the success claim.
   currently lacks usable npm auth and fails `npm whoami` with 401.
 - Current route truth from the 2026-05-25 refresh: active bare binary is
   Homebrew `oauth-mux 0.1.10`; native Codex resolves outside oauth-mux;
-  `codex:max-3#codex-max` is selected; `max-4` is a live selectable fallback;
-  `max-1` and `max-2` remain runtime/broker ready but blocked as `unrecorded`.
+  explicit capability probes proved `max-1` and `max-2` available, so preflight
+  now has a selectable fallback. `max-3` is quota-exhausted, and `max-4` is
+  currently provider-degraded by an old still-running `0.1.9.reinstall`
+  managed resume process rather than by the installed 0.1.10 binary.
 - Local validation at 2026-05-21 03:20 UTC: `just check-local` passed with the
   BrokenPipe/client-disconnect regression, upstream partial-stream
   interruption regression, managed Codex smokes, and cassette replay smokes.
@@ -83,8 +86,11 @@ Todo:
   diagnostics.
 - [x] Land the WIP as a small focused PR before starting live cassette or
   provider-spend work. Landed as PR #279.
-- [ ] Publish or install a build that contains PR #279 before treating
-  installed `oauth-mux codex resume` dogfood as fixed.
+- [x] Publish or install a build that contains PR #279 before treating new
+  installed `oauth-mux codex resume` dogfood as fixed. Completed for GitHub
+  Release and Homebrew as `0.1.10`; existing long-running 0.1.9 processes still
+  need to exit or be restarted before their status artifacts stop showing the
+  old BrokenPipe behavior.
 
 ## Workstream 2 - No-Spend Route And Process Truth Refresh
 

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -129,6 +129,15 @@ if [ -z "${license_line:-}" ]; then
   printf 'Homebrew formula missing license line: %s\n' "$homebrew_formula" >&2
   exit 1
 fi
+version_line="$(awk '/^[[:space:]]+version / { print NR; exit }' "$homebrew_formula")"
+if [ -z "${version_line:-}" ]; then
+  printf 'Homebrew formula missing explicit version line: %s\n' "$homebrew_formula" >&2
+  exit 1
+fi
+if [ "$version_line" -gt "$license_line" ]; then
+  printf 'Homebrew formula must put version before license for brew audit style: %s\n' "$homebrew_formula" >&2
+  exit 1
+fi
 "$repo_root/scripts/homebrew-version-check.sh" "$version" "$homebrew_formula"
 if grep -q 'bin.install "codex"' "$homebrew_formula"; then
   printf 'Homebrew formula must not install codex; shim lanes must be opt-in outside Brew: %s\n' "$homebrew_formula" >&2


### PR DESCRIPTION
## Summary

- move explicit Homebrew formula version before license so hosted Linux brew audit accepts the 0.1.10 formula
- make release smoke assert Homebrew version ordering before audit
- refresh README, productionization ledger, and operational hardening plan with current 0.1.10/npm/dogfood truth

## Validation

- git diff --check
- bash -n scripts/registry-dry-run.sh scripts/release-smoke.sh scripts/homebrew-version-check.sh
- rendered temp formula: ruby -c, homebrew-version-check, version-before-license assertion
- just check-local

Note: full local release-proof was skipped because the release preflight reported 10.6 GiB free and requires 12.0 GiB. Hosted CI remains the release-proof source here.
