### PR TITLE
Fix Codex SQLite resume authority

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -155,9 +155,11 @@ session authority is bridged by reference to the canonical Codex home unless
 `--isolated-session-store` is set. `oauth-mux codex resume` with no id keeps
 native Codex chooser ownership; oauth-mux only checks before spawn that the
 managed overlay exposes the same required session-authority entries so the
-chooser does not open empty. When canonical Codex has `state_5.sqlite*`, those
-files are bridged by reference and `state_5.sqlite` is treated as chooser
-authority; older homes use the legacy session/history/index/snapshot set.
+chooser does not open empty. When canonical Codex has `state_5.sqlite*` or
+`logs_2.sqlite*`, those files are bridged by reference; in canonical bridge
+mode `CODEX_SQLITE_HOME` points at the canonical authority home so Codex 0.132+
+uses the same SQLite resume store as bare Codex. Older homes use the legacy
+session/history/index/snapshot set.
 The portability policy is
 `docs/spec/codex-session-store-portability-policy-2026-05-18.md`: oauth-mux
 does not silently copy or import unmanaged rollout stores into route-local

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -233,9 +233,10 @@ The managed frame preserves native Codex session authority by reference while
 oauth-mux owns auth and the proxy provider override. Resume chooser mode stays
 native: oauth-mux checks the required session-authority entries before child
 spawn and fails with a redacted diagnostic rather than opening an empty
-chooser. Newer Codex `state_5.sqlite*` chooser state is bridged by reference
-when present; older homes fall back to `sessions/`, `history.jsonl`,
-`session_index.jsonl`, and `shell_snapshots/`.
+chooser. Newer Codex `state_5.sqlite*` and `logs_2.sqlite*` chooser state is
+bridged by reference when present, and canonical bridge mode sets
+`CODEX_SQLITE_HOME` to the canonical authority home. Older homes fall back to
+`sessions/`, `history.jsonl`, `session_index.jsonl`, and `shell_snapshots/`.
 See `docs/spec/codex-session-store-portability-policy-2026-05-18.md` for the
 explicit import policy: canonical bridge is supported; silent route-local
 session import/copy is not.

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -73,7 +73,7 @@ refreshed when release truth, route evidence, or tracker state changes.
 | --- | --- | --- |
 | Managed Codex launch/resume | Live-proven | Reference adapter path for `oauth-mux codex` and `oauth-mux codex resume`. |
 | Codex quota handoff | Live-proven for managed Codex | Strongest preserved proof lives in `docs/evidence/codex-engineered-quota-handoff-20260509/`. |
-| Session authority bridge | Implemented | Managed auth/config overlays bridge canonical Codex session authority, including `state_5.sqlite*` when present. |
+| Session authority bridge | Implemented | Managed auth/config overlays bridge canonical Codex session authority, including `state_5.sqlite*` and `logs_2.sqlite*` when present, with canonical `CODEX_SQLITE_HOME` for Codex 0.132+. |
 | Config/TOML preservation | Implemented | Root-partitioned Codex config passthrough keeps user settings, MCP servers, profiles, model defaults, approval/sandbox policy, and non-managed provider definitions. |
 | Experimental Codex settings injection | Implemented | Defaults can be injected without treating user config as disposable. |
 | Native Codex shim pass-through | Implemented in source, release pending | Admin/login/help/version paths bypass route election and exec native Codex. The 2026-05-18 package-lane fix must ship before public Homebrew/curl claims use this as installed truth. |
@@ -175,7 +175,7 @@ browser is needed; local Playwright is not part of this CLI proof path.
 | Upstream Codex usage-limit hook | TIN-939 | #164 | Draft proposal written; use it to request a first-class external-auth usage-limit handoff hook while keeping oauth-mux claims scoped to proven managed-proxy behavior. |
 | Live Codex account-swap acceptance | TIN-951 | #177 | Done for managed Codex; strongest preserved proof is `docs/evidence/codex-engineered-quota-handoff-20260509/`. |
 | Wire cassette coverage | TIN-950 | #176 | Still needed before treating negative permutations as stable release proof. Linear currently marks TIN-950 Done while GitHub #176 remains open; reconcile only after real cassette acceptance or an explicit tracker correction. |
-| Harness session authority bridge | TIN-979 | #191 | Closed for Codex: managed auth/config overlays bridge canonical session authority, `state_5.sqlite*`, and root config while rejecting silent session-store import/copy. Future cross-harness authority work stays under #67/#68. |
+| Harness session authority bridge | TIN-979 / TIN-1624 | #191 / #288 | Closed for the original Codex bridge, with TIN-1624/#288 covering the Codex 0.132 `logs_2.sqlite*` / `CODEX_SQLITE_HOME` parity regression. Managed auth/config overlays bridge canonical session authority and root config while rejecting silent session-store import/copy. Future cross-harness authority work stays under #67/#68. |
 | Codex session-store portability | TIN-936 | #161 | Policy is explicit: canonical bridge is supported; silent route-local session import/copy is rejected until a separate confirmed import command exists. |
 | OTEL-friendly tracing | TIN-1148 | PR #225/#226 lineage | Implemented trace schema should become the standard support-bundle path. |
 | Package parity and install lanes | TIN-1255 | #252 | `0.1.9` is published and verified across GitHub Release, npm, Homebrew, curl installer assets, and deb/rpm release assets. |

--- a/docs/qa-handoff-matrix.md
+++ b/docs/qa-handoff-matrix.md
@@ -48,7 +48,7 @@ capability, such as `codex:max-3#codex-max`.
 
 | Pattern | Entry | Evidence required | Current status |
 | --- | --- | --- | --- |
-| Managed resume chooser | `oauth-mux codex resume` | `resume_authority_check`, native chooser argv, `resume_authority_state_db_bridged` when `state_5.sqlite*` exists, no recursive pre-spawn rollout scan | covered by CLI smoke |
+| Managed resume chooser | `oauth-mux codex resume` | `resume_authority_check`, native chooser argv, `sqlite_authority:"canonical_env"`, `resume_authority_state_db_bridged` / `resume_authority_logs_db_bridged` when Codex SQLite authority exists, no recursive pre-spawn rollout scan | covered by CLI smoke |
 | Managed explicit resume | `oauth-mux codex resume <id>` | canonical session bridge, `resume_lookup_source`, redacted status, runtime identity | live-proven path |
 | Managed last resume | `oauth-mux codex resume --last` | canonical session bridge, writeback check | covered by CLI smoke |
 | Labeled reauth | `oauth-mux codex login-device <account>` | action says `user_handoff`, route label named, no raw identity | live operator flow |

--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -109,13 +109,17 @@ appended after preserved user tables. The regression fixture is a canonical
 config ending in `[tui.model_availability_nux]` with `"gpt-5.5" = 2`.
 `session_started` reports `config_layout:"root_partitioned"`.
 
-Implementation update, 2026-05-10: the session-authority bridge now also
-symlinks `state_5.sqlite`, `state_5.sqlite-wal`, and `state_5.sqlite-shm` when
-canonical Codex has them. `state_5.sqlite` is treated as native chooser
-authority when present; older Codex homes still fall back to the legacy
-`sessions/`, `shell_snapshots/`, `history.jsonl`, and `session_index.jsonl`
-authority set. Redacted status reports `resume_authority_state_db_bridged` and
-`resume_lookup_source`.
+Implementation update, 2026-05-26: Codex 0.132 split native resume state
+between `state_5.sqlite*` and `logs_2.sqlite*`, and native Codex reads those
+databases from `CODEX_SQLITE_HOME` when set. In canonical bridge mode,
+oauth-mux keeps `CODEX_HOME` as the mux-owned auth/config overlay but sets
+child `CODEX_SQLITE_HOME` to the canonical session authority home. The overlay
+also symlinks `state_5.sqlite*` and `logs_2.sqlite*` when canonical Codex has
+them, so drift is visible in no-spend smoke tests. Older Codex homes still fall
+back to the legacy `sessions/`, `shell_snapshots/`, `history.jsonl`, and
+`session_index.jsonl` authority set. Redacted status reports
+`sqlite_authority`, `resume_authority_state_db_bridged`,
+`resume_authority_logs_db_bridged`, and `resume_lookup_source`.
 
 Implementation update, 2026-05-10: managed launch no longer runs broad
 `repairRefreshableCodexAuthFailures()` before child spawn. Network refresh is

--- a/docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md
+++ b/docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md
@@ -73,6 +73,9 @@ Already real on `main`:
 - `sessions/`, `history.jsonl`, `session_index.jsonl`, and
   `shell_snapshots/` are bridged by reference to canonical Codex session
   authority by default.
+- `state_5.sqlite*` and `logs_2.sqlite*` are bridged by reference when present;
+  canonical bridge mode also sets `CODEX_SQLITE_HOME` to the canonical session
+  authority home for Codex 0.132+.
 - `--session-home`, `OMUX_CODEX_SESSION_HOME`, and
   `--isolated-session-store` exist.
 - `oauth-mux codex resume` with no id preserves the native chooser. Before
@@ -608,7 +611,7 @@ Evidence:
 
 - The adapter did start a broker-owned managed frame:
   `session_started`, `auth_authority:"mux_owned_overlay"`,
-  `session_authority:"canonical_bridge"`.
+  `session_authority:"canonical_bridge"`, `sqlite_authority:"canonical_env"`.
 - The explicit resume target was found before launch and writeback was observed.
 - Every proxied upstream request returned `401 auth_unauthorized`, including
   the main `POST /backend-api/codex/responses` turns.

--- a/docs/spec/codex-productionization-todo-2026-05-09.md
+++ b/docs/spec/codex-productionization-todo-2026-05-09.md
@@ -23,9 +23,10 @@ Proven:
   regressions in the managed launch path: generated `config.toml` is
   root-partitioned so trailing user tables such as
   `[tui.model_availability_nux]` cannot swallow the managed
-  `model_provider`; `state_5.sqlite*` is bridged by reference when present for
-  native chooser parity; and broad pre-spawn Codex auth repair has been removed
-  from launch.
+  `model_provider`; `state_5.sqlite*` and `logs_2.sqlite*` are bridged by
+  reference when present for native chooser parity; canonical bridge mode sets
+  `CODEX_SQLITE_HOME` to the canonical authority home for Codex 0.132+; and
+  broad pre-spawn Codex auth repair has been removed from launch.
 
 Not proven:
 
@@ -76,10 +77,12 @@ Not proven:
   route-local silent import/copy remains rejected until a separate confirmed
   import command exists. See
   `docs/spec/codex-session-store-portability-policy-2026-05-18.md`.
-- [x] Bridge newer Codex `state_5.sqlite*` chooser authority by reference when
-  canonical Codex has it. Treat `state_5.sqlite` as chooser authority when
-  present and fall back to legacy `sessions` / `history.jsonl` /
-  `session_index.jsonl` / `shell_snapshots` authority for older Codex homes.
+- [x] Bridge newer Codex `state_5.sqlite*` and `logs_2.sqlite*` chooser
+  authority by reference when canonical Codex has it. Treat `state_5.sqlite`
+  or `logs_2.sqlite` as chooser authority when present, set
+  `CODEX_SQLITE_HOME` to canonical authority in bridge mode, and fall back to
+  legacy `sessions` / `history.jsonl` / `session_index.jsonl` /
+  `shell_snapshots` authority for older Codex homes.
 - [x] Add a managed config passthrough regression with a canonical
   `config.toml` fixture containing representative `[features]`,
   `experimental_*`, MCP, approval/sandbox, profile, custom provider, and model
@@ -158,8 +161,8 @@ Not proven:
 
 - [x] Explicit `oauth-mux codex resume <id>` no longer recursively snapshots all
   rollouts before spawn. It resolves targeted evidence from `state_5.sqlite*`,
-  then `session_index.jsonl`, then a bounded filename lookup, and reports
-  `resume_lookup_source` in redacted status.
+  then `logs_2.sqlite*`, then `session_index.jsonl`, then a bounded filename
+  lookup, and reports `resume_lookup_source` in redacted status.
 - [x] Bare `oauth-mux codex resume` reports authority readiness without scanning
   rollouts before child spawn. The `child_spawn_elapsed_ms` launch timing
   remains the primary startup UX metric.

--- a/docs/spec/codex-session-store-portability-policy-2026-05-18.md
+++ b/docs/spec/codex-session-store-portability-policy-2026-05-18.md
@@ -42,11 +42,17 @@ present:
 - `state_5.sqlite`
 - `state_5.sqlite-wal`
 - `state_5.sqlite-shm`
+- `logs_2.sqlite`
+- `logs_2.sqlite-wal`
+- `logs_2.sqlite-shm`
 
-`state_5.sqlite` is treated as native chooser authority when present. Older
-Codex homes fall back to the legacy session/history/index/snapshot set. Other
-SQLite databases, logs, caches, and telemetry state are not bridged unless a
-future Codex version proves they are required for normal resume/chooser parity.
+`state_5.sqlite` and `logs_2.sqlite` are treated as native chooser authority
+when present. In canonical bridge mode oauth-mux sets child `CODEX_SQLITE_HOME`
+to the canonical session authority home so Codex 0.132+ reads the same runtime
+SQLite store as bare Codex. Older Codex homes fall back to the legacy
+session/history/index/snapshot set. Other SQLite databases, logs, caches, and
+telemetry state are not bridged unless a future Codex version proves they are
+required for normal resume/chooser parity.
 
 ## Resume And Write Policy
 
@@ -82,7 +88,8 @@ Current no-spend regression coverage:
   - proves first-class managed `resume`, `resume --last`, and `resume <id>`
     forwarding;
   - proves canonical `sessions/`, `history.jsonl`, `session_index.jsonl`,
-    `shell_snapshots/`, and `state_5.sqlite*` are bridged by reference;
+    `shell_snapshots/`, `state_5.sqlite*`, and `logs_2.sqlite*` are bridged by
+    reference, with `CODEX_SQLITE_HOME` pointed at the canonical authority home;
   - proves a managed child write appends through bridged session authority;
   - proves missing chooser authority fails before child spawn;
   - proves status output redacts session ids and paths.
@@ -111,4 +118,3 @@ new issue and all of these gates:
 
 Until those gates exist, the supported portability answer is the canonical
 session bridge, not import/export.
-

--- a/docs/spec/harness-session-authority-bridge-2026-05-05.md
+++ b/docs/spec/harness-session-authority-bridge-2026-05-05.md
@@ -20,20 +20,22 @@ when set, otherwise `~/.codex`; `OMUX_CODEX_SESSION_HOME` and
 opts out for tests/privacy.
 
 The synthetic acceptance smoke proves the managed overlay exposes
-`sessions/`, `history.jsonl`, `session_index.jsonl`, and `shell_snapshots/` by
-reference without printing paths. `oauth-mux codex resume` with no id now runs
-the native chooser path only after a pre-spawn authority check verifies those
-entries are available; missing authority emits redacted `resume_authority_check`
-status and exits before spawning Codex. Installed-runtime dogfood has also
-proven managed resume/load through the proxy, including live quota handoff
-evidence tracked in
+`sessions/`, `history.jsonl`, `session_index.jsonl`, `shell_snapshots/`, and
+documented Codex SQLite authority by reference without printing paths.
+`oauth-mux codex resume` with no id now runs the native chooser path only after
+a pre-spawn authority check verifies those entries are available; missing
+authority emits redacted `resume_authority_check` status and exits before
+spawning Codex. Installed-runtime dogfood has also proven managed resume/load
+through the proxy, including live quota handoff evidence tracked in
 `docs/spec/codex-live-quota-handoff-evidence-2026-05-08.md`.
 
-Implementation update, 2026-05-10: newer Codex chooser state can live in
-`state_5.sqlite*`. The managed overlay now bridges `state_5.sqlite`,
-`state_5.sqlite-wal`, and `state_5.sqlite-shm` by reference when canonical
-Codex has them. `state_5.sqlite` is accepted as chooser authority when
-present; older Codex homes still use the legacy file set above.
+Implementation update, 2026-05-26: Codex 0.132 reads native SQLite resume
+state from `CODEX_SQLITE_HOME` when set, and the chooser can depend on
+`logs_2.sqlite*` as well as `state_5.sqlite*`. Canonical bridge mode keeps the
+managed `CODEX_HOME` as mux-owned auth/config, sets child `CODEX_SQLITE_HOME`
+to the canonical session authority home, and bridges both SQLite families by
+reference when present. Isolated mode leaves SQLite state in the overlay and
+removes inherited `CODEX_SQLITE_HOME`.
 
 The 2026-05-06 dogfood-6 auth failure exposed the auth-side counterpart:
 Codex can refresh tokens inside the managed overlay, and the adapter must
@@ -151,13 +153,15 @@ For Codex today, candidate session-authority files are:
 - `~/.codex/session_index.jsonl`
 - `~/.codex/history.jsonl`
 - `~/.codex/shell_snapshots/`
-- `~/.codex/state_5.sqlite*` when present, for newer native chooser state
+- `~/.codex/state_5.sqlite*` when present, for native SQLite state
+- `~/.codex/logs_2.sqlite*` when present, for Codex 0.132+ native chooser
+  previews
 
 The current required set is pinned by fixture smoke coverage and pre-spawn
-chooser authority checks. `state_5.sqlite` is sufficient chooser authority
-when present; otherwise the legacy entries above remain the fallback authority
-set. Add new entries only with evidence that native Codex requires them for
-chooser/resume parity.
+chooser authority checks. `logs_2.sqlite` or `state_5.sqlite` is sufficient
+chooser authority when present; otherwise the legacy entries above remain the
+fallback authority set. Add new entries only with evidence that native Codex
+requires them for chooser/resume parity.
 
 ### 2.4 Cache, Log, and Runtime State
 
@@ -173,9 +177,10 @@ normal operation. Keep this state local to the managed overlay or to an
 oauth-mux-owned runtime directory. If a harness needs a cache bridge, it must
 be explicit and documented separately from session authority.
 
-For Codex, `state_5.sqlite*` is now a narrowly scoped session-authority bridge
-for native chooser parity. Other `logs_*.sqlite`, `state_*.sqlite`, and model
-caches are not bridged by default.
+For Codex, `state_5.sqlite*` and `logs_2.sqlite*` are narrowly scoped
+session-authority bridges for native chooser parity. Other `logs_*.sqlite`,
+`state_*.sqlite`, and model caches are not bridged by default without fresh
+native evidence.
 
 ### 2.5 oauth-mux Evidence Store
 
@@ -243,10 +248,14 @@ For Codex on Unix-like systems, a candidate overlay is:
   state_5.sqlite -> ~/.codex/state_5.sqlite       # when canonical has it
   state_5.sqlite-wal -> ~/.codex/state_5.sqlite-wal
   state_5.sqlite-shm -> ~/.codex/state_5.sqlite-shm
+  logs_2.sqlite -> ~/.codex/logs_2.sqlite         # when canonical has it
+  logs_2.sqlite-wal -> ~/.codex/logs_2.sqlite-wal
+  logs_2.sqlite-shm -> ~/.codex/logs_2.sqlite-shm
 ```
 
 This keeps `resume <id>` and `resume --last` pointed at the canonical session
-authority without mutating canonical auth/config.
+authority without mutating canonical auth/config. For Codex 0.132+,
+`CODEX_SQLITE_HOME` is also set to the canonical authority home in this mode.
 
 Risks to resolve:
 
@@ -314,7 +323,8 @@ adapters can report this consistently:
   "session_authority": "canonical_bridge",
   "auth_authority": "mux_owned_overlay",
   "managed_config": "mux_owned_overlay",
-  "session_paths_printed": false
+  "session_paths_printed": false,
+  "sqlite_authority": "canonical_env"
 }
 ```
 

--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -52,6 +52,9 @@ printf '%s\n' '{"bridge":"preexisting"}' >"$CANONICAL_SESSION_HOME/sessions/omux
 printf '%s\n' 'managed-good-session' >"$CANONICAL_SESSION_HOME/state_5.sqlite"
 printf '%s\n' 'managed-good-session-wal' >"$CANONICAL_SESSION_HOME/state_5.sqlite-wal"
 printf '%s\n' 'managed-good-session-shm' >"$CANONICAL_SESSION_HOME/state_5.sqlite-shm"
+printf '%s\n' 'managed-good-session' >"$CANONICAL_SESSION_HOME/logs_2.sqlite"
+printf '%s\n' 'managed-good-session-logs-wal' >"$CANONICAL_SESSION_HOME/logs_2.sqlite-wal"
+printf '%s\n' 'managed-good-session-logs-shm' >"$CANONICAL_SESSION_HOME/logs_2.sqlite-shm"
 cat >"$CANONICAL_SESSION_HOME/config.toml" <<'EOF'
 model = "gpt-5.5"
 model_provider = "user_provider"
@@ -187,6 +190,7 @@ run_case() {
 
     assert_grep "$label session_started" '"kind":"session_started"' "$ndjson"
     assert_grep "$label canonical session bridge" '"session_authority":"canonical_bridge"' "$ndjson"
+    assert_grep "$label canonical sqlite authority" '"sqlite_authority":"canonical_env"' "$ndjson"
     assert_grep "$label config passthrough status" '"config_passthrough":true,"user_config_present":true' "$ndjson"
     assert_grep "$label config layout" '"config_layout":"root_partitioned"' "$ndjson"
     assert_grep "$label experimental defaults injected" '"experimental_feature_defaults_injected":4' "$ndjson"
@@ -197,6 +201,7 @@ run_case() {
     if [[ "$label" == "resume-chooser" ]]; then
         assert_grep "$label resume authority check" '"kind":"resume_authority_check".*"ok":true' "$ndjson"
         assert_grep "$label state db authority" '"kind":"resume_authority_check".*"resume_authority_state_db_bridged":true' "$ndjson"
+        assert_grep "$label logs db authority" '"kind":"resume_authority_check".*"resume_authority_logs_db_bridged":true' "$ndjson"
         assert_grep "$label no chooser rollout scan before spawn" '"kind":"resume_preflight".*"mode":"chooser".*"rollouts_before":0' "$ndjson"
         assert_grep "$label chooser lookup not scanned" '"kind":"resume_preflight".*"mode":"chooser".*"resume_lookup_source":"not_scanned"' "$ndjson"
         assert_grep "$label resume writeback" '"kind":"resume_writeback".*"mode":"chooser"' "$ndjson"
@@ -233,7 +238,13 @@ run_case() {
           && "$(jq -r .session_bridge.shell_snapshots_samefile "$report")" == "true" \
           && "$(jq -r .session_bridge.state_db_samefile "$report")" == "true" \
           && "$(jq -r .session_bridge.state_db_wal_samefile "$report")" == "true" \
-          && "$(jq -r .session_bridge.state_db_shm_samefile "$report")" == "true" ]]; then
+          && "$(jq -r .session_bridge.state_db_shm_samefile "$report")" == "true" \
+          && "$(jq -r .session_bridge.logs_db_samefile "$report")" == "true" \
+          && "$(jq -r .session_bridge.logs_db_wal_samefile "$report")" == "true" \
+          && "$(jq -r .session_bridge.logs_db_shm_samefile "$report")" == "true" \
+          && "$(jq -r .session_bridge.sqlite_home_env_set "$report")" == "true" \
+          && "$(jq -r .session_bridge.sqlite_home_samefile "$report")" == "true" \
+          && "$(jq -r .session_bridge.sqlite_home_path_printed "$report")" == "false" ]]; then
         echo "  ✓ $label bridged canonical session authority"
     else
         echo "  ✗ $label session bridge failed" >&2
@@ -283,6 +294,31 @@ run_case top "resume-last" '["resume","--last"]' resume --last
 run_case top "resume-id" '["resume","managed-good-session"]' resume managed-good-session
 run_case top "resume-chooser" '["resume"]' resume
 run_case raw "raw-run" '["resume","--last"]' resume --last
+
+echo "smoke-codex-cli-ux: isolated session store keeps sqlite authority local"
+ISOLATED_NDJSON="$TMP/isolated-status.ndjson"
+ISOLATED_STDERR="$TMP/isolated.stderr"
+ISOLATED_REPORT="$TMP/isolated.report"
+env \
+  OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+  OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+  OMUX_STATE_DIR="$STATE_DIR" \
+  CODEX_HOME="$CANONICAL_SESSION_HOME" \
+  CODEX_SQLITE_HOME="$CANONICAL_SESSION_HOME" \
+  OMUX_CODEX_CONFIG_HOME="$CANONICAL_SESSION_HOME" \
+  OMUX_STUB_CODEX_TURNS=0 \
+  OMUX_STUB_CODEX_REPORT="$ISOLATED_REPORT" \
+  "$BIN" codex --profile codex-max --isolated-session-store --json-status-file "$ISOLATED_NDJSON" resume --last 2>"$ISOLATED_STDERR"
+assert_grep "isolated session authority" '"kind":"session_started".*"session_authority":"isolated"' "$ISOLATED_NDJSON"
+assert_grep "isolated sqlite authority" '"kind":"session_started".*"sqlite_authority":"isolated_overlay"' "$ISOLATED_NDJSON"
+if [[ "$(jq -r .sqlite_env.codex_sqlite_home_env_set "$ISOLATED_REPORT")" == "false" \
+      && "$(jq -r .sqlite_env.path_printed "$ISOLATED_REPORT")" == "false" ]]; then
+    echo "  ✓ isolated run scrubbed inherited CODEX_SQLITE_HOME"
+else
+    echo "  ✗ isolated run leaked CODEX_SQLITE_HOME" >&2
+    cat "$ISOLATED_REPORT" >&2
+    exit 1
+fi
 
 echo "smoke-codex-cli-ux: capability-scoped route election matches broker-session-plan"
 MIXED_CONFIG="$TMP/mixed-capability.config.json"

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -217,6 +217,14 @@ def _session_bridge_report(codex_home: Path) -> dict:
     wal_canonical = canonical / "state_5.sqlite-wal"
     shm_overlay = codex_home / "state_5.sqlite-shm"
     shm_canonical = canonical / "state_5.sqlite-shm"
+    logs_overlay = codex_home / "logs_2.sqlite"
+    logs_canonical = canonical / "logs_2.sqlite"
+    logs_wal_overlay = codex_home / "logs_2.sqlite-wal"
+    logs_wal_canonical = canonical / "logs_2.sqlite-wal"
+    logs_shm_overlay = codex_home / "logs_2.sqlite-shm"
+    logs_shm_canonical = canonical / "logs_2.sqlite-shm"
+    sqlite_home_raw = os.environ.get("CODEX_SQLITE_HOME")
+    sqlite_home = Path(sqlite_home_raw) if sqlite_home_raw else None
 
     marker = sessions_overlay / "omux-session-bridge-smoke.jsonl"
     marker.write_text('{"bridge":"ok"}\n')
@@ -230,6 +238,12 @@ def _session_bridge_report(codex_home: Path) -> dict:
         "state_db_samefile": state_canonical.exists() and os.path.samefile(state_overlay, state_canonical),
         "state_db_wal_samefile": wal_canonical.exists() and os.path.samefile(wal_overlay, wal_canonical),
         "state_db_shm_samefile": (not shm_canonical.exists()) or os.path.samefile(shm_overlay, shm_canonical),
+        "logs_db_samefile": logs_canonical.exists() and os.path.samefile(logs_overlay, logs_canonical),
+        "logs_db_wal_samefile": logs_wal_canonical.exists() and os.path.samefile(logs_wal_overlay, logs_wal_canonical),
+        "logs_db_shm_samefile": (not logs_shm_canonical.exists()) or os.path.samefile(logs_shm_overlay, logs_shm_canonical),
+        "sqlite_home_env_set": sqlite_home is not None,
+        "sqlite_home_samefile": sqlite_home is not None and os.path.samefile(sqlite_home, canonical),
+        "sqlite_home_path_printed": False,
         "marker_written_via_overlay": marker.exists(),
         "canonical_marker_exists": (sessions_canonical / marker.name).exists(),
         "paths_printed": False,
@@ -246,6 +260,13 @@ def _append_session_marker(codex_home: Path) -> dict:
         handle.write(json.dumps({"stub_resume_write": True, "argv_len": len(sys.argv) - 1}) + "\n")
     return {
         "checked": True,
+        "path_printed": False,
+    }
+
+
+def _sqlite_env_report() -> dict:
+    return {
+        "codex_sqlite_home_env_set": bool(os.environ.get("CODEX_SQLITE_HOME")),
         "path_printed": False,
     }
 
@@ -277,6 +298,7 @@ def main() -> int:
     config_report = _config_report(codex_home)
     session_bridge = _session_bridge_report(codex_home)
     session_append = _append_session_marker(codex_home)
+    sqlite_env = _sqlite_env_report()
     auth_rewrite = _rewrite_auth_json(codex_home)
 
     started_at = time.time()
@@ -314,6 +336,7 @@ def main() -> int:
         "config": config_report,
         "session_bridge": session_bridge,
         "session_append": session_append,
+        "sqlite_env": sqlite_env,
         "auth_rewrite": auth_rewrite,
     }
     report_path.write_text(json.dumps(report, indent=2))

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -83,9 +83,22 @@ const SessionAuthorityMode = enum {
     }
 };
 
+const CodexSqliteAuthorityMode = enum {
+    canonical_env,
+    isolated_overlay,
+
+    fn toString(self: CodexSqliteAuthorityMode) []const u8 {
+        return switch (self) {
+            .canonical_env => "canonical_env",
+            .isolated_overlay => "isolated_overlay",
+        };
+    }
+};
+
 const SessionCodexHome = struct {
     path: []u8,
     session_authority: SessionAuthorityMode,
+    sqlite_authority: CodexSqliteAuthorityMode,
     authority_home: ?[]u8 = null,
     config_authority_home: ?[]u8 = null,
     auth_initial_hash: [32]u8,
@@ -155,6 +168,7 @@ const RolloutSnapshot = struct {
 
 const ResumeLookupSource = enum {
     state_db,
+    logs_db,
     session_index,
     filename_scan,
     not_scanned,
@@ -162,6 +176,7 @@ const ResumeLookupSource = enum {
     fn toString(self: ResumeLookupSource) []const u8 {
         return switch (self) {
             .state_db => "state_db",
+            .logs_db => "logs_db",
             .session_index => "session_index",
             .filename_scan => "filename_scan",
             .not_scanned => "not_scanned",
@@ -415,21 +430,31 @@ const codex_session_authority_entries = [_]SessionAuthorityEntry{
     .{ .name = "session_index.jsonl", .kind = .file },
 };
 
-const codex_optional_session_authority_entries = [_]SessionAuthorityEntry{
+const codex_optional_state_authority_entries = [_]SessionAuthorityEntry{
     .{ .name = "state_5.sqlite", .kind = .file },
     .{ .name = "state_5.sqlite-wal", .kind = .file },
     .{ .name = "state_5.sqlite-shm", .kind = .file },
 };
 
+const codex_optional_logs_authority_entries = [_]SessionAuthorityEntry{
+    .{ .name = "logs_2.sqlite", .kind = .file },
+    .{ .name = "logs_2.sqlite-wal", .kind = .file },
+    .{ .name = "logs_2.sqlite-shm", .kind = .file },
+};
+
 const ResumeAuthorityCheck = struct {
     mode: ResumeMode,
     authority: SessionAuthorityMode,
+    sqlite_authority: CodexSqliteAuthorityMode,
     required_total: usize = codex_session_authority_entries.len,
     canonical_present: usize = 0,
     overlay_present: usize = 0,
     state_db_canonical_present: bool = false,
     state_db_overlay_present: bool = false,
     state_db_bridged: bool = false,
+    logs_db_canonical_present: bool = false,
+    logs_db_overlay_present: bool = false,
+    logs_db_bridged: bool = false,
     ok: bool = false,
     diagnostic: []const u8 = "not_checked",
 };
@@ -541,6 +566,7 @@ fn traceManagedOverlay(
         trace.string("managed_config", "mux_owned_overlay"),
         trace.string("config_layout", codex_home.config_layout),
         trace.string("session_authority", codex_home.session_authority.toString()),
+        trace.string("sqlite_authority", codex_home.sqlite_authority.toString()),
         trace.boolean("config_passthrough", codex_home.config_passthrough),
         trace.boolean("user_config_present", codex_home.config_source_present),
         trace.uint("config_overridden_keys", @intCast(codex_home.config_overridden_keys)),
@@ -569,6 +595,7 @@ fn traceManagedSessionStart(
         trace.string("claim_level", "broker_owned"),
         trace.string("resume_mode", resume_mode.toString()),
         trace.string("session_authority", codex_home.session_authority.toString()),
+        trace.string("sqlite_authority", codex_home.sqlite_authority.toString()),
         trace.uint("forwarded_arg_count", @intCast(forwarded_arg_count)),
         trace.boolean("child_stdio_inherited", true),
         trace.boolean("codex_home_path_printed", false),
@@ -595,6 +622,7 @@ fn traceManagedSessionEnd(
         trace.int("term_code", if (term) |value| childTermCode(value) else -1),
         trace.string("final_claim_level", proxy.peakClaimLevel().toString()),
         trace.string("session_authority", codex_home.session_authority.toString()),
+        trace.string("sqlite_authority", codex_home.sqlite_authority.toString()),
         trace.boolean("synthetic_swap_observed", proxy.syntheticSwapSeen()),
         trace.boolean("codex_home_path_printed", false),
         trace.boolean("token_material_printed", false),
@@ -1253,8 +1281,8 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         const installed_local_mismatch = envFlag("OMUX_INSTALLED_LOCAL_MISMATCH");
 
         try status_writer.print(
-            "{{\"kind\":\"session_started\",\"adapter\":\"codex\",\"adapter_version\":\"{s}\",\"managed_frame_id\":\"{s}\",\"selected_account\":\"{s}\",\"codex_home_path_printed\":false,\"proxy_port\":{d},\"claim_level\":\"broker_owned\",\"auth_authority\":\"mux_owned_overlay\",\"managed_config\":\"mux_owned_overlay\",\"config_layout\":\"{s}\",\"config_passthrough\":{any},\"user_config_present\":{any},\"config_overridden_keys\":{d},\"experimental_feature_defaults_injected\":{d},\"mcp_stdio_unsupported_fields_removed\":{d},\"config_paths_printed\":false,\"session_authority\":\"{s}\",\"session_paths_printed\":false,\"pre_spawn_network_refresh\":false,\"status_file_present\":{any},\"runtime_identity\":{{",
-            .{ cli.version, managed_frame_id, elected.id, proxy_port, codex_home.config_layout, codex_home.config_passthrough, codex_home.config_source_present, codex_home.config_overridden_keys, codex_home.experimental_feature_defaults_injected, codex_home.mcp_stdio_unsupported_fields_removed, codex_home.session_authority.toString(), status_file_path != null },
+            "{{\"kind\":\"session_started\",\"adapter\":\"codex\",\"adapter_version\":\"{s}\",\"managed_frame_id\":\"{s}\",\"selected_account\":\"{s}\",\"codex_home_path_printed\":false,\"proxy_port\":{d},\"claim_level\":\"broker_owned\",\"auth_authority\":\"mux_owned_overlay\",\"managed_config\":\"mux_owned_overlay\",\"config_layout\":\"{s}\",\"config_passthrough\":{any},\"user_config_present\":{any},\"config_overridden_keys\":{d},\"experimental_feature_defaults_injected\":{d},\"mcp_stdio_unsupported_fields_removed\":{d},\"config_paths_printed\":false,\"session_authority\":\"{s}\",\"sqlite_authority\":\"{s}\",\"session_paths_printed\":false,\"pre_spawn_network_refresh\":false,\"status_file_present\":{any},\"runtime_identity\":{{",
+            .{ cli.version, managed_frame_id, elected.id, proxy_port, codex_home.config_layout, codex_home.config_passthrough, codex_home.config_source_present, codex_home.config_overridden_keys, codex_home.experimental_feature_defaults_injected, codex_home.mcp_stdio_unsupported_fields_removed, codex_home.session_authority.toString(), codex_home.sqlite_authority.toString(), status_file_path != null },
         );
         try runtime_identity.writeJsonFields(status_writer);
         try status_writer.writeAll(",\"command_spelling\":");
@@ -1307,6 +1335,16 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     try env_map.put("CODEX_HOME", codex_home.path);
     if (codex_home.authority_home) |authority_home| {
         try env_map.put("OMUX_CODEX_SESSION_HOME", authority_home);
+    }
+    switch (codex_home.sqlite_authority) {
+        .canonical_env => {
+            if (codex_home.authority_home) |authority_home| {
+                try env_map.put("CODEX_SQLITE_HOME", authority_home);
+            }
+        },
+        .isolated_overlay => {
+            _ = env_map.remove("CODEX_SQLITE_HOME");
+        },
     }
     if (codex_home.config_authority_home) |config_home| {
         try env_map.put("OMUX_CODEX_CONFIG_HOME", config_home);
@@ -1642,6 +1680,7 @@ fn createSessionCodexHomeUnder(
     return .{
         .path = session_home,
         .session_authority = session_authority,
+        .sqlite_authority = if (session_authority == .canonical_bridge) .canonical_env else .isolated_overlay,
         .authority_home = if (session_authority_home) |home| try allocator.dupe(u8, home) else null,
         .config_authority_home = if (config_authority_home) |home| try allocator.dupe(u8, home) else null,
         .auth_initial_hash = auth_initial_hash,
@@ -1727,7 +1766,15 @@ fn bridgeCodexSessionAuthority(
         defer allocator.free(link);
         try std.fs.symLinkAbsolute(target, link, .{ .is_directory = entry.kind == .directory });
     }
-    for (codex_optional_session_authority_entries) |entry| {
+    for (codex_optional_state_authority_entries) |entry| {
+        const target = try std.fs.path.join(allocator, &.{ authority_home, entry.name });
+        defer allocator.free(target);
+        if (!authorityEntryPresent(target, entry.kind)) continue;
+        const link = try std.fs.path.join(allocator, &.{ session_home, entry.name });
+        defer allocator.free(link);
+        try std.fs.symLinkAbsolute(target, link, .{ .is_directory = entry.kind == .directory });
+    }
+    for (codex_optional_logs_authority_entries) |entry| {
         const target = try std.fs.path.join(allocator, &.{ authority_home, entry.name });
         defer allocator.free(target);
         if (!authorityEntryPresent(target, entry.kind)) continue;
@@ -1745,6 +1792,7 @@ fn checkResumeAuthority(
     var result = ResumeAuthorityCheck{
         .mode = request.mode,
         .authority = codex_home.session_authority,
+        .sqlite_authority = codex_home.sqlite_authority,
         .ok = true,
         .diagnostic = "not_required",
     };
@@ -1766,6 +1814,9 @@ fn checkResumeAuthority(
     result.state_db_canonical_present = authorityStateDbPresent(allocator, authority_home) catch false;
     result.state_db_overlay_present = authorityStateDbPresent(allocator, codex_home.path) catch false;
     result.state_db_bridged = result.state_db_canonical_present and result.state_db_overlay_present;
+    result.logs_db_canonical_present = authorityLogsDbPresent(allocator, authority_home) catch false;
+    result.logs_db_overlay_present = authorityLogsDbPresent(allocator, codex_home.path) catch false;
+    result.logs_db_bridged = result.logs_db_canonical_present and result.logs_db_overlay_present;
 
     var legacy_ok = true;
     for (codex_session_authority_entries) |entry| {
@@ -1787,8 +1838,10 @@ fn checkResumeAuthority(
             result.diagnostic = "overlay_entry_missing";
         }
     }
-    result.ok = result.state_db_bridged or legacy_ok;
-    if (result.ok) result.diagnostic = if (result.state_db_bridged) "state_db_available" else "available";
+    result.ok = result.logs_db_bridged or result.state_db_bridged or legacy_ok;
+    if (result.ok) {
+        result.diagnostic = if (result.logs_db_bridged) "logs_db_available" else if (result.state_db_bridged) "state_db_available" else "available";
+    }
     return result;
 }
 
@@ -1802,6 +1855,12 @@ fn authorityEntryPresent(path: []const u8, kind: SessionAuthorityEntryKind) bool
 
 fn authorityStateDbPresent(allocator: std.mem.Allocator, home: []const u8) !bool {
     const path = try std.fs.path.join(allocator, &.{ home, "state_5.sqlite" });
+    defer allocator.free(path);
+    return authorityEntryPresent(path, .file);
+}
+
+fn authorityLogsDbPresent(allocator: std.mem.Allocator, home: []const u8) !bool {
+    const path = try std.fs.path.join(allocator, &.{ home, "logs_2.sqlite" });
     defer allocator.free(path);
     return authorityEntryPresent(path, .file);
 }
@@ -1881,6 +1940,13 @@ fn lookupExplicitResumePreflight(
         return result;
     }
 
+    if (try logsDbContainsResumeId(allocator, authority_home, explicit_id)) {
+        result.lookup_source = .logs_db;
+        result.explicit_target_found_before = true;
+        result.target_snapshot = try findRolloutTargetByFilename(allocator, authority_home, explicit_id);
+        return result;
+    }
+
     if (try sessionIndexContainsResumeId(allocator, authority_home, explicit_id)) {
         result.lookup_source = .session_index;
         result.explicit_target_found_before = true;
@@ -1901,7 +1967,20 @@ fn stateDbContainsResumeId(
     authority_home: []const u8,
     explicit_id: []const u8,
 ) !bool {
-    for (codex_optional_session_authority_entries) |entry| {
+    for (codex_optional_state_authority_entries) |entry| {
+        const path = try std.fs.path.join(allocator, &.{ authority_home, entry.name });
+        defer allocator.free(path);
+        if (try fileContainsNeedleBounded(allocator, path, explicit_id)) return true;
+    }
+    return false;
+}
+
+fn logsDbContainsResumeId(
+    allocator: std.mem.Allocator,
+    authority_home: []const u8,
+    explicit_id: []const u8,
+) !bool {
+    for (codex_optional_logs_authority_entries) |entry| {
         const path = try std.fs.path.join(allocator, &.{ authority_home, entry.name });
         defer allocator.free(path);
         if (try fileContainsNeedleBounded(allocator, path, explicit_id)) return true;
@@ -2096,10 +2175,11 @@ fn writeResumeAuthorityCheckStatus(
     check: ResumeAuthorityCheck,
 ) !void {
     try writer.print(
-        "{{\"kind\":\"resume_authority_check\",\"mode\":\"{s}\",\"session_authority\":\"{s}\",\"ok\":{any},\"diagnostic\":\"{s}\",\"required_entries\":{d},\"canonical_present\":{d},\"overlay_present\":{d},\"resume_authority_state_db_bridged\":{any},\"state_db_canonical_present\":{any},\"state_db_overlay_present\":{any},\"session_id_printed\":false,\"path_printed\":false}}\n",
+        "{{\"kind\":\"resume_authority_check\",\"mode\":\"{s}\",\"session_authority\":\"{s}\",\"sqlite_authority\":\"{s}\",\"ok\":{any},\"diagnostic\":\"{s}\",\"required_entries\":{d},\"canonical_present\":{d},\"overlay_present\":{d},\"resume_authority_state_db_bridged\":{any},\"state_db_canonical_present\":{any},\"state_db_overlay_present\":{any},\"resume_authority_logs_db_bridged\":{any},\"logs_db_canonical_present\":{any},\"logs_db_overlay_present\":{any},\"session_id_printed\":false,\"path_printed\":false}}\n",
         .{
             check.mode.toString(),
             check.authority.toString(),
+            check.sqlite_authority.toString(),
             check.ok,
             check.diagnostic,
             check.required_total,
@@ -2108,6 +2188,9 @@ fn writeResumeAuthorityCheckStatus(
             check.state_db_bridged,
             check.state_db_canonical_present,
             check.state_db_overlay_present,
+            check.logs_db_bridged,
+            check.logs_db_canonical_present,
+            check.logs_db_overlay_present,
         },
     );
 }
@@ -2930,6 +3013,7 @@ test "createSessionCodexHomeUnder copies auth and does not clobber source config
     const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null, null);
     defer codex_home.deinit(std.testing.allocator);
     try std.testing.expectEqual(SessionAuthorityMode.isolated, codex_home.session_authority);
+    try std.testing.expectEqual(CodexSqliteAuthorityMode.isolated_overlay, codex_home.sqlite_authority);
 
     const session_auth = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "auth.json" });
     defer std.testing.allocator.free(session_auth);
@@ -3258,6 +3342,7 @@ test "config passthrough is independent from session authority" {
     const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, session_path, config_path);
     defer codex_home.deinit(std.testing.allocator);
     try std.testing.expectEqual(SessionAuthorityMode.canonical_bridge, codex_home.session_authority);
+    try std.testing.expectEqual(CodexSqliteAuthorityMode.canonical_env, codex_home.sqlite_authority);
     try std.testing.expect(codex_home.config_source_present);
     try std.testing.expect(codex_home.config_passthrough);
 
@@ -3455,6 +3540,16 @@ test "createSessionCodexHomeUnder bridges canonical session authority without co
         defer wal.close();
         try wal.writeAll("wal");
     }
+    {
+        const logs = try tmp.dir.createFile("canonical/logs_2.sqlite", .{ .mode = 0o600 });
+        defer logs.close();
+        try logs.writeAll("managed-good-session");
+    }
+    {
+        const logs_wal = try tmp.dir.createFile("canonical/logs_2.sqlite-wal", .{ .mode = 0o600 });
+        defer logs_wal.close();
+        try logs_wal.writeAll("logs-wal");
+    }
 
     const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
     defer std.testing.allocator.free(root_path);
@@ -3466,6 +3561,7 @@ test "createSessionCodexHomeUnder bridges canonical session authority without co
     const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, canonical_path, canonical_path);
     defer codex_home.deinit(std.testing.allocator);
     try std.testing.expectEqual(SessionAuthorityMode.canonical_bridge, codex_home.session_authority);
+    try std.testing.expectEqual(CodexSqliteAuthorityMode.canonical_env, codex_home.sqlite_authority);
 
     var link_buf: [std.fs.max_path_bytes]u8 = undefined;
     const sessions_link = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "sessions" });
@@ -3490,6 +3586,22 @@ test "createSessionCodexHomeUnder bridges canonical session authority without co
     const expected_wal_target = try std.fs.path.join(std.testing.allocator, &.{ canonical_path, "state_5.sqlite-wal" });
     defer std.testing.allocator.free(expected_wal_target);
     try std.testing.expectEqualStrings(expected_wal_target, wal_target);
+
+    const logs_link = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "logs_2.sqlite" });
+    defer std.testing.allocator.free(logs_link);
+    var logs_link_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const logs_target = try std.fs.readLinkAbsolute(logs_link, &logs_link_buf);
+    const expected_logs_target = try std.fs.path.join(std.testing.allocator, &.{ canonical_path, "logs_2.sqlite" });
+    defer std.testing.allocator.free(expected_logs_target);
+    try std.testing.expectEqualStrings(expected_logs_target, logs_target);
+
+    const logs_wal_link = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "logs_2.sqlite-wal" });
+    defer std.testing.allocator.free(logs_wal_link);
+    var logs_wal_link_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const logs_wal_target = try std.fs.readLinkAbsolute(logs_wal_link, &logs_wal_link_buf);
+    const expected_logs_wal_target = try std.fs.path.join(std.testing.allocator, &.{ canonical_path, "logs_2.sqlite-wal" });
+    defer std.testing.allocator.free(expected_logs_wal_target);
+    try std.testing.expectEqualStrings(expected_logs_wal_target, logs_wal_target);
 
     const bridged_session = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "sessions", "2026", "05", "05", "session.jsonl" });
     defer std.testing.allocator.free(bridged_session);
@@ -3546,7 +3658,43 @@ test "resume authority accepts bridged state db as chooser authority" {
     const check = try checkResumeAuthority(std.testing.allocator, &codex_home, .{ .mode = .chooser });
     try std.testing.expect(check.ok);
     try std.testing.expect(check.state_db_bridged);
+    try std.testing.expect(!check.logs_db_bridged);
     try std.testing.expectEqualStrings("state_db_available", check.diagnostic);
+}
+
+test "resume authority accepts bridged logs db as chooser authority" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("account");
+    try tmp.dir.makePath("canonical");
+    {
+        const auth = try tmp.dir.createFile("account/auth.json", .{ .mode = 0o600 });
+        defer auth.close();
+        try auth.writeAll("{\"tokens\":{\"access_token\":\"fixture\"}}\n");
+    }
+    {
+        const logs = try tmp.dir.createFile("canonical/logs_2.sqlite", .{ .mode = 0o600 });
+        defer logs.close();
+        try logs.writeAll("managed-good-session");
+    }
+
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const auth_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "account", "auth.json" });
+    defer std.testing.allocator.free(auth_path);
+    const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
+    defer std.testing.allocator.free(canonical_path);
+
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, canonical_path, canonical_path);
+    defer codex_home.deinit(std.testing.allocator);
+
+    const check = try checkResumeAuthority(std.testing.allocator, &codex_home, .{ .mode = .chooser });
+    try std.testing.expect(check.ok);
+    try std.testing.expect(!check.state_db_bridged);
+    try std.testing.expect(check.logs_db_bridged);
+    try std.testing.expectEqual(CodexSqliteAuthorityMode.canonical_env, check.sqlite_authority);
+    try std.testing.expectEqualStrings("logs_db_available", check.diagnostic);
 }
 
 test "explicit resume preflight prefers state db and targeted rollout stat" {
@@ -3597,6 +3745,30 @@ test "explicit resume preflight can use state db without scanning rollout files"
     var preflight = try lookupExplicitResumePreflight(std.testing.allocator, canonical_path, "state-only-session");
     defer preflight.deinit();
     try std.testing.expectEqual(ResumeLookupSource.state_db, preflight.lookup_source);
+    try std.testing.expectEqual(true, preflight.explicit_target_found_before.?);
+    try std.testing.expect(preflight.target_snapshot == null);
+    try std.testing.expectEqual(@as(usize, 0), preflight.rolloutsBefore());
+}
+
+test "explicit resume preflight can use logs db without scanning rollout files" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("canonical");
+    {
+        const logs = try tmp.dir.createFile("canonical/logs_2.sqlite", .{ .mode = 0o600 });
+        defer logs.close();
+        try logs.writeAll("logs-only-session");
+    }
+
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
+    defer std.testing.allocator.free(canonical_path);
+
+    var preflight = try lookupExplicitResumePreflight(std.testing.allocator, canonical_path, "logs-only-session");
+    defer preflight.deinit();
+    try std.testing.expectEqual(ResumeLookupSource.logs_db, preflight.lookup_source);
     try std.testing.expectEqual(true, preflight.explicit_target_found_before.?);
     try std.testing.expect(preflight.target_snapshot == null);
     try std.testing.expectEqual(@as(usize, 0), preflight.rolloutsBefore());


### PR DESCRIPTION
## Summary
- route managed Codex canonical bridge mode through canonical `CODEX_SQLITE_HOME` while keeping `CODEX_HOME` as the mux-owned auth/config overlay
- bridge `logs_2.sqlite*` by reference alongside `state_5.sqlite*` and expose redacted `sqlite_authority` / `resume_authority_logs_db_bridged` diagnostics
- add no-spend smoke coverage for logs DB parity and isolated-mode `CODEX_SQLITE_HOME` scrubbing

## Root Cause
Codex 0.132 moved enough native resume picker behavior onto SQLite runtime state that oauth-mux’s overlay-local `logs_2.sqlite` could diverge from canonical `~/.codex/logs_2.sqlite`, so managed `oauth-mux codex resume` and bare `codex resume` could present different session lists.

## Validation
- `zig fmt --check src/adapters/codex/main.zig`
- `python3 -m py_compile scripts/test-stub-codex.py`
- `just test`
- `just smoke-codex-cli-ux-local`
- `git diff --check`

Fixes #288
Linear: TIN-1624