### PR TITLE
[codex] Require proxy metadata in Codex capture review

### DIFF
--- a/docs/spec/codex-wire-evidence-2026-05-03.md
+++ b/docs/spec/codex-wire-evidence-2026-05-03.md
@@ -82,6 +82,7 @@ evidence:
    ```bash
    scripts/capture-codex-wire.sh review captures/codex-wire-<TS> \
      --require-preflight-ok \
+     --require-proxy-meta \
      --require-path-kind responses \
      --require-status 200 \
      --require-quota-type usage_limit_reached

--- a/scripts/review-codex-wire-capture.py
+++ b/scripts/review-codex-wire-capture.py
@@ -75,6 +75,7 @@ def main() -> int:
     parser.add_argument("capture_dir", help="capture run dir or its http/ subdir")
     parser.add_argument("--json", action="store_true", help="emit machine-readable summary")
     parser.add_argument("--require-preflight-ok", action="store_true", help="fail unless capture-preflight-summary.json is present and ok:true")
+    parser.add_argument("--require-proxy-meta", action="store_true", help="fail unless meta.json records same-run proxy preflight metadata")
     parser.add_argument("--require-path-kind", action="append", default=[], help="fail unless at least one flow has this normalized path kind")
     parser.add_argument("--require-status", action="append", type=int, default=[], help="fail unless at least one flow has this HTTP status")
     parser.add_argument("--require-quota-type", action="append", default=[], help="fail unless at least one 429 error.type matches this value")
@@ -89,6 +90,8 @@ def main() -> int:
 
     preflight_path = capture_root / "capture-preflight-summary.json"
     preflight_summary = _load_optional_json(preflight_path)
+    meta_path = capture_root / "meta.json"
+    meta_summary = _load_optional_json(meta_path)
     flows = []
     redaction_failures: list[str] = []
     malformed: list[str] = []
@@ -138,6 +141,24 @@ def main() -> int:
             detail = f": {issues}" if issues else ""
             requirement_failures.append(f"capture preflight was not ok{detail}")
 
+    meta_preflight_summary = None
+    meta_preflight_present = False
+    if isinstance(meta_summary, dict):
+        meta_preflight_summary = meta_summary.get("preflight_summary")
+        if isinstance(meta_preflight_summary, str) and meta_preflight_summary:
+            meta_preflight_present = (capture_root / meta_preflight_summary).is_file()
+
+    if args.require_proxy_meta:
+        if not isinstance(meta_summary, dict):
+            requirement_failures.append("capture meta.json is missing or unreadable")
+        else:
+            if meta_summary.get("kind") != "phase_0_wire_capture":
+                requirement_failures.append("capture meta.json kind is not phase_0_wire_capture")
+            if meta_preflight_summary != "capture-preflight-summary.json":
+                requirement_failures.append("capture meta.json does not point at capture-preflight-summary.json")
+            elif not meta_preflight_present:
+                requirement_failures.append("capture meta.json preflight summary is missing")
+
     for kind in args.require_path_kind:
         if path_counts.get(kind, 0) < 1:
             requirement_failures.append(f"required path kind not observed: {kind}")
@@ -159,6 +180,12 @@ def main() -> int:
             "ok": preflight_summary.get("ok") if isinstance(preflight_summary, dict) else None,
             "issues": preflight_summary.get("issues", []) if isinstance(preflight_summary, dict) else [],
         },
+        "meta": {
+            "present": isinstance(meta_summary, dict),
+            "kind": meta_summary.get("kind") if isinstance(meta_summary, dict) else None,
+            "preflight_summary": meta_preflight_summary,
+            "preflight_summary_present": meta_preflight_present,
+        },
         "path_counts": path_counts,
         "status_counts": status_counts,
         "quota_shapes": quota_shapes,
@@ -172,6 +199,7 @@ def main() -> int:
     else:
         print(f"flows: {summary['flow_count']}")
         print(f"preflight: {json.dumps(summary['preflight'], sort_keys=True)}")
+        print(f"meta: {json.dumps(summary['meta'], sort_keys=True)}")
         print(f"paths: {json.dumps(path_counts, sort_keys=True)}")
         print(f"statuses: {json.dumps(status_counts, sort_keys=True)}")
         if quota_shapes:

--- a/scripts/smoke-codex-capture-review.sh
+++ b/scripts/smoke-codex-capture-review.sh
@@ -27,6 +27,17 @@ cat >"$TMP/codex-wire-synth/capture-preflight-summary.json" <<'JSON'
 }
 JSON
 
+cat >"$TMP/codex-wire-synth/meta.json" <<'JSON'
+{
+  "ts_utc": "20260526T000000Z",
+  "kind": "phase_0_wire_capture",
+  "addon": "scripts/codex-wire-addon.py",
+  "preflight_summary": "capture-preflight-summary.json",
+  "host_filter": "chatgpt.com",
+  "ports": { "http": 9080, "https": 9080 }
+}
+JSON
+
 cat >"$CAP/00001-POST-backend-api_codex_responses.json" <<'JSON'
 {
   "captured_at": 1788000000.0,
@@ -89,6 +100,7 @@ JSON
 
 "$ROOT/scripts/capture-codex-wire.sh" review "$TMP/codex-wire-synth" \
   --require-preflight-ok \
+  --require-proxy-meta \
   --require-path-kind responses \
   --require-status 200 \
   --require-status 429 \
@@ -103,6 +115,10 @@ assert summary["ok"] is True, summary
 assert summary["flow_count"] == 2, summary
 assert summary["preflight"]["present"] is True, summary
 assert summary["preflight"]["ok"] is True, summary
+assert summary["meta"]["present"] is True, summary
+assert summary["meta"]["kind"] == "phase_0_wire_capture", summary
+assert summary["meta"]["preflight_summary"] == "capture-preflight-summary.json", summary
+assert summary["meta"]["preflight_summary_present"] is True, summary
 assert summary["path_counts"]["responses"] == 2, summary
 assert summary["status_counts"]["200"] == 1, summary
 assert summary["status_counts"]["429"] == 1, summary
@@ -111,6 +127,34 @@ assert shape["error_type"] == "usage_limit_reached", shape
 assert shape["has_resets_at"] is True, shape
 assert shape["plan_type"] == "pro", shape
 assert summary["requirement_failures"] == [], summary
+PY
+
+BAD_META="$TMP/codex-wire-bad-meta"
+mkdir -p "$BAD_META/http"
+cp "$TMP/codex-wire-synth/capture-preflight-summary.json" "$BAD_META/capture-preflight-summary.json"
+cp "$CAP/00001-POST-backend-api_codex_responses.json" "$BAD_META/http/00001-POST-backend-api_codex_responses.json"
+cat >"$BAD_META/meta.json" <<'JSON'
+{
+  "kind": "phase_0_wire_capture",
+  "preflight_summary": "wrong-preflight-summary.json"
+}
+JSON
+
+if "$ROOT/scripts/capture-codex-wire.sh" review "$BAD_META" \
+  --require-preflight-ok \
+  --require-proxy-meta \
+  --json >"$TMP/bad-meta-summary.json"; then
+  echo "smoke-codex-capture-review: expected bad proxy metadata to fail" >&2
+  exit 1
+fi
+
+python3 - "$TMP/bad-meta-summary.json" <<'PY'
+import json
+import sys
+summary = json.load(open(sys.argv[1]))
+assert summary["ok"] is False, summary
+assert summary["redaction_failures"] == [], summary
+assert "capture meta.json does not point at capture-preflight-summary.json" in summary["requirement_failures"], summary
 PY
 
 if "$ROOT/scripts/capture-codex-wire.sh" review "$TMP/codex-wire-synth" \


### PR DESCRIPTION
## Summary

- add `--require-proxy-meta` to the Codex wire capture review gate
- validate same-run `meta.json` points at `capture-preflight-summary.json`
- extend the synthetic capture-review smoke with good and bad proxy metadata cases
- update the wire evidence runbook command so future promoted captures require proxy metadata

## Why

This tightens the #176 capture-promotion path without adding a new lifecycle surface. A promoted capture should prove it came from the same proxy/preflight run, not just from loose flow JSON next to a preflight summary.

Refs #176.
Linear: TIN-950 tracker is currently Done, but GitHub #176 remains open until real operator-confirmed cassettes are promoted.

## Validation

- `python3 -m py_compile scripts/review-codex-wire-capture.py`
- `./scripts/smoke-codex-capture-review.sh`
- `git diff --check -- docs/spec/codex-wire-evidence-2026-05-03.md scripts/review-codex-wire-capture.py scripts/smoke-codex-capture-review.sh`
