### PR TITLE
Promote broker-owned Codex WebSocket cassette

### DIFF
--- a/docs/spec/codex-wire-evidence-2026-05-03.md
+++ b/docs/spec/codex-wire-evidence-2026-05-03.md
@@ -134,6 +134,42 @@ confirm the shapes themselves match upstream reality.
   The current capture was taken after the addon redaction fix and passed the
   local-path review gate.
 
+2026-05-27 broker-owned WebSocket success capture:
+
+- Capture run directory: `captures/codex-wire-20260527T133757Z/`
+  (ignored; raw `flows.binary` not committed).
+- Capture path: `oauth-mux codex broker-run --profile codex-max
+  --capability codex-max --prompt ... --confirm-spend --json` through
+  mitmproxy.
+- oauth-mux provenance: user-local `0.1.12`, build id
+  `v0.1.12-7-g01b4069`, SHA256
+  `6e32a3952dc1faa6b0a1960c1e0b8f6440bdd2ce473687fe5cabd1ac594bdf29`.
+- Codex binary: `codex-cli 0.132.0`.
+- Preflight: `ok:true`, `fallback_ready:true`,
+  `single_route_at_risk:false`, `selectable_fallback_routes:1`.
+- Broker-run result: `ok:true`, `reason:"live_turn_completed"`,
+  `proof_status:"live_broker_owned_session_one_turn"`,
+  `spare_fallback_ready:true`, `mutates_route_health:false`, and
+  token/account/prompt transcript redaction reported true.
+- Review gate:
+  ```bash
+  scripts/capture-codex-wire.sh review captures/codex-wire-20260527T133757Z \
+    --require-preflight-ok \
+    --require-proxy-meta \
+    --require-path-kind responses \
+    --require-status 101 \
+    --require-status 200 \
+    --json
+  ```
+- Review result: `ok:true`, 11 flows, path counts `responses:1`,
+  `codex_other:2`, `other:8`; status counts `101:1`, `200:8`,
+  `204:1`, `401:1`; no malformed, redaction, or requirement failures.
+- Promoted fixture:
+  `test/fixtures/codex-wire/broker-owned-websocket-success/`.
+  It keeps the scrubbed `/backend-api/codex/responses` WebSocket upgrade
+  flow and same-run proxy metadata, and CI replays it through
+  `just smoke-codex-cassette-replay`.
+
 ## Capture Promotion Checklist
 
 Before any captured flow is committed as a cassette or cited as live

--- a/docs/spec/oauth-mux-this-week-sprint-2026-05-26.md
+++ b/docs/spec/oauth-mux-this-week-sprint-2026-05-26.md
@@ -166,10 +166,18 @@ Known evidence:
   deliberately sanitizes secret-shaped strings and local paths; the raw
   capture remains gitignored.
 - Codex 0.132 `/backend-api/codex/responses` was observed as a WebSocket `101`,
-  not a simple `200` SSE-only path. That remains raw upstream wire evidence
-  until recaptured with the current local-path redaction gate. Managed
-  oauth-mux currently contains WS attempts with a local HTTP 426 fallback
-  signal until WS pass-through has cassette-backed semantics.
+  not a simple `200` SSE-only path. The earlier raw capture remains
+  unpromotable, but the 2026-05-27 broker-owned capture below is now the
+  promoted fixture for the normal WebSocket upgrade shape.
+- Current-release broker-owned scratch capture
+  `captures/codex-wire-20260527T133757Z` exists locally and is gitignored;
+  it was captured from `oauth-mux codex broker-run --confirm-spend`, completed
+  one live provider turn, and passed the current proxy-meta and redaction
+  gates with `/backend-api/codex/responses -> 101`.
+- The scrubbed fixture
+  `test/fixtures/codex-wire/broker-owned-websocket-success/` now preserves
+  that normal WebSocket upgrade shape and is covered by capture-review and
+  cassette-replay smokes.
 - Cookie and `Set-Cookie` redaction is now review-gated after PR `#292`.
 - Local workspace path redaction is review-gated before fixture promotion.
 - No quota/exhaustion shapes have been captured yet.
@@ -177,7 +185,7 @@ Known evidence:
 Todos:
 
 - [ ] Run a just-in-time capture preflight before any proxy.
-- [ ] Recapture a successful-turn cassette with current local-path redaction
+- [x] Recapture a successful-turn cassette with current local-path redaction
   before promoting any normal-turn WebSocket fixture.
 - [ ] Target quota/error capture with current fallback capacity and capture
   provenance, not from a single-route-at-risk state.

--- a/scripts/smoke-codex-capture-review.sh
+++ b/scripts/smoke-codex-capture-review.sh
@@ -152,6 +152,25 @@ assert summary["status_counts"]["401"] == 2, summary
 assert summary["redaction_failures"] == [], summary
 PY
 
+WS_FIXTURE="$ROOT/test/fixtures/codex-wire/broker-owned-websocket-success"
+"$ROOT/scripts/capture-codex-wire.sh" review "$WS_FIXTURE" \
+  --require-preflight-ok \
+  --require-proxy-meta \
+  --require-path-kind responses \
+  --require-status 101 \
+  --json >"$TMP/websocket-success-fixture-summary.json"
+
+python3 - "$TMP/websocket-success-fixture-summary.json" <<'PY'
+import json
+import sys
+summary = json.load(open(sys.argv[1]))
+assert summary["ok"] is True, summary
+assert summary["flow_count"] == 1, summary
+assert summary["path_counts"]["responses"] == 1, summary
+assert summary["status_counts"]["101"] == 1, summary
+assert summary["redaction_failures"] == [], summary
+PY
+
 BAD_META="$TMP/codex-wire-bad-meta"
 mkdir -p "$BAD_META/http"
 cp "$TMP/codex-wire-synth/capture-preflight-summary.json" "$BAD_META/capture-preflight-summary.json"

--- a/scripts/smoke-codex-cassette-replay.sh
+++ b/scripts/smoke-codex-cassette-replay.sh
@@ -262,3 +262,79 @@ assert [r["status_replayed"] for r in records if r.get("match") is True] == [401
 
 print("smoke-codex-cassette-replay: auth failure fixture replay passed.")
 PY
+
+kill "$SERVER_PID" 2>/dev/null || true
+wait "$SERVER_PID" 2>/dev/null || true
+unset SERVER_PID
+
+WS_FIXTURE="$ROOT/test/fixtures/codex-wire/broker-owned-websocket-success/http"
+WS_PORTFILE="$TMP/ws-fixture.port"
+WS_LOGFILE="$TMP/ws-fixture.log"
+WS_ERR="$TMP/ws-fixture.stderr"
+
+OMUX_CASSETTE_DIR="$WS_FIXTURE" \
+  OMUX_STUB_PORT=0 \
+  OMUX_STUB_PORTFILE="$WS_PORTFILE" \
+  OMUX_STUB_LOGFILE="$WS_LOGFILE" \
+  python3 "$ROOT/scripts/test-cassette-upstream.py" 2>"$WS_ERR" &
+SERVER_PID=$!
+
+python3 - "$WS_PORTFILE" "$WS_LOGFILE" "$WS_ERR" <<'PY'
+import http.client
+import json
+import pathlib
+import sys
+import time
+
+portfile = pathlib.Path(sys.argv[1])
+logfile = pathlib.Path(sys.argv[2])
+server_err = pathlib.Path(sys.argv[3])
+
+deadline = time.monotonic() + 5
+while time.monotonic() < deadline:
+    if portfile.exists() and portfile.read_text().strip():
+        break
+    time.sleep(0.05)
+else:
+    print("smoke-codex-cassette-replay: websocket fixture server did not write port", file=sys.stderr)
+    print(server_err.read_text() if server_err.exists() else "", file=sys.stderr)
+    raise SystemExit(1)
+
+port = int(portfile.read_text().strip())
+conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+try:
+    conn.request(
+        "GET",
+        "/backend-api/codex/responses",
+        headers={
+            "Connection": "Upgrade",
+            "Upgrade": "websocket",
+            "Sec-WebSocket-Version": "13",
+            "Sec-WebSocket-Key": "not-real",
+        },
+    )
+    resp = conn.getresponse()
+    body = resp.read()
+finally:
+    conn.close()
+
+assert resp.status == 101, (resp.status, body)
+assert body == b"", body
+
+deadline = time.monotonic() + 2
+while True:
+    if logfile.exists():
+        records = [json.loads(line) for line in logfile.read_text().splitlines() if line.strip()]
+    else:
+        records = []
+    if len(records) >= 1 or time.monotonic() >= deadline:
+        break
+    time.sleep(0.02)
+assert [r["status_replayed"] for r in records if r.get("match") is True] == [101], records
+
+print("smoke-codex-cassette-replay: websocket success fixture replay passed.")
+PY
+
+kill "$SERVER_PID" 2>/dev/null || true
+wait "$SERVER_PID" 2>/dev/null || true
+unset SERVER_PID

--- a/test/fixtures/codex-wire/broker-owned-websocket-success/capture-preflight-summary.json
+++ b/test/fixtures/codex-wire/broker-owned-websocket-success/capture-preflight-summary.json
@@ -1,0 +1,16 @@
+{
+  "ok": true,
+  "issues": [],
+  "warnings": [],
+  "oauth_mux": {
+    "version": "0.1.12",
+    "build_id": "v0.1.12-7-g01b4069",
+    "binary_source": "user_local"
+  },
+  "route_summary": {
+    "session_start_ready": true,
+    "fallback_ready": true,
+    "single_route_at_risk": false,
+    "selectable_fallback_routes": 1
+  }
+}

--- a/test/fixtures/codex-wire/broker-owned-websocket-success/http/00001-GET-backend-api_codex_responses.json
+++ b/test/fixtures/codex-wire/broker-owned-websocket-success/http/00001-GET-backend-api_codex_responses.json
@@ -1,0 +1,172 @@
+{
+  "captured_at": 1779889108.326567,
+  "host": "chatgpt.com",
+  "scheme": "https",
+  "method": "GET",
+  "path": "/backend-api/codex/responses",
+  "request": {
+    "headers": [
+      [
+        "Host",
+        "chatgpt.com"
+      ],
+      [
+        "Connection",
+        "Upgrade"
+      ],
+      [
+        "Upgrade",
+        "websocket"
+      ],
+      [
+        "Sec-WebSocket-Version",
+        "13"
+      ],
+      [
+        "Sec-WebSocket-Key",
+        "redacted"
+      ],
+      [
+        "chatgpt-account-id",
+        "c50857-<bd460f0c46>"
+      ],
+      [
+        "authorization",
+        "redacted-authorization-<4fd5a7f592>"
+      ],
+      [
+        "user-agent",
+        "oauth-mux/0.132.0 (Mac OS 26.5.0; arm64) ghostty/1.3.2-HEAD-_ff6e126 (oauth-mux; 0.1.12)"
+      ],
+      [
+        "originator",
+        "oauth-mux"
+      ],
+      [
+        "openai-beta",
+        "responses_websockets=2026-02-06"
+      ],
+      [
+        "version",
+        "0.132.0"
+      ],
+      [
+        "x-codex-beta-features",
+        "terminal_resize_reflow"
+      ],
+      [
+        "x-codex-turn-metadata",
+        "{\"session_id\":\"redacted\",\"thread_id\":\"redacted\",\"turn_id\":\"\",\"workspaces\":{\"~/git/oauth-mux\":{\"associated_remote_urls\":{\"origin\":\"redacted\"},\"latest_git_commit_hash\":\"redacted\",\"has_changes\":false}},\"sandbox\":\"seatbelt\"}"
+      ],
+      [
+        "x-client-request-id",
+        "redacted"
+      ],
+      [
+        "session-id",
+        "redacted"
+      ],
+      [
+        "thread-id",
+        "redacted"
+      ],
+      [
+        "x-codex-window-id",
+        "redacted:0"
+      ],
+      [
+        "sec-websocket-extensions",
+        "permessage-deflate; client_max_window_bits"
+      ]
+    ],
+    "body": {
+      "__non_json__": true,
+      "len": 0,
+      "head_hex": ""
+    }
+  },
+  "response": {
+    "status": 101,
+    "reason": "Switching Protocols",
+    "headers": [
+      [
+        "Date",
+        "Wed, 27 May 2026 13:38:28 GMT"
+      ],
+      [
+        "Connection",
+        "upgrade"
+      ],
+      [
+        "upgrade",
+        "websocket"
+      ],
+      [
+        "sec-websocket-accept",
+        "redacted"
+      ],
+      [
+        "sec-websocket-extensions",
+        "permessage-deflate"
+      ],
+      [
+        "x-models-etag",
+        "W/\"c144cb72224dc66970072d2589eff85f\""
+      ],
+      [
+        "x-openai-proxy-wasm",
+        "v0.1"
+      ],
+      [
+        "cf-cache-status",
+        "DYNAMIC"
+      ],
+      [
+        "Set-Cookie",
+        "__cf_bm=<redacted>"
+      ],
+      [
+        "Report-To",
+        "{\"endpoints\":[{\"url\":\"redacted\"}],\"group\":\"cf-nel\",\"max_age\":604800}"
+      ],
+      [
+        "NEL",
+        "{\"success_fraction\":0.01,\"report_to\":\"cf-nel\",\"max_age\":604800}"
+      ],
+      [
+        "Strict-Transport-Security",
+        "max-age=31536000; includeSubDomains; preload"
+      ],
+      [
+        "X-Content-Type-Options",
+        "nosniff"
+      ],
+      [
+        "Referrer-Policy",
+        "strict-origin-when-cross-origin"
+      ],
+      [
+        "Cross-Origin-Opener-Policy",
+        "same-origin-allow-popups"
+      ],
+      [
+        "Server",
+        "cloudflare"
+      ],
+      [
+        "CF-RAY",
+        "redacted-BOS"
+      ],
+      [
+        "alt-svc",
+        "h3=\":443\"; ma=86400"
+      ]
+    ],
+    "body": {
+      "__non_json__": true,
+      "len": 0,
+      "head_hex": ""
+    }
+  },
+  "timing_ms": 380
+}

--- a/test/fixtures/codex-wire/broker-owned-websocket-success/meta.json
+++ b/test/fixtures/codex-wire/broker-owned-websocket-success/meta.json
@@ -1,0 +1,11 @@
+{
+  "ts_utc": "20260527T133757Z",
+  "kind": "phase_0_wire_capture",
+  "addon": "scripts/codex-wire-addon.py",
+  "preflight_summary": "capture-preflight-summary.json",
+  "host_filter": "chatgpt.com",
+  "ports": {
+    "http": 9080,
+    "https": 9080
+  }
+}


### PR DESCRIPTION
Summary
- Promote a scrubbed broker-owned Codex `/backend-api/codex/responses` WebSocket 101 fixture from a live oauth-mux `broker-run` capture.
- Extend capture-review and cassette-replay smokes so CI exercises the proxy metadata gate and WebSocket replay path.
- Update the evidence and sprint docs to separate this normal-turn WebSocket proof from the still-missing quota/exhaustion cassette.

Validation
- `just test`
- `./scripts/smoke-codex-capture-review.sh`
- `just smoke-codex-cassette-replay-local`
- `scripts/capture-codex-wire.sh review test/fixtures/codex-wire/broker-owned-websocket-success --require-preflight-ok --require-proxy-meta --require-path-kind responses --require-status 101 --json`
- `bash -n scripts/capture-codex-wire.sh scripts/smoke-codex-capture-review.sh scripts/smoke-codex-cassette-replay.sh`
- `python3 -m py_compile scripts/review-codex-wire-capture.py scripts/codex-wire-addon.py scripts/test-cassette-upstream.py`
- `git diff --check`

Advances #176.