### PR TITLE
[codex] Prepare oauth-mux 0.1.11 release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,7 +10,7 @@ on:
       version:
         description: "Version to stage and publish"
         required: false
-        default: "0.1.10"
+        default: "0.1.11"
         type: string
       dry_run:
         description: "Run npm publish --dry-run instead of publishing"

--- a/.github/workflows/registry-dry-run.yml
+++ b/.github/workflows/registry-dry-run.yml
@@ -10,7 +10,7 @@ on:
       version:
         description: "Version to stage and dry-run"
         required: false
-        default: "0.1.10"
+        default: "0.1.11"
         type: string
       lanes:
         description: "Comma-separated lanes: plan,github,npm,homebrew,system"

--- a/.github/workflows/release-proof.yml
+++ b/.github/workflows/release-proof.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: "Release version to stage and smoke-test"
         required: false
-        default: "0.1.10"
+        default: "0.1.11"
         type: string
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ diagnostic infrastructure. They are not product success.
 
 ## Current Truth
 
-Public install lanes are versioned by channel. The current verified release is
-`0.1.10` for GitHub Release, curl installer, deb/rpm assets, and Homebrew.
-The npm package lane still reports `0.1.9` until CI npm auth is repaired. The
-2026-05-18/19 install-parity work fixed a package-lane bug where a public
-Homebrew `codex` shim routed native admin commands such as `codex --version`
-through oauth-mux route election. Homebrew remains binary-only by default:
-`brew install jesssullivan/omux/oauth-mux` installs `oauth-mux` and must not
-install or link a managed `codex` shim.
+Public install lanes are versioned by channel. This source tree is staged as
+`0.1.11`, carrying the Codex 0.132 SQLite resume authority fix and the Codex
+capture-review proxy metadata gate. The previously verified public release is
+`0.1.10` for GitHub Release, curl installer, deb/rpm assets, and Homebrew; npm
+still reports `0.1.9` until CI npm auth is repaired. After `v0.1.11` is tagged,
+verify each public lane before using it as installed truth. Homebrew remains
+binary-only by default: `brew install jesssullivan/omux/oauth-mux` installs
+`oauth-mux` and must not install or link a managed `codex` shim.
 
 What works today:
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .oauth_mux,
-    .version = "0.1.10",
+    .version = "0.1.11",
     .fingerprint = 0x21c445132f61984e,
     .minimum_zig_version = "0.14.0",
     .paths = .{

--- a/dist/npm/package.json
+++ b/dist/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oauth-mux",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "OAuth fallback muxing for AI harness subscriptions",
   "license": "MIT",
   "repository": "Jesssullivan/oauth-mux",
@@ -17,11 +17,11 @@
     "postinstall": "node install.js"
   },
   "optionalDependencies": {
-    "oauth-mux-darwin-arm64": "0.1.10",
-    "oauth-mux-darwin-x64": "0.1.10",
-    "oauth-mux-linux-arm64": "0.1.10",
-    "oauth-mux-linux-x64": "0.1.10",
-    "oauth-mux-windows-arm64": "0.1.10",
-    "oauth-mux-windows-x64": "0.1.10"
+    "oauth-mux-darwin-arm64": "0.1.11",
+    "oauth-mux-darwin-x64": "0.1.11",
+    "oauth-mux-linux-arm64": "0.1.11",
+    "oauth-mux-linux-x64": "0.1.11",
+    "oauth-mux-windows-arm64": "0.1.11",
+    "oauth-mux-windows-x64": "0.1.11"
   }
 }

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -1,6 +1,6 @@
 # Productionization Ledger
 
-Updated: 2026-05-25
+Updated: 2026-05-26
 
 This ledger is the short operator map for oauth-mux productionization. It is
 subordinate to the broker contract and Codex adapter contract, and it should be
@@ -8,19 +8,20 @@ refreshed when release truth, route evidence, or tracker state changes.
 
 ## Current Snapshot
 
-- Repo state: `main` matches `origin/main` at `33133e3`, including the
-  BrokenPipe/client-disconnect hardening from PR #279, the 0.1.10
-  provenance/release preparation from PR #280, and the explicit Homebrew
-  formula-version guard from PR #281.
+- Repo state: `main` matches `origin/main` at `3a553bf`, including the
+  BrokenPipe/client-disconnect hardening from PR #279, the Codex 0.132 SQLite
+  resume authority fix from PR #289, and the Codex capture-review proxy
+  metadata gate from PR #290.
 - CI state: GitHub Actions is the live source for the latest run. Main CI for
   PR #281 completed green on 2026-05-25. Release workflow `26408682726`
   published `v0.1.10`; system package install QA `26409604539` passed against
   the published deb/rpm assets. npm dry-run/publish remains blocked by npm auth
   and returns `npm whoami` 401.
-- Version truth: GitHub Release, curl installer assets, deb/rpm assets, and the
-  public Homebrew tap resolve to `0.1.10`; this was rechecked on 2026-05-25.
-  npm `latest` is still `0.1.9` because the CI npm lane currently lacks usable
-  npm auth and fails `npm whoami` with 401. The 2026-05-18/19 shim
+- Version truth: source is staged for `0.1.11`; GitHub Release, curl installer
+  assets, deb/rpm assets, and the public Homebrew tap still resolve to
+  `0.1.10` until `v0.1.11` is tagged, the release workflow publishes, and lane
+  QA is checked. npm `latest` is still `0.1.9` because the CI npm lane currently
+  lacks usable npm auth and fails `npm whoami` with 401. The 2026-05-18/19 shim
   investigation fixed a package-lane ownership bug: the Homebrew formula must
   not install or link a managed `codex` shim by default.
 - Installed provenance: PATH may resolve Homebrew before user-local dogfood.
@@ -76,7 +77,7 @@ refreshed when release truth, route evidence, or tracker state changes.
 | Session authority bridge | Implemented | Managed auth/config overlays bridge canonical Codex session authority, including `state_5.sqlite*` and `logs_2.sqlite*` when present, with canonical `CODEX_SQLITE_HOME` for Codex 0.132+. |
 | Config/TOML preservation | Implemented | Root-partitioned Codex config passthrough keeps user settings, MCP servers, profiles, model defaults, approval/sandbox policy, and non-managed provider definitions. |
 | Experimental Codex settings injection | Implemented | Defaults can be injected without treating user config as disposable. |
-| Native Codex shim pass-through | Implemented in source, release pending | Admin/login/help/version paths bypass route election and exec native Codex. The 2026-05-18 package-lane fix must ship before public Homebrew/curl claims use this as installed truth. |
+| Native Codex shim pass-through | Implemented | Admin/login/help/version paths bypass route election and exec native Codex. Public Homebrew remains binary-only and must not install the shim by default. |
 | Home Manager lane | Implemented in source | Module defaults to binary-only install; managed `codex` shim is explicit opt-in. |
 | Route-health recovery | Implemented | Transient provider degradation can recover after retry windows without becoming permanent auth death. Source after PR #279 also separates downstream client disconnects from upstream/provider failures so client `BrokenPipe` does not poison route health. |
 | Redacted diagnostics and tracing | Implemented | JSON diagnostics and `OMUX_TRACE=1` support route/session/auth/runtime debugging without token, raw account id, session id, or path leakage. |
@@ -141,7 +142,11 @@ and non-Codex provider work.
 
 ## Release And Distribution Posture
 
-`0.1.10` version availability is complete for GitHub Release, curl installer,
+`0.1.11` is the next staged release and should carry two focused changes:
+Codex 0.132 resume authority parity for `logs_2.sqlite*` / `CODEX_SQLITE_HOME`,
+and the #176 capture-review `--require-proxy-meta` gate. Run
+`just release-proof 0.1.11` before any tag or registry mutation. `0.1.10`
+version availability remains complete for GitHub Release, curl installer,
 deb/rpm assets, and Homebrew as of 2026-05-25: GitHub Release `v0.1.10` is
 published and non-draft, Homebrew stable/linked keg is `0.1.10`, and hosted
 system package install QA passed for the published `.deb` / `.rpm` assets. npm


### PR DESCRIPTION
## Summary

- bump source/package metadata and release workflow defaults to 0.1.11
- document that 0.1.11 carries the Codex 0.132 SQLite resume authority fix and the #176 capture-review proxy metadata gate
- refresh the productionization ledger without claiming public install lanes are updated before the tag workflow publishes them

## Validation

- `git diff --check`
- `just release-proof 0.1.11` on dirty release-prep diff as preliminary host/package proof
- `just release-proof 0.1.11` again on clean commit `591283a`

## Release Boundary

No tag, GitHub Release, Homebrew, npm, or registry mutation has been performed. Public lane truth remains 0.1.10 until v0.1.11 is tagged, the release workflow publishes, and lane QA is verified.