### PR TITLE
Forward Codex capture review flags

### DIFF
--- a/scripts/capture-codex-wire.sh
+++ b/scripts/capture-codex-wire.sh
@@ -31,7 +31,8 @@ USAGE
   scripts/capture-codex-wire.sh init             # one-time mitmproxy CA install check
   scripts/capture-codex-wire.sh preflight        # no-spend capture readiness report
   scripts/capture-codex-wire.sh proxy            # start the HTTP capture proxy in foreground
-  scripts/capture-codex-wire.sh review DIR       # summarize/redaction-check a capture
+  scripts/capture-codex-wire.sh review DIR [REVIEW_FLAGS...]
+                                              # summarize/redaction-check a capture
   scripts/capture-codex-wire.sh help
 
 WORKFLOW
@@ -263,8 +264,9 @@ cmd_review() {
     echo "error: review requires a capture directory" >&2
     exit 64
   fi
+  shift || true
   require_cmd python3 "install python3"
-  exec python3 "$ROOT/scripts/review-codex-wire-capture.py" "$dir"
+  exec python3 "$ROOT/scripts/review-codex-wire-capture.py" "$dir" "$@"
 }
 
 case "$cmd" in
@@ -272,6 +274,6 @@ case "$cmd" in
   init)           cmd_init ;;
   preflight)      cmd_preflight ;;
   proxy)          cmd_proxy ;;
-  review)         shift; cmd_review "${1:-}" ;;
+  review)         shift; cmd_review "$@" ;;
   *)              usage; exit 64 ;;
 esac

--- a/scripts/smoke-codex-capture-review.sh
+++ b/scripts/smoke-codex-capture-review.sh
@@ -87,7 +87,7 @@ cat >"$CAP/00002-POST-backend-api_codex_responses.json" <<'JSON'
 }
 JSON
 
-python3 "$ROOT/scripts/review-codex-wire-capture.py" "$TMP/codex-wire-synth" \
+"$ROOT/scripts/capture-codex-wire.sh" review "$TMP/codex-wire-synth" \
   --require-preflight-ok \
   --require-path-kind responses \
   --require-status 200 \
@@ -113,7 +113,7 @@ assert shape["plan_type"] == "pro", shape
 assert summary["requirement_failures"] == [], summary
 PY
 
-if python3 "$ROOT/scripts/review-codex-wire-capture.py" "$TMP/codex-wire-synth" \
+if "$ROOT/scripts/capture-codex-wire.sh" review "$TMP/codex-wire-synth" \
   --require-quota-type usage_not_included \
   --json >"$TMP/missing-requirement-summary.json"; then
   echo "smoke-codex-capture-review: expected missing requirement to fail" >&2


### PR DESCRIPTION
Refs #176.

Summary:
- forward extra arguments from scripts/capture-codex-wire.sh review to the Python reviewer
- update the capture-review smoke to exercise gated review through the wrapper command documented for operators

Validation:
- bash -n scripts/capture-codex-wire.sh scripts/smoke-codex-capture-review.sh
- python3 -m py_compile scripts/review-codex-wire-capture.py
- scripts/smoke-codex-capture-review.sh
- git diff --check
- just check-local