### PR TITLE
Contain Codex WebSocket fallback locally

### DIFF
--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -282,8 +282,9 @@ upstream's path layout — see `model-provider-info/src/lib.rs` L233–240):
 - `POST /backend-api/codex/responses`
 - `POST /backend-api/codex/responses/compact`
 - `POST /backend-api/codex/memories/trace_summarize`
-- WebSocket upgrade on the same base, protocol header
-  `responses_websockets=2026-02-06` (per `core/src/client.rs` L132–134).
+- WebSocket upgrade attempts on the same base, with
+  `OpenAI-Beta: responses_websockets=2026-02-06`, must be contained locally
+  until managed WS pass-through is implemented.
 
 The proxy MUST forward all other paths under that prefix transparently
 (future endpoints) and MUST NOT block on unknown paths.
@@ -356,15 +357,19 @@ committed.
 
 ### 4.5 WebSocket handling
 
-If the WS upgrade variant is in use (`responses_websockets=2026-02-06`),
-the proxy upgrades the inbound socket and opens a corresponding outbound
-TLS WS to chatgpt.com, signed with the elected account's headers at
-upgrade time. WS-level account swap mid-connection is **not implemented in
-Phase 2**; the proxy closes the WS cleanly on `usage_limit_reached`
-detection (which arrives over the WS frame stream as an error type the
-app-server then surfaces) and lets the app-server reopen against the new
-account on the next user turn. Phase 4+ may revisit if wire capture proves
-WS reauth is feasible without thread-id loss.
+Phase 2 managed Codex does **not** implement WebSocket pass-through. If
+Codex opens the Responses WebSocket transport anyway, the proxy MUST return a
+local HTTP `426 Upgrade Required` response with typed
+`oauth_mux_unsupported_transport` JSON, emit `proxy_unsupported_transport`,
+emit `codex.proxy.unsupported_transport`, and MUST NOT call upstream. Codex
+0.132 treats HTTP 426 from the WS attempt as its own signal to fall back to
+the HTTP/SSE Responses transport.
+
+This is a containment boundary, not a product success claim. Forwarding a WS
+upgrade as a plain HTTP `GET` is forbidden because it can surface as upstream
+`405 Method Not Allowed` and be misclassified as an ordinary `ok` proxy turn.
+Actual WS pass-through remains future work and must be backed by cassette
+evidence before being presented as managed transport support.
 
 ## 5. TUI Strategy
 

--- a/docs/spec/codex-wire-evidence-2026-05-03.md
+++ b/docs/spec/codex-wire-evidence-2026-05-03.md
@@ -436,9 +436,12 @@ request, **NOT as a `Sec-WebSocket-Protocol` value.** The original
 spec was wrong on this; the wire proxy must not advertise it as a
 WS subprotocol upstream.
 
-The Phase 2 v1 wire proxy does NOT support WS upgrade; codex falls
-back to chunked HTTP / SSE when the upgrade is rejected. Phase 2.2
-adds WS pass-through.
+The Phase 2 v1 managed wire proxy does NOT support WS upgrade. When a
+Responses WebSocket upgrade reaches the proxy, oauth-mux returns a local
+HTTP `426 Upgrade Required` fallback signal with typed
+`oauth_mux_unsupported_transport` JSON and does not call upstream. Codex
+0.132 treats that 426 as its HTTP/SSE fallback path. Phase 2.2+ may add WS
+pass-through only after cassette evidence proves the managed semantics.
 
 _OPERATOR-CONFIRM_: capture an upgrade attempt (force WS via codex
 config or the env that triggers it); verify `OpenAI-Beta` header

--- a/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
+++ b/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
@@ -240,9 +240,10 @@ Todo:
 - [x] Re-run no-spend route truth immediately before capture and keep the
   generated preflight summary with the capture scratch directory.
 - [x] Capture one successful live turn with the Codex 0.132
-  `/backend-api/codex/responses` WebSocket `101` path observed and
-  review-gated. Scratch capture: `captures/codex-wire-20260526T171741Z`
-  (gitignored, not committed).
+  `/backend-api/codex/responses` WebSocket `101` raw upstream path observed
+  and review-gated. This is cassette evidence for upstream shape, not a
+  managed WS support claim. Scratch capture:
+  `captures/codex-wire-20260526T171741Z` (gitignored, not committed).
 - [ ] Capture or explicitly record not-observed status for quota/error shapes:
   `usage_limit_reached`, `usage_not_included`, and all-fallbacks-exhausted.
 - [x] Add one scrubbed real-shape replay fixture and wire it into CI-safe

--- a/docs/spec/oauth-mux-this-week-sprint-2026-05-26.md
+++ b/docs/spec/oauth-mux-this-week-sprint-2026-05-26.md
@@ -156,7 +156,9 @@ Known evidence:
   deliberately sanitizes secret-shaped strings and local paths; the raw
   capture remains gitignored.
 - Codex 0.132 `/backend-api/codex/responses` was observed as a WebSocket `101`,
-  not a simple `200` SSE-only path.
+  not a simple `200` SSE-only path. That remains raw upstream wire evidence;
+  managed oauth-mux currently contains WS attempts with a local HTTP 426
+  fallback signal until WS pass-through has cassette-backed semantics.
 - Cookie and `Set-Cookie` redaction is now review-gated after PR `#292`.
 - Local workspace path redaction is review-gated before fixture promotion.
 - No quota/exhaustion shapes have been captured yet.
@@ -165,7 +167,8 @@ Todos:
 
 - [ ] Run a just-in-time no-spend preflight before any proxy.
 - [ ] Capture another successful-turn cassette only if it adds fixture value
-  beyond the existing WebSocket `101` shape.
+  beyond the existing raw WebSocket `101` shape or proves managed HTTP/SSE
+  fallback behavior.
 - [ ] Target quota/error capture under explicit spend approval and fallback
   capacity, not from a single-route-at-risk state.
 - [x] Promote the smallest scrubbed fixture that proves the real path shape.

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -64,6 +64,9 @@ The traced decisions are:
   printing token material, raw account ids, `CODEX_HOME`, or session ids.
 - `codex.proxy.turn`: per-request Codex proxy classification, path kind,
   status, claim level, streaming/delivery flags, and selected route label.
+- `codex.proxy.unsupported_transport`: local containment of an unsupported
+  Codex transport, including the fallback signal and proof that upstream was
+  not called.
 - `codex.proxy.retry`: same-turn retry boundary, including reason and the
   class of sticky header dropped before switching account routes.
 - `codex.proxy.no_account_selectable`: terminal no-account condition with only

--- a/scripts/smoke-codex-acceptance.sh
+++ b/scripts/smoke-codex-acceptance.sh
@@ -144,6 +144,7 @@ OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_TRACE=1 \
   OMUX_TRACE_FILE="$TRACE_FILE" \
   OMUX_STUB_CANONICAL_SESSION_HOME="$CANONICAL_SESSION_HOME" \
+  OMUX_STUB_CODEX_WEBSOCKET_PROBE=1 \
   OMUX_STUB_CODEX_TURNS=3 \
   OMUX_STUB_CODEX_PIDFILE="$STUB_PIDFILE" \
   OMUX_STUB_CODEX_REPORT="$STUB_REPORT" \
@@ -186,6 +187,14 @@ assert_grep "runtime identity marks repo-local binary" '"binary_source":"repo_lo
 assert_grep "runtime identity records binary sha" '"binary_sha256":"[0-9a-f]{64}"' "$NDJSON"
 assert_grep "runtime identity marks path printed" '"path_printed":true' "$NDJSON"
 assert_grep "runtime identity records installed/local mismatch bit" '"installed_local_mismatch_detected":false' "$NDJSON"
+assert_grep "websocket upgrade got local HTTP fallback signal" '"kind":"proxy_unsupported_transport".*"transport":"websocket".*"method":"GET".*"path_kind":"responses".*"status":426.*"fallback_signal":"http_426".*"upstream_called":false.*"delivered_to_codex":true' "$NDJSON"
+if grep -q -E '"kind":"proxy_turn".*"method":"GET".*"path_kind":"responses".*"status":405.*"classification":"ok"' "$NDJSON"; then
+    echo "  ✗ websocket upgrade was forwarded as plain GET and misclassified as ok" >&2
+    cat "$NDJSON" >&2
+    exit 1
+else
+    echo "  ✓ websocket upgrade was not misclassified as proxy_turn ok"
+fi
 assert_grep "proxy_turn 200 ok"         '"kind":"proxy_turn".*"status":200.*"classification":"ok"' "$NDJSON"
 assert_grep "proxy_turn 429 quota_exhausted" '"kind":"proxy_turn".*"status":429.*"classification":"quota_exhausted"' "$NDJSON"
 assert_grep "quota 429 was not delivered to Codex" '"kind":"proxy_turn".*"status":429.*"delivered_to_codex":false' "$NDJSON"
@@ -238,6 +247,24 @@ else
     echo "  ✗ child managed-frame env marker report failed" >&2
     cat "$STUB_REPORT" >&2
     exit 1
+fi
+if jq -e '.websocket_probe.checked == true
+          and .websocket_probe.status == 426
+          and .websocket_probe.body_has_unsupported_transport == true
+          and .websocket_probe.path_printed == false
+          and .websocket_probe.token_material_printed == false' "$STUB_REPORT" >/dev/null; then
+    echo "  ✓ child saw typed local WebSocket fallback response"
+else
+    echo "  ✗ child WebSocket probe did not see local fallback response" >&2
+    cat "$STUB_REPORT" >&2
+    exit 1
+fi
+if jq -e 'select(.method == "GET")' "$UPLOG" >/dev/null; then
+    echo "  ✗ WebSocket upgrade leaked to upstream as GET" >&2
+    cat "$UPLOG" >&2
+    exit 1
+else
+    echo "  ✓ WebSocket upgrade was not forwarded upstream"
 fi
 if [[ "$(jq -r .session_bridge.checked "$STUB_REPORT")" == "true" \
       && "$(jq -r .session_bridge.sessions_samefile "$STUB_REPORT")" == "true" \

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -40,6 +40,8 @@ Env (set by the smoke harness):
   OMUX_STUB_CODEX_DISCONNECT_TURNS — optional comma-separated turn indexes that
                             should send the request then close the proxy socket
                             before reading the streamed response.
+  OMUX_STUB_CODEX_WEBSOCKET_PROBE — optional "1" to send a Codex-shaped
+                            WebSocket upgrade GET before normal POST turns.
   The report records argv after the stub binary so CLI forwarding smokes can
   assert `oauth-mux codex ...` command shape without provider traffic.
 """
@@ -202,6 +204,46 @@ def _post_and_disconnect(proxy_url: str, body: bytes, turn: int) -> tuple[int, s
     return 0, "client_disconnected_before_response"
 
 
+def _websocket_probe(proxy_url: str) -> dict:
+    if os.environ.get("OMUX_STUB_CODEX_WEBSOCKET_PROBE") != "1":
+        return {"checked": False}
+
+    m = re.match(r"http://([^/]+)(/.*)$", proxy_url)
+    if not m:
+        print(f"stub-codex: cannot parse base_url={proxy_url}", file=sys.stderr)
+        sys.exit(2)
+    netloc, prefix = m.group(1), m.group(2)
+    conn = http.client.HTTPConnection(netloc, timeout=15)
+    headers = {
+        "Connection": "keep-alive, Upgrade",
+        "Upgrade": "websocket",
+        "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
+        "Sec-WebSocket-Version": "13",
+        "User-Agent": "stub-codex/0",
+        "x-codex-installation-id": "stub-install-1",
+        "OpenAI-Beta": "responses_websockets=2026-02-06",
+    }
+    account_id = os.environ.get("OMUX_STUB_CODEX_CHATGPT_ACCOUNT_ID")
+    auth_token = _auth_token_for_turn(0)
+    if account_id:
+        headers["ChatGPT-Account-ID"] = account_id
+    if auth_token:
+        headers["Authorization"] = f"Bearer {auth_token}"
+    try:
+        conn.request("GET", prefix + "/responses", headers=headers)
+        resp = conn.getresponse()
+        body = resp.read().decode("utf-8", errors="replace")
+        return {
+            "checked": True,
+            "status": resp.status,
+            "body_has_unsupported_transport": "oauth_mux_unsupported_transport" in body,
+            "path_printed": False,
+            "token_material_printed": False,
+        }
+    finally:
+        conn.close()
+
+
 def _session_bridge_report(codex_home: Path) -> dict:
     canonical_raw = os.environ.get("OMUX_STUB_CANONICAL_SESSION_HOME")
     if not canonical_raw:
@@ -305,6 +347,7 @@ def main() -> int:
     session_append = _append_session_marker(codex_home)
     sqlite_env = _sqlite_env_report()
     auth_rewrite = _rewrite_auth_json(codex_home)
+    websocket_probe = _websocket_probe(proxy_url)
 
     started_at = time.time()
     print(
@@ -343,6 +386,7 @@ def main() -> int:
         "session_append": session_append,
         "sqlite_env": sqlite_env,
         "auth_rewrite": auth_rewrite,
+        "websocket_probe": websocket_probe,
     }
     report_path.write_text(json.dumps(report, indent=2))
     print(f"stub-codex: pid_stable={report['pid_stable']} turns={turns}", file=sys.stderr, flush=True)

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -26,7 +26,8 @@
 //!      load-bearing ones from §4.2 (User-Agent, originator,
 //!      x-codex-installation-id, x-codex-turn-state,
 //!      x-codex-turn-metadata, OpenAI-Beta, traceparent, tracestate).
-//!   4. Send to chatgpt.com over TLS.
+//!   4. Reject unsupported WebSocket upgrade attempts locally; otherwise send
+//!      to chatgpt.com over TLS.
 //!   5. Classify the response (200 / 401 / 429+usage_limit_reached /
 //!      429+usage_not_included / other-429 / 5xx).
 //!   6. Report quota/observe to the broker pool. On
@@ -51,9 +52,9 @@
 //!     framing — the TUI animation moves in real time. Error responses are
 //!     small and need a retry decision before any bytes reach Codex, so they
 //!     stay buffered (with a 64 KiB cap).
-//!   - No WebSocket upgrade support; if codex requests a WS upgrade
-//!     we propagate the upstream's response (which on `chatgpt.com`
-//!     is HTTP 426 / falls back to chunked). Phase 2.2 adds WS.
+//!   - No WebSocket upgrade support. If Codex requests a WS upgrade, the proxy
+//!     returns a local HTTP 426 fallback signal and never forwards it upstream
+//!     as a plain HTTP GET. Phase 2.2 adds WS pass-through.
 //!   - Same-turn retry is attempted for buffered 429 `usage_limit_reached`
 //!     responses before any bytes are written to codex. The retry drops
 //!     `x-codex-turn-state` because that token is likely tied to the previous
@@ -231,6 +232,33 @@ pub const Proxy = struct {
             try writeStatus(writer, 400, "Bad Request");
             return;
         };
+
+        if (isWebSocketUpgradeRequest(&req)) {
+            self.logEvent("proxy_unsupported_transport", .{
+                .transport = "websocket",
+                .method = req.method,
+                .path_kind = pathKind(req.path),
+                .status = 426,
+                .fallback_signal = "http_426",
+                .upstream_called = false,
+                .delivered_to_codex = true,
+            });
+            trace.append(self.allocator, "codex.proxy.unsupported_transport", .warn, &.{
+                trace.string("provider", "codex"),
+                trace.string("transport", "websocket"),
+                trace.string("method", req.method),
+                trace.string("path_kind", pathKind(req.path)),
+                trace.uint("status", 426),
+                trace.string("fallback_signal", "http_426"),
+                trace.boolean("upstream_called", false),
+                trace.boolean("delivered_to_codex", true),
+                trace.boolean("token_material_printed", false),
+                trace.boolean("raw_account_id_printed", false),
+                trace.boolean("session_ids_printed", false),
+            });
+            try writeUnsupportedWebSocketResponse(writer);
+            return;
+        }
 
         var attempted = std.ArrayListUnmanaged([]const u8){};
         var rejections = std.ArrayListUnmanaged(CandidateRejection){};
@@ -1036,6 +1064,26 @@ fn asciiEqlIgnoreCase(a: []const u8, b: []const u8) bool {
     return true;
 }
 
+fn asciiTokenContainsIgnoreCase(value: []const u8, expected: []const u8) bool {
+    var parts = std.mem.splitScalar(u8, value, ',');
+    while (parts.next()) |part| {
+        const token = std.mem.trim(u8, part, " \t\r\n");
+        if (asciiEqlIgnoreCase(token, expected)) return true;
+    }
+    return false;
+}
+
+fn isWebSocketUpgradeRequest(req: *const Request) bool {
+    if (!std.mem.eql(u8, req.method, "GET")) return false;
+    if (req.headers.find("Sec-WebSocket-Key") != null) return true;
+    const upgrade = req.headers.find("Upgrade") orelse return false;
+    if (!asciiTokenContainsIgnoreCase(upgrade, "websocket")) return false;
+    if (req.headers.find("Connection")) |connection| {
+        return asciiTokenContainsIgnoreCase(connection, "upgrade");
+    }
+    return true;
+}
+
 fn parseRequest(a: std.mem.Allocator, reader: anytype) !Request {
     // Request line: METHOD SP PATH SP HTTP/1.1 CRLF
     const start_line = try readLine(a, reader, 8 * 1024);
@@ -1549,6 +1597,16 @@ fn writeNoAccountNextActionJson(writer: anytype, action: NoAccountNextAction) !v
     try writer.writeByte('}');
 }
 
+fn writeUnsupportedWebSocketResponse(writer: anytype) !void {
+    const body =
+        "{\"error\":{\"type\":\"oauth_mux_unsupported_transport\",\"code\":\"oauth_mux_unsupported_transport\",\"message\":\"oauth-mux: Codex WebSocket responses transport is not supported by this managed proxy; falling back to HTTP Responses transport.\"}}\n";
+    try writer.writeAll("HTTP/1.1 426 Upgrade Required\r\n");
+    try writer.writeAll("Content-Type: application/json\r\n");
+    try writer.print("Content-Length: {d}\r\n", .{body.len});
+    try writer.writeAll("Connection: close\r\n\r\n");
+    try writer.writeAll(body);
+}
+
 fn writeNoAccountRejectionSummaryJson(writer: anytype, rejections: []const CandidateRejection) !void {
     try writer.writeByte('{');
     try writer.print("\"total\":{d}", .{rejections.len});
@@ -1772,6 +1830,48 @@ test "upstreamPathForRequest maps built-in openai provider paths to Codex upstre
     const adjacent = try upstreamPathForRequest(std.testing.allocator, "/backend-api/responses_websockets");
     defer std.testing.allocator.free(adjacent);
     try std.testing.expectEqualStrings("/backend-api/responses_websockets", adjacent);
+}
+
+test "websocket upgrade requests are detected before upstream forwarding" {
+    var headers = HeaderList.init(std.testing.allocator);
+    defer headers.items.deinit(std.testing.allocator);
+    try headers.append("Host", "127.0.0.1:1234");
+    try headers.append("Connection", "keep-alive, Upgrade");
+    try headers.append("Upgrade", "websocket");
+    try headers.append("Sec-WebSocket-Key", "fixture");
+    try headers.append("OpenAI-Beta", "responses_websockets=2026-02-06");
+
+    const req = Request{
+        .method = "GET",
+        .path = "/backend-api/responses",
+        .headers = headers,
+        .body = &.{},
+    };
+    try std.testing.expect(isWebSocketUpgradeRequest(&req));
+}
+
+test "plain responses GET is not classified as websocket upgrade" {
+    var headers = HeaderList.init(std.testing.allocator);
+    defer headers.items.deinit(std.testing.allocator);
+    try headers.append("Host", "127.0.0.1:1234");
+
+    const req = Request{
+        .method = "GET",
+        .path = "/backend-api/responses",
+        .headers = headers,
+        .body = &.{},
+    };
+    try std.testing.expect(!isWebSocketUpgradeRequest(&req));
+}
+
+test "unsupported websocket response is local and explicit" {
+    var out = std.ArrayListUnmanaged(u8){};
+    defer out.deinit(std.testing.allocator);
+    try writeUnsupportedWebSocketResponse(out.writer(std.testing.allocator));
+    try std.testing.expect(std.mem.startsWith(u8, out.items, "HTTP/1.1 426 Upgrade Required\r\n"));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "oauth_mux_unsupported_transport") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "falling back to HTTP Responses transport") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "Connection: close\r\n") != null);
 }
 
 const TestSinkWriter = struct {


### PR DESCRIPTION
## Summary

- detect Codex Responses WebSocket upgrade attempts before account election or upstream forwarding
- return a local HTTP 426 fallback signal with typed `oauth_mux_unsupported_transport` evidence instead of forwarding the upgrade as a plain GET
- extend the Codex acceptance smoke so CI proves the child sees 426, upstream sees no GET, and no `405`/`classification:"ok"` proxy turn appears
- update transport docs to distinguish raw upstream WebSocket `101` cassette evidence from managed WS support

## Verification

- `zig fmt --check src/adapters/codex/main.zig src/adapters/codex/wire_proxy.zig`
- `python3 -m py_compile scripts/test-stub-codex.py scripts/test-stub-upstream.py`
- `just test`
- `just build`
- `just smoke-codex-acceptance-local`
- `just smoke-codex-cli-ux-local`
- `git diff --check`
- `just check-local` (first sandbox run hit `ps` permission denial in `dogfood-process-snapshot.py`; rerun outside sandbox passed)

Closes #303.
Contributes to #176.
