### PR TITLE
Fix Codex resume provider namespace parity

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -150,7 +150,7 @@ oauth-mux codex resume <session-id>
 ```
 
 These commands launch the real Codex CLI inside an oauth-mux managed frame.
-Auth and the proxy provider are mux-owned in a temporary overlay, while Codex
+Auth and the proxy base URL are mux-owned in a temporary overlay, while Codex
 session authority is bridged by reference to the canonical Codex home unless
 `--isolated-session-store` is set. `oauth-mux codex resume` with no id keeps
 native Codex chooser ownership; oauth-mux only checks before spawn that the
@@ -170,10 +170,12 @@ canonical config authority from `OMUX_CODEX_CONFIG_HOME`, then parent
 `CODEX_HOME`, then `~/.codex`, preserving settings such as `[features]`,
 legacy `experimental_*`, MCP servers, approval/sandbox policy, profiles, model
 defaults, and custom non-managed providers. oauth-mux strips the selected
-`model_provider` and stale `[model_providers.oauth_mux_openai]` entries before
-appending its proxy provider. Forwarded Codex `--config` / `-c` assignments
-that try to override mux-owned provider keys fail before child spawn with a
-redacted `config_passthrough_check` status event. The generated config uses
+`model_provider`, `openai_base_url`, and stale
+`[model_providers.oauth_mux_openai]` entries before appending
+`model_provider = "openai"` plus a localhost `openai_base_url`. Forwarded Codex
+`--config` / `-c` assignments that try to override mux-owned provider/base-url
+keys fail before child spawn with a redacted `config_passthrough_check` status
+event. The generated config uses
 `config_layout:"root_partitioned"` so managed root keys cannot land inside a
 trailing user table.
 When a Codex experimental feature key is absent, the managed overlay defaults

--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -81,8 +81,8 @@ startup diagnostics, not quota-handoff evidence.
 
 Implementation update, 2026-05-09: the managed overlay now preserves canonical
 Codex `config.toml` behavior settings when a canonical config is present, while
-stripping oauth-mux-owned provider-selection conflicts before appending the
-managed proxy provider. This protects `/experimental` / `[features]`, MCP,
+stripping oauth-mux-owned routing conflicts before appending the managed proxy
+base URL. This protects `/experimental` / `[features]`, MCP,
 hooks/rules, approval/sandbox, profiles, model defaults, and custom
 non-managed provider definitions from being silently shadowed by the temporary
 `CODEX_HOME`. Config authority is independent from session authority:
@@ -95,17 +95,14 @@ canonical config instead of inheriting a reduced generated overlay.
 Profile-scoped `model_provider` lines are removed, stale
 `[model_providers.oauth_mux_openai]` tables and subtables are removed, and
 forwarded Codex `--config` / `-c` assignments that attempt to override
-`model_provider`, `*.model_provider`, or `model_providers.oauth_mux_openai*`
-fail before child spawn with a redacted `config_passthrough_check` status
-event. Track remaining edge-layer work in
+`model_provider`, `*.model_provider`, `openai_base_url`, or
+`model_providers.oauth_mux_openai*` fail before child spawn with a redacted
+`config_passthrough_check` status event. Track remaining edge-layer work in
 <https://github.com/Jesssullivan/oauth-mux/issues/211>.
 
 Implementation update, 2026-05-10: the managed config writer now partitions
-canonical config into root lines and table sections. `model_provider =
-"oauth_mux_openai"` is emitted only at TOML root, stale
-`[model_providers.oauth_mux_openai*]` sections are stripped, preserved user
-tables remain below the root override, and the generated provider table is
-appended after preserved user tables. The regression fixture is a canonical
+canonical config into root lines and table sections. The managed root override
+is emitted before preserved user tables. The regression fixture is a canonical
 config ending in `[tui.model_availability_nux]` with `"gpt-5.5" = 2`.
 `session_started` reports `config_layout:"root_partitioned"`.
 
@@ -120,6 +117,15 @@ back to the legacy `sessions/`, `shell_snapshots/`, `history.jsonl`, and
 `session_index.jsonl` authority set. Redacted status reports
 `sqlite_authority`, `resume_authority_state_db_bridged`,
 `resume_authority_logs_db_bridged`, and `resume_lookup_source`.
+
+Implementation update, 2026-05-26: native resume picker parity also depends on
+the active provider namespace. Codex filters persisted `threads` by
+`model_provider`; a custom `oauth_mux_openai` provider made managed resume show
+only oauth-mux-created rows. The managed config therefore keeps
+`model_provider = "openai"` and sets `openai_base_url` to the localhost mux
+proxy. The proxy accepts built-in OpenAI-provider paths such as
+`/backend-api/responses` and forwards them to the ChatGPT Codex upstream shape
+under `/backend-api/codex/...`, adding the currently elected account headers.
 
 Implementation update, 2026-05-10: managed launch no longer runs broad
 `repairRefreshableCodexAuthFailures()` before child spawn. Network refresh is
@@ -202,13 +208,12 @@ both layers, Level 3 is the default and Level 4 is reachable.
 3. Materializes that account's `auth.json`-equivalent tuple.
 4. Writes a temporary, adapter-owned `CODEX_HOME` directory containing the
    selected account's `auth.json` and a generated `config.toml` whose
-   selected custom provider (`model_provider = "oauth_mux_openai"` and
-   `[model_providers.oauth_mux_openai]`) points at the wire-layer proxy.
-   Codex 0.128+ rejects overriding the reserved built-in `openai`
-   provider id. The generated config preserves canonical user behavior
-   settings and strips only mux-owned provider-selection conflicts. Unsafe
-   forwarded `--config` / `-c` provider overrides fail before child spawn with
-   redacted status. Session-authority paths are bridged per
+   built-in provider namespace (`model_provider = "openai"`) points at the
+   wire-layer proxy via `openai_base_url`. The generated config preserves
+   canonical user behavior settings and strips only mux-owned routing
+   conflicts. Unsafe forwarded `--config` / `-c` provider/base-url overrides
+   fail before child spawn with redacted status. Session-authority paths are
+   bridged per
    `docs/spec/harness-session-authority-bridge-2026-05-05.md`, not copied
    wholesale into this overlay. Operators may pass `--isolated-session-store`
    for a test/private namespace or `--session-home <path>` for an explicit

--- a/docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md
+++ b/docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md
@@ -134,9 +134,10 @@ Adapter-owned options are consumed by oauth-mux:
 Harness-owned args are forwarded exactly, in order, without reinterpretation.
 The only exception is mux-owned provider configuration: forwarded Codex
 `--config` / `-c` assignments that override `model_provider`,
-`*.model_provider`, or `model_providers.oauth_mux_openai*` MUST fail before
-child spawn with a redacted typed diagnostic. Other Codex config overrides
-remain harness-owned and are forwarded.
+`*.model_provider`, `openai_base_url`, or
+`model_providers.oauth_mux_openai*` MUST fail before child spawn with a
+redacted typed diagnostic. Other Codex config overrides remain harness-owned
+and are forwarded.
 
 ### 3.3 Parser Rules
 

--- a/docs/spec/codex-productionization-todo-2026-05-09.md
+++ b/docs/spec/codex-productionization-todo-2026-05-09.md
@@ -23,10 +23,11 @@ Proven:
   regressions in the managed launch path: generated `config.toml` is
   root-partitioned so trailing user tables such as
   `[tui.model_availability_nux]` cannot swallow the managed
-  `model_provider`; `state_5.sqlite*` and `logs_2.sqlite*` are bridged by
-  reference when present for native chooser parity; canonical bridge mode sets
-  `CODEX_SQLITE_HOME` to the canonical authority home for Codex 0.132+; and
-  broad pre-spawn Codex auth repair has been removed from launch.
+  `model_provider` / `openai_base_url`; `state_5.sqlite*` and
+  `logs_2.sqlite*` are bridged by reference when present for native chooser
+  parity; canonical bridge mode sets `CODEX_SQLITE_HOME` to the canonical
+  authority home for Codex 0.132+; and broad pre-spawn Codex auth repair has
+  been removed from launch.
 
 Not proven:
 
@@ -59,7 +60,7 @@ Not proven:
   initial slice):
   `/experimental` / `[features]`, MCP, hooks/rules, approval/sandbox, profiles,
   model defaults, and other user behavior settings must pass through while
-  oauth-mux overrides only the proxy provider keys.
+  oauth-mux overrides only the proxy routing keys.
 - [x] Default missing Codex experimental feature keys in the managed child
   config (`terminal_resize_reflow`, `memories`, `external_migration`, `goals`,
   and `prevent_idle_sleep`) while preserving explicit canonical values,

--- a/docs/spec/harness-session-authority-bridge-2026-05-05.md
+++ b/docs/spec/harness-session-authority-bridge-2026-05-05.md
@@ -113,9 +113,9 @@ Adapter-controlled configuration needed to interpose the broker:
 - account/profile policy settings that belong to oauth-mux.
 
 oauth-mux owns this boundary. For Codex, this is the generated
-`config.toml` selecting `model_provider = "oauth_mux_openai"` and a
-localhost proxy base URL. The adapter must not write that configuration into
-the canonical `~/.codex/config.toml` by default.
+`config.toml` selecting `model_provider = "openai"` and `openai_base_url =
+"http://127.0.0.1:<port>/backend-api"`. The adapter must not write that
+configuration into the canonical `~/.codex/config.toml` by default.
 
 Managed config is not permission to erase harness behavior settings. For Codex,
 the temporary overlay must preserve or deliberately reapply unrelated native
@@ -127,10 +127,10 @@ initial implementation is landed. Config authority follows
 `~/.codex`, and is independent from session authority. A parent `CODEX_HOME`
 that is itself an oauth-mux temporary overlay is not reusable authority;
 nested managed sessions fall back to canonical config/session state instead of
-recursively inheriting a reduced overlay. oauth-mux removes provider-selection
-conflicts, including profile-scoped `model_provider`, then appends the managed
-proxy provider. Forwarded `--config` / `-c` attempts to override mux-owned
-provider keys fail before child spawn with redacted status.
+recursively inheriting a reduced overlay. oauth-mux removes routing conflicts,
+including profile-scoped `model_provider` and `openai_base_url`, then appends
+the managed proxy base URL. Forwarded `--config` / `-c` attempts to override
+mux-owned provider/base-url keys fail before child spawn with redacted status.
 
 ### 2.3 Session Authority Store
 

--- a/docs/spec/oauth-mux-this-week-sprint-2026-05-26.md
+++ b/docs/spec/oauth-mux-this-week-sprint-2026-05-26.md
@@ -1,0 +1,292 @@
+# oauth-mux This-Week Sprint
+Date: 2026-05-26
+Target window: 2026-05-26 through 2026-05-31
+Status: active sprint todo list; subordinate to `AGENTS.md`,
+`docs/spec/broker-mcp-contract-2026-05-03.md`,
+`docs/spec/codex-adapter-contract-2026-05-03.md`, and
+`docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md`.
+
+## Sprint Goal
+
+Convert the `0.1.11` release into reliable next evidence: clean dogfood
+baselines, real Codex cassette coverage, and a disciplined backlog that does
+not expand public claims ahead of proof.
+
+The product anchor stays unchanged: `oauth-mux codex` must keep a managed
+Codex harness usable when auth, quota, tier, or local runtime state changes.
+Restart, supervised relaunch, broad daemon claims, and schema-modeled provider
+support are not success metrics.
+
+## Current Truth
+
+- Before this P0 branch, `oauth-mux` main was clean and synced to
+  `origin/main`.
+- Public release `v0.1.11` is published and verified for GitHub Release,
+  Homebrew, user-local dogfood, curl installer assets, and deb/rpm assets.
+- npm remains stale at `0.1.9`; do not claim npm `0.1.11`.
+- Current no-spend Codex preflight reports `fallback_ready:true`,
+  `selectable_fallback_routes:2`, `session_start_ready:true`,
+  `single_route_at_risk:false`, `spends_provider_calls:false`, and
+  `mutates_route_health:false`.
+- `TIN-1591` remains contained, not resolved. Dogfood evidence is local
+  release/install validation until process/fd baselines are clean enough for
+  broader live reliability claims.
+- GitHub `#176` remains open even though Linear `TIN-950` is Done. Treat that
+  as a tracker mismatch until real quota/error cassettes land or Linear is
+  explicitly clarified.
+- Live regression found after `0.1.11`: native `codex resume` and
+  `oauth-mux codex resume` used the same SQLite authority and cwd, but Codex
+  filtered picker rows by `threads.model_provider`; the managed
+  `oauth_mux_openai` provider created a shadow resume namespace. P0 fix is to
+  keep `model_provider = "openai"` and route through mux with `openai_base_url`.
+- Local P0 proof on 2026-05-26: `just test`,
+  `just smoke-codex-cli-ux-local`, local dogfood reinstall, and a live
+  `/Users/jess/git/blahaj` resume-picker check all passed with managed resume
+  showing the same `[Cwd]` rows as native Codex.
+
+## Workstream P0 - Resume Picker Namespace Parity
+
+Priority: P0 before cassette or live reliability claims.
+
+Completion metric:
+
+- Managed generated config keeps Codex's native provider namespace:
+  `model_provider = "openai"`.
+- Managed generated config routes provider traffic through localhost
+  `openai_base_url` without writing canonical `~/.codex/config.toml`.
+- The proxy maps built-in provider paths such as `/backend-api/responses` and
+  `/backend-api/models` to the ChatGPT Codex upstream path shape.
+- Native and managed `codex resume` show the same `[Cwd]` picker rows for the
+  same working directory.
+- CI smoke fails if the shadow `oauth_mux_openai` provider returns to generated
+  config.
+
+Todos:
+
+- [x] Patch generated config and proxy path mapping.
+- [x] Extend smoke/stub assertions for native provider namespace plus proxy URL.
+- [x] Re-run `just test` and `just smoke-codex-cli-ux-local`.
+- [x] Reinstall the fixed binary locally and verify the live picker from a repo
+  with known native and managed rows.
+- [ ] Update the release/HM plan after the fix lands on a clean public ref.
+
+## Non-Goals
+
+- Do not close `#176` from a successful-turn cassette alone.
+- Do not promote daemon, sidecar, same-thread, or unmanaged hot-swap claims.
+- Do not start `#163` live sidecar spend proof this week.
+- Do not expand non-Codex provider claims before Codex cassette evidence is
+  stronger.
+- Do not delete divergent local branches without preserving or explicitly
+  retiring their work.
+
+## Workstream A - TIN-1591 Process/FD Hygiene
+
+Priority: P0.
+
+Completion metric:
+
+- A repeatable no-spend snapshot routine exists for dogfood evidence sessions.
+- The routine records soft fd limit, active oauth-mux/Codex process counts,
+  managed children, listener candidates, duplicate helper groups, and explicit
+  cleanup eligibility.
+- At least two snapshots from a clean baseline agree enough to distinguish
+  normal agent fanout from leak/process residue.
+- Cleanup rules require exact operator approval before killing active Codex,
+  Claude, MCP, or browser helper processes.
+
+Todos:
+
+- [ ] Add a short `TIN-1591` runbook section to `docs/dogfood-process-fanout.md`
+  or a sibling doc with the exact snapshot command, interpretation rules, and
+  cleanup approval policy.
+- [ ] Re-run `python3 scripts/dogfood-process-snapshot.py --json` from a clean
+  shell and save only a redacted summary if it changes the claim posture.
+- [ ] Decide whether the soft fd limit `256` is acceptable for dogfood evidence
+  or whether the runbook must require a higher limit.
+- [ ] Define which process classes are never killed by automation.
+- [ ] Re-check no proxy/capture/long-running validation processes before each
+  live or cassette run.
+
+Validation:
+
+```bash
+python3 scripts/dogfood-process-snapshot.py --json \
+  | jq '{summary, process_summary, safe_cleanup, no_provider_spend, mutates_processes, spends_provider_calls}'
+pgrep -fl 'mitmdump|capture-codex-wire|gh run watch|nix build .#checks.aarch64-darwin.fish-syntax-test' || true
+git diff --check
+```
+
+## Workstream B - GitHub #176 / Linear TIN-950 Cassettes
+
+Priority: P0 after Workstream A baseline is clean enough.
+
+Completion metric:
+
+- Capture review requires proxy metadata and installed preflight proof.
+- At least one scrubbed real-shape replay fixture is committed.
+- Quota/error shapes are captured or explicitly marked not observed:
+  `usage_limit_reached`, `usage_not_included`, all-fallbacks-exhausted, and
+  auth/error-path drift.
+- Replay fails diagnostically on shape drift.
+
+Known evidence:
+
+- Clean scratch capture `captures/codex-wire-20260526T171741Z` exists locally
+  and is gitignored.
+- Codex 0.132 `/backend-api/codex/responses` was observed as a WebSocket `101`,
+  not a simple `200` SSE-only path.
+- Cookie and `Set-Cookie` redaction is now review-gated after PR `#292`.
+- No quota/exhaustion shapes have been captured yet.
+
+Todos:
+
+- [ ] Run a just-in-time no-spend preflight before any proxy.
+- [ ] Capture another successful-turn cassette only if it adds fixture value
+  beyond the existing WebSocket `101` shape.
+- [ ] Target quota/error capture under explicit spend approval and fallback
+  capacity, not from a single-route-at-risk state.
+- [ ] Promote the smallest scrubbed fixture that proves the real path shape.
+- [ ] Add or extend CI-safe replay smoke coverage for the scrubbed fixture.
+- [ ] Reconcile `TIN-950` Done versus GitHub `#176` open after the fixture and
+  error-shape decision are recorded.
+
+Validation:
+
+```bash
+scripts/capture-codex-wire.sh preflight
+scripts/capture-codex-wire.sh review captures/codex-wire-<TS> \
+  --require-preflight-ok \
+  --require-proxy-meta \
+  --require-path-kind responses \
+  --require-status 101 \
+  --require-status 200
+python3 -m py_compile scripts/review-codex-wire-capture.py scripts/codex-wire-addon.py
+./scripts/smoke-codex-capture-review.sh
+just smoke-codex-cassette-replay-local
+git diff --check
+```
+
+## Workstream C - GitHub #212 / Linear TIN-1079 Exhaustion Matrix
+
+Priority: P1, only after Workstream A and enough Workstream B evidence.
+
+Completion metric:
+
+- `TIN-1079` moves from Backlog only when fallback capacity is current and the
+  run has explicit spend approval.
+- The matrix separates no-spend inventory, provider-spend probes, and actual
+  engineered exhaustion.
+- Evidence records selected route, fallback pool, reset-window normalization,
+  and whether route health was mutated.
+
+Todos:
+
+- [ ] Refresh no-spend route inventory with `accounts list`, `route explain`,
+  `codex preflight`, and `broker-session-plan`.
+- [ ] Identify one intentionally exhausted or limited route and one credited
+  fallback route for a controlled run.
+- [ ] Define stop conditions before the run: single-route-at-risk, missing
+  fallback, proxy redaction failure, or TIN-1591 contamination.
+- [ ] Record whether the test is allowed to mutate route health.
+- [ ] Update `TIN-1079` with the exact current matrix before live execution.
+
+Validation:
+
+```bash
+oauth-mux accounts list --provider codex --json
+oauth-mux route explain --profile codex-max --capability codex-max --json
+oauth-mux codex preflight --profile codex-max --capability codex-max --json
+oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json
+```
+
+## Workstream D - Doc Accuracy And Release Hygiene
+
+Priority: P1.
+
+Completion metric:
+
+- Current-state docs consistently say `0.1.11` is published for GitHub Release
+  and Homebrew, while npm is stale at `0.1.9`.
+- Historical snapshots remain clearly historical.
+- `SHA256SUMS.full` semantics are decided before `0.1.12`.
+- Public copy does not claim non-Codex stay-afloat, daemon beta, sidecar UX, or
+  npm `0.1.11`.
+
+Todos:
+
+- [ ] Audit current-state docs for stale `0.1.10` / staged `0.1.11` language.
+- [ ] Mark older no-spend snapshots as historical where they still mention
+  outdated selected routes or stale installed binaries.
+- [ ] Decide whether `SHA256SUMS.full` must include `publish-files.txt` and
+  `release-handoff.md`.
+- [ ] Add a release hygiene todo for npm auth or explicitly keep npm out of the
+  `0.1.11` public claim.
+
+Validation:
+
+```bash
+rg -n "0\\.1\\.10|0\\.1\\.11 is the next staged|v0\\.1\\.10|npm.*0\\.1\\.11" \
+  README.md docs .github scripts || true
+npm view oauth-mux version --json
+brew info jesssullivan/omux/oauth-mux --json=v2 \
+  | jq '.formulae[] | {stable: .versions.stable, installed: [.installed[]?.version]}'
+git diff --check
+```
+
+## Workstream E - GitHub #163 / Linear TIN-938 Sidecar
+
+Priority: P2, constrained.
+
+Completion metric:
+
+- A no-spend loopback smoke proves sidecar process lifecycle, local transport,
+  connection ordering, and attach/readiness semantics.
+- No live sidecar provider call is made.
+- Docs explicitly classify the sidecar as exploratory until cassette evidence
+  and quota/error replay coverage are stronger.
+
+Todos:
+
+- [ ] Read upstream Codex 0.132 app-server/remote attach behavior before
+  writing code.
+- [ ] Define a loopback-only fixture or stub for transport and readiness.
+- [ ] Add a smoke name and acceptance text without claiming managed TUI UX.
+
+## Workstream F - GitHub #68 / Linear TIN-736 Provider Proof
+
+Priority: P2/P3, secondary to Codex.
+
+Completion metric:
+
+- One next provider is admitted through the provider-authoring checklist with
+  fixture-backed positive and negative proof.
+- Provider matrix distinguishes schema-modeled, no-spend proven,
+  fixture-backed, and live-proven states.
+
+Todos:
+
+- [ ] Choose the next provider only after Codex cassette acceptance is stronger.
+- [ ] Prefer Claude command-owned auth-status proof before broader OAuth
+  providers.
+- [ ] Keep Figma/MCP provider proof under separate tickets; do not roll it into
+  Codex continuity claims.
+
+## Branch/Worktree Hygiene Parking Lot
+
+These are organizational tasks, not product blockers.
+
+- [ ] oauth-mux: classify local merged/superseded branches before deletion.
+- [ ] lab: retire merged `codex/oauth-mux-fish-path-precedence` only after
+  operator approval.
+- [ ] homebrew-omux: preserve or retire divergent local `main` and old `0.1.9`
+  tap branches before any reset.
+
+## Sprint Exit Criteria
+
+- TIN-1591 has a runbook and at least one fresh clean-baseline snapshot.
+- #176 has either a scrubbed real-shape fixture PR or a recorded blocker with
+  exact missing evidence.
+- #212 has a current no-spend matrix and a clear go/no-go gate for spend.
+- Docs no longer imply `0.1.11` is staged or that npm is current.
+- No new public continuity claims are made beyond the evidence above.

--- a/docs/tracker-updates/2026-05-09/codex-config-overlay-issue.md
+++ b/docs/tracker-updates/2026-05-09/codex-config-overlay-issue.md
@@ -1,5 +1,11 @@
 # P1: Preserve Codex config and experimental settings in managed overlay
 
+2026-05-26 note: the custom `oauth_mux_openai` provider described in this
+historical tracker update was superseded by the resume-picker namespace parity
+fix. Managed Codex now keeps `model_provider = "openai"` and routes through the
+localhost mux with `openai_base_url`, because Codex filters persisted resume
+threads by provider namespace.
+
 ## Problem
 
 `oauth-mux codex` currently creates a temporary `CODEX_HOME` and writes a fresh

--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -261,8 +261,9 @@ run_case() {
         exit 1
     fi
 
-    if [[ "$(jq -r .config.proxy_provider_selected "$report")" == "true" \
-          && "$(jq -r .config.proxy_provider_present "$report")" == "true" \
+    if [[ "$(jq -r .config.native_provider_namespace "$report")" == "true" \
+          && "$(jq -r .config.proxy_base_url_present "$report")" == "true" \
+          && "$(jq -r .config.shadow_mux_provider_absent "$report")" == "true" \
           && "$(jq -r .config.user_feature_apps "$report")" == "true" \
           && "$(jq -r .config.user_feature_memories "$report")" == "true" \
           && "$(jq -r .config.user_feature_multi_agent "$report")" == "true" \
@@ -486,7 +487,7 @@ if [[ -e "$BAD_CONFIG_REPORT" ]]; then
 else
     echo "  ✓ config override fails before child spawn"
 fi
-if grep -q -E 'openai|profile_provider|'"$CANONICAL_SESSION_HOME" "$BAD_CONFIG_NDJSON" "$BAD_CONFIG_STDERR"; then
+if grep -q -E 'model_provider="openai"|profile_provider|https://example.invalid|'"$CANONICAL_SESSION_HOME" "$BAD_CONFIG_NDJSON" "$BAD_CONFIG_STDERR"; then
     echo "  ✗ config override diagnostic leaked value or path" >&2
     cat "$BAD_CONFIG_NDJSON" >&2
     cat "$BAD_CONFIG_STDERR" >&2

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -59,9 +59,11 @@ from pathlib import Path
 
 def _read_proxy_url(codex_home: Path) -> str:
     cfg = (codex_home / "config.toml").read_text()
-    m = re.search(r'base_url\s*=\s*"([^"]+)"', cfg)
+    m = re.search(r'openai_base_url\s*=\s*"([^"]+)"', cfg)
     if not m:
-        print("stub-codex: config.toml missing base_url", file=sys.stderr)
+        m = re.search(r'base_url\s*=\s*"([^"]+)"', cfg)
+    if not m:
+        print("stub-codex: config.toml missing proxy base URL", file=sys.stderr)
         sys.exit(2)
     return m.group(1)
 
@@ -70,9 +72,12 @@ def _config_report(codex_home: Path) -> dict:
     cfg = (codex_home / "config.toml").read_text()
     return {
         "checked": True,
-        "proxy_provider_selected": 'model_provider = "oauth_mux_openai"' in cfg,
-        "proxy_provider_present": "[model_providers.oauth_mux_openai]" in cfg,
-        "config_layout_root_partitioned": cfg.find('model_provider = "oauth_mux_openai"') < cfg.find("[tui.model_availability_nux]")
+        "native_provider_namespace": 'model_provider = "openai"' in cfg,
+        "proxy_base_url_present": 'openai_base_url = "http://127.0.0.1:' in cfg
+        and "/backend-api" in cfg,
+        "shadow_mux_provider_absent": 'model_provider = "oauth_mux_openai"' not in cfg
+        and "[model_providers.oauth_mux_openai]" not in cfg,
+        "config_layout_root_partitioned": cfg.find('model_provider = "openai"') < cfg.find("[tui.model_availability_nux]")
         if "[tui.model_availability_nux]" in cfg
         else True,
         "user_feature_apps": "apps = true" in cfg,

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -278,6 +278,7 @@ const ConfigOverrideCheck = struct {
     total_config_overrides: usize = 0,
     mux_owned_overrides: usize = 0,
     model_provider_override: bool = false,
+    openai_base_url_override: bool = false,
     managed_provider_override: bool = false,
 };
 
@@ -2436,6 +2437,7 @@ fn writeManagedConfigToml(
                 &feature_defaults,
                 &observation.experimental_feature_defaults_injected,
                 &observation.mcp_stdio_unsupported_fields_removed,
+                proxy_port,
             );
             managed_root_written = true;
             if (contents.items.len != 0 and contents.items[contents.items.len - 1] != '\n') try w.writeAll("\n");
@@ -2449,15 +2451,9 @@ fn writeManagedConfigToml(
     if (!managed_root_written) {
         observation.experimental_feature_defaults_injected += try feature_defaults.writeMissingAsRootDotted(w);
         if (observation.experimental_feature_defaults_injected != 0) try w.writeAll("\n");
-        try writeManagedConfigRoot(w);
+        try writeManagedConfigRoot(w, proxy_port);
     }
-    observation.overridden_keys += 1;
-    try w.print("[model_providers.oauth_mux_openai]\n", .{});
-    try w.print("name = \"oauth-mux OpenAI proxy\"\n", .{});
-    try w.print("base_url = \"http://127.0.0.1:{d}/backend-api/codex\"\n", .{proxy_port});
-    try w.writeAll("wire_api = \"responses\"\n");
-    try w.writeAll("requires_openai_auth = true\n");
-    observation.overridden_keys += 1;
+    observation.overridden_keys += 2;
 
     const f = try std.fs.cwd().createFile(path, .{ .mode = 0o600, .truncate = true });
     defer f.close();
@@ -2465,10 +2461,11 @@ fn writeManagedConfigToml(
     return observation;
 }
 
-fn writeManagedConfigRoot(writer: anytype) !void {
+fn writeManagedConfigRoot(writer: anytype, proxy_port: u16) !void {
     try writer.writeAll("# Managed by oauth-mux. Proxy override; unrelated Codex config above is preserved.\n");
     try writer.writeAll("# Anchor: docs/spec/codex-adapter-contract-2026-05-03.md §4\n\n");
-    try writer.writeAll("model_provider = \"oauth_mux_openai\"\n\n");
+    try writer.writeAll("model_provider = \"openai\"\n");
+    try writer.print("openai_base_url = \"http://127.0.0.1:{d}/backend-api\"\n\n", .{proxy_port});
 }
 
 fn writeConfigPassthrough(
@@ -2478,6 +2475,7 @@ fn writeConfigPassthrough(
     feature_defaults: *CodexExperimentalFeatureDefaults,
     experimental_feature_defaults_injected: *usize,
     mcp_stdio_unsupported_fields_removed: *usize,
+    proxy_port: u16,
 ) !usize {
     var overridden: usize = 0;
     var root = std.ArrayListUnmanaged(u8){};
@@ -2524,6 +2522,10 @@ fn writeConfigPassthrough(
                         overridden += 1;
                         continue;
                     },
+                    .openai_base_url => {
+                        overridden += 1;
+                        continue;
+                    },
                 }
             }
             try root.writer(allocator).writeAll(line);
@@ -2536,6 +2538,10 @@ fn writeConfigPassthrough(
         if (configAssignmentOverridesMuxProvider(trimmed_left)) |classification| {
             switch (classification) {
                 .model_provider, .managed_provider => {
+                    overridden += 1;
+                    continue;
+                },
+                .openai_base_url => {
                     overridden += 1;
                     continue;
                 },
@@ -2568,7 +2574,7 @@ fn writeConfigPassthrough(
         try writer.writeAll(root.items);
         if (root.items[root.items.len - 1] != '\n') try writer.writeAll("\n");
     }
-    try writeManagedConfigRoot(writer);
+    try writeManagedConfigRoot(writer, proxy_port);
     if (tables.items.len != 0) {
         try writer.writeAll(tables.items);
         if (tables.items[tables.items.len - 1] != '\n') try writer.writeAll("\n");
@@ -2711,6 +2717,7 @@ fn recordConfigOverride(result: *ConfigOverrideCheck, assignment: []const u8) vo
         result.mux_owned_overrides += 1;
         switch (classification) {
             .model_provider => result.model_provider_override = true,
+            .openai_base_url => result.openai_base_url_override = true,
             .managed_provider => result.managed_provider_override = true,
         }
     }
@@ -2718,6 +2725,7 @@ fn recordConfigOverride(result: *ConfigOverrideCheck, assignment: []const u8) vo
 
 const ConfigOverrideClassification = enum {
     model_provider,
+    openai_base_url,
     managed_provider,
 };
 
@@ -2725,6 +2733,9 @@ fn configAssignmentOverridesMuxProvider(assignment: []const u8) ?ConfigOverrideC
     const key = tomlAssignmentKey(assignment) orelse return null;
     if (std.mem.eql(u8, key, "model_provider") or std.mem.endsWith(u8, key, ".model_provider")) {
         return .model_provider;
+    }
+    if (std.mem.eql(u8, key, "openai_base_url")) {
+        return .openai_base_url;
     }
     if (std.mem.eql(u8, key, "model_providers.oauth_mux_openai") or
         std.mem.startsWith(u8, key, "model_providers.oauth_mux_openai."))
@@ -2736,12 +2747,13 @@ fn configAssignmentOverridesMuxProvider(assignment: []const u8) ?ConfigOverrideC
 
 fn writeConfigOverrideCheckStatus(writer: anytype, check: ConfigOverrideCheck) !void {
     try writer.print(
-        "{{\"kind\":\"config_passthrough_check\",\"ok\":{any},\"total_config_overrides\":{d},\"mux_owned_overrides\":{d},\"model_provider_override\":{any},\"managed_provider_override\":{any},\"paths_printed\":false,\"values_printed\":false}}\n",
+        "{{\"kind\":\"config_passthrough_check\",\"ok\":{any},\"total_config_overrides\":{d},\"mux_owned_overrides\":{d},\"model_provider_override\":{any},\"openai_base_url_override\":{any},\"managed_provider_override\":{any},\"paths_printed\":false,\"values_printed\":false}}\n",
         .{
             check.ok,
             check.total_config_overrides,
             check.mux_owned_overrides,
             check.model_provider_override,
+            check.openai_base_url_override,
             check.managed_provider_override,
         },
     );
@@ -3032,8 +3044,9 @@ test "createSessionCodexHomeUnder copies auth and does not clobber source config
     const generated_config = try std.fs.cwd().readFileAlloc(std.testing.allocator, session_config, 4096);
     defer std.testing.allocator.free(generated_config);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "127.0.0.1:45678") != null);
-    try std.testing.expect(std.mem.indexOf(u8, generated_config, "model_provider = \"oauth_mux_openai\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, generated_config, "[model_providers.oauth_mux_openai]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "model_provider = \"openai\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "openai_base_url = \"http://127.0.0.1:45678/backend-api\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "[model_providers.oauth_mux_openai]") == null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "[model_providers.openai]") == null);
     try std.testing.expectEqual(@as(usize, 5), codex_home.experimental_feature_defaults_injected);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "features.terminal_resize_reflow = true") != null);
@@ -3140,15 +3153,17 @@ test "createSessionCodexHomeUnder preserves canonical config behavior settings" 
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "\"gpt-5.5\" = 2") != null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "https://stale.invalid") == null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "model_provider = \"user_provider\"") == null);
-    try std.testing.expect(std.mem.indexOf(u8, generated_config, "model_provider = \"oauth_mux_openai\"") != null);
-    const managed_provider_idx = std.mem.indexOf(u8, generated_config, "model_provider = \"oauth_mux_openai\"").?;
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "model_provider = \"openai\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "openai_base_url = \"http://127.0.0.1:45678/backend-api\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "[model_providers.oauth_mux_openai]") == null);
+    const managed_provider_idx = std.mem.indexOf(u8, generated_config, "model_provider = \"openai\"").?;
     const tui_table_idx = std.mem.indexOf(u8, generated_config, "[tui.model_availability_nux]").?;
     const features_idx = std.mem.indexOf(u8, generated_config, "[features]").?;
     const mcp_idx = std.mem.indexOf(u8, generated_config, "[mcp_servers.design]").?;
     try std.testing.expect(managed_provider_idx < tui_table_idx);
     try std.testing.expect(features_idx < mcp_idx);
     try std.testing.expect(std.mem.indexOf(u8, generated_config[features_idx..mcp_idx], "terminal_resize_reflow = true") != null);
-    try std.testing.expect(std.mem.indexOf(u8, generated_config, "http://127.0.0.1:45678/backend-api/codex") != null);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "http://127.0.0.1:45678/backend-api") != null);
 }
 
 test "config passthrough preserves explicit experimental feature choices" {
@@ -3234,11 +3249,13 @@ test "config passthrough partitions root model provider before trailing table" {
     const generated_config = try std.fs.cwd().readFileAlloc(std.testing.allocator, overlay_config, 8192);
     defer std.testing.allocator.free(generated_config);
 
-    const provider_idx = std.mem.indexOf(u8, generated_config, "model_provider = \"oauth_mux_openai\"").?;
+    const provider_idx = std.mem.indexOf(u8, generated_config, "model_provider = \"openai\"").?;
+    const base_url_idx = std.mem.indexOf(u8, generated_config, "openai_base_url = \"http://127.0.0.1:45678/backend-api\"").?;
     const tui_idx = std.mem.indexOf(u8, generated_config, "[tui.model_availability_nux]").?;
-    const managed_table_idx = std.mem.indexOf(u8, generated_config, "[model_providers.oauth_mux_openai]").?;
     try std.testing.expect(provider_idx < tui_idx);
-    try std.testing.expect(tui_idx < managed_table_idx);
+    try std.testing.expect(provider_idx < base_url_idx);
+    try std.testing.expect(base_url_idx < tui_idx);
+    try std.testing.expect(std.mem.indexOf(u8, generated_config, "[model_providers.oauth_mux_openai]") == null);
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "\"gpt-5.5\" = 2") != null);
 }
 
@@ -3258,7 +3275,7 @@ test "config passthrough strips profile-scoped model_provider overrides" {
         \\experimental_apply_patch = true
         \\
     ;
-    const overridden = try writeConfigPassthrough(std.testing.allocator, buf.writer(std.testing.allocator), source, &feature_defaults, &experimental_feature_defaults_injected, &mcp_stdio_unsupported_fields_removed);
+    const overridden = try writeConfigPassthrough(std.testing.allocator, buf.writer(std.testing.allocator), source, &feature_defaults, &experimental_feature_defaults_injected, &mcp_stdio_unsupported_fields_removed, 45678);
 
     try std.testing.expectEqual(@as(usize, 1), overridden);
     try std.testing.expectEqual(@as(usize, 5), experimental_feature_defaults_injected);
@@ -3283,13 +3300,15 @@ test "forwarded Codex config overrides cannot replace managed provider" {
     const unsafe_argv = [_][]const u8{
         "--config",                                         "model_provider=\"openai\"",
         "--config=profiles.work.model_provider=\"custom\"", "-c=model_providers.oauth_mux_openai.base_url=\"https://example.invalid\"",
+        "-c",                                               "openai_base_url=\"https://example.invalid\"",
         "--model",                                          "gpt-5.5",
     };
     const unsafe = checkForwardedConfigOverrides(&unsafe_argv);
     try std.testing.expect(!unsafe.ok);
-    try std.testing.expectEqual(@as(usize, 3), unsafe.total_config_overrides);
-    try std.testing.expectEqual(@as(usize, 3), unsafe.mux_owned_overrides);
+    try std.testing.expectEqual(@as(usize, 4), unsafe.total_config_overrides);
+    try std.testing.expectEqual(@as(usize, 4), unsafe.mux_owned_overrides);
     try std.testing.expect(unsafe.model_provider_override);
+    try std.testing.expect(unsafe.openai_base_url_override);
     try std.testing.expect(unsafe.managed_provider_override);
 }
 

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -7,10 +7,11 @@
 //! The proxy is the load-bearing piece that lets account swap happen
 //! without restarting the unmodified `codex` child process. It sits at
 //! 127.0.0.1:<dynamic-port> with codex's generated
-//! `model_provider = "oauth_mux_openai"` / custom model provider block
-//! pointed at it (via a generated config.toml in the per-session
-//! CODEX_HOME). Codex 0.128+ rejects overriding the reserved built-in
-//! `openai` provider id, so the adapter must select a custom provider id.
+//! `openai_base_url` pointed at it while keeping Codex's built-in
+//! `model_provider = "openai"` namespace (via a generated config.toml in
+//! the per-session CODEX_HOME). Keeping the built-in provider id is
+//! load-bearing for native resume-picker parity because Codex filters
+//! persisted sessions by `threads.model_provider`.
 //! On every request:
 //!
 //!   1. Read the inbound request from codex.
@@ -1253,7 +1254,9 @@ fn forwardAndStream(
     defer if (!std.mem.eql(u8, scheme, DEFAULT_UPSTREAM_SCHEME)) a.free(scheme);
     const host = upstreamHost(a);
     defer if (!std.mem.eql(u8, host, DEFAULT_UPSTREAM_HOST)) a.free(host);
-    const url = try std.fmt.allocPrint(a, "{s}://{s}{s}", .{ scheme, host, req.path });
+    const upstream_path = try upstreamPathForRequest(a, req.path);
+    defer a.free(upstream_path);
+    const url = try std.fmt.allocPrint(a, "{s}://{s}{s}", .{ scheme, host, upstream_path });
     defer a.free(url);
     const uri = try std.Uri.parse(url);
 
@@ -1314,12 +1317,40 @@ fn forwardAndStream(
 fn pathKind(path: []const u8) []const u8 {
     if (std.mem.eql(u8, path, "/backend-api/codex/responses")) return "responses";
     if (std.mem.startsWith(u8, path, "/backend-api/codex/responses?")) return "responses";
+    if (std.mem.eql(u8, path, "/backend-api/responses")) return "responses";
+    if (std.mem.startsWith(u8, path, "/backend-api/responses?")) return "responses";
     if (std.mem.eql(u8, path, "/backend-api/codex/responses/compact")) return "responses_compact";
     if (std.mem.startsWith(u8, path, "/backend-api/codex/responses/compact?")) return "responses_compact";
+    if (std.mem.eql(u8, path, "/backend-api/responses/compact")) return "responses_compact";
+    if (std.mem.startsWith(u8, path, "/backend-api/responses/compact?")) return "responses_compact";
+    if (std.mem.eql(u8, path, "/backend-api/models")) return "models";
+    if (std.mem.startsWith(u8, path, "/backend-api/models?")) return "models";
+    if (std.mem.eql(u8, path, "/backend-api/codex/models")) return "models";
+    if (std.mem.startsWith(u8, path, "/backend-api/codex/models?")) return "models";
     if (std.mem.indexOf(u8, path, "/backend-api/codex/memories/trace_summarize") != null) return "memories_trace_summarize";
     if (std.mem.indexOf(u8, path, "responses_websockets") != null) return "responses_websocket";
     if (std.mem.startsWith(u8, path, "/backend-api/codex/")) return "codex_other";
     return "unknown";
+}
+
+fn upstreamPathForRequest(a: std.mem.Allocator, path: []const u8) ![]const u8 {
+    if (std.mem.startsWith(u8, path, "/backend-api/codex/")) {
+        return try a.dupe(u8, path);
+    }
+    if (pathHasEndpointPrefix(path, "/backend-api/responses")) {
+        return try std.fmt.allocPrint(a, "/backend-api/codex{s}", .{path["/backend-api".len..]});
+    }
+    if (pathHasEndpointPrefix(path, "/backend-api/models")) {
+        return try std.fmt.allocPrint(a, "/backend-api/codex{s}", .{path["/backend-api".len..]});
+    }
+    return try a.dupe(u8, path);
+}
+
+fn pathHasEndpointPrefix(path: []const u8, endpoint: []const u8) bool {
+    if (std.mem.eql(u8, path, endpoint)) return true;
+    if (!std.mem.startsWith(u8, path, endpoint)) return false;
+    if (path.len <= endpoint.len) return false;
+    return path[endpoint.len] == '?' or path[endpoint.len] == '/';
 }
 
 fn classifyHttpErrorBody(body: []const u8) []const u8 {
@@ -1708,11 +1739,39 @@ test "classify 401 -> auth_unauthorized" {
 test "pathKind redacts Codex endpoint paths into stable classes" {
     try std.testing.expectEqualStrings("responses", pathKind("/backend-api/codex/responses"));
     try std.testing.expectEqualStrings("responses", pathKind("/backend-api/codex/responses?after=1"));
+    try std.testing.expectEqualStrings("responses", pathKind("/backend-api/responses"));
+    try std.testing.expectEqualStrings("responses", pathKind("/backend-api/responses?after=1"));
     try std.testing.expectEqualStrings("responses_compact", pathKind("/backend-api/codex/responses/compact"));
     try std.testing.expectEqualStrings("responses_compact", pathKind("/backend-api/codex/responses/compact?after=1"));
+    try std.testing.expectEqualStrings("responses_compact", pathKind("/backend-api/responses/compact"));
+    try std.testing.expectEqualStrings("responses_compact", pathKind("/backend-api/responses/compact?after=1"));
+    try std.testing.expectEqualStrings("models", pathKind("/backend-api/models?client_version=0.132.0"));
+    try std.testing.expectEqualStrings("models", pathKind("/backend-api/codex/models?client_version=0.132.0"));
     try std.testing.expectEqualStrings("memories_trace_summarize", pathKind("/backend-api/codex/memories/trace_summarize"));
     try std.testing.expectEqualStrings("codex_other", pathKind("/backend-api/codex/unknown/shape"));
     try std.testing.expectEqualStrings("unknown", pathKind("/not-codex"));
+}
+
+test "upstreamPathForRequest maps built-in openai provider paths to Codex upstream" {
+    const responses = try upstreamPathForRequest(std.testing.allocator, "/backend-api/responses?after=1");
+    defer std.testing.allocator.free(responses);
+    try std.testing.expectEqualStrings("/backend-api/codex/responses?after=1", responses);
+
+    const compact = try upstreamPathForRequest(std.testing.allocator, "/backend-api/responses/compact");
+    defer std.testing.allocator.free(compact);
+    try std.testing.expectEqualStrings("/backend-api/codex/responses/compact", compact);
+
+    const models = try upstreamPathForRequest(std.testing.allocator, "/backend-api/models?client_version=0.132.0");
+    defer std.testing.allocator.free(models);
+    try std.testing.expectEqualStrings("/backend-api/codex/models?client_version=0.132.0", models);
+
+    const already_codex = try upstreamPathForRequest(std.testing.allocator, "/backend-api/codex/responses");
+    defer std.testing.allocator.free(already_codex);
+    try std.testing.expectEqualStrings("/backend-api/codex/responses", already_codex);
+
+    const adjacent = try upstreamPathForRequest(std.testing.allocator, "/backend-api/responses_websockets");
+    defer std.testing.allocator.free(adjacent);
+    try std.testing.expectEqualStrings("/backend-api/responses_websockets", adjacent);
 }
 
 const TestSinkWriter = struct {


### PR DESCRIPTION
Closes #294.

## Summary

- keep managed Codex in the native `openai` provider namespace so Codex's resume picker sees the same `threads.model_provider` rows as native Codex
- route the managed child through oauth-mux with mux-owned `openai_base_url` instead of a shadow `[model_providers.oauth_mux_openai]` table
- map built-in OpenAI-provider Codex paths (`/backend-api/responses`, `/backend-api/models`) to the ChatGPT Codex upstream shape under `/backend-api/codex/...`
- update smoke/stub assertions and specs, plus this week's sprint queue

## Validation

- `python3 -m py_compile scripts/test-stub-codex.py`
- `zig fmt --check src/adapters/codex/main.zig src/adapters/codex/wire_proxy.zig`
- `git diff --check`
- `just test`
- `just smoke-codex-cli-ux-local`
- `just install-local-dogfood`
- live native vs managed `codex resume --no-alt-screen` from `/Users/jess/git/blahaj` showed the same `[Cwd]` picker rows
- no-spend `oauth-mux codex preflight --profile codex-max --capability codex-max --json`
- no-spend `oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json`

## Notes

`v0.1.11` is already behind this fix. A public/Home Manager lane should consume a clean ref that includes this PR rather than the existing `v0.1.11` tag.
