### PR TITLE
Remove no-spend capture framing

### DIFF
--- a/docs/dogfood-process-fanout.md
+++ b/docs/dogfood-process-fanout.md
@@ -6,7 +6,7 @@ Use this runbook when Codex/Claude dogfood feels persistently slow, duplicated,
 or memory-heavy and you need to distinguish normal accumulated sessions from
 orphan helper fanout or a suspected RSS leak.
 
-The snapshot path is no-spend and non-mutating:
+The snapshot path is read-only and non-mutating:
 
 - it does not call provider APIs;
 - it does not mutate oauth-mux config, route health, or credential stores;
@@ -99,8 +99,8 @@ Use these labels when filing follow-up evidence:
 
 ## TIN-1591 Evidence Gate
 
-Before using dogfood evidence for live reliability claims, collect a no-spend
-snapshot and inspect:
+Before using dogfood evidence for live reliability claims, collect a read-only
+process/fd snapshot and inspect:
 
 ```bash
 python3 scripts/dogfood-process-snapshot.py --json \

--- a/docs/spec/codex-wire-evidence-2026-05-03.md
+++ b/docs/spec/codex-wire-evidence-2026-05-03.md
@@ -20,15 +20,15 @@ the live capture lands.
 
 TIN-950 adds the capture/replay tooling only:
 
-- `scripts/capture-codex-wire.sh preflight` writes a no-spend
-  capture-readiness report with installed `oauth-mux` provenance,
+- `scripts/capture-codex-wire.sh preflight` writes a capture-readiness
+  report with installed `oauth-mux` provenance,
   native Codex version, mitmproxy availability, mitmproxy CA readiness,
   current route fallback readiness, latest status verdict, and
   stale-process hints. Run this immediately before starting any
-  intercepting proxy or live provider spend.
+  intercepting proxy or provider-backed capture.
 - `scripts/capture-codex-wire.sh proxy` starts the operator-controlled
-  mitmproxy HTTP capture path after rerunning the no-spend preflight
-  into the same capture root.
+  mitmproxy HTTP capture path after rerunning the preflight into the same
+  capture root.
 - `scripts/codex-wire-addon.py` writes reviewed, redacted per-flow JSON
   from that capture path.
 - `scripts/capture-codex-wire.sh review captures/codex-wire-<TS>`

--- a/docs/spec/oauth-mux-this-week-sprint-2026-05-26.md
+++ b/docs/spec/oauth-mux-this-week-sprint-2026-05-26.md
@@ -28,14 +28,14 @@ support are not success metrics.
   Homebrew, user-local dogfood, curl installer assets, deb/rpm assets, and the
   lab Home Manager source pin.
 - npm remains stale at `0.1.9`; do not claim npm `0.1.12`.
-- Current real-host no-spend Codex preflight reports `fallback_ready:true`,
+- Current real-host Codex preflight reports `fallback_ready:true`,
   `selectable_routes:2`, `selectable_fallback_routes:1`,
   `session_start_ready:true`, `single_route_at_risk:false`,
   `spends_provider_calls:false`, and `mutates_route_health:false`.
 - Current route matrix selects `codex:max-1#codex-max`, keeps `max-4`
   as the selectable fallback, and leaves `max-2` and `max-3` blocked as
   `quota_exhausted` until their reset windows.
-- `TIN-1591` remains contained, not resolved. Fresh no-spend snapshot
+- `TIN-1591` remains contained, not resolved. Fresh process/fd snapshot
   `process-snapshot-20260527T124603Z-cassette-gate-20260527` recorded
   `nofile.soft:256`, `process_count:765`, `managed_codex_children:3`,
   `active_codex_or_oauth_mux_processes:7`,
@@ -101,7 +101,7 @@ Priority: P0.
 
 Completion metric:
 
-- A repeatable no-spend snapshot routine exists for dogfood evidence sessions.
+- A repeatable process/fd snapshot routine exists for dogfood evidence sessions.
 - The routine records soft fd limit, active oauth-mux/Codex process counts,
   managed children, listener candidates, duplicate helper groups, and explicit
   cleanup eligibility.
@@ -121,8 +121,8 @@ Todos:
   or whether the runbook must require a higher limit. Decision: `256` is not
   acceptable for broad live reliability or quota-cassette claims when the fresh
   snapshot already shows 73.4% of the soft limit and active agent fanout.
-  Proceed only with local/no-spend evidence, or raise the limit and collect a
-  cleaner repeated baseline before live claims.
+  Proceed only with explicitly annotated local evidence, or raise the limit and
+  collect a cleaner repeated baseline before live claims.
 - [x] Define which process classes are never killed by automation.
 - [ ] Re-check no proxy/capture/long-running validation processes before each
   live or cassette run.
@@ -131,7 +131,7 @@ Validation:
 
 ```bash
 python3 scripts/dogfood-process-snapshot.py --json \
-  | jq '{summary, process_summary, safe_cleanup, no_provider_spend, mutates_processes, spends_provider_calls}'
+  | jq '{summary, process_summary, safe_cleanup, mutates_processes, spends_provider_calls}'
 pgrep -fl 'mitmdump|capture-codex-wire|gh run watch|nix build .#checks.aarch64-darwin.fish-syntax-test' || true
 git diff --check
 ```
@@ -176,11 +176,11 @@ Known evidence:
 
 Todos:
 
-- [ ] Run a just-in-time no-spend preflight before any proxy.
+- [ ] Run a just-in-time capture preflight before any proxy.
 - [ ] Recapture a successful-turn cassette with current local-path redaction
   before promoting any normal-turn WebSocket fixture.
-- [ ] Target quota/error capture under explicit spend approval and fallback
-  capacity, not from a single-route-at-risk state.
+- [ ] Target quota/error capture with current fallback capacity and capture
+  provenance, not from a single-route-at-risk state.
 - [x] Promote the smallest scrubbed fixture that proves the real path shape.
 - [x] Add or extend CI-safe replay smoke coverage for the scrubbed fixture.
 - [x] Gate obvious local home/tmp paths before any cassette fixture promotion.
@@ -210,15 +210,15 @@ Priority: P1, only after Workstream A and enough Workstream B evidence.
 Completion metric:
 
 - `TIN-1079` moves from Backlog only when fallback capacity is current and the
-  run has explicit spend approval.
-- The matrix separates no-spend inventory, provider-spend probes, and actual
-  engineered exhaustion.
+  run has clear capture provenance.
+- The matrix separates route inventory, provider probes, and actual engineered
+  exhaustion.
 - Evidence records selected route, fallback pool, reset-window normalization,
   and whether route health was mutated.
 
 Todos:
 
-- [x] Refresh no-spend route inventory with `accounts list`, `route explain`,
+- [x] Refresh route inventory with `accounts list`, `route explain`,
   `codex preflight`, and `broker-session-plan`.
 - [ ] Identify one intentionally exhausted or limited route and one credited
   fallback route for a controlled run.
@@ -254,7 +254,7 @@ Completion metric:
 Todos:
 
 - [x] Audit current-state docs for stale `0.1.10` / staged `0.1.11` language.
-- [ ] Mark older no-spend snapshots as historical where they still mention
+- [ ] Mark older preflight snapshots as historical where they still mention
   outdated selected routes or stale installed binaries.
 - [x] Decide whether `SHA256SUMS.full` must include `publish-files.txt` and
   `release-handoff.md`.
@@ -278,7 +278,7 @@ Priority: P2, constrained.
 
 Completion metric:
 
-- A no-spend loopback smoke proves sidecar process lifecycle, local transport,
+- A local loopback smoke proves sidecar process lifecycle, local transport,
   connection ordering, and attach/readiness semantics.
 - No live sidecar provider call is made.
 - Docs explicitly classify the sidecar as exploratory until cassette evidence
@@ -299,8 +299,8 @@ Completion metric:
 
 - One next provider is admitted through the provider-authoring checklist with
   fixture-backed positive and negative proof.
-- Provider matrix distinguishes schema-modeled, no-spend proven,
-  fixture-backed, and live-proven states.
+- Provider matrix distinguishes schema-modeled, fixture-backed, and live-proven
+  states.
 
 Todos:
 
@@ -325,7 +325,8 @@ These are organizational tasks, not product blockers.
 - TIN-1591 has a runbook and at least one fresh clean-baseline snapshot.
 - #176 has either a scrubbed real-shape fixture PR or a recorded blocker with
   exact missing evidence.
-- #212 has a current no-spend matrix and a clear go/no-go gate for spend.
+- #212 has a current route matrix and a clear go/no-go gate for provider-call
+  execution.
 - Docs no longer imply `0.1.11` is current for resume picker parity or that npm
   is current.
 - No new public continuity claims are made beyond the evidence above.

--- a/scripts/capture-codex-wire.sh
+++ b/scripts/capture-codex-wire.sh
@@ -29,7 +29,7 @@ capture-codex-wire.sh - Phase 0 evidence capture for the Codex adapter.
 
 USAGE
   scripts/capture-codex-wire.sh init             # one-time mitmproxy CA install check
-  scripts/capture-codex-wire.sh preflight        # no-spend capture readiness report
+  scripts/capture-codex-wire.sh preflight        # capture readiness report
   scripts/capture-codex-wire.sh proxy            # start the HTTP capture proxy in foreground
   scripts/capture-codex-wire.sh review DIR [REVIEW_FLAGS...]
                                               # summarize/redaction-check a capture
@@ -40,7 +40,7 @@ WORKFLOW
      mitmproxy CA, follow the instructions it prints. macOS:
        security add-trusted-cert -d -r trustRoot \
          -k ~/Library/Keychains/login.keychain-db ~/.mitmproxy/mitmproxy-ca-cert.cer
-  2. Run the no-spend capture preflight:
+  2. Run the capture preflight:
        scripts/capture-codex-wire.sh preflight
      It records installed binary identity, Codex version, mitmproxy
      availability, mitmproxy CA readiness, route fallback readiness,
@@ -48,7 +48,7 @@ WORKFLOW
      under captures/.
   3. In one shell:
        scripts/capture-codex-wire.sh proxy
-     The proxy first reruns the no-spend preflight into the same capture
+     The proxy first reruns the preflight into the same capture
      root, then listens on 127.0.0.1:9080 as a normal HTTP proxy.
   4. In another shell:
        export HTTPS_PROXY=http://127.0.0.1:9080
@@ -285,7 +285,7 @@ cmd_proxy() {
   fi
 
   echo "capture run dir: $RUN_DIR"
-  echo "running no-spend capture preflight into the capture root..."
+  echo "running capture preflight into the capture root..."
   OMUX_CAPTURE_PREFLIGHT_DIR="$RUN_DIR" cmd_preflight
 
   cat >"$RUN_DIR/meta.json" <<META


### PR DESCRIPTION
## Summary
- replace current sprint/capture/process prose that framed no-spend as an operating constraint
- keep preflight as capture readiness/provenance, not permission gating
- keep formal `spends_provider_calls` schema fields intact where they describe command behavior

## Verification
- `bash -n scripts/capture-codex-wire.sh`
- `python3 -m py_compile scripts/review-codex-wire-capture.py scripts/codex-wire-addon.py scripts/dogfood-process-snapshot.py`
- `./scripts/smoke-codex-capture-review.sh`
- `just smoke-codex-cassette-replay-local`
- `git diff --check`