### PR TITLE
Run Codex capture preflight before proxy

### DIFF
--- a/docs/spec/codex-wire-evidence-2026-05-03.md
+++ b/docs/spec/codex-wire-evidence-2026-05-03.md
@@ -25,8 +25,9 @@ TIN-950 adds the capture/replay tooling only:
   current route fallback readiness, latest status verdict, and
   stale-process hints. Run this immediately before starting any
   intercepting proxy or live provider spend.
-- `scripts/capture-codex-wire.sh` starts the operator-controlled
-  mitmproxy HTTP capture path.
+- `scripts/capture-codex-wire.sh proxy` starts the operator-controlled
+  mitmproxy HTTP capture path after rerunning the no-spend preflight
+  into the same capture root.
 - `scripts/codex-wire-addon.py` writes reviewed, redacted per-flow JSON
   from that capture path.
 - `scripts/capture-codex-wire.sh review captures/codex-wire-<TS>`
@@ -73,6 +74,9 @@ evidence:
 1. Run `scripts/capture-codex-wire.sh preflight` and confirm
    `ok:true`, `fallback_ready:true`, and `single_route_at_risk:false`
    unless the operator explicitly accepts a single-route-at-risk capture.
+   `scripts/capture-codex-wire.sh proxy` reruns this check into the
+   capture root before starting mitmproxy, so promoted captures must keep
+   that same-run `capture-preflight-summary.json`.
 2. Run the gated review against the capture root, not the raw `.flows`
    file:
    ```bash

--- a/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
+++ b/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
@@ -230,7 +230,7 @@ Todo:
 - [x] Add explicit capture review promotion gates for preflight success,
   required endpoint path kinds, required HTTP statuses, and required quota
   `error.type` values.
-- [ ] Re-run no-spend route truth immediately before capture and keep the
+- [x] Re-run no-spend route truth immediately before capture and keep the
   generated preflight summary with the capture scratch directory.
 - [ ] Capture at least one normal `200` Codex turn with streaming preserved.
 - [ ] Capture or explicitly record not-observed status for `401`,

--- a/scripts/capture-codex-wire.sh
+++ b/scripts/capture-codex-wire.sh
@@ -43,11 +43,13 @@ WORKFLOW
   2. Run the no-spend capture preflight:
        scripts/capture-codex-wire.sh preflight
      It records installed binary identity, Codex version, mitmproxy
-     availability, route fallback readiness, latest status summary, and
-     active oauth-mux/Codex process hints under captures/.
+     availability, mitmproxy CA readiness, route fallback readiness,
+     latest status summary, and active oauth-mux/Codex process hints
+     under captures/.
   3. In one shell:
        scripts/capture-codex-wire.sh proxy
-     The proxy listens on 127.0.0.1:9080 as a normal HTTP proxy.
+     The proxy first reruns the no-spend preflight into the same capture
+     root, then listens on 127.0.0.1:9080 as a normal HTTP proxy.
   4. In another shell:
        export HTTPS_PROXY=http://127.0.0.1:9080
        export HTTP_PROXY=http://127.0.0.1:9080
@@ -281,16 +283,21 @@ cmd_proxy() {
     echo "error: missing $addon" >&2
     exit 65
   fi
+
+  echo "capture run dir: $RUN_DIR"
+  echo "running no-spend capture preflight into the capture root..."
+  OMUX_CAPTURE_PREFLIGHT_DIR="$RUN_DIR" cmd_preflight
+
   cat >"$RUN_DIR/meta.json" <<META
 {
   "ts_utc": "$TS",
   "kind": "phase_0_wire_capture",
   "addon": "scripts/codex-wire-addon.py",
+  "preflight_summary": "capture-preflight-summary.json",
   "host_filter": "chatgpt.com",
   "ports": { "http": 9080, "https": 9080 }
 }
 META
-  echo "capture run dir: $RUN_DIR"
   echo "proxy listening on 127.0.0.1:9080 (combined HTTP+HTTPS)"
   echo "stop with ^C"
   exec mitmdump \

--- a/scripts/smoke-codex-capture-review.sh
+++ b/scripts/smoke-codex-capture-review.sh
@@ -225,6 +225,10 @@ if [ "$1" = "--version" ]; then
   echo "Mitmproxy: 12.0.0"
   exit 0
 fi
+if [ -n "${OMUX_FAKE_MITMDUMP_LOG:-}" ]; then
+  printf '%s\n' "$@" >"$OMUX_FAKE_MITMDUMP_LOG"
+  exit 0
+fi
 echo "unexpected mitmdump args: $*" >&2
 exit 2
 SH
@@ -256,6 +260,29 @@ assert summary["oauth_mux"]["build_id"] == "v0.1.10", summary
 assert summary["status_verdict"] == "brokered_with_fallback", summary
 assert summary["blocked_route_reasons"][0]["reason"] == "quota_exhausted", summary
 PY
+
+PROXY_MITMDUMP_LOG="$TMP/proxy-mitmdump-args.txt"
+OMUX_CAPTURE_DIR="$TMP/proxy-captures" OMUX_MITMPROXY_CA="$MITMPROXY_CA" SSL_CERT_FILE="$MITMPROXY_CA" OMUX_FAKE_MITMDUMP_LOG="$PROXY_MITMDUMP_LOG" PATH="$BIN:$PATH" \
+  "$ROOT/scripts/capture-codex-wire.sh" proxy >"$TMP/proxy.out"
+
+PROXY_SUMMARY="$(find "$TMP/proxy-captures" -name capture-preflight-summary.json -print | head -1)"
+PROXY_META="$(find "$TMP/proxy-captures" -name meta.json -print | head -1)"
+test -n "$PROXY_SUMMARY"
+test -n "$PROXY_META"
+test -s "$PROXY_MITMDUMP_LOG"
+
+python3 - "$PROXY_SUMMARY" "$PROXY_META" <<'PY'
+import json
+import pathlib
+import sys
+summary = json.load(open(sys.argv[1]))
+meta = json.load(open(sys.argv[2]))
+assert summary["ok"] is True, summary
+assert meta["preflight_summary"] == "capture-preflight-summary.json", meta
+assert pathlib.Path(sys.argv[1]).parent == pathlib.Path(sys.argv[2]).parent, (sys.argv[1], sys.argv[2])
+PY
+
+grep -q -- '--set' "$PROXY_MITMDUMP_LOG"
 
 if OMUX_CAPTURE_DIR="$TMP/captures-missing-ca" OMUX_MITMPROXY_CA="$TMP/missing-mitmproxy-ca.cer" PATH="$BIN:$PATH" \
   "$ROOT/scripts/capture-codex-wire.sh" preflight >"$TMP/preflight-missing-ca.out"; then


### PR DESCRIPTION
## Summary
- make `capture-codex-wire.sh proxy` rerun no-spend preflight into the same capture root before starting mitmdump
- record the same-run preflight artifact in `meta.json`
- extend the offline capture-review smoke with a fake proxy startup path
- mark the #176 same-run preflight checklist item complete in docs

## Validation
- bash -n scripts/capture-codex-wire.sh scripts/smoke-codex-capture-review.sh
- git diff --check
- scripts/smoke-codex-capture-review.sh
- just check-local