### PR TITLE
Refresh oauth-mux 0.1.11 workstream ledger

### DIFF
--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -8,50 +8,40 @@ refreshed when release truth, route evidence, or tracker state changes.
 
 ## Current Snapshot
 
-- Repo state: `main` matches `origin/main` at `3a553bf`, including the
+- Repo state: `main` matches `origin/main` at `0051c57`, including the
   BrokenPipe/client-disconnect hardening from PR #279, the Codex 0.132 SQLite
-  resume authority fix from PR #289, and the Codex capture-review proxy
-  metadata gate from PR #290.
-- CI state: GitHub Actions is the live source for the latest run. Main CI for
-  PR #281 completed green on 2026-05-25. Release workflow `26408682726`
-  published `v0.1.10`; system package install QA `26409604539` passed against
-  the published deb/rpm assets. npm dry-run/publish remains blocked by npm auth
-  and returns `npm whoami` 401.
-- Version truth: source is staged for `0.1.11`; GitHub Release, curl installer
-  assets, deb/rpm assets, and the public Homebrew tap still resolve to
-  `0.1.10` until `v0.1.11` is tagged, the release workflow publishes, and lane
-  QA is checked. npm `latest` is still `0.1.9` because the CI npm lane currently
-  lacks usable npm auth and fails `npm whoami` with 401. The 2026-05-18/19 shim
-  investigation fixed a package-lane ownership bug: the Homebrew formula must
-  not install or link a managed `codex` shim by default.
-- Installed provenance: PATH may resolve Homebrew before user-local dogfood.
-  Use `which -a oauth-mux`, `which -a codex`, `oauth-mux version --json`, and
-  `codex preflight` before treating any installed-command run as release
-  evidence. `version --json` must be checked for both binary SHA-256 and
-  `runtime_identity.build_id`; source builds after this update report a git
-  describe-style build id, while tagged releases report the exact tag such as
-  `v0.1.10`.
+  resume authority fix from PR #289, the Codex capture-review proxy metadata
+  gate from PR #290, the `0.1.11` release from PR #291, and the post-release
+  capture cookie redaction hardening from PR #292.
+- CI/release state: GitHub Actions is the live source for release proof. Release
+  workflow `26463502300` published `v0.1.11`; release assets are present and
+  the public GitHub Release is non-draft/non-prerelease. npm dry-run/publish
+  remains blocked/stale; npm `latest` still reports `0.1.9`.
+- Version truth: source version is `0.1.11`. GitHub Release, curl installer
+  assets, deb/rpm assets, and the public Homebrew tap resolve to `0.1.11`. npm
+  remains stale at `0.1.9`. The Homebrew formula remains binary-only by
+  default and must not install or link a managed `codex` shim.
+- Installed provenance: user-local dogfood is PATH-first on neo and reports
+  `0.1.11` with build id `v0.1.11`; Homebrew also reports `0.1.11`. Continue
+  checking `which -a oauth-mux`, `which -a codex`, `oauth-mux version --json`,
+  and `codex preflight` before treating any installed-command run as release
+  evidence.
 - Homebrew truth: the public `jesssullivan/omux` tap advertises `oauth-mux
-  0.1.10` and the local linked keg is `0.1.10`. Homebrew is a binary-only
-  package lane by default: QA must prove
-  `brew install jesssullivan/omux/oauth-mux` installs `oauth-mux`, does not
-  install an `OMUX_CODEX_SHIM`, and leaves native `codex` command resolution
-  unchanged. The formula must declare explicit version metadata because Linux
-  Homebrew can infer `64-linux` from the x86_64 Linux tarball name.
-- Codex route truth: the 2026-05-25 dogfood refresh uses Homebrew
-  `oauth-mux 0.1.10` and native Codex `0.132.0`. Explicit capability probes
-  proved `codex:max-1#codex-max` and `codex:max-2#codex-max` available, so
-  current preflight reports `session_start_ready:true`, `fallback_ready:true`,
-  and `single_route_at_risk:false`. `codex:max-3#codex-max` is quota-exhausted
-  until reset. An extant managed resume process is still running from
-  `/opt/homebrew/Cellar/oauth-mux/0.1.9.reinstall/bin/oauth-mux`; its status
-  artifact continues to show pre-0.1.10 `BrokenPipe` provider-degraded events
-  and can re-poison `max-4` until that old process exits or is restarted.
-- Latest local status truth: `oauth-mux codex status-latest --json` currently
-  reports `brokered_without_fallback` from a rolling local artifact. This is
-  stale relative to current route truth and does not supersede the preserved
-  quota-handoff proof; status artifacts must be refreshed before being used in
-  public claims.
+  0.1.11`, the local linked keg is `0.1.11`, and
+  `brew fetch --force jesssullivan/omux/oauth-mux` passes after tap PR #8 fixed
+  stale `0.1.11` checksums. Homebrew is a binary-only package lane by default:
+  QA must prove it installs `oauth-mux`, does not install an
+  `OMUX_CODEX_SHIM`, and leaves native `codex` command resolution unchanged.
+- Codex route truth: the 2026-05-26 no-spend preflight uses user-local
+  `oauth-mux 0.1.11` and native Codex outside oauth-mux. It reports
+  `ok:true`, `session_start_ready:true`, `fallback_ready:true`,
+  `selectable_fallback_routes:2`, `single_route_at_risk:false`,
+  `spends_provider_calls:false`, and `mutates_route_health:false`.
+- Process/fd truth: TIN-1591 remains contained, not resolved. Current snapshots
+  still show active Codex/oauth-mux fanout, a soft fd limit of `256`, and
+  orphan-listener candidates. Treat dogfood evidence as local release/install
+  validation only until repeated clean-baseline snapshots support broader live
+  reliability claims.
 - Daemon truth: `oauth-mux daemon status --json` still reports
   `status:"not_running"`, `contract:"experimental_socket_stub"`, and
   `hosts_stay_afloat:false`; its foreground tick snapshot is observational only
@@ -134,25 +124,26 @@ MCP repair prompts, but oauth-mux must not claim to keep them alive.
 
 The current testable workstream plan lives at
 `docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md`. The BrokenPipe
-regression fix is landed in source; the immediate operational risk is stale
-installed package/dogfood provenance. Next work should prioritize installed
-build-id proof, package parity/release hygiene, no-spend route/process truth
-refresh, real Codex wire cassettes, tracker reconciliation, then later sidecar
-and non-Codex provider work.
+regression fix and Codex 0.132 resume authority fix are published in the
+current public release. The immediate operational risk is no longer stale
+install provenance; it is process/fd fanout contaminating dogfood evidence and
+the remaining lack of quota/error real cassettes. Next work should prioritize
+TIN-1591 cleanup policy, real Codex quota/error cassettes, the #176/TIN-950
+tracker mismatch, then later sidecar and non-Codex provider work.
 
 ## Release And Distribution Posture
 
-`0.1.11` is the next staged release and should carry two focused changes:
-Codex 0.132 resume authority parity for `logs_2.sqlite*` / `CODEX_SQLITE_HOME`,
-and the #176 capture-review `--require-proxy-meta` gate. Run
-`just release-proof 0.1.11` before any tag or registry mutation. `0.1.10`
-version availability remains complete for GitHub Release, curl installer,
-deb/rpm assets, and Homebrew as of 2026-05-25: GitHub Release `v0.1.10` is
-published and non-draft, Homebrew stable/linked keg is `0.1.10`, and hosted
-system package install QA passed for the published `.deb` / `.rpm` assets. npm
-publication remains blocked on npm auth; npm `latest` still reports `0.1.9`.
-Negative Codex
-cassettes, broader adapter proof, and daemon beta truth remain follow-up work.
+`0.1.11` is the current verified public release. It carries Codex 0.132 resume
+authority parity for `logs_2.sqlite*` / `CODEX_SQLITE_HOME` and the #176
+capture-review `--require-proxy-meta` gate. `just release-proof 0.1.11` passed
+before tag/release mutation. GitHub Release `v0.1.11` is published and
+non-draft with 23 assets. The public Homebrew tap is fixed for the published
+asset checksums; local `brew fetch --force jesssullivan/omux/oauth-mux` passes
+and both user-local and Homebrew installs report `0.1.11`. npm publication
+remains blocked/stale; npm `latest` still reports `0.1.9`. Post-release PR
+#292 tightened capture cookie redaction and is not part of the `v0.1.11` tag.
+Negative Codex cassettes, broader adapter proof, and daemon beta truth remain
+follow-up work.
 Windows managed-`codex` parity is intentionally assigned to the npm wrapper
 lane rather than raw tarballs until a native Windows operator need is proven.
 Future public install copy must avoid claiming a version or lane behavior until
@@ -183,7 +174,7 @@ browser is needed; local Playwright is not part of this CLI proof path.
 | Harness session authority bridge | TIN-979 / TIN-1624 | #191 / #288 | Closed for the original Codex bridge, with TIN-1624/#288 covering the Codex 0.132 `logs_2.sqlite*` / `CODEX_SQLITE_HOME` parity regression. Managed auth/config overlays bridge canonical session authority and root config while rejecting silent session-store import/copy. Future cross-harness authority work stays under #67/#68. |
 | Codex session-store portability | TIN-936 | #161 | Policy is explicit: canonical bridge is supported; silent route-local session import/copy is rejected until a separate confirmed import command exists. |
 | OTEL-friendly tracing | TIN-1148 | PR #225/#226 lineage | Implemented trace schema should become the standard support-bundle path. |
-| Package parity and install lanes | TIN-1255 | #252 | `0.1.9` is published and verified across GitHub Release, npm, Homebrew, curl installer assets, and deb/rpm release assets. |
+| Package parity and install lanes | TIN-1255 | #252 | `0.1.11` is published and verified across GitHub Release, Homebrew, curl installer assets, and deb/rpm release assets; npm remains stale at `0.1.9`. |
 | Home Manager and Windows shim parity | not assigned | #257 | Home Manager source lane is implemented with opt-in shim; Windows raw tarballs stay binary-only and npm is the managed-shim lane. |
 | Provider proof beyond Codex | TIN-736 | #68 | Claude next; other agents stay adapter-candidate only. |
 | Website truth refresh | TIN-734 / TIN-925 | external site repo | `omux.xoxd.ai` source lives outside this repo and must be refreshed from the ledger, QA matrix, and install-lane docs. |

--- a/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
+++ b/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
@@ -15,32 +15,36 @@ prepared fallback remain diagnostic infrastructure, not the success claim.
 
 ## Current Verified State
 
-- Local checkout: `main` is at `33133e3`, where PR #279 landed the
-  BrokenPipe/client-disconnect reliability slice, PR #280 prepared the
-  0.1.10 provenance/release lane, and PR #281 required explicit Homebrew
-  formula version metadata.
-- GitHub read-only refresh at 2026-05-25: no open PRs, no GitHub Discussions,
-  and open issues are `#67`, `#68`, `#163`, `#176`, and `#212`.
-- Linear: `TIN-1517` and `TIN-1518` are Done. `TIN-950` is marked Done, but
-  GitHub `#176` is still open for real Codex wire cassettes; treat that as a
-  tracker hygiene mismatch until reconciled. `TIN-1079` is Backlog, `TIN-938`
-  is Todo, and `TIN-736` is In Progress.
-- Release truth: public GitHub Release `v0.1.10` is published, not
-  draft/prerelease, with installer, Homebrew, tarball, deb/rpm, and checksum
-  assets; the public Homebrew tap reports stable and linked keg `0.1.10`.
-  `npm view oauth-mux version` still reports `0.1.9` because the CI npm lane
-  currently lacks usable npm auth and fails `npm whoami` with 401.
-- Current route truth from the 2026-05-25 refresh: active bare binary is
-  Homebrew `oauth-mux 0.1.10`; native Codex resolves outside oauth-mux;
-  explicit capability probes proved `max-1` and `max-2` available, so preflight
-  now has a selectable fallback. `max-3` is quota-exhausted, and `max-4` is
-  currently provider-degraded by an old still-running `0.1.9.reinstall`
-  managed resume process rather than by the installed 0.1.10 binary.
-- Local validation at 2026-05-21 03:20 UTC: `just check-local` passed with the
-  BrokenPipe/client-disconnect regression, upstream partial-stream
-  interruption regression, managed Codex smokes, and cassette replay smokes.
-  On 2026-05-25, dogfood logs showed the public/Homebrew `0.1.9` binary still
-  lacks that fix because it predates PR #279.
+- Local upstream `main` is at `0051c57`, after PR #292 tightened capture cookie
+  redaction. PR #289 fixed the Codex 0.132 SQLite resume authority regression,
+  PR #290 added the #176 `--require-proxy-meta` capture gate, and PR #291 cut
+  the `0.1.11` release.
+- GitHub read-only refresh at 2026-05-26: no open PRs; open issues remain
+  `#67`, `#68`, `#163`, `#176`, and `#212`.
+- Linear: `TIN-1624` is Done for the resume authority fix. `TIN-1591`,
+  `TIN-738`, `TIN-937`, `TIN-736`, `TIN-893`, and `TIN-895` remain In
+  Progress. `TIN-938` is Todo, `TIN-1079` is Backlog, and `TIN-950` is still
+  marked Done even though GitHub `#176` remains open for real cassette
+  acceptance.
+- Release truth: public GitHub Release `v0.1.11` is published, not
+  draft/prerelease, with installer, Homebrew, tarball, deb/rpm, npm tarball,
+  handoff, and checksum assets. The public Homebrew tap reports stable/linked
+  keg `0.1.11`, and `brew fetch --force jesssullivan/omux/oauth-mux` passes
+  after tap PR #8 corrected stale checksums. `npm view oauth-mux version` still
+  reports `0.1.9`; `oauth-mux@0.1.11` is not published to npm.
+- Current install truth: `/Users/jess/.local/bin/oauth-mux` is PATH-first and
+  reports `0.1.11` with build id `v0.1.11`; `/opt/homebrew/bin/oauth-mux` also
+  reports `0.1.11`. Native Codex resolves outside oauth-mux.
+- Current no-spend route truth: `oauth-mux codex preflight --profile codex-max
+  --capability codex-max --json` reports `ok:true`, `session_start_ready:true`,
+  `fallback_ready:true`, `selectable_fallback_routes:2`,
+  `single_route_at_risk:false`, `spends_provider_calls:false`, and
+  `mutates_route_health:false`.
+- Current process/fd truth for TIN-1591 remains containment, not resolution:
+  soft fd limit is `256`, there are still active Codex/oauth-mux processes and
+  orphan-listener candidates, and one-snapshot helper fanout is not leak proof.
+  Do not use dogfood probes for broad live reliability claims until repeated
+  clean-baseline snapshots support that claim.
 
 ## Workstream 1 - BrokenPipe And Network-Blip Reliability
 
@@ -88,9 +92,7 @@ Todo:
   provider-spend work. Landed as PR #279.
 - [x] Publish or install a build that contains PR #279 before treating new
   installed `oauth-mux codex resume` dogfood as fixed. Completed for GitHub
-  Release and Homebrew as `0.1.10`; existing long-running 0.1.9 processes still
-  need to exit or be restarted before their status artifacts stop showing the
-  old BrokenPipe behavior.
+  Release, user-local, and Homebrew as `0.1.11`.
 
 ## Workstream 2 - No-Spend Route And Process Truth Refresh
 
@@ -210,7 +212,9 @@ Test commands:
 scripts/capture-codex-wire.sh preflight
 scripts/capture-codex-wire.sh review captures/codex-wire-<TS> \
   --require-preflight-ok \
+  --require-proxy-meta \
   --require-path-kind responses \
+  --require-status 101 \
   --require-status 200 \
   --require-quota-type usage_limit_reached
 just smoke-codex-cassette-replay-local
@@ -232,21 +236,24 @@ Todo:
   `error.type` values.
 - [x] Re-run no-spend route truth immediately before capture and keep the
   generated preflight summary with the capture scratch directory.
-- [ ] Capture at least one normal `200` Codex turn with streaming preserved.
-- [ ] Capture or explicitly record not-observed status for `401`,
+- [x] Capture one successful live turn with the Codex 0.132
+  `/backend-api/codex/responses` WebSocket `101` path observed and
+  review-gated. Scratch capture: `captures/codex-wire-20260526T171741Z`
+  (gitignored, not committed).
+- [ ] Capture or explicitly record not-observed status for quota/error shapes:
   `usage_limit_reached`, `usage_not_included`, and all-fallbacks-exhausted.
 - [ ] Add one scrubbed real-shape replay fixture and wire it into CI-safe
   cassette smoke coverage.
 
 ## Workstream 4 - Release, Docs, And Workflow Hygiene
 
-Priority: P0/P1 mixed; low risk and can proceed while Workstream 1 is being
-prepared.
+Priority: P1. Release `0.1.11` is shipped; keep docs and install lanes aligned
+before expanding public claims.
 
 Completion metric:
 
-- Current-state docs describe `0.1.9` as the latest verified public release
-  truth and `0.1.10` as the next staged source/package version until published.
+- Current-state docs describe `0.1.11` as the latest verified public release
+  truth and npm `0.1.9` as a stale package-lane exception.
 - Historical docs may keep older versions only when clearly framed as
   historical evidence.
 - Manual workflow defaults use the current project version or are deliberately
@@ -274,8 +281,11 @@ Todo:
 - [x] Add a short pointer from the productionization ledger to this plan.
 - [x] Stage `0.1.10` source/release metadata for the post-`0.1.9` BrokenPipe
   and install-provenance fixes.
-- [x] Publish `v0.1.10` GitHub Release assets and update the public Homebrew tap
-  to `0.1.10`; npm remains blocked on CI npm auth.
+- [x] Publish `v0.1.11` GitHub Release assets and update the public Homebrew tap
+  to `0.1.11`; npm remains blocked/stale at `0.1.9`.
+- [x] Fix the post-release Homebrew checksum drift and verify
+  `brew fetch --force jesssullivan/omux/oauth-mux` passes against the public
+  tap.
 - [x] When running the stale-version search, confirm remaining older-version
   hits are explicitly historical, such as the 2026-05-17 no-spend snapshot or
   the `0.1.1` npm deprecation cleanup workflow.

--- a/docs/tracker-updates/2026-05-26/README.md
+++ b/docs/tracker-updates/2026-05-26/README.md
@@ -1,0 +1,126 @@
+# Tracker Update Drafts - 2026-05-26
+
+Status: local coordination draft. Do not post to GitHub or Linear without
+explicit operator approval.
+
+## Verified Install State
+
+- Public release: `v0.1.11`
+  <https://github.com/Jesssullivan/oauth-mux/releases/tag/v0.1.11>
+- Source version: `scripts/project-version.sh` reports `0.1.11`.
+- User-local dogfood binary is PATH-first:
+  `/Users/jess/.local/bin/oauth-mux`, version `0.1.11`, build id `v0.1.11`.
+- Homebrew binary is installed:
+  `/opt/homebrew/bin/oauth-mux`, version `0.1.11`.
+- Homebrew tap checksum drift was fixed in
+  <https://github.com/Jesssullivan/homebrew-omux/pull/8>.
+- `brew fetch --force jesssullivan/omux/oauth-mux` passes.
+- npm remains stale: `npm view oauth-mux version` reports `0.1.9`; npm
+  `oauth-mux@0.1.11` is not published.
+- Release checksum note: `SHA256SUMS` / `SHA256SUMS.full` cover binary and
+  package artifacts, but `SHA256SUMS.full` does not list `publish-files.txt` or
+  `release-handoff.md`. Decide whether "full" should mean every release asset
+  before the next release.
+
+## Current GitHub Queue
+
+Open PRs in `Jesssullivan/oauth-mux`: none.
+
+Open issues:
+
+- `#67` - broker daemon and adapter contract umbrella.
+- `#68` - provider proof beyond Codex.
+- `#163` - Codex remote app-server sidecar.
+- `#176` - real Codex wire cassettes.
+- `#212` - quota reset and engineered in-session exhaustion plan.
+
+Recently landed:
+
+- `#289` - Codex 0.132 SQLite resume authority fix; closed `#288`.
+- `#290` - capture review `--require-proxy-meta` gate.
+- `#291` - `0.1.11` release.
+- `#292` - post-release capture cookie redaction hardening; does not close
+  `#176`.
+
+## Current Linear Queue
+
+Core open or active:
+
+- `TIN-1591` In Progress - process/fd hygiene. Contained, not resolved.
+- `TIN-738` In Progress - broker daemon and adapter contract umbrella.
+- `TIN-937` In Progress - usage-limit diagnostics without restart.
+- `TIN-938` Todo - remote app-server sidecar; keep no-spend loopback only.
+- `TIN-1079` Backlog - engineered quota reset/exhaustion plan; maps to `#212`.
+- `TIN-736` In Progress - provider proof beyond Codex; maps to `#68`.
+- `TIN-893` In Progress - paid Codex cohort.
+- `TIN-895` In Progress - paid cohort soak/public claim policy.
+
+Closed but relevant:
+
+- `TIN-1624` Done - Codex 0.132 resume authority; maps to `#288` / PR `#289`.
+- `TIN-979` Done - original harness session authority split.
+- `TIN-936` Done - session-store portability policy.
+- `TIN-950` Done - real Codex wire cassettes in Linear, but GitHub `#176`
+  remains open. Treat this as tracker mismatch until real quota/error cassette
+  acceptance lands or Linear is clarified.
+
+## Branch And Worktree Hygiene
+
+`oauth-mux`:
+
+- `main` is clean and in sync with `origin/main`.
+- Stale worktree registration for `/private/tmp/oauth-mux-tin1517` was removed
+  with `git worktree prune --verbose`; only the active oauth-mux worktree
+  remains registered.
+- Local branch residue remains from squashed/merged work. Classify before
+  deleting because squash merges do not show ancestry containment reliably.
+- Cleanup candidates after operator approval:
+  `codex/homebrew-explicit-version-metadata` (PR `#281` merged),
+  `codex/homebrew-formula-order-and-dogfood-truth` (PR `#282` merged),
+  `codex/live-version-provenance` (PR `#280` merged),
+  `codex/codex-sqlite-resume-authority` (PR `#289` merged).
+- Keep/classify before deletion:
+  `jess/tin-1517-harden-codex-managed-route-election` has closed PR `#272`
+  rather than merged ancestry, and `archive/broker-mcp-codex-adapter-20260518`
+  is explicitly archival.
+
+`lab`:
+
+- `main` is clean and in sync with `origin/main`.
+- Home Manager Fish PATH precedence is merged in
+  <https://github.com/tinyland-inc/lab/pull/505>.
+- Open PR `#504` is unrelated YubiKey policy work.
+- Cleanup candidates after operator approval:
+  `codex/oauth-mux-fish-path-precedence` (PR `#505` merged) and
+  `jess/tin-1252-pzm-materialized-session-vars` (PR `#475` merged).
+- Keep: `jess/yubikey-touchless-gpg-policy` while PR `#504` remains open.
+
+`homebrew-omux`:
+
+- Remote `origin/main` includes the `0.1.11` checksum fix.
+- Local checkout is on `codex/oauth-mux-0.1.11-checksums`.
+- Local `main` is divergent from `origin/main` because older tap work is still
+  preserved locally. Do not reset it without first preserving or explicitly
+  retiring the local-only commit.
+- Cleanup candidates after operator approval:
+  `codex/oauth-mux-0.1.11-checksums` (PR `#8` merged) and
+  `codex/oauth-mux-0.1.9-tap-v2` (PR `#3` merged).
+- Keep/classify before deletion:
+  `codex/oauth-mux-0.1.9-tap` has closed PR `#2` and diverged local state;
+  `codex/add-oauth-mux-formula` has no matching PR from the audit.
+
+## Backlog Priority
+
+1. Resolve/contain `TIN-1591` with an exact cleanup policy and repeated
+   snapshots before using dogfood runs for broad reliability claims.
+2. Continue `#176` with real cassette evidence under `--require-proxy-meta`.
+   The successful Codex 0.132 capture observed `/backend-api/codex/responses`
+   as a WebSocket `101`, but quota/error shapes are still missing.
+3. Move `#212` / `TIN-1079` out of backlog only when fallback capacity and
+   operator-approved provider spend are ready for engineered exhaustion.
+4. Keep `#163` / `TIN-938` to a no-spend loopback sidecar smoke until cassette
+   evidence is stronger.
+5. Keep `#68` / `TIN-736` secondary to the Codex reference adapter; admit the
+   next provider only through fixture-backed proof.
+6. Tighten release hygiene before `0.1.12`: decide whether `SHA256SUMS.full`
+   should include every uploaded release asset, including handoff metadata.


### PR DESCRIPTION
## Summary
- update productionization and hardening docs from staged 0.1.11 / public 0.1.10 truth to published 0.1.11 truth
- capture current GitHub/Linear backlog, branch/worktree hygiene, and TIN-1591 containment in a local tracker update draft
- record remaining gaps: npm still at 0.1.9, #176 quota/error cassettes missing, and SHA256SUMS.full coverage decision before the next release

## Validation
- git diff --check
- just test