### PR TITLE
Add claim-bearing process evidence gate

### DIFF
--- a/docs/dogfood-process-fanout.md
+++ b/docs/dogfood-process-fanout.md
@@ -8,7 +8,7 @@ orphan helper fanout or a suspected RSS leak.
 
 The snapshot path is read-only and non-mutating:
 
-- it does not call provider APIs;
+- it does not contact provider endpoints;
 - it does not mutate oauth-mux config, route health, or credential stores;
 - it does not kill processes;
 - it does not sleep in the foreground;
@@ -48,6 +48,9 @@ The report groups visible Codex, Claude, and oauth-mux process trees and records
 - helper/listener processes that are not inside a visible agent tree.
 - an `evidence_gate` verdict for whether the current process/fd state is clean
   enough for unannotated live reliability or quota-cassette claims.
+- `safe_cleanup.review_groups` lists the exact active sessions, orphan listener
+  candidates, live validation processes, and high-fd processes that need
+  operator review before claim-bearing evidence.
 
 Commands, temp paths, home paths, and common bearer/token spellings are redacted.
 The script intentionally does not read process environments.
@@ -107,6 +110,27 @@ python3 scripts/dogfood-process-snapshot.py --json \
   | jq '{summary, process_summary, resource_limits, fd_summary, evidence_gate, safe_cleanup}'
 ```
 
+To make a claim-bearing workflow fail closed before cassette capture:
+
+```bash
+python3 scripts/dogfood-process-snapshot.py \
+  --require-gate quota_cassette_claims_admitted \
+  --json
+```
+
+`scripts/capture-codex-wire.sh preflight` also writes `process-gate.json` and
+summarizes the same gate in `capture-preflight-summary.json`. Treat that summary
+as capture provenance; use `--require-gate quota_cassette_claims_admitted`
+immediately before starting a claim-bearing proxy run when you need a hard stop,
+then require the captured provenance during promotion review:
+
+```bash
+scripts/capture-codex-wire.sh review captures/codex-wire-<TS> \
+  --require-preflight-ok \
+  --require-proxy-meta \
+  --require-process-gate quota_cassette_claims_admitted
+```
+
 Treat the evidence as contaminated when the snapshot shows active work you
 cannot classify, such as:
 
@@ -131,6 +155,10 @@ The machine-readable gate is intentionally conservative:
 - `evidence_gate.fd_soft_limit_pct_threshold` is currently `70.0`. The
   percentage uses the collector process's soft `nofile` limit as a local
   pressure proxy; it is not a per-target process rlimit read.
+- `--require-clean` exits nonzero unless `process_fd_clean_baseline` is true.
+  `--require-gate <name>` exits nonzero unless the named gate is true; use
+  `quota_cassette_claims_admitted` before calling a quota/rate-limit cassette
+  clean evidence.
 
 Containment is enough to proceed with local release/install validation. Real
 cassette or live quota claims need either a clean baseline or an explicit note

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -38,16 +38,19 @@ refreshed when release truth, route evidence, or tracker state changes.
   Homebrew is a binary-only package lane by default: QA must prove it installs
   `oauth-mux`, does not install an `OMUX_CODEX_SHIM`, and leaves native `codex`
   command resolution unchanged.
-- Codex route truth: the 2026-05-26 no-spend preflight uses user-local
+- Codex route truth: the 2026-05-26 local preflight uses user-local
   post-PR #295 oauth-mux and native Codex outside oauth-mux. It reports
   `ok:true`, `session_start_ready:true`, `fallback_ready:true`,
   `selectable_fallback_routes:2`, `single_route_at_risk:false`,
   `spends_provider_calls:false`, and `mutates_route_health:false`.
 - Process/fd truth: TIN-1591 remains contained, not resolved. Current snapshots
-  still show active Codex/oauth-mux fanout, a soft fd limit of `256`, max
-  visible fd use at 73.4% of that limit, and orphan-listener candidates. Treat
-  dogfood evidence as local release/install validation only until repeated
-  clean-baseline snapshots support broader live reliability claims.
+  still show active Codex/oauth-mux fanout, a soft fd limit of `256`, and
+  orphan-listener candidates. The latest gate snapshot
+  `process-snapshot-20260527T144821Z-tin1591-gate-20260527` has max visible fd
+  use at 43.4% of the collector soft limit, so the current blocker is process
+  topology rather than fd pressure. Treat dogfood evidence as local
+  release/install validation only until repeated clean-baseline snapshots
+  support broader live reliability claims.
 - Daemon truth: `oauth-mux daemon status --json` still reports
   `status:"not_running"`, `contract:"experimental_socket_stub"`, and
   `hosts_stay_afloat:false`; its foreground tick snapshot is observational only
@@ -103,7 +106,7 @@ DX:
 
 AX:
 
-- Agents use no-spend inspection surfaces first: `discover`, `providers list`,
+- Agents use local inspection surfaces first: `discover`, `providers list`,
   `accounts list`, `doctor runtime`, `route explain`, `repair-plan`,
   `stay-afloat --once`, `codex preflight`, `status-latest`, and
   `daemon status`.
@@ -189,7 +192,7 @@ browser is needed; local Playwright is not part of this CLI proof path.
 
 ## Acceptance Gates
 
-- No-spend state refresh passes with current installed binary:
+- Local state refresh passes with current installed binary:
   `doctor`, `providers list`, `accounts list`, `route explain`,
   `codex preflight`, `broker-session-plan`, `stay-afloat next`,
   `status-latest`, and `daemon status`.

--- a/docs/spec/oauth-mux-this-week-sprint-2026-05-26.md
+++ b/docs/spec/oauth-mux-this-week-sprint-2026-05-26.md
@@ -36,13 +36,14 @@ support are not success metrics.
   as the selectable fallback, and leaves `max-2` and `max-3` blocked as
   `quota_exhausted` until their reset windows.
 - `TIN-1591` remains contained, not resolved. Fresh process/fd snapshot
-  `process-snapshot-20260527T124603Z-cassette-gate-20260527` recorded
-  `nofile.soft:256`, `process_count:765`, `managed_codex_children:3`,
-  `active_codex_or_oauth_mux_processes:7`,
-  `orphan_listener_candidate_count:3`, and `max_fd_soft_limit_pct:68.8`.
-  The gate admits local release validation, but blocks unannotated live
-  reliability and quota-cassette claims until active sessions/listeners are
-  closed or explicitly accounted for.
+  `process-snapshot-20260527T144821Z-tin1591-gate-20260527` recorded
+  `nofile.soft:256`, `process_count:595`, `managed_codex_children:4`,
+  `active_codex_or_oauth_mux_processes:9`,
+  `orphan_listener_candidate_count:3`, and `max_fd_soft_limit_pct:43.4`.
+  The fail-closed gate admits local release validation, but blocks unannotated
+  live reliability and quota-cassette claims until active sessions/listeners
+  are closed or explicitly accounted for. The current blocker is process
+  topology, not fd pressure.
 - GitHub `#176` remains open even though Linear `TIN-950` is Done. Treat that
   as a tracker mismatch until real quota/error cassettes land or Linear is
   explicitly clarified.
@@ -115,23 +116,37 @@ Todos:
 - [x] Add a short `TIN-1591` runbook section to `docs/dogfood-process-fanout.md`
   or a sibling doc with the exact snapshot command, interpretation rules, and
   cleanup approval policy.
-- [x] Re-run `python3 scripts/dogfood-process-snapshot.py --json` from a clean
-  shell and save only a redacted summary if it changes the claim posture.
+- [x] Re-run `python3 scripts/dogfood-process-snapshot.py --json` and save only
+  a redacted summary if it changes the claim posture.
+- [x] Add a fail-closed `--require-gate quota_cassette_claims_admitted` mode so
+  cassette capture can refuse contaminated process/fd evidence before the proxy
+  starts.
+- [x] Add capture-review `--require-process-gate
+  quota_cassette_claims_admitted` so fixture promotion fails when same-run
+  process/fd provenance is missing or blocked.
+- [x] Fix `oauth-mux codex ...` parent classification so oauth-mux adapter
+  parents are not mislabeled as native Codex processes.
 - [x] Decide whether the soft fd limit `256` is acceptable for dogfood evidence
   or whether the runbook must require a higher limit. Decision: `256` is not
-  acceptable for broad live reliability or quota-cassette claims when the fresh
-  snapshot already shows 73.4% of the soft limit and active agent fanout.
-  Proceed only with explicitly annotated local evidence, or raise the limit and
-  collect a cleaner repeated baseline before live claims.
+  acceptable as the only baseline for broad live reliability or quota-cassette
+  claims. Current fd pressure is below the 70% gate, but active agent fanout and
+  orphan listener candidates still block clean evidence. Proceed only with
+  explicitly annotated local evidence, or reduce fanout and collect a cleaner
+  repeated baseline before live claims.
 - [x] Define which process classes are never killed by automation.
 - [ ] Re-check no proxy/capture/long-running validation processes before each
   live or cassette run.
+- [ ] Collect two clean-baseline snapshots after active oauth-mux/Codex sessions
+  and orphan listener candidates are closed or explicitly accounted for.
 
 Validation:
 
 ```bash
 python3 scripts/dogfood-process-snapshot.py --json \
   | jq '{summary, process_summary, safe_cleanup, mutates_processes, spends_provider_calls}'
+python3 scripts/dogfood-process-snapshot.py \
+  --require-gate quota_cassette_claims_admitted \
+  --json
 pgrep -fl 'mitmdump|capture-codex-wire|gh run watch|nix build .#checks.aarch64-darwin.fish-syntax-test' || true
 git diff --check
 ```
@@ -143,6 +158,10 @@ Priority: P0 after Workstream A baseline is clean enough.
 Completion metric:
 
 - Capture review requires proxy metadata and installed preflight proof.
+- Capture preflight includes the TIN-1591 process/fd gate and records whether
+  quota-cassette claims are admitted before proxy evidence is promoted.
+- Claim-bearing capture review requires the recorded process/fd gate to admit
+  `quota_cassette_claims_admitted`.
 - At least one scrubbed real-shape replay fixture is committed.
 - Quota/error shapes are captured or explicitly marked not observed:
   `usage_limit_reached`, `usage_not_included`, all-fallbacks-exhausted, and
@@ -203,6 +222,7 @@ scripts/capture-codex-wire.sh preflight
 scripts/capture-codex-wire.sh review captures/codex-wire-<TS> \
   --require-preflight-ok \
   --require-proxy-meta \
+  --require-process-gate quota_cassette_claims_admitted \
   --require-path-kind responses \
   --require-status 101 \
   --require-status 200

--- a/scripts/capture-codex-wire.sh
+++ b/scripts/capture-codex-wire.sh
@@ -44,8 +44,8 @@ WORKFLOW
        scripts/capture-codex-wire.sh preflight
      It records installed binary identity, Codex version, mitmproxy
      availability, mitmproxy CA readiness, route fallback readiness,
-     latest status summary, and active oauth-mux/Codex process hints
-     under captures/.
+     latest status summary, process/fd evidence gate, and active
+     oauth-mux/Codex process hints under captures/.
   3. In one shell:
        scripts/capture-codex-wire.sh proxy
      The proxy first reruns the preflight into the same capture
@@ -60,7 +60,10 @@ WORKFLOW
      usage_limit_reached body.
   5. Stop the proxy with ^C. Find captures under captures/.
   6. Run:
-       scripts/capture-codex-wire.sh review captures/codex-wire-<TS>
+       scripts/capture-codex-wire.sh review captures/codex-wire-<TS> \
+         --require-preflight-ok \
+         --require-proxy-meta \
+         --require-process-gate quota_cassette_claims_admitted
   7. Distill findings into docs/spec/codex-wire-evidence-2026-05-03.md.
 
 REDACTION
@@ -121,6 +124,8 @@ cmd_preflight() {
   local version_json="$report_dir/oauth-mux-version.json"
   local preflight_json="$report_dir/codex-preflight.json"
   local status_json="$report_dir/codex-status-latest.json"
+  local process_gate_json="$report_dir/process-gate.json"
+  local process_gate_stderr="$report_dir/process-gate.stderr"
   local codex_version_txt="$report_dir/codex-version.txt"
   local commands_txt="$report_dir/commands.txt"
   local processes_txt="$report_dir/processes.txt"
@@ -144,18 +149,19 @@ cmd_preflight() {
   codex --version >"$codex_version_txt" 2>&1 || true
   oauth-mux codex preflight --profile "$profile" --capability "$capability" --json >"$preflight_json" || true
   oauth-mux codex status-latest --json >"$status_json" 2>/dev/null || printf '{}\n' >"$status_json"
+  python3 "$ROOT/scripts/dogfood-process-snapshot.py" --json >"$process_gate_json" 2>"$process_gate_stderr" || printf '{}\n' >"$process_gate_json"
   ps -o pid,ppid,stat,lstart,etime,command -ax 2>/dev/null | grep -E 'oauth-mux codex|oauth-mux|codex' >"$processes_txt" || true
 
   if command -v mitmdump >/dev/null 2>&1; then
     mitmdump --version >"$report_dir/mitmdump-version.txt" 2>&1 || true
   fi
 
-  python3 - "$version_json" "$preflight_json" "$status_json" "$commands_txt" "$processes_txt" "$summary_json" "$profile" "$capability" "$require_fallback" "$mitmproxy_ca" "$ssl_cert_file" <<'PY'
+  python3 - "$version_json" "$preflight_json" "$status_json" "$process_gate_json" "$commands_txt" "$processes_txt" "$summary_json" "$profile" "$capability" "$require_fallback" "$mitmproxy_ca" "$ssl_cert_file" <<'PY'
 import json
 import pathlib
 import sys
 
-version_path, preflight_path, status_path, commands_path, processes_path, out_path, profile, capability, require_fallback, mitmproxy_ca_path, ssl_cert_file = sys.argv[1:]
+version_path, preflight_path, status_path, process_gate_path, commands_path, processes_path, out_path, profile, capability, require_fallback, mitmproxy_ca_path, ssl_cert_file = sys.argv[1:]
 
 
 def load_json(path):
@@ -168,12 +174,16 @@ def load_json(path):
 version = load_json(version_path)
 preflight = load_json(preflight_path)
 status = load_json(status_path)
+process_gate = load_json(process_gate_path)
 commands = pathlib.Path(commands_path).read_text(errors="replace")
 processes = pathlib.Path(processes_path).read_text(errors="replace")
 
 route_summary = preflight.get("route_summary") or {}
 selected = preflight.get("selected")
 runtime_identity = version.get("runtime_identity") or {}
+evidence_gate = process_gate.get("evidence_gate") or {}
+safe_cleanup = process_gate.get("safe_cleanup") or {}
+review_groups = safe_cleanup.get("review_groups") or {}
 mitmdump_available = bool([line for line in commands.splitlines() if line.strip().endswith("mitmdump") or "/mitmdump" in line])
 mitmproxy_ca = pathlib.Path(mitmproxy_ca_path).expanduser()
 mitmproxy_ca_exists = mitmproxy_ca.is_file()
@@ -243,12 +253,29 @@ summary = {
     "blocked_route_reasons": preflight.get("blocked_route_reasons") or [],
     "status_verdict": status.get("verdict"),
     "status_path": status.get("path"),
+    "process_gate": {
+        "present": bool(process_gate),
+        "process_fd_clean_baseline": evidence_gate.get("process_fd_clean_baseline"),
+        "unannotated_live_claims_admitted": evidence_gate.get("unannotated_live_claims_admitted"),
+        "quota_cassette_claims_admitted": evidence_gate.get("quota_cassette_claims_admitted"),
+        "local_release_validation_admitted": evidence_gate.get("local_release_validation_admitted"),
+        "requires_operator_annotation": evidence_gate.get("requires_operator_annotation"),
+        "blocking_reasons": evidence_gate.get("blocking_reasons") or [],
+        "caution_reasons": evidence_gate.get("caution_reasons") or [],
+        "safe_cleanup_review_counts": {
+            "active_codex_or_oauth_mux_processes": len(review_groups.get("active_codex_or_oauth_mux_processes") or []),
+            "orphan_listener_candidates": len(review_groups.get("orphan_listener_candidates") or []),
+            "live_validation_processes": len(review_groups.get("live_validation_processes") or []),
+            "high_fd_processes": len(review_groups.get("high_fd_processes") or []),
+        },
+    },
     "warnings": warnings,
     "stale_mux_process_hints": stale_mux_process_hints,
     "report_files": {
         "oauth_mux_version": pathlib.Path(version_path).name,
         "codex_preflight": pathlib.Path(preflight_path).name,
         "codex_status_latest": pathlib.Path(status_path).name,
+        "process_gate": pathlib.Path(process_gate_path).name,
         "commands": pathlib.Path(commands_path).name,
         "processes": pathlib.Path(processes_path).name,
     },
@@ -261,6 +288,7 @@ print(f"ok: {str(summary['ok']).lower()}")
 print(f"oauth-mux: {summary['oauth_mux'].get('version')} {summary['oauth_mux'].get('build_id')} {summary['oauth_mux'].get('binary_source')}")
 print(f"selected: {selected}")
 print(f"route_summary: {json.dumps(route_summary, sort_keys=True)}")
+print(f"process_gate: {json.dumps(summary['process_gate'], sort_keys=True)}")
 print(f"mitmproxy_ca: {json.dumps(summary['mitmproxy_ca'], sort_keys=True)}")
 if warnings:
     print("warnings:")

--- a/scripts/dogfood-process-snapshot.py
+++ b/scripts/dogfood-process-snapshot.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""No-spend agent process fanout snapshot for oauth-mux dogfood sessions."""
+"""Read-only agent process fanout snapshot for oauth-mux dogfood sessions."""
 
 from __future__ import annotations
 
@@ -249,6 +249,8 @@ def is_oauth_mux_process(proc: dict[str, Any]) -> bool:
 
 
 def is_codex_process(proc: dict[str, Any]) -> bool:
+    if is_oauth_mux_process(proc):
+        return False
     command = proc["command"].lower()
     return proc["command_name"].lower() == "codex" or "/codex" in command or " codex " in command
 
@@ -291,6 +293,18 @@ def has_ancestor(
             return True
         current = parent
     return False
+
+
+def current_invocation_ancestor_pids(by_pid: dict[int, dict[str, Any]], start_ppid: int | None = None) -> set[int]:
+    ancestors: set[int] = set()
+    current_pid = os.getppid() if start_ppid is None else start_ppid
+    while current_pid > 0 and current_pid not in ancestors:
+        current = by_pid.get(current_pid)
+        if current is None:
+            break
+        ancestors.add(current_pid)
+        current_pid = current["ppid"]
+    return ancestors
 
 
 def depth_first_tree(pid: int, children: dict[int, list[int]], by_pid: dict[int, dict[str, Any]], depth: int = 0) -> list[dict[str, Any]]:
@@ -412,6 +426,60 @@ def build_evidence_gate(
     }
 
 
+def process_review_row(proc: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "pid": proc.get("pid"),
+        "ppid": proc.get("ppid"),
+        "command_name": proc.get("command_name"),
+        "role": proc.get("role"),
+        "elapsed": proc.get("elapsed"),
+        "elapsed_seconds": proc.get("elapsed_seconds"),
+        "rss_mib": proc.get("rss_mib"),
+        "cpu_pct": proc.get("cpu_pct"),
+        "fd_count": proc.get("fd_count"),
+        "listener_ports": proc.get("listener_ports", []),
+    }
+
+
+def build_safe_cleanup(
+    evidence_gate: dict[str, Any],
+    active_codex_or_oauth_mux_processes: list[dict[str, Any]],
+    orphan_listener_candidates: list[dict[str, Any]],
+    live_validation_processes: list[dict[str, Any]],
+    fd_summary: dict[str, Any],
+) -> dict[str, Any]:
+    high_fd_processes = [
+        proc
+        for proc in fd_summary.get("top_processes", [])
+        if isinstance(proc.get("fd_soft_limit_pct"), (int, float))
+        and proc["fd_soft_limit_pct"] >= LIVE_CLAIM_FD_SOFT_LIMIT_PCT
+    ]
+    return {
+        "automation_may_kill": False,
+        "requires_operator_approval": True,
+        "claim_blocking": not evidence_gate.get("process_fd_clean_baseline", False),
+        "review_groups": {
+            "active_codex_or_oauth_mux_processes": [
+                process_review_row(proc) for proc in active_codex_or_oauth_mux_processes
+            ],
+            "orphan_listener_candidates": [
+                process_review_row(proc) for proc in orphan_listener_candidates
+            ],
+            "live_validation_processes": [
+                process_review_row(proc) for proc in live_validation_processes
+            ],
+            "high_fd_processes": high_fd_processes,
+        },
+        "guidance": [
+            "Do not kill active Codex or Claude sessions from this report.",
+            "Close old shells or agent sessions manually when their work is complete.",
+            "Prefer the normal shell/session exit path before any PID-level action.",
+            "Collect a second snapshot after cleanup before treating process/fd state as clean.",
+            "Only collect a leak bug after repeated snapshots show unexplained RSS growth for the same PID.",
+        ],
+    }
+
+
 def build_snapshot(args: argparse.Namespace) -> dict[str, Any]:
     processes, ps_warnings = parse_ps()
     listeners, lsof_warnings = parse_lsof()
@@ -521,6 +589,20 @@ def build_snapshot(args: argparse.Namespace) -> dict[str, Any]:
         for signature, group in sorted(helper_groups.items())
         if len(group) > 1
     ]
+    current_ancestor_pids = current_invocation_ancestor_pids(by_pid)
+    ignored_current_invocation_live_validation_processes = [
+        {
+            "pid": proc["pid"],
+            "ppid": proc["ppid"],
+            "command_name": proc["command_name"],
+            "role": proc["role"],
+            "command": proc["command"],
+            "elapsed": proc["elapsed"],
+            "elapsed_seconds": proc["elapsed_seconds"],
+        }
+        for proc in processes
+        if proc["pid"] in current_ancestor_pids and is_live_validation_process(proc)
+    ]
     live_validation_processes = [
         {
             "pid": proc["pid"],
@@ -532,7 +614,7 @@ def build_snapshot(args: argparse.Namespace) -> dict[str, Any]:
             "elapsed_seconds": proc["elapsed_seconds"],
         }
         for proc in processes
-        if is_live_validation_process(proc)
+        if proc["pid"] not in current_ancestor_pids and is_live_validation_process(proc)
     ]
 
     accumulated_sessions = [
@@ -601,13 +683,12 @@ def build_snapshot(args: argparse.Namespace) -> dict[str, Any]:
     return {
         "kind": "dogfood_process_snapshot",
         "mode": "agent_process_fanout_snapshot",
-        "schema_version": 1,
+        "schema_version": 2,
         "collected_at": utc_now(),
         "host": os.uname().nodename,
         "pid": os.getpid(),
         "scope": "agent_process_fanout",
         "spends_provider_calls": False,
-        "no_provider_spend": True,
         "mutates_user_config": False,
         "mutates_route_health": False,
         "mutates_processes": False,
@@ -630,6 +711,7 @@ def build_snapshot(args: argparse.Namespace) -> dict[str, Any]:
             "duplicate_helper_group_count": len(duplicate_helper_groups),
             "accumulated_session_count": len(accumulated_sessions),
             "live_validation_process_count": len(live_validation_processes),
+            "ignored_current_invocation_live_validation_process_count": len(ignored_current_invocation_live_validation_processes),
             "heap_leak_proven": False,
             "heap_leak_evidence": "single snapshot only; compare two snapshots before calling this a leak",
         },
@@ -645,16 +727,15 @@ def build_snapshot(args: argparse.Namespace) -> dict[str, Any]:
         "orphan_listener_candidates": orphan_listener_candidates,
         "duplicate_helper_groups": duplicate_helper_groups,
         "live_validation_processes": live_validation_processes,
+        "ignored_current_invocation_live_validation_processes": ignored_current_invocation_live_validation_processes,
         "accumulated_sessions": accumulated_sessions,
-        "safe_cleanup": {
-            "automation_may_kill": False,
-            "requires_operator_approval": True,
-            "guidance": [
-                "Do not kill active Codex or Claude sessions from this report.",
-                "Close old shells or agent sessions manually when their work is complete.",
-                "Only collect a leak bug after repeated snapshots show unexplained RSS growth for the same PID.",
-            ],
-        },
+        "safe_cleanup": build_safe_cleanup(
+            evidence_gate,
+            active_codex_or_oauth_mux_processes,
+            orphan_listener_candidates,
+            live_validation_processes,
+            fd_summary,
+        ),
         "warnings": warnings,
     }
 
@@ -977,6 +1058,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--out", help="write JSON and Markdown artifacts to this directory")
     parser.add_argument("--tag", help="short label to add to written artifact names")
     parser.add_argument("--compare", nargs=2, metavar=("BASELINE_JSON", "CURRENT_JSON"), help="compare two snapshot JSON files")
+    parser.add_argument("--require-clean", action="store_true", help="exit nonzero unless process/fd evidence is clean")
+    parser.add_argument(
+        "--require-gate",
+        choices=[
+            "process_fd_clean_baseline",
+            "unannotated_live_claims_admitted",
+            "quota_cassette_claims_admitted",
+            "local_release_validation_admitted",
+        ],
+        help="exit nonzero unless the named evidence gate is admitted",
+    )
     parser.add_argument("--schedule-followup-seconds", type=int, help="after writing --out artifacts, schedule a background follow-up snapshot")
     parser.add_argument("--accumulated-seconds", type=int, default=4 * 60 * 60, help="elapsed time threshold for accumulated-session classification")
     parser.add_argument("--rss-growth-kib", type=int, default=64 * 1024, help="minimum same-PID RSS growth for comparison suspicion")
@@ -990,6 +1082,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         parser.error("--schedule-followup-seconds requires --out")
     if args.followup_after_seconds is not None and not args.followup_baseline:
         parser.error("--followup-after-seconds requires --followup-baseline")
+    if args.compare and (args.require_clean or args.require_gate):
+        parser.error("--require-clean/--require-gate apply only to snapshots, not comparisons")
     return args
 
 
@@ -1029,6 +1123,15 @@ def main(argv: list[str]) -> int:
             "no foreground sleep is running",
             file=sys.stderr,
         )
+
+    if not args.compare:
+        gate = payload.get("evidence_gate", {})
+        required_gate = args.require_gate or ("process_fd_clean_baseline" if args.require_clean else None)
+        if required_gate is not None and gate.get(required_gate) is not True:
+            reasons = gate.get("blocking_reasons", []) + gate.get("caution_reasons", [])
+            reason_text = ", ".join(str(item.get("reason")) for item in reasons) or "gate_not_admitted"
+            print(f"process/fd evidence gate failed: {required_gate}: {reason_text}", file=sys.stderr)
+            return 2
 
     return 0
 

--- a/scripts/review-codex-wire-capture.py
+++ b/scripts/review-codex-wire-capture.py
@@ -25,6 +25,12 @@ TOKEN_PATTERNS = [
 ]
 
 COOKIE_HEADERS = {"cookie", "set-cookie"}
+PROCESS_GATE_NAMES = {
+    "process_fd_clean_baseline",
+    "unannotated_live_claims_admitted",
+    "quota_cassette_claims_admitted",
+    "local_release_validation_admitted",
+}
 
 
 def _local_path_patterns() -> list[re.Pattern[str]]:
@@ -107,6 +113,13 @@ def main() -> int:
     parser.add_argument("--json", action="store_true", help="emit machine-readable summary")
     parser.add_argument("--require-preflight-ok", action="store_true", help="fail unless capture-preflight-summary.json is present and ok:true")
     parser.add_argument("--require-proxy-meta", action="store_true", help="fail unless meta.json records same-run proxy preflight metadata")
+    parser.add_argument(
+        "--require-process-gate",
+        action="append",
+        choices=sorted(PROCESS_GATE_NAMES),
+        default=[],
+        help="fail unless capture preflight process_gate admits this gate",
+    )
     parser.add_argument("--require-path-kind", action="append", default=[], help="fail unless at least one flow has this normalized path kind")
     parser.add_argument("--require-status", action="append", type=int, default=[], help="fail unless at least one flow has this HTTP status")
     parser.add_argument("--require-quota-type", action="append", default=[], help="fail unless at least one 429 error.type matches this value")
@@ -180,6 +193,20 @@ def main() -> int:
             detail = f": {issues}" if issues else ""
             requirement_failures.append(f"capture preflight was not ok{detail}")
 
+    preflight_process_gate = None
+    if isinstance(preflight_summary, dict):
+        preflight_process_gate = preflight_summary.get("process_gate")
+
+    for gate_name in args.require_process_gate:
+        if not isinstance(preflight_summary, dict):
+            requirement_failures.append("capture preflight summary is missing or unreadable")
+            break
+        if not isinstance(preflight_process_gate, dict):
+            requirement_failures.append("capture preflight process_gate is missing or unreadable")
+            break
+        if preflight_process_gate.get(gate_name) is not True:
+            requirement_failures.append(f"capture preflight process gate not admitted: {gate_name}")
+
     meta_preflight_summary = None
     meta_preflight_present = False
     if isinstance(meta_summary, dict):
@@ -218,6 +245,7 @@ def main() -> int:
             "present": isinstance(preflight_summary, dict),
             "ok": preflight_summary.get("ok") if isinstance(preflight_summary, dict) else None,
             "issues": preflight_summary.get("issues", []) if isinstance(preflight_summary, dict) else [],
+            "process_gate": preflight_process_gate if isinstance(preflight_process_gate, dict) else None,
         },
         "meta": {
             "present": isinstance(meta_summary, dict),
@@ -238,6 +266,8 @@ def main() -> int:
     else:
         print(f"flows: {summary['flow_count']}")
         print(f"preflight: {json.dumps(summary['preflight'], sort_keys=True)}")
+        if summary["preflight"].get("process_gate") is not None:
+            print(f"process_gate: {json.dumps(summary['preflight']['process_gate'], sort_keys=True)}")
         print(f"meta: {json.dumps(summary['meta'], sort_keys=True)}")
         print(f"paths: {json.dumps(path_counts, sort_keys=True)}")
         print(f"statuses: {json.dumps(status_counts, sort_keys=True)}")

--- a/scripts/smoke-codex-capture-review.sh
+++ b/scripts/smoke-codex-capture-review.sh
@@ -23,6 +23,15 @@ cat >"$TMP/codex-wire-synth/capture-preflight-summary.json" <<'JSON'
     "session_start_ready": true,
     "fallback_ready": true,
     "single_route_at_risk": false
+  },
+  "process_gate": {
+    "process_fd_clean_baseline": true,
+    "unannotated_live_claims_admitted": true,
+    "quota_cassette_claims_admitted": true,
+    "local_release_validation_admitted": true,
+    "requires_operator_annotation": false,
+    "blocking_reasons": [],
+    "caution_reasons": []
   }
 }
 JSON
@@ -104,6 +113,7 @@ JSON
 "$ROOT/scripts/capture-codex-wire.sh" review "$TMP/codex-wire-synth" \
   --require-preflight-ok \
   --require-proxy-meta \
+  --require-process-gate quota_cassette_claims_admitted \
   --require-path-kind responses \
   --require-status 200 \
   --require-status 429 \
@@ -118,6 +128,7 @@ assert summary["ok"] is True, summary
 assert summary["flow_count"] == 2, summary
 assert summary["preflight"]["present"] is True, summary
 assert summary["preflight"]["ok"] is True, summary
+assert summary["preflight"]["process_gate"]["quota_cassette_claims_admitted"] is True, summary
 assert summary["meta"]["present"] is True, summary
 assert summary["meta"]["kind"] == "phase_0_wire_capture", summary
 assert summary["meta"]["preflight_summary"] == "capture-preflight-summary.json", summary
@@ -130,6 +141,41 @@ assert shape["error_type"] == "usage_limit_reached", shape
 assert shape["has_resets_at"] is True, shape
 assert shape["plan_type"] == "pro", shape
 assert summary["requirement_failures"] == [], summary
+PY
+
+BAD_PROCESS_GATE="$TMP/codex-wire-bad-process-gate"
+mkdir -p "$BAD_PROCESS_GATE/http"
+cp "$TMP/codex-wire-synth/meta.json" "$BAD_PROCESS_GATE/meta.json"
+cp "$CAP/00001-POST-backend-api_codex_responses.json" "$BAD_PROCESS_GATE/http/00001-POST-backend-api_codex_responses.json"
+cat >"$BAD_PROCESS_GATE/capture-preflight-summary.json" <<'JSON'
+{
+  "ok": true,
+  "issues": [],
+  "process_gate": {
+    "quota_cassette_claims_admitted": false,
+    "blocking_reasons": [
+      {"reason": "active_oauth_mux_or_codex_processes", "count": 1}
+    ],
+    "caution_reasons": []
+  }
+}
+JSON
+
+if "$ROOT/scripts/capture-codex-wire.sh" review "$BAD_PROCESS_GATE" \
+  --require-preflight-ok \
+  --require-proxy-meta \
+  --require-process-gate quota_cassette_claims_admitted \
+  --json >"$TMP/bad-process-gate-summary.json"; then
+  echo "smoke-codex-capture-review: expected blocked process gate to fail" >&2
+  exit 1
+fi
+
+python3 - "$TMP/bad-process-gate-summary.json" <<'PY'
+import json
+import sys
+summary = json.load(open(sys.argv[1]))
+assert summary["ok"] is False, summary
+assert "capture preflight process gate not admitted: quota_cassette_claims_admitted" in summary["requirement_failures"], summary
 PY
 
 FIXTURE="$ROOT/test/fixtures/codex-wire/auth-refresh-token-expired"
@@ -429,6 +475,9 @@ assert summary["mitmproxy_ca"]["exists"] is True, summary
 assert summary["mitmproxy_ca"]["ssl_cert_file_matches_ca"] is True, summary
 assert summary["route_summary"]["fallback_ready"] is True, summary
 assert summary["route_summary"]["single_route_at_risk"] is False, summary
+assert summary["process_gate"]["present"] is True, summary
+assert isinstance(summary["process_gate"]["blocking_reasons"], list), summary
+assert isinstance(summary["process_gate"]["safe_cleanup_review_counts"]["active_codex_or_oauth_mux_processes"], int), summary
 assert summary["oauth_mux"]["build_id"] == "v0.1.10", summary
 assert summary["status_verdict"] == "brokered_with_fallback", summary
 assert summary["blocked_route_reasons"][0]["reason"] == "quota_exhausted", summary

--- a/scripts/smoke-dogfood-process-snapshot.sh
+++ b/scripts/smoke-dogfood-process-snapshot.sh
@@ -9,7 +9,7 @@ python3 "$ROOT/scripts/dogfood-process-snapshot.py" --json >"$TMP/snapshot.json"
 
 jq -e '
   .kind == "dogfood_process_snapshot"
-  and .schema_version == 1
+  and .schema_version == 2
   and .spends_provider_calls == false
   and .mutates_user_config == false
   and .mutates_route_health == false
@@ -19,9 +19,15 @@ jq -e '
   and .foreground_sleep == false
   and .safe_cleanup.automation_may_kill == false
   and .safe_cleanup.requires_operator_approval == true
+  and (.safe_cleanup.claim_blocking | type == "boolean")
+  and (.safe_cleanup.review_groups.active_codex_or_oauth_mux_processes | type == "array")
+  and (.safe_cleanup.review_groups.orphan_listener_candidates | type == "array")
+  and (.safe_cleanup.review_groups.live_validation_processes | type == "array")
+  and (.safe_cleanup.review_groups.high_fd_processes | type == "array")
   and (.process_summary.oauth_mux_processes | type == "number")
   and (.process_summary.active_codex_or_oauth_mux_processes | type == "number")
   and (.summary.live_validation_process_count | type == "number")
+  and (.summary.ignored_current_invocation_live_validation_process_count | type == "number")
   and (.resource_limits.nofile.available | type == "boolean")
   and (.fd_summary.visible_fd_process_count | type == "number")
   and .fd_summary.fd_soft_limit_basis == "collector_process_nofile_soft_limit"
@@ -39,6 +45,7 @@ jq -e '
   and (.orphan_listener_candidates | type == "array")
   and (.duplicate_helper_groups | type == "array")
   and (.live_validation_processes | type == "array")
+  and (.ignored_current_invocation_live_validation_processes | type == "array")
 ' "$TMP/snapshot.json" >/dev/null
 
 ROOT_PATH="$ROOT" python3 - <<'PY'
@@ -58,6 +65,21 @@ assert module.is_numeric_fd_tag("cwd") is False
 assert module.is_numeric_fd_tag("txt") is False
 assert module.is_numeric_fd_tag("mem") is False
 assert module.is_numeric_fd_tag("") is False
+oauth_mux_codex_parent = {
+    "command_name": "oauth-mux",
+    "command": "/Users/test/bin/oauth-mux codex resume --last",
+}
+assert module.is_oauth_mux_process(oauth_mux_codex_parent) is True
+assert module.is_codex_process(oauth_mux_codex_parent) is False
+native_codex = {"command_name": "codex", "command": "/nix/store/bin/codex resume --last"}
+assert module.is_codex_process(native_codex) is True
+ancestor_map = {
+    10: {"pid": 10, "ppid": 9},
+    9: {"pid": 9, "ppid": 1},
+    1: {"pid": 1, "ppid": 0},
+    20: {"pid": 20, "ppid": 1},
+}
+assert module.current_invocation_ancestor_pids(ancestor_map, 10) == {10, 9, 1}
 
 clean = module.build_evidence_gate(
     {
@@ -105,7 +127,26 @@ assert {row["reason"] for row in blocked["caution_reasons"]} == {
     "accumulated_sessions_visible",
     "duplicate_helper_groups_visible",
 }
+
+cleanup = module.build_safe_cleanup(
+    blocked,
+    [{"pid": 1, "ppid": 0, "command_name": "codex", "role": "native_codex", "elapsed": "00:01", "elapsed_seconds": 1, "rss_mib": 1.0, "cpu_pct": 0.0, "fd_count": 180, "listener_ports": []}],
+    [{"pid": 2, "ppid": 0, "command_name": "node", "role": "helper", "elapsed": "00:01", "elapsed_seconds": 1, "rss_mib": 1.0, "cpu_pct": 0.0, "fd_count": 20, "listener_ports": ["9229"]}],
+    [{"pid": 3, "ppid": 0, "command_name": "mitmdump", "role": "other", "elapsed": "00:01", "elapsed_seconds": 1}],
+    {"top_processes": [{"pid": 1, "ppid": 0, "command_name": "codex", "role": "native_codex", "fd_count": 180, "fd_soft_limit_pct": 70.3}]},
+)
+assert cleanup["automation_may_kill"] is False
+assert cleanup["requires_operator_approval"] is True
+assert cleanup["claim_blocking"] is True
+assert cleanup["review_groups"]["active_codex_or_oauth_mux_processes"][0]["pid"] == 1
+assert cleanup["review_groups"]["orphan_listener_candidates"][0]["listener_ports"] == ["9229"]
+assert cleanup["review_groups"]["live_validation_processes"][0]["pid"] == 3
+assert cleanup["review_groups"]["high_fd_processes"][0]["fd_soft_limit_pct"] == 70.3
 PY
+
+python3 "$ROOT/scripts/dogfood-process-snapshot.py" \
+  --require-gate local_release_validation_admitted \
+  --json >"$TMP/required-local-release.json"
 
 python3 "$ROOT/scripts/dogfood-process-snapshot.py" \
   --compare "$TMP/snapshot.json" "$TMP/snapshot.json" \


### PR DESCRIPTION
## Summary
- add fail-closed `dogfood-process-snapshot.py --require-clean` and `--require-gate <gate>` checks for claim-bearing process/fd evidence
- expose operator-review cleanup groups without allowing automated process termination
- add process/fd gate provenance to Codex wire-capture preflight summaries
- fix `oauth-mux codex ...` parent classification so managed adapter parents are not mislabeled as native Codex
- update TIN-1591 sprint and productionization docs with the current contaminated host boundary

## Validation
- `python3 -m py_compile scripts/dogfood-process-snapshot.py scripts/review-codex-wire-capture.py scripts/codex-wire-addon.py`
- `bash -n scripts/capture-codex-wire.sh scripts/smoke-codex-capture-review.sh scripts/smoke-dogfood-process-snapshot.sh`
- `./scripts/smoke-dogfood-process-snapshot.sh`
- `./scripts/smoke-codex-capture-review.sh`
- `python3 scripts/dogfood-process-snapshot.py --require-gate quota_cassette_claims_admitted --json` exits 2 on the current contaminated host, as intended
- `git diff --check`
- `just check-local`

TIN-1591
