### PR TITLE
Refresh 0.1.12 release truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,14 @@ diagnostic infrastructure. They are not product success.
 
 ## Current Truth
 
-Public install lanes are versioned by channel. This source tree is staged as
-`0.1.12`, carrying the Codex 0.132 SQLite resume authority fix, the Codex
-capture-review proxy metadata gate, and the provider-namespace resume picker
-fix from PR #295. The currently verified public release is `0.1.11` for GitHub
-Release, curl installer, deb/rpm assets, and Homebrew, but `0.1.11` predates
-the PR #295 resume picker fix. npm still reports `0.1.9` until CI npm auth is
-repaired. After `v0.1.12` is tagged, verify each public lane before using it as
-installed truth. Homebrew remains binary-only by default:
-`brew install jesssullivan/omux/oauth-mux` installs `oauth-mux` and must not
-install or link a managed `codex` shim.
+Public install lanes are versioned by channel. `0.1.12` is the current verified
+public release for GitHub Release, curl installer, deb/rpm assets, Homebrew,
+user-local dogfood, and the Home Manager source lane. It carries the Codex
+0.132 SQLite resume authority fix, the Codex capture-review proxy metadata
+gate, and the provider-namespace resume picker fix from PR #295. npm still
+reports `0.1.9` until CI npm auth is repaired. Homebrew remains binary-only by
+default: `brew install jesssullivan/omux/oauth-mux` installs `oauth-mux` and
+must not install or link a managed `codex` shim.
 
 What works today:
 

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -8,33 +8,34 @@ refreshed when release truth, route evidence, or tracker state changes.
 
 ## Current Snapshot
 
-- Repo state: `main` matches `origin/main` at `a38f4f3`, including the
+- Release state: `v0.1.12` points at `38ac7e0`, including the
   BrokenPipe/client-disconnect hardening from PR #279, the Codex 0.132 SQLite
   resume authority fix from PR #289, the Codex capture-review proxy metadata
   gate from PR #290, the `0.1.11` release from PR #291, the post-release
   capture cookie redaction hardening from PR #292, and the provider-namespace
-  resume picker parity fix from PR #295.
+  resume picker parity fix from PR #295, followed by the `0.1.12` release prep
+  from PR #296.
 - CI/release state: GitHub Actions is the live source for release proof. Release
-  workflow `26463502300` published `v0.1.11`; release assets are present and
-  the public GitHub Release is non-draft/non-prerelease. `v0.1.11` predates
-  PR #295, so `0.1.12` is the next required public release before public
-  install lanes can claim native/managed resume picker parity. npm
-  dry-run/publish remains blocked/stale; npm `latest` still reports `0.1.9`.
+  workflow `26469045026` published `v0.1.12`; release assets are present and
+  the public GitHub Release is non-draft/non-prerelease. npm dry-run/publish
+  remains blocked/stale; npm `latest` still reports `0.1.9`.
 - Version truth: source version is `0.1.12`. GitHub Release, curl installer
-  assets, deb/rpm assets, and the public Homebrew tap currently resolve to
-  `0.1.11`. npm remains stale at `0.1.9`. The Homebrew formula remains
-  binary-only by default and must not install or link a managed `codex` shim.
+  assets, deb/rpm assets, public Homebrew tap, user-local dogfood, and the lab
+  Home Manager source lane resolve to `0.1.12`. npm remains stale at `0.1.9`.
+  The Homebrew formula remains binary-only by default and must not install or
+  link a managed `codex` shim.
 - Installed provenance: user-local dogfood is PATH-first in the oauth-mux repo
-  shell and reports the post-PR #295 source build; Homebrew also reports
-  `0.1.11`. Continue checking `which -a oauth-mux`, `which -a codex`,
+  shell and reports `0.1.12` with build id `v0.1.12`; Homebrew also reports
+  `0.1.12`. Continue checking `which -a oauth-mux`, `which -a codex`,
   `oauth-mux version --json`, and `codex preflight` before treating any
   installed-command run as release evidence.
 - Homebrew truth: the public `jesssullivan/omux` tap advertises `oauth-mux
-  0.1.11`, the local linked keg is `0.1.11`, and
-  `brew fetch --force jesssullivan/omux/oauth-mux` passes after tap PR #8 fixed
-  stale `0.1.11` checksums. Homebrew is a binary-only package lane by default:
-  QA must prove it installs `oauth-mux`, does not install an
-  `OMUX_CODEX_SHIM`, and leaves native `codex` command resolution unchanged.
+  0.1.12`, the local linked keg is `0.1.12`, and
+  `brew fetch --force jesssullivan/omux/oauth-mux` passes after tap PR #10
+  corrected checksums against the published GitHub Release artifacts.
+  Homebrew is a binary-only package lane by default: QA must prove it installs
+  `oauth-mux`, does not install an `OMUX_CODEX_SHIM`, and leaves native `codex`
+  command resolution unchanged.
 - Codex route truth: the 2026-05-26 no-spend preflight uses user-local
   post-PR #295 oauth-mux and native Codex outside oauth-mux. It reports
   `ok:true`, `session_start_ready:true`, `fallback_ready:true`,
@@ -68,7 +69,7 @@ refreshed when release truth, route evidence, or tracker state changes.
 | Managed Codex launch/resume | Live-proven | Reference adapter path for `oauth-mux codex` and `oauth-mux codex resume`. |
 | Codex quota handoff | Live-proven for managed Codex | Strongest preserved proof lives in `docs/evidence/codex-engineered-quota-handoff-20260509/`. |
 | Session authority bridge | Implemented | Managed auth/config overlays bridge canonical Codex session authority, including `state_5.sqlite*` and `logs_2.sqlite*` when present, with canonical `CODEX_SQLITE_HOME` for Codex 0.132+. |
-| Resume picker namespace parity | Implemented in source | PR #295 keeps managed Codex on the built-in `openai` provider namespace while routing through mux via `openai_base_url`, so native and managed `codex resume` enumerate the same provider-filtered session rows. Public packages need `0.1.12` before this can be claimed for installed lanes. |
+| Resume picker namespace parity | Published | PR #295 keeps managed Codex on the built-in `openai` provider namespace while routing through mux via `openai_base_url`, so native and managed `codex resume` enumerate the same provider-filtered session rows. Published in `0.1.12`. |
 | Config/TOML preservation | Implemented | Root-partitioned Codex config passthrough keeps user settings, MCP servers, profiles, model defaults, approval/sandbox policy, and non-managed provider definitions. |
 | Experimental Codex settings injection | Implemented | Defaults can be injected without treating user config as disposable. |
 | Native Codex shim pass-through | Implemented | Admin/login/help/version paths bypass route election and exec native Codex. Public Homebrew remains binary-only and must not install the shim by default. |
@@ -137,17 +138,18 @@ tracker mismatch, then later sidecar and non-Codex provider work.
 
 ## Release And Distribution Posture
 
-`0.1.11` is the current verified public release. It carries Codex 0.132 resume
-authority parity for `logs_2.sqlite*` / `CODEX_SQLITE_HOME` and the #176
-capture-review `--require-proxy-meta` gate, but it does not carry PR #295's
-provider-namespace resume picker fix. `0.1.12` is the next release candidate
-for public install lanes. Run `just release-proof 0.1.12` before any tag,
-registry, or tap mutation. GitHub Release `v0.1.11` remains published and
-non-draft with 23 assets. The public Homebrew tap is fixed for the published
-`0.1.11` asset checksums; local `brew fetch --force
-jesssullivan/omux/oauth-mux` passes. npm publication remains blocked/stale;
-npm `latest` still reports `0.1.9`. Negative Codex cassettes, broader adapter
-proof, and daemon beta truth remain follow-up work.
+`0.1.12` is the current verified public release. It carries Codex 0.132 resume
+authority parity for `logs_2.sqlite*` / `CODEX_SQLITE_HOME`, the #176
+capture-review `--require-proxy-meta` gate, and PR #295's provider-namespace
+resume picker fix. `just release-proof 0.1.12` passed before tag/release
+mutation, and release workflow `26469045026` published GitHub Release
+`v0.1.12` as non-draft/non-prerelease with 23 assets. The public Homebrew tap
+is updated to `0.1.12`, `brew fetch --force jesssullivan/omux/oauth-mux`
+passes, and the local Homebrew keg reports `0.1.12`. Lab PR #507 pins the Home
+Manager source lane to the same release commit with `codexShim` disabled. npm
+publication remains blocked/stale; npm `latest` still reports `0.1.9`.
+Negative Codex cassettes, broader adapter proof, and daemon beta truth remain
+follow-up work.
 Windows managed-`codex` parity is intentionally assigned to the npm wrapper
 lane rather than raw tarballs until a native Windows operator need is proven.
 Future public install copy must avoid claiming a version or lane behavior until
@@ -178,7 +180,7 @@ browser is needed; local Playwright is not part of this CLI proof path.
 | Harness session authority bridge | TIN-979 / TIN-1624 | #191 / #288 | Closed for the original Codex bridge, with TIN-1624/#288 covering the Codex 0.132 `logs_2.sqlite*` / `CODEX_SQLITE_HOME` parity regression. Managed auth/config overlays bridge canonical session authority and root config while rejecting silent session-store import/copy. Future cross-harness authority work stays under #67/#68. |
 | Codex session-store portability | TIN-936 | #161 | Policy is explicit: canonical bridge is supported; silent route-local session import/copy is rejected until a separate confirmed import command exists. |
 | OTEL-friendly tracing | TIN-1148 | PR #225/#226 lineage | Implemented trace schema should become the standard support-bundle path. |
-| Package parity and install lanes | TIN-1255 | #252 | `0.1.11` is published and verified across GitHub Release, Homebrew, curl installer assets, and deb/rpm release assets, but it predates PR #295; `0.1.12` is required for public resume picker parity. npm remains stale at `0.1.9`. |
+| Package parity and install lanes | TIN-1255 | #252 | `0.1.12` is published and verified across GitHub Release, Homebrew, curl installer assets, deb/rpm release assets, user-local dogfood, and lab Home Manager source pin; npm remains stale at `0.1.9`. |
 | Home Manager and Windows shim parity | not assigned | #257 | Home Manager source lane is implemented with opt-in shim; Windows raw tarballs stay binary-only and npm is the managed-shim lane. |
 | Provider proof beyond Codex | TIN-736 | #68 | Claude next; other agents stay adapter-candidate only. |
 | Website truth refresh | TIN-734 / TIN-925 | external site repo | `omux.xoxd.ai` source lives outside this repo and must be refreshed from the ledger, QA matrix, and install-lane docs. |

--- a/docs/spec/oauth-mux-this-week-sprint-2026-05-26.md
+++ b/docs/spec/oauth-mux-this-week-sprint-2026-05-26.md
@@ -8,10 +8,9 @@ Status: active sprint todo list; subordinate to `AGENTS.md`,
 
 ## Sprint Goal
 
-Convert the post-`0.1.11` fixes into reliable next evidence: a `0.1.12`
-release for resume picker parity, clean dogfood baselines, real Codex cassette
-coverage, and a disciplined backlog that does not expand public claims ahead
-of proof.
+Convert the `0.1.12` release into reliable next evidence: clean dogfood
+baselines, real Codex cassette coverage, and a disciplined backlog that does
+not expand public claims ahead of proof.
 
 The product anchor stays unchanged: `oauth-mux codex` must keep a managed
 Codex harness usable when auth, quota, tier, or local runtime state changes.
@@ -22,11 +21,9 @@ support are not success metrics.
 
 - Before this P0 branch, `oauth-mux` main was clean and synced to
   `origin/main`.
-- Public release `v0.1.11` is published and verified for GitHub Release,
-  Homebrew, user-local dogfood, curl installer assets, and deb/rpm assets, but
-  it predates PR #295's provider-namespace resume picker fix.
-- Source is staged as `0.1.12` for that fix; run `just release-proof 0.1.12`
-  before any tag, registry, or tap mutation.
+- Public release `v0.1.12` is published and verified for GitHub Release,
+  Homebrew, user-local dogfood, curl installer assets, deb/rpm assets, and the
+  lab Home Manager source pin.
 - npm remains stale at `0.1.9`; do not claim npm `0.1.12`.
 - Current no-spend Codex preflight reports `fallback_ready:true`,
   `selectable_fallback_routes:2`, `session_start_ready:true`,
@@ -210,9 +207,8 @@ Priority: P1.
 
 Completion metric:
 
-- Current-state docs consistently say `0.1.11` is published for GitHub Release
-  and Homebrew but predates PR #295; `0.1.12` is required for public resume
-  picker parity, while npm is stale at `0.1.9`.
+- Current-state docs consistently say `0.1.12` is published for GitHub Release
+  and Homebrew, while npm is stale at `0.1.9`.
 - Historical snapshots remain clearly historical.
 - `SHA256SUMS.full` semantics are explicit before `0.1.12`: it remains a
   checksum manifest for publishable payloads listed in `publish-files.txt`, not


### PR DESCRIPTION
## Summary
- update current-truth docs now that v0.1.12 is published
- record Homebrew, user-local dogfood, and lab Home Manager source pin as verified 0.1.12 lanes
- keep npm explicitly stale at 0.1.9

## Verification
- git diff --check
- rg stale 0.1.11 staged/current-release phrases over README and release truth docs

Linear: none; post-release documentation truth pass after #296.