### PR TITLE
Add Codex capture review promotion gates

### DIFF
--- a/docs/spec/codex-wire-evidence-2026-05-03.md
+++ b/docs/spec/codex-wire-evidence-2026-05-03.md
@@ -32,6 +32,9 @@ TIN-950 adds the capture/replay tooling only:
 - `scripts/capture-codex-wire.sh review captures/codex-wire-<TS>`
   summarizes endpoint/status coverage, extracts 429 quota shapes, and
   fails on obvious secret-like values before a capture is promoted.
+  Promotion gates can require a successful preflight summary and exact
+  observed path/status/quota shapes, so missing evidence fails as
+  `requirement_failures` rather than passing by omission.
 - `scripts/test-cassette-upstream.py` replays reviewed capture JSON by
   `(method, path)`, ignoring query strings for route matching.
 - `just smoke-codex-cassette-replay` proves the replayer on a tiny
@@ -70,12 +73,22 @@ evidence:
 1. Run `scripts/capture-codex-wire.sh preflight` and confirm
    `ok:true`, `fallback_ready:true`, and `single_route_at_risk:false`
    unless the operator explicitly accepts a single-route-at-risk capture.
-2. Run `scripts/capture-codex-wire.sh review captures/codex-wire-<TS>`
-   against the capture root, not the raw `.flows` file.
+2. Run the gated review against the capture root, not the raw `.flows`
+   file:
+   ```bash
+   scripts/capture-codex-wire.sh review captures/codex-wire-<TS> \
+     --require-preflight-ok \
+     --require-path-kind responses \
+     --require-status 200 \
+     --require-quota-type usage_limit_reached
+   ```
+   Add `--require-status 401`, `--require-status 429`, or other
+   `--require-*` gates for the specific evidence being promoted.
 3. Confirm the summary includes the expected path/status mix for the
    scenario being promoted: normal 200, 401 refresh, 429
    `usage_limit_reached`, compact, memory, or other Codex endpoint.
-4. Confirm `redaction_failures` and `malformed` are empty.
+4. Confirm `redaction_failures`, `malformed`, and `requirement_failures`
+   are empty.
 5. Manually inspect the fixture-sized JSON selected for promotion.
    The reviewer catches obvious token/JWT/API-key strings; it is not a
    formal proof that all account-identifying material is gone.

--- a/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
+++ b/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
@@ -208,6 +208,11 @@ Test commands:
 
 ```bash
 scripts/capture-codex-wire.sh preflight
+scripts/capture-codex-wire.sh review captures/codex-wire-<TS> \
+  --require-preflight-ok \
+  --require-path-kind responses \
+  --require-status 200 \
+  --require-quota-type usage_limit_reached
 just smoke-codex-cassette-replay-local
 just smoke-codex-cassette-all-exhausted-local
 just check-local
@@ -222,6 +227,9 @@ Todo:
   `oauth-mux` provenance, native Codex version, mitmproxy availability,
   fallback readiness, latest status verdict, and stale-process hints before
   starting the intercepting proxy.
+- [x] Add explicit capture review promotion gates for preflight success,
+  required endpoint path kinds, required HTTP statuses, and required quota
+  `error.type` values.
 - [ ] Re-run no-spend route truth immediately before capture and keep the
   generated preflight summary with the capture scratch directory.
 - [ ] Capture at least one normal `200` Codex turn with streaming preserved.

--- a/scripts/review-codex-wire-capture.py
+++ b/scripts/review-codex-wire-capture.py
@@ -55,20 +55,44 @@ def _find_http_dir(path: Path) -> Path:
     return path
 
 
+def _capture_root(path: Path) -> Path:
+    if path.name == "http":
+        return path.parent
+    return path
+
+
+def _load_optional_json(path: Path) -> Any | None:
+    try:
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return None
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("capture_dir", help="capture run dir or its http/ subdir")
     parser.add_argument("--json", action="store_true", help="emit machine-readable summary")
+    parser.add_argument("--require-preflight-ok", action="store_true", help="fail unless capture-preflight-summary.json is present and ok:true")
+    parser.add_argument("--require-path-kind", action="append", default=[], help="fail unless at least one flow has this normalized path kind")
+    parser.add_argument("--require-status", action="append", type=int, default=[], help="fail unless at least one flow has this HTTP status")
+    parser.add_argument("--require-quota-type", action="append", default=[], help="fail unless at least one 429 error.type matches this value")
     args = parser.parse_args()
 
-    http_dir = _find_http_dir(Path(args.capture_dir))
+    input_dir = Path(args.capture_dir)
+    capture_root = _capture_root(input_dir)
+    http_dir = _find_http_dir(input_dir)
     if not http_dir.is_dir():
         print(f"error: not a directory: {http_dir}", file=sys.stderr)
         return 64
 
+    preflight_path = capture_root / "capture-preflight-summary.json"
+    preflight_summary = _load_optional_json(preflight_path)
     flows = []
     redaction_failures: list[str] = []
     malformed: list[str] = []
+    requirement_failures: list[str] = []
     path_counts: dict[str, int] = {}
     status_counts: dict[str, int] = {}
     quota_shapes: list[dict[str, Any]] = []
@@ -106,20 +130,48 @@ def main() -> int:
                     redaction_failures.append(f"{p.name}: possible secret-like value matched {pat.pattern}")
                     break
 
+    if args.require_preflight_ok:
+        if not isinstance(preflight_summary, dict):
+            requirement_failures.append("capture preflight summary is missing or unreadable")
+        elif preflight_summary.get("ok") is not True:
+            issues = preflight_summary.get("issues") or []
+            detail = f": {issues}" if issues else ""
+            requirement_failures.append(f"capture preflight was not ok{detail}")
+
+    for kind in args.require_path_kind:
+        if path_counts.get(kind, 0) < 1:
+            requirement_failures.append(f"required path kind not observed: {kind}")
+
+    for status in args.require_status:
+        if status_counts.get(str(status), 0) < 1:
+            requirement_failures.append(f"required HTTP status not observed: {status}")
+
+    observed_quota_types = {str(shape.get("error_type")) for shape in quota_shapes}
+    for quota_type in args.require_quota_type:
+        if quota_type not in observed_quota_types:
+            requirement_failures.append(f"required quota error.type not observed: {quota_type}")
+
     summary = {
-        "ok": not malformed and not redaction_failures,
+        "ok": not malformed and not redaction_failures and not requirement_failures,
         "flow_count": len(flows),
+        "preflight": {
+            "present": isinstance(preflight_summary, dict),
+            "ok": preflight_summary.get("ok") if isinstance(preflight_summary, dict) else None,
+            "issues": preflight_summary.get("issues", []) if isinstance(preflight_summary, dict) else [],
+        },
         "path_counts": path_counts,
         "status_counts": status_counts,
         "quota_shapes": quota_shapes,
         "malformed": malformed,
         "redaction_failures": redaction_failures,
+        "requirement_failures": requirement_failures,
     }
 
     if args.json:
         print(json.dumps(summary, indent=2, sort_keys=True))
     else:
         print(f"flows: {summary['flow_count']}")
+        print(f"preflight: {json.dumps(summary['preflight'], sort_keys=True)}")
         print(f"paths: {json.dumps(path_counts, sort_keys=True)}")
         print(f"statuses: {json.dumps(status_counts, sort_keys=True)}")
         if quota_shapes:
@@ -131,6 +183,10 @@ def main() -> int:
         if redaction_failures:
             print("redaction_failures:")
             for item in redaction_failures:
+                print(f"  - {item}")
+        if requirement_failures:
+            print("requirement_failures:")
+            for item in requirement_failures:
                 print(f"  - {item}")
 
     return 0 if summary["ok"] else 1

--- a/scripts/smoke-codex-capture-review.sh
+++ b/scripts/smoke-codex-capture-review.sh
@@ -10,6 +10,23 @@ trap 'rm -rf "$TMP"' EXIT
 CAP="$TMP/codex-wire-synth/http"
 mkdir -p "$CAP"
 
+cat >"$TMP/codex-wire-synth/capture-preflight-summary.json" <<'JSON'
+{
+  "ok": true,
+  "issues": [],
+  "oauth_mux": {
+    "version": "0.1.10",
+    "build_id": "v0.1.10",
+    "binary_source": "homebrew"
+  },
+  "route_summary": {
+    "session_start_ready": true,
+    "fallback_ready": true,
+    "single_route_at_risk": false
+  }
+}
+JSON
+
 cat >"$CAP/00001-POST-backend-api_codex_responses.json" <<'JSON'
 {
   "captured_at": 1788000000.0,
@@ -70,7 +87,13 @@ cat >"$CAP/00002-POST-backend-api_codex_responses.json" <<'JSON'
 }
 JSON
 
-python3 "$ROOT/scripts/review-codex-wire-capture.py" "$TMP/codex-wire-synth" --json >"$TMP/summary.json"
+python3 "$ROOT/scripts/review-codex-wire-capture.py" "$TMP/codex-wire-synth" \
+  --require-preflight-ok \
+  --require-path-kind responses \
+  --require-status 200 \
+  --require-status 429 \
+  --require-quota-type usage_limit_reached \
+  --json >"$TMP/summary.json"
 
 python3 - "$TMP/summary.json" <<'PY'
 import json
@@ -78,6 +101,8 @@ import sys
 summary = json.load(open(sys.argv[1]))
 assert summary["ok"] is True, summary
 assert summary["flow_count"] == 2, summary
+assert summary["preflight"]["present"] is True, summary
+assert summary["preflight"]["ok"] is True, summary
 assert summary["path_counts"]["responses"] == 2, summary
 assert summary["status_counts"]["200"] == 1, summary
 assert summary["status_counts"]["429"] == 1, summary
@@ -85,6 +110,25 @@ shape = summary["quota_shapes"][0]
 assert shape["error_type"] == "usage_limit_reached", shape
 assert shape["has_resets_at"] is True, shape
 assert shape["plan_type"] == "pro", shape
+assert summary["requirement_failures"] == [], summary
+PY
+
+if python3 "$ROOT/scripts/review-codex-wire-capture.py" "$TMP/codex-wire-synth" \
+  --require-quota-type usage_not_included \
+  --json >"$TMP/missing-requirement-summary.json"; then
+  echo "smoke-codex-capture-review: expected missing requirement to fail" >&2
+  exit 1
+fi
+
+python3 - "$TMP/missing-requirement-summary.json" <<'PY'
+import json
+import sys
+summary = json.load(open(sys.argv[1]))
+assert summary["ok"] is False, summary
+assert summary["redaction_failures"] == [], summary
+assert summary["requirement_failures"] == [
+    "required quota error.type not observed: usage_not_included"
+], summary
 PY
 
 cat >"$CAP/00003-POST-secret-leak.json" <<'JSON'


### PR DESCRIPTION
Refs #176.

Summary:
- add explicit capture-review gates for preflight success, required path kinds, required HTTP statuses, and required quota error.type values
- include preflight and requirement failure details in the review summary
- extend the offline capture-review smoke to prove successful gates, missing evidence failures, and redaction failures
- update the #176 wire evidence and hardening docs with the gated review command

Validation:
- python3 -m py_compile scripts/review-codex-wire-capture.py
- bash -n scripts/smoke-codex-capture-review.sh
- scripts/smoke-codex-capture-review.sh
- git diff --check
- just check-local