### PR TITLE
Gate Codex wire fixture promotion

### DIFF
--- a/docs/spec/codex-wire-evidence-2026-05-03.md
+++ b/docs/spec/codex-wire-evidence-2026-05-03.md
@@ -98,6 +98,38 @@ confirm the shapes themselves match upstream reality.
   same day are not fixture candidates because response cookies were not
   yet redacted in per-flow JSON.
 
+2026-05-26 current-release auth-failure capture:
+
+- Capture run directory: `captures/codex-wire-20260526T193856Z/`
+  (ignored; raw `flows.binary` not committed).
+- Capture path: `codex exec` through mitmproxy with `SSL_CERT_FILE`
+  pointed at the mitmproxy CA, after a same-run proxy preflight.
+- oauth-mux provenance: user-local `0.1.12`, build id `v0.1.12`,
+  SHA256 `caa5fb51a34eed5f01ba52e494b14baaf62b4631450a4f33ec6333c04b804787`.
+- Preflight: `ok:true`, `fallback_ready:true`,
+  `single_route_at_risk:false`, `selectable_fallback_routes:2`.
+- Review gate:
+  ```bash
+  scripts/capture-codex-wire.sh review captures/codex-wire-20260526T193856Z \
+    --require-preflight-ok \
+    --require-proxy-meta \
+    --require-path-kind responses \
+    --require-status 401 \
+    --json
+  ```
+- Review result after the local-path gate: `ok:true`, 11 flows, path counts
+  `responses:4`, `oauth_token:2`, `codex_other:1`, `other:4`; status counts
+  `401:11`; no malformed, redaction, or requirement failures.
+- Observed auth shape: `/oauth/token` returned
+  `invalid_request_error` / `refresh_token_reused`; repeated
+  `/backend-api/codex/responses` WebSocket upgrade attempts returned
+  `401 token_expired`.
+- Hygiene note: an earlier scratch run
+  `captures/codex-wire-20260526T193558Z/` exposed that
+  `x-codex-turn-metadata` can include local workspace paths in per-flow JSON.
+  The current capture was taken after the addon redaction fix and passed the
+  local-path review gate.
+
 ## Capture Promotion Checklist
 
 Before any captured flow is committed as a cassette or cited as live
@@ -131,7 +163,9 @@ evidence:
    are empty.
 5. Manually inspect the fixture-sized JSON selected for promotion.
    The reviewer catches obvious token/JWT/API-key strings; it is not a
-   formal proof that all account-identifying material is gone.
+   formal proof that all account-identifying material is gone. It also
+   rejects obvious local home/tmp paths because Codex turn metadata can
+   include workspace paths.
 6. Textual non-JSON responses such as `text/event-stream` may include
    `body_text` so the cassette replayer can serve realistic SSE frames.
    Keep only reviewed, fixture-sized text bodies and remove prompt,

--- a/docs/spec/oauth-mux-this-week-sprint-2026-05-26.md
+++ b/docs/spec/oauth-mux-this-week-sprint-2026-05-26.md
@@ -135,9 +135,15 @@ Known evidence:
 
 - Clean scratch capture `captures/codex-wire-20260526T171741Z` exists locally
   and is gitignored.
+- Current-release auth-failure scratch capture
+  `captures/codex-wire-20260526T193856Z` exists locally and is gitignored;
+  it observed `refresh_token_reused` on `/oauth/token` and `token_expired`
+  on `/backend-api/codex/responses`, with same-run proxy metadata and no
+  review failures after the local-path redaction addon fix.
 - Codex 0.132 `/backend-api/codex/responses` was observed as a WebSocket `101`,
   not a simple `200` SSE-only path.
 - Cookie and `Set-Cookie` redaction is now review-gated after PR `#292`.
+- Local workspace path redaction is review-gated before fixture promotion.
 - No quota/exhaustion shapes have been captured yet.
 
 Todos:
@@ -149,6 +155,7 @@ Todos:
   capacity, not from a single-route-at-risk state.
 - [ ] Promote the smallest scrubbed fixture that proves the real path shape.
 - [ ] Add or extend CI-safe replay smoke coverage for the scrubbed fixture.
+- [x] Gate obvious local home/tmp paths before any cassette fixture promotion.
 - [ ] Reconcile `TIN-950` Done versus GitHub `#176` open after the fixture and
   error-shape decision are recorded.
 

--- a/scripts/codex-wire-addon.py
+++ b/scripts/codex-wire-addon.py
@@ -13,6 +13,7 @@ Redactions:
   - Cookie and Set-Cookie values: keep names only, replace values with
     "<redacted>"
   - ChatGPT-Account-ID: keep first 6 chars + sha256(value)[:10]
+  - Local home/tmp paths: replace with "~" or "<tmp>"
   - Body fields tokens.access_token / refresh_token / id_token: replace
     with sha256(value)[:10] (so swap-correctness can be argued from the
     capture without leaking material)
@@ -64,6 +65,17 @@ def _hash10(s: str) -> str:
     return hashlib.sha256(s.encode("utf-8")).hexdigest()[:10]
 
 
+def _redact_text(value: str) -> str:
+    out = value
+    home = os.environ.get("HOME")
+    if home:
+        out = out.replace(home, "~")
+    tmpdir = os.environ.get("TMPDIR")
+    if tmpdir:
+        out = out.replace(tmpdir.rstrip("/"), "<tmp>")
+    return out.replace("/private/tmp/", "<tmp>/").replace("/tmp/", "<tmp>/")
+
+
 def _redact_header(name: str, value: str) -> str:
     name_low = name.lower()
     if name_low == "authorization":
@@ -88,7 +100,7 @@ def _redact_header(name: str, value: str) -> str:
         return f"{name}=<redacted>"
     if name_low == "chatgpt-account-id":
         return f"{value[:6]}-<{_hash10(value)}>"
-    return value
+    return _redact_text(value)
 
 
 def _redact_obj(node: Any) -> Any:
@@ -102,6 +114,8 @@ def _redact_obj(node: Any) -> Any:
         return out
     if isinstance(node, list):
         return [_redact_obj(x) for x in node]
+    if isinstance(node, str):
+        return _redact_text(node)
     return node
 
 

--- a/scripts/review-codex-wire-capture.py
+++ b/scripts/review-codex-wire-capture.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -24,6 +25,21 @@ TOKEN_PATTERNS = [
 ]
 
 COOKIE_HEADERS = {"cookie", "set-cookie"}
+
+
+def _local_path_patterns() -> list[re.Pattern[str]]:
+    patterns = [
+        re.compile(r"/Users/[A-Za-z0-9._-]+(?:/[^\s\"']*)?"),
+        re.compile(r"/home/[A-Za-z0-9._-]+(?:/[^\s\"']*)?"),
+        re.compile(r"/private/tmp/[^\s\"']+"),
+        re.compile(r"/tmp/[^\s\"']+"),
+        re.compile(r"/private/var/folders/[^\s\"']+"),
+        re.compile(r"/var/folders/[^\s\"']+"),
+    ]
+    home = os.environ.get("HOME")
+    if home:
+        patterns.insert(0, re.compile(re.escape(home) + r"(?:/[^\s\"']*)?"))
+    return patterns
 
 
 def _walk_strings(node: Any):
@@ -114,6 +130,7 @@ def main() -> int:
     path_counts: dict[str, int] = {}
     status_counts: dict[str, int] = {}
     quota_shapes: list[dict[str, Any]] = []
+    local_path_patterns = _local_path_patterns()
 
     for p in sorted(http_dir.glob("*.json")):
         try:
@@ -146,6 +163,10 @@ def main() -> int:
             for pat in TOKEN_PATTERNS:
                 if pat.search(s):
                     redaction_failures.append(f"{p.name}: possible secret-like value matched {pat.pattern}")
+                    break
+            for pat in local_path_patterns:
+                if pat.search(s):
+                    redaction_failures.append(f"{p.name}: local path is not redacted")
                     break
         for side, name, value in _iter_headers(record):
             if name.lower() in COOKIE_HEADERS and "<redacted>" not in value:

--- a/scripts/smoke-codex-capture-review.sh
+++ b/scripts/smoke-codex-capture-review.sh
@@ -132,6 +132,26 @@ assert shape["plan_type"] == "pro", shape
 assert summary["requirement_failures"] == [], summary
 PY
 
+FIXTURE="$ROOT/test/fixtures/codex-wire/auth-refresh-token-expired"
+"$ROOT/scripts/capture-codex-wire.sh" review "$FIXTURE" \
+  --require-preflight-ok \
+  --require-proxy-meta \
+  --require-path-kind responses \
+  --require-status 401 \
+  --json >"$TMP/auth-failure-fixture-summary.json"
+
+python3 - "$TMP/auth-failure-fixture-summary.json" <<'PY'
+import json
+import sys
+summary = json.load(open(sys.argv[1]))
+assert summary["ok"] is True, summary
+assert summary["flow_count"] == 2, summary
+assert summary["path_counts"]["oauth_token"] == 1, summary
+assert summary["path_counts"]["responses"] == 1, summary
+assert summary["status_counts"]["401"] == 2, summary
+assert summary["redaction_failures"] == [], summary
+PY
+
 BAD_META="$TMP/codex-wire-bad-meta"
 mkdir -p "$BAD_META/http"
 cp "$TMP/codex-wire-synth/capture-preflight-summary.json" "$BAD_META/capture-preflight-summary.json"
@@ -262,6 +282,49 @@ assert summary["ok"] is False, summary
 failures = "\n".join(summary["redaction_failures"])
 assert "request Cookie header is not redacted" in failures, summary
 assert "response Set-Cookie header is not redacted" in failures, summary
+PY
+
+BAD_LOCAL_PATH="$TMP/codex-wire-bad-local-path"
+mkdir -p "$BAD_LOCAL_PATH/http"
+cp "$TMP/codex-wire-synth/capture-preflight-summary.json" "$BAD_LOCAL_PATH/capture-preflight-summary.json"
+cp "$TMP/codex-wire-synth/meta.json" "$BAD_LOCAL_PATH/meta.json"
+cat >"$BAD_LOCAL_PATH/http/00001-GET-backend-api_codex_responses.json" <<'JSON'
+{
+  "captured_at": 1788000003.0,
+  "host": "chatgpt.com",
+  "scheme": "https",
+  "method": "GET",
+  "path": "/backend-api/codex/responses",
+  "request": {
+    "headers": [
+      ["x-codex-turn-metadata", "{\"workspaces\":{\"/Users/jess/git/oauth-mux\":{\"has_changes\":false}}}"]
+    ],
+    "body": {}
+  },
+  "response": {
+    "status": 401,
+    "reason": "Unauthorized",
+    "headers": [["content-type", "application/json"]],
+    "body": {
+      "error": {"code": "token_expired"}
+    }
+  },
+  "timing_ms": 1
+}
+JSON
+
+if python3 "$ROOT/scripts/review-codex-wire-capture.py" "$BAD_LOCAL_PATH" --json >"$TMP/bad-local-path-summary.json"; then
+  echo "smoke-codex-capture-review: expected unredacted local path fixture to fail" >&2
+  exit 1
+fi
+
+python3 - "$TMP/bad-local-path-summary.json" <<'PY'
+import json
+import sys
+summary = json.load(open(sys.argv[1]))
+assert summary["ok"] is False, summary
+failures = "\n".join(summary["redaction_failures"])
+assert "local path is not redacted" in failures, summary
 PY
 
 BIN="$TMP/bin"

--- a/scripts/smoke-codex-cassette-replay.sh
+++ b/scripts/smoke-codex-cassette-replay.sh
@@ -193,3 +193,72 @@ print("smoke-codex-cassette-replay: all 12 assertions passed.")
 print(f"  cassette dir: {portfile.parent / 'cassette'}")
 print(f"  replay log: {logfile}")
 PY
+
+kill "$SERVER_PID" 2>/dev/null || true
+wait "$SERVER_PID" 2>/dev/null || true
+unset SERVER_PID
+
+FIXTURE="$ROOT/test/fixtures/codex-wire/auth-refresh-token-expired/http"
+FIXTURE_PORTFILE="$TMP/auth-fixture.port"
+FIXTURE_LOGFILE="$TMP/auth-fixture.log"
+FIXTURE_ERR="$TMP/auth-fixture.stderr"
+
+OMUX_CASSETTE_DIR="$FIXTURE" \
+  OMUX_STUB_PORT=0 \
+  OMUX_STUB_PORTFILE="$FIXTURE_PORTFILE" \
+  OMUX_STUB_LOGFILE="$FIXTURE_LOGFILE" \
+  python3 "$ROOT/scripts/test-cassette-upstream.py" 2>"$FIXTURE_ERR" &
+SERVER_PID=$!
+
+python3 - "$FIXTURE_PORTFILE" "$FIXTURE_LOGFILE" "$FIXTURE_ERR" <<'PY'
+import http.client
+import json
+import pathlib
+import sys
+import time
+
+portfile = pathlib.Path(sys.argv[1])
+logfile = pathlib.Path(sys.argv[2])
+server_err = pathlib.Path(sys.argv[3])
+
+deadline = time.monotonic() + 5
+while time.monotonic() < deadline:
+    if portfile.exists() and portfile.read_text().strip():
+        break
+    time.sleep(0.05)
+else:
+    print("smoke-codex-cassette-replay: auth fixture server did not write port", file=sys.stderr)
+    print(server_err.read_text() if server_err.exists() else "", file=sys.stderr)
+    raise SystemExit(1)
+
+port = int(portfile.read_text().strip())
+
+def request(method: str, path: str):
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    try:
+        conn.request(method, path, body=b"{}" if method == "POST" else None)
+        resp = conn.getresponse()
+        body = resp.read().decode("utf-8", "replace")
+        return resp.status, body
+    finally:
+        conn.close()
+
+status1, body1 = request("POST", "/oauth/token")
+assert status1 == 401, (status1, body1)
+assert json.loads(body1)["error"]["code"] == "redacted_refresh_reused", body1
+
+status2, body2 = request("GET", "/backend-api/codex/responses")
+assert status2 == 401, (status2, body2)
+err = json.loads(body2)["error"]
+assert err["code"] == "token_expired", err
+
+deadline = time.monotonic() + 2
+while True:
+    records = [json.loads(line) for line in logfile.read_text().splitlines() if line.strip()]
+    if len(records) >= 2 or time.monotonic() >= deadline:
+        break
+    time.sleep(0.02)
+assert [r["status_replayed"] for r in records if r.get("match") is True] == [401, 401], records
+
+print("smoke-codex-cassette-replay: auth failure fixture replay passed.")
+PY

--- a/test/fixtures/codex-wire/auth-refresh-token-expired/capture-preflight-summary.json
+++ b/test/fixtures/codex-wire/auth-refresh-token-expired/capture-preflight-summary.json
@@ -1,0 +1,16 @@
+{
+  "ok": true,
+  "issues": [],
+  "warnings": [],
+  "oauth_mux": {
+    "version": "0.1.12",
+    "build_id": "v0.1.12",
+    "binary_source": "user_local"
+  },
+  "route_summary": {
+    "session_start_ready": true,
+    "fallback_ready": true,
+    "single_route_at_risk": false,
+    "selectable_fallback_routes": 2
+  }
+}

--- a/test/fixtures/codex-wire/auth-refresh-token-expired/http/00001-POST-oauth_exchange.json
+++ b/test/fixtures/codex-wire/auth-refresh-token-expired/http/00001-POST-oauth_exchange.json
@@ -1,0 +1,118 @@
+{
+  "captured_at": 1779824348.660991,
+  "host": "auth.openai.com",
+  "scheme": "https",
+  "method": "POST",
+  "path": "/oauth/token",
+  "request": {
+    "headers": [
+      [
+        "content-type",
+        "application/json"
+      ],
+      [
+        "accept",
+        "*/*"
+      ],
+      [
+        "originator",
+        "codex_exec"
+      ],
+      [
+        "user-agent",
+        "codex_exec/0.132.0 (Mac OS 26.5.0; arm64) ghostty/1.3.2-HEAD-_ff6e126"
+      ],
+      [
+        "content-length",
+        "182"
+      ]
+    ],
+    "body": {
+      "client_id": "<redacted-public-client-id>",
+      "grant_type": "<redacted>"
+    }
+  },
+  "response": {
+    "status": 401,
+    "reason": "",
+    "headers": [
+      [
+        "date",
+        "Tue, 26 May 2026 19:39:08 GMT"
+      ],
+      [
+        "content-type",
+        "application/json"
+      ],
+      [
+        "content-length",
+        "231"
+      ],
+      [
+        "server",
+        "cloudflare"
+      ],
+      [
+        "openai-version",
+        "2020-10-01"
+      ],
+      [
+        "x-request-id",
+        "08a3605a-c3e7-4595-9541-95486f79bb3f"
+      ],
+      [
+        "openai-processing-ms",
+        "21"
+      ],
+      [
+        "x-content-type-options",
+        "nosniff"
+      ],
+      [
+        "x-openai-proxy-wasm",
+        "v0.1"
+      ],
+      [
+        "set-cookie",
+        "unified_session_manifest=<redacted>"
+      ],
+      [
+        "timing-allow-origin",
+        "*"
+      ],
+      [
+        "cf-cache-status",
+        "DYNAMIC"
+      ],
+      [
+        "strict-transport-security",
+        "max-age=31536000; includeSubDomains; preload"
+      ],
+      [
+        "nel",
+        "{\"report_to\":\"cf-nel\",\"success_fraction\":0.1,\"max_age\":604800}"
+      ],
+      [
+        "report-to",
+        "{\"group\":\"cf-nel\",\"max_age\":604800,\"endpoints\":[{\"url\":\"https://a.nel.cloudflare.com/report/v4?s=vWbl9DG9r0Mwerk4hGdnZKr%2FhuVPPSsSYleQJ0mRgZQNelhLauEZ4psKPqWz9NyZBiRPIQuEEMy3ffFFvbO%2FBVqCCV9jhMw1NR9eXVASApTPSTV4mOVQc5XGs6AK4FXOzg%3D%3D\"}]}"
+      ],
+      [
+        "cf-ray",
+        "a01f3e832bfd1275-BOS"
+      ],
+      [
+        "alt-svc",
+        "h3=\":443\"; ma=86400"
+      ]
+    ],
+    "body": {
+      "error": {
+        "message": "Your OAuth refresh credential has already been used. Please try signing in again.",
+        "type": "invalid_request_error",
+        "param": null,
+        "code": "redacted_refresh_reused"
+      }
+    }
+  },
+  "timing_ms": 59
+}

--- a/test/fixtures/codex-wire/auth-refresh-token-expired/http/00002-GET-backend-api_codex_responses.json
+++ b/test/fixtures/codex-wire/auth-refresh-token-expired/http/00002-GET-backend-api_codex_responses.json
@@ -1,0 +1,188 @@
+{
+  "captured_at": 1779824355.767891,
+  "host": "chatgpt.com",
+  "scheme": "https",
+  "method": "GET",
+  "path": "/backend-api/codex/responses",
+  "request": {
+    "headers": [
+      [
+        "Host",
+        "chatgpt.com"
+      ],
+      [
+        "Connection",
+        "Upgrade"
+      ],
+      [
+        "Upgrade",
+        "websocket"
+      ],
+      [
+        "Sec-WebSocket-Version",
+        "13"
+      ],
+      [
+        "Sec-WebSocket-Key",
+        "redacted"
+      ],
+      [
+        "chatgpt-account-id",
+        "79b941-<38079d6ace>"
+      ],
+      [
+        "authorization",
+        "<redacted>"
+      ],
+      [
+        "user-agent",
+        "codex_exec/0.132.0 (Mac OS 26.5.0; arm64) ghostty/1.3.2-HEAD-_ff6e126 (codex_exec; 0.132.0)"
+      ],
+      [
+        "originator",
+        "codex_exec"
+      ],
+      [
+        "openai-beta",
+        "responses_websockets=2026-02-06"
+      ],
+      [
+        "version",
+        "0.132.0"
+      ],
+      [
+        "x-codex-beta-features",
+        "terminal_resize_reflow,prevent_idle_sleep"
+      ],
+      [
+        "x-codex-turn-metadata",
+        "{\"session_id\":\"redacted\",\"thread_id\":\"redacted\",\"turn_id\":\"\",\"workspaces\":{\"~/repo\":{\"associated_remote_urls\":{\"origin\":\"redacted\"},\"latest_git_commit_hash\":\"redacted\",\"has_changes\":true}},\"sandbox\":\"seatbelt\"}"
+      ],
+      [
+        "x-client-request-id",
+        "redacted"
+      ],
+      [
+        "session-id",
+        "redacted"
+      ],
+      [
+        "thread-id",
+        "redacted"
+      ],
+      [
+        "x-codex-window-id",
+        "redacted"
+      ],
+      [
+        "sec-websocket-extensions",
+        "permessage-deflate; client_max_window_bits"
+      ]
+    ],
+    "body": {
+      "__non_json__": true,
+      "len": 0,
+      "head_hex": ""
+    }
+  },
+  "response": {
+    "status": 401,
+    "reason": "Unauthorized",
+    "headers": [
+      [
+        "Date",
+        "Tue, 26 May 2026 19:39:15 GMT"
+      ],
+      [
+        "Content-Type",
+        "text/plain"
+      ],
+      [
+        "Content-Length",
+        "191"
+      ],
+      [
+        "Connection",
+        "keep-alive"
+      ],
+      [
+        "x-openai-ide-error-code",
+        "token_expired"
+      ],
+      [
+        "x-openai-authorization-error",
+        "401"
+      ],
+      [
+        "x-error-json",
+        "ewogICJlcnJvciI6IHsKICAgICJtZXNzYWdlIjogIlByb3ZpZGVkIGF1dGhlbnRpY2F0aW9uIHRva2VuIGlzIGV4cGlyZWQuIFBsZWFzZSB0cnkgc2lnbmluZyBpbiBhZ2Fpbi4iLAogICAgInR5cGUiOiBudWxsLAogICAgImNvZGUiOiAidG9rZW5fZXhwaXJlZCIsCiAgICAicGFyYW0iOiBudWxsCiAgfSwKICAic3RhdHVzIjogNDAxCn0="
+      ],
+      [
+        "x-request-id",
+        "c10e77d7-4ad2-4461-9d11-2be750ddc6c2"
+      ],
+      [
+        "x-openai-internal-caller",
+        "unknown_through_ide"
+      ],
+      [
+        "x-openai-proxy-wasm",
+        "v0.1"
+      ],
+      [
+        "cf-cache-status",
+        "DYNAMIC"
+      ],
+      [
+        "Set-Cookie",
+        "__cf_bm=<redacted>"
+      ],
+      [
+        "Report-To",
+        "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=%2Fopwod1nbsMKu4wb%2Bm7lRWp7zl3nieVaT6J3RYaV3Nw0whw2d%2B70S3dKxv1CtA%2FUwb3zPRHybfcTYRaUuG%2BWXxBYrIGqrzUZk6u6YfehC2yGXOFn%2BTt3nxWBxyEb\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+      ],
+      [
+        "NEL",
+        "{\"success_fraction\":0.01,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+      ],
+      [
+        "Strict-Transport-Security",
+        "max-age=31536000; includeSubDomains; preload"
+      ],
+      [
+        "X-Content-Type-Options",
+        "nosniff"
+      ],
+      [
+        "Referrer-Policy",
+        "strict-origin-when-cross-origin"
+      ],
+      [
+        "Cross-Origin-Opener-Policy",
+        "same-origin-allow-popups"
+      ],
+      [
+        "Server",
+        "cloudflare"
+      ],
+      [
+        "CF-RAY",
+        "a01f3eae79a1f5c2-BOS"
+      ],
+      [
+        "alt-svc",
+        "h3=\":443\"; ma=86400"
+      ]
+    ],
+    "body": {
+      "error": {
+        "message": "Provided authentication token is expired. Please try signing in again.",
+        "type": null,
+        "code": "token_expired",
+        "param": null
+      },
+      "status": 401
+    }
+  },
+  "timing_ms": 232
+}

--- a/test/fixtures/codex-wire/auth-refresh-token-expired/meta.json
+++ b/test/fixtures/codex-wire/auth-refresh-token-expired/meta.json
@@ -1,0 +1,11 @@
+{
+  "ts_utc": "20260526T193856Z",
+  "kind": "phase_0_wire_capture",
+  "addon": "scripts/codex-wire-addon.py",
+  "preflight_summary": "capture-preflight-summary.json",
+  "host_filter": "chatgpt.com",
+  "ports": {
+    "http": 9080,
+    "https": 9080
+  }
+}


### PR DESCRIPTION
## Summary

- redact local home/tmp paths in Codex wire addon output before fixture promotion
- make the capture reviewer reject obvious unredacted local paths
- add a scrubbed real auth-failure fixture from the current 0.1.12 capture and replay it in smoke coverage
- update the #176/TIN-950 evidence notes with the current auth-failure capture and remaining quota-cassette gap

Refs #176.

## Validation

- `python3 -m py_compile scripts/review-codex-wire-capture.py scripts/codex-wire-addon.py scripts/test-cassette-upstream.py`
- `./scripts/smoke-codex-capture-review.sh`
- `./scripts/smoke-codex-cassette-replay.sh`
- `scripts/capture-codex-wire.sh review test/fixtures/codex-wire/auth-refresh-token-expired --require-preflight-ok --require-proxy-meta --require-path-kind responses --require-status 401 --json`
- `git diff --check`
- `just test`

## Notes

This does not close #176. It promotes an auth-failure shape and tightens fixture hygiene; quota/exhaustion cassettes are still pending.
