### PR TITLE
Contain Codex reconnect GET transport locally

### DIFF
--- a/scripts/smoke-codex-acceptance.sh
+++ b/scripts/smoke-codex-acceptance.sh
@@ -188,6 +188,7 @@ assert_grep "runtime identity records binary sha" '"binary_sha256":"[0-9a-f]{64}
 assert_grep "runtime identity marks path printed" '"path_printed":true' "$NDJSON"
 assert_grep "runtime identity records installed/local mismatch bit" '"installed_local_mismatch_detected":false' "$NDJSON"
 assert_grep "websocket upgrade got local HTTP fallback signal" '"kind":"proxy_unsupported_transport".*"transport":"websocket".*"method":"GET".*"path_kind":"responses".*"status":426.*"fallback_signal":"http_426".*"upstream_called":false.*"delivered_to_codex":true' "$NDJSON"
+assert_grep "plain responses GET got local HTTP fallback signal" '"kind":"proxy_unsupported_transport".*"transport":"responses_get".*"method":"GET".*"path_kind":"responses".*"status":426.*"fallback_signal":"http_426".*"upstream_called":false.*"delivered_to_codex":true' "$NDJSON"
 if grep -q -E '"kind":"proxy_turn".*"method":"GET".*"path_kind":"responses".*"status":405.*"classification":"ok"' "$NDJSON"; then
     echo "  ✗ websocket upgrade was forwarded as plain GET and misclassified as ok" >&2
     cat "$NDJSON" >&2
@@ -252,7 +253,9 @@ if jq -e '.websocket_probe.checked == true
           and .websocket_probe.status == 426
           and .websocket_probe.body_has_unsupported_transport == true
           and .websocket_probe.path_printed == false
-          and .websocket_probe.token_material_printed == false' "$STUB_REPORT" >/dev/null; then
+          and .websocket_probe.token_material_printed == false
+          and (.websocket_probe.variants | length) == 2
+          and all(.websocket_probe.variants[]; .status == 426 and .body_has_unsupported_transport == true and .path_printed == false and .token_material_printed == false)' "$STUB_REPORT" >/dev/null; then
     echo "  ✓ child saw typed local WebSocket fallback response"
 else
     echo "  ✗ child WebSocket probe did not see local fallback response" >&2

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -213,8 +213,23 @@ def _websocket_probe(proxy_url: str) -> dict:
         print(f"stub-codex: cannot parse base_url={proxy_url}", file=sys.stderr)
         sys.exit(2)
     netloc, prefix = m.group(1), m.group(2)
-    conn = http.client.HTTPConnection(netloc, timeout=15)
-    headers = {
+    def run_get(label: str, headers: dict) -> dict:
+        conn = http.client.HTTPConnection(netloc, timeout=15)
+        try:
+            conn.request("GET", prefix + "/responses", headers=headers)
+            resp = conn.getresponse()
+            body = resp.read().decode("utf-8", errors="replace")
+            return {
+                "label": label,
+                "status": resp.status,
+                "body_has_unsupported_transport": "oauth_mux_unsupported_transport" in body,
+                "path_printed": False,
+                "token_material_printed": False,
+            }
+        finally:
+            conn.close()
+
+    websocket_headers = {
         "Connection": "keep-alive, Upgrade",
         "Upgrade": "websocket",
         "Sec-WebSocket-Key": "dGhlIHNhbXBsZSBub25jZQ==",
@@ -226,22 +241,33 @@ def _websocket_probe(proxy_url: str) -> dict:
     account_id = os.environ.get("OMUX_STUB_CODEX_CHATGPT_ACCOUNT_ID")
     auth_token = _auth_token_for_turn(0)
     if account_id:
-        headers["ChatGPT-Account-ID"] = account_id
+        websocket_headers["ChatGPT-Account-ID"] = account_id
     if auth_token:
-        headers["Authorization"] = f"Bearer {auth_token}"
-    try:
-        conn.request("GET", prefix + "/responses", headers=headers)
-        resp = conn.getresponse()
-        body = resp.read().decode("utf-8", errors="replace")
-        return {
-            "checked": True,
-            "status": resp.status,
-            "body_has_unsupported_transport": "oauth_mux_unsupported_transport" in body,
-            "path_printed": False,
-            "token_material_printed": False,
-        }
-    finally:
-        conn.close()
+        websocket_headers["Authorization"] = f"Bearer {auth_token}"
+
+    beta_only_headers = {
+        "User-Agent": "stub-codex/0",
+        "x-codex-installation-id": "stub-install-1",
+        "OpenAI-Beta": "responses_websockets=2026-02-06",
+    }
+    if account_id:
+        beta_only_headers["ChatGPT-Account-ID"] = account_id
+    if auth_token:
+        beta_only_headers["Authorization"] = f"Bearer {auth_token}"
+
+    variants = [
+        run_get("websocket_upgrade", websocket_headers),
+        run_get("responses_get_beta_only", beta_only_headers),
+    ]
+    primary = variants[0]
+    return {
+        "checked": True,
+        "status": primary["status"],
+        "body_has_unsupported_transport": primary["body_has_unsupported_transport"],
+        "path_printed": False,
+        "token_material_printed": False,
+        "variants": variants,
+    }
 
 
 def _session_bridge_report(codex_home: Path) -> dict:

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -233,9 +233,9 @@ pub const Proxy = struct {
             return;
         };
 
-        if (isWebSocketUpgradeRequest(&req)) {
+        if (unsupportedResponsesGetTransport(&req)) |transport| {
             self.logEvent("proxy_unsupported_transport", .{
-                .transport = "websocket",
+                .transport = transport,
                 .method = req.method,
                 .path_kind = pathKind(req.path),
                 .status = 426,
@@ -245,7 +245,7 @@ pub const Proxy = struct {
             });
             trace.append(self.allocator, "codex.proxy.unsupported_transport", .warn, &.{
                 trace.string("provider", "codex"),
-                trace.string("transport", "websocket"),
+                trace.string("transport", transport),
                 trace.string("method", req.method),
                 trace.string("path_kind", pathKind(req.path)),
                 trace.uint("status", 426),
@@ -1084,6 +1084,13 @@ fn isWebSocketUpgradeRequest(req: *const Request) bool {
     return true;
 }
 
+fn unsupportedResponsesGetTransport(req: *const Request) ?[]const u8 {
+    if (!std.mem.eql(u8, req.method, "GET")) return null;
+    if (!std.mem.eql(u8, pathKind(req.path), "responses")) return null;
+    if (isWebSocketUpgradeRequest(req)) return "websocket";
+    return "responses_get";
+}
+
 fn parseRequest(a: std.mem.Allocator, reader: anytype) !Request {
     // Request line: METHOD SP PATH SP HTTP/1.1 CRLF
     const start_line = try readLine(a, reader, 8 * 1024);
@@ -1862,6 +1869,51 @@ test "plain responses GET is not classified as websocket upgrade" {
         .body = &.{},
     };
     try std.testing.expect(!isWebSocketUpgradeRequest(&req));
+}
+
+test "responses GET reconnect requests are contained locally" {
+    var headers = HeaderList.init(std.testing.allocator);
+    defer headers.items.deinit(std.testing.allocator);
+    try headers.append("Host", "127.0.0.1:1234");
+    try headers.append("OpenAI-Beta", "responses_websockets=2026-02-06");
+
+    const req = Request{
+        .method = "GET",
+        .path = "/backend-api/responses",
+        .headers = headers,
+        .body = &.{},
+    };
+    try std.testing.expectEqualStrings("responses_get", unsupportedResponsesGetTransport(&req) orelse "none");
+}
+
+test "websocket responses GET reports websocket transport" {
+    var headers = HeaderList.init(std.testing.allocator);
+    defer headers.items.deinit(std.testing.allocator);
+    try headers.append("Host", "127.0.0.1:1234");
+    try headers.append("Upgrade", "websocket");
+    try headers.append("OpenAI-Beta", "responses_websockets=2026-02-06");
+
+    const req = Request{
+        .method = "GET",
+        .path = "/backend-api/responses",
+        .headers = headers,
+        .body = &.{},
+    };
+    try std.testing.expectEqualStrings("websocket", unsupportedResponsesGetTransport(&req) orelse "none");
+}
+
+test "non-responses GET requests are still proxyable" {
+    var headers = HeaderList.init(std.testing.allocator);
+    defer headers.items.deinit(std.testing.allocator);
+    try headers.append("Host", "127.0.0.1:1234");
+
+    const req = Request{
+        .method = "GET",
+        .path = "/backend-api/models",
+        .headers = headers,
+        .body = &.{},
+    };
+    try std.testing.expect(unsupportedResponsesGetTransport(&req) == null);
 }
 
 test "unsupported websocket response is local and explicit" {


### PR DESCRIPTION
## Summary

- treat all GET requests to the Codex Responses endpoint as unsupported local transport before upstream forwarding
- preserve the existing WebSocket 426 fallback signal while adding a distinct responses_get status value for incomplete reconnect/fallback shapes
- extend the stub Codex acceptance probe to send both a full WebSocket upgrade and a beta-only plain Responses GET
- assert neither reconnect GET shape reaches upstream or becomes proxy_turn status=405 classification=ok

## Root Cause

Codex reconnect fallback can issue GET /backend-api/responses without a complete WebSocket upgrade header. The proxy only contained full WebSocket upgrades, so partial/plain reconnect GETs could be forwarded upstream and classified as normal non-quota HTTP turns.

## Verification

- zig fmt --check src/adapters/codex/wire_proxy.zig
- python3 -m py_compile scripts/test-stub-codex.py
- zig build test
- zig build
- ./scripts/smoke-codex-acceptance.sh
- ./scripts/smoke-codex-provider-degraded.sh
- git diff --check
- just check-local

Closes #311
Linear: TIN-1631