### PR TITLE
Add Codex capture preflight guard

### DIFF
--- a/docs/spec/codex-wire-evidence-2026-05-03.md
+++ b/docs/spec/codex-wire-evidence-2026-05-03.md
@@ -19,6 +19,12 @@ the live capture lands.
 
 TIN-950 adds the capture/replay tooling only:
 
+- `scripts/capture-codex-wire.sh preflight` writes a no-spend
+  capture-readiness report with installed `oauth-mux` provenance,
+  native Codex version, mitmproxy availability, current route fallback
+  readiness, latest status verdict, and stale-process hints. Run this
+  immediately before starting any intercepting proxy or live provider
+  spend.
 - `scripts/capture-codex-wire.sh` starts the operator-controlled
   mitmproxy HTTP capture path.
 - `scripts/codex-wire-addon.py` writes reviewed, redacted per-flow JSON
@@ -48,6 +54,9 @@ confirm the shapes themselves match upstream reality.
   type fires)
 - Capture timestamp range: _OPERATOR-CONFIRM_
 - Capture run directory: `captures/codex-wire-<TS>/`
+- Capture preflight summary: _OPERATOR-CONFIRM_
+  (`captures/codex-wire-<TS>/capture-preflight-summary.json`, recorded
+  before the proxy was started)
 - mitmdump version: _OPERATOR-CONFIRM_
 - Capture review summary: _OPERATOR-CONFIRM_ (`capture-codex-wire.sh review`)
 - Replay tooling: `scripts/test-cassette-upstream.py`
@@ -58,20 +67,23 @@ confirm the shapes themselves match upstream reality.
 Before any captured flow is committed as a cassette or cited as live
 evidence:
 
-1. Run `scripts/capture-codex-wire.sh review captures/codex-wire-<TS>`
+1. Run `scripts/capture-codex-wire.sh preflight` and confirm
+   `ok:true`, `fallback_ready:true`, and `single_route_at_risk:false`
+   unless the operator explicitly accepts a single-route-at-risk capture.
+2. Run `scripts/capture-codex-wire.sh review captures/codex-wire-<TS>`
    against the capture root, not the raw `.flows` file.
-2. Confirm the summary includes the expected path/status mix for the
+3. Confirm the summary includes the expected path/status mix for the
    scenario being promoted: normal 200, 401 refresh, 429
    `usage_limit_reached`, compact, memory, or other Codex endpoint.
-3. Confirm `redaction_failures` and `malformed` are empty.
-4. Manually inspect the fixture-sized JSON selected for promotion.
+4. Confirm `redaction_failures` and `malformed` are empty.
+5. Manually inspect the fixture-sized JSON selected for promotion.
    The reviewer catches obvious token/JWT/API-key strings; it is not a
    formal proof that all account-identifying material is gone.
-5. Textual non-JSON responses such as `text/event-stream` may include
+6. Textual non-JSON responses such as `text/event-stream` may include
    `body_text` so the cassette replayer can serve realistic SSE frames.
    Keep only reviewed, fixture-sized text bodies and remove prompt,
    transcript, or account-identifying content before promotion.
-6. Commit only scrubbed per-flow JSON. Do not commit
+7. Commit only scrubbed per-flow JSON. Do not commit
    `captures/**/flows.binary`.
 
 ## 1. Endpoints Observed

--- a/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
+++ b/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
@@ -207,6 +207,7 @@ Completion metric:
 Test commands:
 
 ```bash
+scripts/capture-codex-wire.sh preflight
 just smoke-codex-cassette-replay-local
 just smoke-codex-cassette-all-exhausted-local
 just check-local
@@ -217,7 +218,12 @@ Todo:
 
 - [ ] Prepare the tracker reconciliation note for `TIN-950` versus `#176`;
   do not post it without explicit operator approval.
-- [ ] Re-run no-spend route truth immediately before capture.
+- [x] Add a no-spend capture preflight command that records installed
+  `oauth-mux` provenance, native Codex version, mitmproxy availability,
+  fallback readiness, latest status verdict, and stale-process hints before
+  starting the intercepting proxy.
+- [ ] Re-run no-spend route truth immediately before capture and keep the
+  generated preflight summary with the capture scratch directory.
 - [ ] Capture at least one normal `200` Codex turn with streaming preserved.
 - [ ] Capture or explicitly record not-observed status for `401`,
   `usage_limit_reached`, `usage_not_included`, and all-fallbacks-exhausted.

--- a/scripts/capture-codex-wire.sh
+++ b/scripts/capture-codex-wire.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cmd="${1:-help}"
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-CAP_DIR="$ROOT/captures"
+CAP_DIR="${OMUX_CAPTURE_DIR:-$ROOT/captures}"
 TS="$(date -u +%Y%m%dT%H%M%SZ)"
 RUN_DIR="$CAP_DIR/codex-wire-$TS"
 
@@ -29,6 +29,7 @@ capture-codex-wire.sh - Phase 0 evidence capture for the Codex adapter.
 
 USAGE
   scripts/capture-codex-wire.sh init             # one-time mitmproxy CA install check
+  scripts/capture-codex-wire.sh preflight        # no-spend capture readiness report
   scripts/capture-codex-wire.sh proxy            # start the HTTP capture proxy in foreground
   scripts/capture-codex-wire.sh review DIR       # summarize/redaction-check a capture
   scripts/capture-codex-wire.sh help
@@ -38,10 +39,15 @@ WORKFLOW
      mitmproxy CA, follow the instructions it prints. macOS:
        security add-trusted-cert -d -r trustRoot \
          -k ~/Library/Keychains/login.keychain-db ~/.mitmproxy/mitmproxy-ca-cert.cer
-  2. In one shell:
+  2. Run the no-spend capture preflight:
+       scripts/capture-codex-wire.sh preflight
+     It records installed binary identity, Codex version, mitmproxy
+     availability, route fallback readiness, latest status summary, and
+     active oauth-mux/Codex process hints under captures/.
+  3. In one shell:
        scripts/capture-codex-wire.sh proxy
      The proxy listens on 127.0.0.1:9080 as a normal HTTP proxy.
-  3. In another shell:
+  4. In another shell:
        export HTTPS_PROXY=http://127.0.0.1:9080
        export HTTP_PROXY=http://127.0.0.1:9080
        export NO_PROXY=
@@ -49,10 +55,10 @@ WORKFLOW
      Drive a normal turn, force a 401 (revoke a token externally), and
      drive an account to weekly quota exhaustion to capture the 429 +
      usage_limit_reached body.
-  4. Stop the proxy with ^C. Find captures under captures/.
-  5. Run:
+  5. Stop the proxy with ^C. Find captures under captures/.
+  6. Run:
        scripts/capture-codex-wire.sh review captures/codex-wire-<TS>
-  6. Distill findings into docs/spec/codex-wire-evidence-2026-05-03.md.
+  7. Distill findings into docs/spec/codex-wire-evidence-2026-05-03.md.
 
 REDACTION
   The mitmproxy addon redacts Authorization, Cookie, and ChatGPT-Account-
@@ -90,6 +96,136 @@ cmd_init() {
   echo "  rustls clients (codex CLI is rustls): also export"
   echo "    SSL_CERT_FILE=$ca"
   echo "  before running codex behind the proxy."
+}
+
+cmd_preflight() {
+  local profile="${OMUX_CAPTURE_PROFILE:-codex-max}"
+  local capability="${OMUX_CAPTURE_CAPABILITY:-codex-max}"
+  local require_fallback="${OMUX_CAPTURE_REQUIRE_FALLBACK:-1}"
+  local report_dir="${OMUX_CAPTURE_PREFLIGHT_DIR:-$RUN_DIR}"
+
+  require_cmd python3 "install python3"
+  require_cmd oauth-mux "install oauth-mux or put the intended binary on PATH"
+  require_cmd codex "install Codex CLI or put the intended binary on PATH"
+
+  mkdir -p "$report_dir"
+
+  local version_json="$report_dir/oauth-mux-version.json"
+  local preflight_json="$report_dir/codex-preflight.json"
+  local status_json="$report_dir/codex-status-latest.json"
+  local codex_version_txt="$report_dir/codex-version.txt"
+  local commands_txt="$report_dir/commands.txt"
+  local processes_txt="$report_dir/processes.txt"
+  local summary_json="$report_dir/capture-preflight-summary.json"
+
+  {
+    echo "oauth-mux:"
+    type -a oauth-mux 2>/dev/null || command -v oauth-mux || true
+    echo
+    echo "codex:"
+    type -a codex 2>/dev/null || command -v codex || true
+    echo
+    echo "mitmdump:"
+    command -v mitmdump 2>/dev/null || true
+  } >"$commands_txt"
+
+  oauth-mux version --json >"$version_json"
+  codex --version >"$codex_version_txt" 2>&1 || true
+  oauth-mux codex preflight --profile "$profile" --capability "$capability" --json >"$preflight_json" || true
+  oauth-mux codex status-latest --json >"$status_json" 2>/dev/null || printf '{}\n' >"$status_json"
+  ps -o pid,ppid,stat,lstart,etime,command -ax 2>/dev/null | grep -E 'oauth-mux codex|oauth-mux|codex' >"$processes_txt" || true
+
+  if command -v mitmdump >/dev/null 2>&1; then
+    mitmdump --version >"$report_dir/mitmdump-version.txt" 2>&1 || true
+  fi
+
+  python3 - "$version_json" "$preflight_json" "$status_json" "$commands_txt" "$processes_txt" "$summary_json" "$profile" "$capability" "$require_fallback" <<'PY'
+import json
+import pathlib
+import sys
+
+version_path, preflight_path, status_path, commands_path, processes_path, out_path, profile, capability, require_fallback = sys.argv[1:]
+
+
+def load_json(path):
+    try:
+        return json.loads(pathlib.Path(path).read_text())
+    except Exception:
+        return {}
+
+
+version = load_json(version_path)
+preflight = load_json(preflight_path)
+status = load_json(status_path)
+commands = pathlib.Path(commands_path).read_text(errors="replace")
+processes = pathlib.Path(processes_path).read_text(errors="replace")
+
+route_summary = preflight.get("route_summary") or {}
+selected = preflight.get("selected")
+runtime_identity = version.get("runtime_identity") or {}
+mitmdump_available = bool([line for line in commands.splitlines() if line.strip().endswith("mitmdump") or "/mitmdump" in line])
+stale_mux_process_hints = [
+    line for line in processes.splitlines()
+    if "oauth-mux" in line and ("0.1.9" in line or ".reinstall" in line)
+]
+
+issues = []
+if not preflight.get("ok"):
+    issues.append("codex preflight is not ok")
+if not route_summary.get("session_start_ready"):
+    issues.append("session_start_ready is false")
+if require_fallback != "0" and not route_summary.get("fallback_ready"):
+    issues.append("fallback_ready is false")
+if route_summary.get("single_route_at_risk"):
+    issues.append("single_route_at_risk is true")
+if not mitmdump_available:
+    issues.append("mitmdump is not installed or not on PATH")
+if stale_mux_process_hints:
+    issues.append("stale oauth-mux process hints found")
+
+summary = {
+    "ok": not issues,
+    "profile": profile,
+    "capability": capability,
+    "issues": issues,
+    "oauth_mux": {
+        "version": version.get("version"),
+        "binary_path": runtime_identity.get("binary_path"),
+        "binary_source": runtime_identity.get("binary_source"),
+        "build_id": runtime_identity.get("build_id"),
+        "binary_sha256": runtime_identity.get("binary_sha256"),
+    },
+    "codex_version_file": pathlib.Path(status_path).with_name("codex-version.txt").name,
+    "mitmdump_available": mitmdump_available,
+    "selected": selected,
+    "route_summary": route_summary,
+    "blocked_route_reasons": preflight.get("blocked_route_reasons") or [],
+    "status_verdict": status.get("verdict"),
+    "status_path": status.get("path"),
+    "stale_mux_process_hints": stale_mux_process_hints,
+    "report_files": {
+        "oauth_mux_version": pathlib.Path(version_path).name,
+        "codex_preflight": pathlib.Path(preflight_path).name,
+        "codex_status_latest": pathlib.Path(status_path).name,
+        "commands": pathlib.Path(commands_path).name,
+        "processes": pathlib.Path(processes_path).name,
+    },
+}
+
+pathlib.Path(out_path).write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+
+print(f"capture preflight report: {out_path}")
+print(f"ok: {str(summary['ok']).lower()}")
+print(f"oauth-mux: {summary['oauth_mux'].get('version')} {summary['oauth_mux'].get('build_id')} {summary['oauth_mux'].get('binary_source')}")
+print(f"selected: {selected}")
+print(f"route_summary: {json.dumps(route_summary, sort_keys=True)}")
+if issues:
+    print("issues:")
+    for issue in issues:
+        print(f"  - {issue}")
+
+sys.exit(0 if summary["ok"] else 1)
+PY
 }
 
 cmd_proxy() {
@@ -134,6 +270,7 @@ cmd_review() {
 case "$cmd" in
   help|-h|--help) usage ;;
   init)           cmd_init ;;
+  preflight)      cmd_preflight ;;
   proxy)          cmd_proxy ;;
   review)         shift; cmd_review "${1:-}" ;;
   *)              usage; exit 64 ;;

--- a/scripts/smoke-codex-capture-review.sh
+++ b/scripts/smoke-codex-capture-review.sh
@@ -129,4 +129,101 @@ assert summary["ok"] is False, summary
 assert summary["redaction_failures"], summary
 PY
 
+BIN="$TMP/bin"
+mkdir -p "$BIN"
+
+cat >"$BIN/oauth-mux" <<'SH'
+#!/usr/bin/env sh
+set -eu
+if [ "$1" = "version" ] && [ "$2" = "--json" ]; then
+  cat <<'JSON'
+{"version":"0.1.10","runtime_identity":{"binary_path":"/tmp/fake/oauth-mux","binary_source":"test","binary_sha256":"abc","build_id":"v0.1.10"}}
+JSON
+  exit 0
+fi
+if [ "$1" = "codex" ] && [ "$2" = "preflight" ]; then
+  if [ "${OMUX_FAKE_PREFLIGHT_FAIL:-0}" = "1" ]; then
+    cat <<'JSON'
+{"ok":false,"selected":null,"route_summary":{"routes_total":4,"broker_ready_routes":4,"unreadable_routes":0,"selectable_routes":0,"selectable_broker_routes":0,"selectable_fallback_routes":0,"blocked_broker_routes":4,"auth_unready_routes":0,"session_start_ready":false,"fallback_ready":false,"single_route_at_risk":false},"blocked_route_reasons":[{"reason":"network_error","count":4}]}
+JSON
+    exit 1
+  fi
+  cat <<'JSON'
+{"ok":true,"selected":{"provider":"codex","account":"max-1","capability":"codex-max","health_key":"codex:max-1#codex-max"},"route_summary":{"routes_total":4,"broker_ready_routes":4,"unreadable_routes":0,"selectable_routes":3,"selectable_broker_routes":3,"selectable_fallback_routes":2,"blocked_broker_routes":1,"auth_unready_routes":0,"session_start_ready":true,"fallback_ready":true,"single_route_at_risk":false},"blocked_route_reasons":[{"reason":"quota_exhausted","count":1}]}
+JSON
+  exit 0
+fi
+if [ "$1" = "codex" ] && [ "$2" = "status-latest" ]; then
+  cat <<'JSON'
+{"verdict":"brokered_with_fallback","path":"/tmp/status.ndjson"}
+JSON
+  exit 0
+fi
+echo "unexpected oauth-mux args: $*" >&2
+exit 2
+SH
+
+cat >"$BIN/codex" <<'SH'
+#!/usr/bin/env sh
+set -eu
+if [ "$1" = "--version" ]; then
+  echo "codex-cli 0.132.0"
+  exit 0
+fi
+echo "unexpected codex args: $*" >&2
+exit 2
+SH
+
+cat >"$BIN/mitmdump" <<'SH'
+#!/usr/bin/env sh
+set -eu
+if [ "$1" = "--version" ]; then
+  echo "Mitmproxy: 12.0.0"
+  exit 0
+fi
+echo "unexpected mitmdump args: $*" >&2
+exit 2
+SH
+
+chmod +x "$BIN/oauth-mux" "$BIN/codex" "$BIN/mitmdump"
+
+OMUX_CAPTURE_DIR="$TMP/captures" PATH="$BIN:$PATH" \
+  "$ROOT/scripts/capture-codex-wire.sh" preflight >"$TMP/preflight.out"
+
+SUMMARY="$(find "$TMP/captures" -name capture-preflight-summary.json -print | head -1)"
+test -n "$SUMMARY"
+
+python3 - "$SUMMARY" <<'PY'
+import json
+import sys
+summary = json.load(open(sys.argv[1]))
+assert summary["ok"] is True, summary
+assert summary["mitmdump_available"] is True, summary
+assert summary["route_summary"]["fallback_ready"] is True, summary
+assert summary["route_summary"]["single_route_at_risk"] is False, summary
+assert summary["oauth_mux"]["build_id"] == "v0.1.10", summary
+assert summary["status_verdict"] == "brokered_with_fallback", summary
+assert summary["blocked_route_reasons"][0]["reason"] == "quota_exhausted", summary
+PY
+
+if OMUX_CAPTURE_DIR="$TMP/captures-failed" OMUX_FAKE_PREFLIGHT_FAIL=1 PATH="$BIN:$PATH" \
+  "$ROOT/scripts/capture-codex-wire.sh" preflight >"$TMP/preflight-failed.out"; then
+  echo "expected failing capture preflight" >&2
+  exit 1
+fi
+
+FAILED_SUMMARY="$(find "$TMP/captures-failed" -name capture-preflight-summary.json -print | head -1)"
+test -n "$FAILED_SUMMARY"
+
+python3 - "$FAILED_SUMMARY" <<'PY'
+import json
+import sys
+summary = json.load(open(sys.argv[1]))
+assert summary["ok"] is False, summary
+assert "codex preflight is not ok" in summary["issues"], summary
+assert "session_start_ready is false" in summary["issues"], summary
+assert "fallback_ready is false" in summary["issues"], summary
+assert summary["blocked_route_reasons"][0]["reason"] == "network_error", summary
+PY
+
 printf 'smoke-codex-capture-review: all assertions passed.\n'


### PR DESCRIPTION
Refs #176.

Summary:
- add a no-spend Codex wire-capture preflight command that records oauth-mux provenance, native Codex version, route readiness, status-latest, mitmdump availability, and process hints
- keep failed route preflight reportable by writing a summary artifact even when codex preflight exits nonzero
- document the preflight gate in the wire evidence and operational hardening docs
- extend capture-review smoke coverage for successful and failed preflight summaries

Validation:
- bash -n scripts/capture-codex-wire.sh scripts/smoke-codex-capture-review.sh
- scripts/smoke-codex-capture-review.sh
- git diff --check
- just check-local