### PR TITLE
Refresh sprint ledger after cassette fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ bazel-*
 
 # Distribution artifacts
 dist/build/
+dist/dogfood/
 dist/out/
 dist/live-qa/
 dist/codex-canary/

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -14,7 +14,9 @@ refreshed when release truth, route evidence, or tracker state changes.
   gate from PR #290, the `0.1.11` release from PR #291, the post-release
   capture cookie redaction hardening from PR #292, and the provider-namespace
   resume picker parity fix from PR #295, followed by the `0.1.12` release prep
-  from PR #296.
+  from PR #296. Main after the release also includes PR #299, which promoted a
+  scrubbed auth-failure cassette fixture and local-path redaction gate; that
+  follow-up is not part of the published `0.1.12` release.
 - CI/release state: GitHub Actions is the live source for release proof. Release
   workflow `26469045026` published `v0.1.12`; release assets are present and
   the public GitHub Release is non-draft/non-prerelease. npm dry-run/publish
@@ -42,10 +44,10 @@ refreshed when release truth, route evidence, or tracker state changes.
   `selectable_fallback_routes:2`, `single_route_at_risk:false`,
   `spends_provider_calls:false`, and `mutates_route_health:false`.
 - Process/fd truth: TIN-1591 remains contained, not resolved. Current snapshots
-  still show active Codex/oauth-mux fanout, a soft fd limit of `256`, and
-  orphan-listener candidates. Treat dogfood evidence as local release/install
-  validation only until repeated clean-baseline snapshots support broader live
-  reliability claims.
+  still show active Codex/oauth-mux fanout, a soft fd limit of `256`, max
+  visible fd use at 73.4% of that limit, and orphan-listener candidates. Treat
+  dogfood evidence as local release/install validation only until repeated
+  clean-baseline snapshots support broader live reliability claims.
 - Daemon truth: `oauth-mux daemon status --json` still reports
   `status:"not_running"`, `contract:"experimental_socket_stub"`, and
   `hosts_stay_afloat:false`; its foreground tick snapshot is observational only
@@ -176,7 +178,7 @@ browser is needed; local Playwright is not part of this CLI proof path.
 | Codex next-turn broker switch | TIN-916 | #131 | Closed for the proven managed Codex live handoff. Remaining negative/permutation work lives in #212/#176; same-thread, mid-turn, and unmanaged daemon behavior remain separate non-claims. |
 | Upstream Codex usage-limit hook | TIN-939 | #164 | Draft proposal written; use it to request a first-class external-auth usage-limit handoff hook while keeping oauth-mux claims scoped to proven managed-proxy behavior. |
 | Live Codex account-swap acceptance | TIN-951 | #177 | Done for managed Codex; strongest preserved proof is `docs/evidence/codex-engineered-quota-handoff-20260509/`. |
-| Wire cassette coverage | TIN-950 | #176 | Still needed before treating negative permutations as stable release proof. Linear currently marks TIN-950 Done while GitHub #176 remains open; reconcile only after real cassette acceptance or an explicit tracker correction. |
+| Wire cassette coverage | TIN-950 | #176 | PR #299 promoted a scrubbed current-release auth-failure fixture and replay smoke. Quota/rate-limit and all-fallbacks-exhausted cassette evidence is still needed before treating negative permutations as stable release proof. Linear currently marks TIN-950 Done while GitHub #176 remains open; reconcile only after real cassette acceptance or an explicit tracker correction. |
 | Harness session authority bridge | TIN-979 / TIN-1624 | #191 / #288 | Closed for the original Codex bridge, with TIN-1624/#288 covering the Codex 0.132 `logs_2.sqlite*` / `CODEX_SQLITE_HOME` parity regression. Managed auth/config overlays bridge canonical session authority and root config while rejecting silent session-store import/copy. Future cross-harness authority work stays under #67/#68. |
 | Codex session-store portability | TIN-936 | #161 | Policy is explicit: canonical bridge is supported; silent route-local session import/copy is rejected until a separate confirmed import command exists. |
 | OTEL-friendly tracing | TIN-1148 | PR #225/#226 lineage | Implemented trace schema should become the standard support-bundle path. |

--- a/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
+++ b/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
@@ -15,10 +15,12 @@ prepared fallback remain diagnostic infrastructure, not the success claim.
 
 ## Current Verified State
 
-- Local upstream `main` is at `0051c57`, after PR #292 tightened capture cookie
-  redaction. PR #289 fixed the Codex 0.132 SQLite resume authority regression,
-  PR #290 added the #176 `--require-proxy-meta` capture gate, and PR #291 cut
-  the `0.1.11` release.
+- Local upstream `main` is at `7a06632`, after PR #299 promoted a scrubbed
+  current-release auth-failure wire fixture and local-path redaction gate.
+  PR #289 fixed the Codex 0.132 SQLite resume authority regression, PR #290
+  added the #176 `--require-proxy-meta` capture gate, PR #291 cut the
+  `0.1.11` release, and PR #296 cut the `0.1.12` release for resume-picker
+  namespace parity.
 - GitHub read-only refresh at 2026-05-26: no open PRs; open issues remain
   `#67`, `#68`, `#163`, `#176`, and `#212`.
 - Linear: `TIN-1624` is Done for the resume authority fix. `TIN-1591`,
@@ -26,25 +28,25 @@ prepared fallback remain diagnostic infrastructure, not the success claim.
   Progress. `TIN-938` is Todo, `TIN-1079` is Backlog, and `TIN-950` is still
   marked Done even though GitHub `#176` remains open for real cassette
   acceptance.
-- Release truth: public GitHub Release `v0.1.11` is published, not
+- Release truth: public GitHub Release `v0.1.12` is published, not
   draft/prerelease, with installer, Homebrew, tarball, deb/rpm, npm tarball,
   handoff, and checksum assets. The public Homebrew tap reports stable/linked
-  keg `0.1.11`, and `brew fetch --force jesssullivan/omux/oauth-mux` passes
-  after tap PR #8 corrected stale checksums. `npm view oauth-mux version` still
-  reports `0.1.9`; `oauth-mux@0.1.11` is not published to npm.
+  keg `0.1.12`. `npm view oauth-mux version` still reports `0.1.9`;
+  `oauth-mux@0.1.12` is not published to npm.
 - Current install truth: `/Users/jess/.local/bin/oauth-mux` is PATH-first and
-  reports `0.1.11` with build id `v0.1.11`; `/opt/homebrew/bin/oauth-mux` also
-  reports `0.1.11`. Native Codex resolves outside oauth-mux.
+  reports `0.1.12` with build id `v0.1.12`; `/opt/homebrew/bin/oauth-mux` also
+  reports `0.1.12`. Native Codex resolves outside oauth-mux.
 - Current no-spend route truth: `oauth-mux codex preflight --profile codex-max
   --capability codex-max --json` reports `ok:true`, `session_start_ready:true`,
   `fallback_ready:true`, `selectable_fallback_routes:2`,
   `single_route_at_risk:false`, `spends_provider_calls:false`, and
   `mutates_route_health:false`.
 - Current process/fd truth for TIN-1591 remains containment, not resolution:
-  soft fd limit is `256`, there are still active Codex/oauth-mux processes and
-  orphan-listener candidates, and one-snapshot helper fanout is not leak proof.
-  Do not use dogfood probes for broad live reliability claims until repeated
-  clean-baseline snapshots support that claim.
+  the fresh 2026-05-26 snapshot shows soft fd limit `256`, max visible fd use
+  at 73.4% of that limit, active Codex/oauth-mux processes, and orphan-listener
+  candidates. One-snapshot helper fanout is not leak proof. Do not use dogfood
+  probes for broad live reliability claims until repeated clean-baseline
+  snapshots support that claim.
 
 ## Workstream 1 - BrokenPipe And Network-Blip Reliability
 
@@ -92,7 +94,8 @@ Todo:
   provider-spend work. Landed as PR #279.
 - [x] Publish or install a build that contains PR #279 before treating new
   installed `oauth-mux codex resume` dogfood as fixed. Completed for GitHub
-  Release, user-local, and Homebrew as `0.1.11`.
+  Release, user-local, and Homebrew as `0.1.11`; the fix remains included in
+  current release `0.1.12`.
 
 ## Workstream 2 - No-Spend Route And Process Truth Refresh
 
@@ -242,17 +245,17 @@ Todo:
   (gitignored, not committed).
 - [ ] Capture or explicitly record not-observed status for quota/error shapes:
   `usage_limit_reached`, `usage_not_included`, and all-fallbacks-exhausted.
-- [ ] Add one scrubbed real-shape replay fixture and wire it into CI-safe
+- [x] Add one scrubbed real-shape replay fixture and wire it into CI-safe
   cassette smoke coverage.
 
 ## Workstream 4 - Release, Docs, And Workflow Hygiene
 
-Priority: P1. Release `0.1.11` is shipped; keep docs and install lanes aligned
+Priority: P1. Release `0.1.12` is shipped; keep docs and install lanes aligned
 before expanding public claims.
 
 Completion metric:
 
-- Current-state docs describe `0.1.11` as the latest verified public release
+- Current-state docs describe `0.1.12` as the latest verified public release
   truth and npm `0.1.9` as a stale package-lane exception.
 - Historical docs may keep older versions only when clearly framed as
   historical evidence.
@@ -265,9 +268,9 @@ Test commands:
 
 ```bash
 scripts/project-version.sh
-gh release view v0.1.9 --json tagName,publishedAt,url
-npm view oauth-mux version
-brew info --json=v2 jesssullivan/omux/oauth-mux | jq -r '.formulae[0].versions.stable'
+gh release view v0.1.12 --json tagName,publishedAt,url
+npm_config_cache=/private/tmp/omux-npm-cache npm view oauth-mux version
+HOMEBREW_NO_INSTALL_FROM_API=1 brew info --json=v2 jesssullivan/omux/oauth-mux | jq -r '.formulae[0].versions.stable'
 rg -n "0\\.1\\.[0-8]" README.md docs/productionization-ledger.md docs/adoption.md docs/qa-handoff-matrix.md .github/workflows
 git diff --check
 ```
@@ -283,6 +286,8 @@ Todo:
   and install-provenance fixes.
 - [x] Publish `v0.1.11` GitHub Release assets and update the public Homebrew tap
   to `0.1.11`; npm remains blocked/stale at `0.1.9`.
+- [x] Publish `v0.1.12` GitHub Release assets and update the public Homebrew tap
+  to `0.1.12`; npm remains blocked/stale at `0.1.9`.
 - [x] Fix the post-release Homebrew checksum drift and verify
   `brew fetch --force jesssullivan/omux/oauth-mux` passes against the public
   tap.

--- a/docs/spec/oauth-mux-this-week-sprint-2026-05-26.md
+++ b/docs/spec/oauth-mux-this-week-sprint-2026-05-26.md
@@ -19,8 +19,9 @@ support are not success metrics.
 
 ## Current Truth
 
-- Before this P0 branch, `oauth-mux` main was clean and synced to
-  `origin/main`.
+- `oauth-mux` main is clean and synced to `origin/main` at `7a06632`
+  after PR #299 promoted the scrubbed auth-failure fixture and local-path
+  redaction gate.
 - Public release `v0.1.12` is published and verified for GitHub Release,
   Homebrew, user-local dogfood, curl installer assets, deb/rpm assets, and the
   lab Home Manager source pin.
@@ -29,9 +30,15 @@ support are not success metrics.
   `selectable_fallback_routes:2`, `session_start_ready:true`,
   `single_route_at_risk:false`, `spends_provider_calls:false`, and
   `mutates_route_health:false`.
-- `TIN-1591` remains contained, not resolved. Dogfood evidence is local
-  release/install validation until process/fd baselines are clean enough for
-  broader live reliability claims.
+- Current no-spend route matrix selects `codex:max-1#codex-max`, keeps
+  `max-2` and `max-4` as selectable fallbacks, and leaves `max-3` as
+  `probe_needed` / `unrecorded`; probing `max-3` would spend provider calls.
+- `TIN-1591` remains contained, not resolved. Fresh no-spend snapshot
+  `process-snapshot-20260526T200604Z-baseline-20260526` recorded
+  `nofile.soft:256`, `process_count:653`, `managed_codex_children:2`,
+  `orphan_listener_candidate_count:8`, and `max_fd_soft_limit_pct:73.4`.
+  Dogfood evidence remains local release/install validation until process/fd
+  baselines are clean enough for broader live reliability claims.
 - GitHub `#176` remains open even though Linear `TIN-950` is Done. Treat that
   as a tracker mismatch until real quota/error cassettes land or Linear is
   explicitly clarified.
@@ -101,10 +108,14 @@ Todos:
 - [x] Add a short `TIN-1591` runbook section to `docs/dogfood-process-fanout.md`
   or a sibling doc with the exact snapshot command, interpretation rules, and
   cleanup approval policy.
-- [ ] Re-run `python3 scripts/dogfood-process-snapshot.py --json` from a clean
+- [x] Re-run `python3 scripts/dogfood-process-snapshot.py --json` from a clean
   shell and save only a redacted summary if it changes the claim posture.
-- [ ] Decide whether the soft fd limit `256` is acceptable for dogfood evidence
-  or whether the runbook must require a higher limit.
+- [x] Decide whether the soft fd limit `256` is acceptable for dogfood evidence
+  or whether the runbook must require a higher limit. Decision: `256` is not
+  acceptable for broad live reliability or quota-cassette claims when the fresh
+  snapshot already shows 73.4% of the soft limit and active agent fanout.
+  Proceed only with local/no-spend evidence, or raise the limit and collect a
+  cleaner repeated baseline before live claims.
 - [x] Define which process classes are never killed by automation.
 - [ ] Re-check no proxy/capture/long-running validation processes before each
   live or cassette run.
@@ -140,6 +151,10 @@ Known evidence:
   it observed `refresh_token_reused` on `/oauth/token` and `token_expired`
   on `/backend-api/codex/responses`, with same-run proxy metadata and no
   review failures after the local-path redaction addon fix.
+- PR #299 promoted a scrubbed auth-failure fixture from that run and wired it
+  into CI-safe capture-review and replay smokes. The committed fixture
+  deliberately sanitizes secret-shaped strings and local paths; the raw
+  capture remains gitignored.
 - Codex 0.132 `/backend-api/codex/responses` was observed as a WebSocket `101`,
   not a simple `200` SSE-only path.
 - Cookie and `Set-Cookie` redaction is now review-gated after PR `#292`.
@@ -153,8 +168,8 @@ Todos:
   beyond the existing WebSocket `101` shape.
 - [ ] Target quota/error capture under explicit spend approval and fallback
   capacity, not from a single-route-at-risk state.
-- [ ] Promote the smallest scrubbed fixture that proves the real path shape.
-- [ ] Add or extend CI-safe replay smoke coverage for the scrubbed fixture.
+- [x] Promote the smallest scrubbed fixture that proves the real path shape.
+- [x] Add or extend CI-safe replay smoke coverage for the scrubbed fixture.
 - [x] Gate obvious local home/tmp paths before any cassette fixture promotion.
 - [ ] Reconcile `TIN-950` Done versus GitHub `#176` open after the fixture and
   error-shape decision are recorded.
@@ -190,7 +205,7 @@ Completion metric:
 
 Todos:
 
-- [ ] Refresh no-spend route inventory with `accounts list`, `route explain`,
+- [x] Refresh no-spend route inventory with `accounts list`, `route explain`,
   `codex preflight`, and `broker-session-plan`.
 - [ ] Identify one intentionally exhausted or limited route and one credited
   fallback route for a controlled run.
@@ -238,8 +253,8 @@ Validation:
 ```bash
 rg -n "0\\.1\\.10|0\\.1\\.11 is the next staged|v0\\.1\\.10|npm.*0\\.1\\.12" \
   README.md docs .github scripts || true
-npm view oauth-mux version --json
-brew info jesssullivan/omux/oauth-mux --json=v2 \
+npm_config_cache=/private/tmp/omux-npm-cache npm view oauth-mux version --json
+HOMEBREW_NO_INSTALL_FROM_API=1 brew info jesssullivan/omux/oauth-mux --json=v2 \
   | jq '.formulae[] | {stable: .versions.stable, installed: [.installed[]?.version]}'
 git diff --check
 ```


### PR DESCRIPTION
## Summary

- refresh the active sprint and hardening docs after PR #299 landed the scrubbed auth-failure fixture
- record the current no-spend route matrix: selected `max-1`, fallback `max-2`/`max-4`, and `max-3` requiring an explicit provider-spend probe
- record the fresh TIN-1591 process/fd snapshot posture without turning it into a live reliability claim
- ignore generated `dist/dogfood/` process snapshot artifacts so the runbook does not dirty the tree

## Validation

- `scripts/project-version.sh` -> `0.1.12`
- `gh release view v0.1.12 --json tagName,publishedAt,url`
- `npm_config_cache=/private/tmp/omux-npm-cache npm view oauth-mux version --json` -> `0.1.9`
- `HOMEBREW_NO_INSTALL_FROM_API=1 brew info jesssullivan/omux/oauth-mux --json=v2` -> stable/linked `0.1.12`
- `git diff --check`
- `just test`

## Notes

This is tracker/doc hygiene only. It does not close #176 or TIN-1591; quota/rate-limit cassette evidence and cleaner repeated process/fd baselines remain pending.
