### PR TITLE
Classify Codex child startup exits

### DIFF
--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -461,6 +461,50 @@ if grep -q -E 'managed-good-session|'"$BAD_AUTHORITY_HOME" "$BAD_AUTHORITY_NDJSO
     exit 1
 fi
 
+echo "smoke-codex-cli-ux: sqlite lock shaped child startup failure records abort"
+SQLITE_LOCK_NDJSON="$TMP/sqlite-lock/status.ndjson"
+SQLITE_LOCK_STDERR="$TMP/sqlite-lock.stderr"
+SQLITE_LOCK_REPORT="$TMP/sqlite-lock.report"
+SQLITE_LOCK_HEALTH_BEFORE="$TMP/sqlite-lock.health.before"
+mkdir -p "$(dirname "$SQLITE_LOCK_NDJSON")"
+cp "$STATE_DIR/health.json" "$SQLITE_LOCK_HEALTH_BEFORE"
+if OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+     OMUX_STATE_DIR="$STATE_DIR" \
+     OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+     CODEX_HOME="$CANONICAL_SESSION_HOME" \
+     OMUX_CODEX_SESSION_HOME="$CANONICAL_SESSION_HOME" \
+     OMUX_CODEX_CONFIG_HOME="$CANONICAL_SESSION_HOME" \
+     OMUX_STUB_CODEX_FAIL_MODE="sqlite_locked" \
+     OMUX_STUB_CODEX_REPORT="$SQLITE_LOCK_REPORT" \
+     "$BIN" codex --profile codex-max --json-status-file "$SQLITE_LOCK_NDJSON" resume 2>"$SQLITE_LOCK_STDERR"; then
+    echo "  ✗ sqlite lock failure unexpectedly succeeded" >&2
+    exit 1
+fi
+assert_grep "sqlite lock session started" '"kind":"session_started".*"sqlite_authority":"canonical_env"' "$SQLITE_LOCK_NDJSON"
+assert_grep "sqlite lock terminal abort status" '"kind":"session_aborted".*"reason":"child_exit_nonzero".*"exit_code":1.*"term_kind":"exited".*"term_code":1' "$SQLITE_LOCK_NDJSON"
+assert_grep "sqlite lock stderr preserved" 'database is locked' "$SQLITE_LOCK_STDERR"
+if grep -q '"kind":"session_ended"' "$SQLITE_LOCK_NDJSON"; then
+    echo "  ✗ sqlite lock failure was recorded as a normal session end" >&2
+    cat "$SQLITE_LOCK_NDJSON" >&2
+    exit 1
+fi
+if [[ -e "$SQLITE_LOCK_REPORT" ]]; then
+    echo "  ✗ sqlite lock startup failure wrote a normal stub report unexpectedly" >&2
+    cat "$SQLITE_LOCK_REPORT" >&2
+    exit 1
+fi
+if ! cmp -s "$STATE_DIR/health.json" "$SQLITE_LOCK_HEALTH_BEFORE"; then
+    echo "  ✗ sqlite lock failure mutated route health" >&2
+    diff -u "$SQLITE_LOCK_HEALTH_BEFORE" "$STATE_DIR/health.json" >&2 || true
+    exit 1
+fi
+if grep -q -E 'managed-good-session|'"$CANONICAL_SESSION_HOME" "$SQLITE_LOCK_NDJSON"; then
+    echo "  ✗ sqlite lock status leaked path or session id" >&2
+    cat "$SQLITE_LOCK_NDJSON" >&2
+    exit 1
+fi
+echo "  ✓ sqlite lock shaped startup failure records abort without route-health mutation"
+
 echo "smoke-codex-cli-ux: forwarded config provider override fails before spawn"
 BAD_CONFIG_NDJSON="$TMP/bad-config/status.ndjson"
 BAD_CONFIG_STDERR="$TMP/bad-config.stderr"

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -42,6 +42,8 @@ Env (set by the smoke harness):
                             before reading the streamed response.
   OMUX_STUB_CODEX_WEBSOCKET_PROBE — optional "1" to send a Codex-shaped
                             WebSocket upgrade GET before normal POST turns.
+  OMUX_STUB_CODEX_FAIL_MODE — optional startup failure mode. "sqlite_locked"
+                            emits Codex's sqlite lock startup error and exits 1.
   The report records argv after the stub binary so CLI forwarding smokes can
   assert `oauth-mux codex ...` command shape without provider traffic.
 """
@@ -367,6 +369,22 @@ def main() -> int:
     turn_delay_ms = int(os.environ.get("OMUX_STUB_CODEX_TURN_DELAY_MS", "50"))
 
     codex_home = Path(os.environ["CODEX_HOME"])
+    if os.environ.get("OMUX_STUB_CODEX_FAIL_MODE") == "sqlite_locked":
+        state_path = codex_home / "state_5.sqlite"
+        print("Codex couldn't start because another Codex process is using its local data.", file=sys.stderr)
+        print("Quit any other copies of Codex that may still be running, then try again.", file=sys.stderr)
+        print("Technical details:", file=sys.stderr)
+        print(f"  Location: {state_path}", file=sys.stderr)
+        print(
+            f"  Cause: failed to initialize state runtime at {codex_home}: error returned from database: (code: 5) database is locked",
+            file=sys.stderr,
+        )
+        print(
+            f"ERROR: failed to initialize sqlite state db at {state_path}: failed to initialize state runtime at {codex_home}: error returned from database: (code: 5) database is locked",
+            file=sys.stderr,
+        )
+        return 1
+
     proxy_url = _read_proxy_url(codex_home)
     config_report = _config_report(codex_home)
     session_bridge = _session_bridge_report(codex_home)

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -395,7 +395,7 @@ fn childTermCode(term: std.process.Child.Term) u32 {
 
 fn childTermAbortReason(term: std.process.Child.Term) ?[]const u8 {
     return switch (term) {
-        .Exited => null,
+        .Exited => |code| if (code == 0) null else "child_exit_nonzero",
         .Signal => "child_signal",
         .Stopped => "child_stopped",
         .Unknown => "child_unknown",
@@ -1632,6 +1632,12 @@ test "proxy thread suppresses expected localhost connection close errors" {
     try std.testing.expect(isBenignProxyConnectionClose(error.ConnectionResetByPeer));
     try std.testing.expect(isBenignProxyConnectionClose(error.EndOfStream));
     try std.testing.expect(!isBenignProxyConnectionClose(error.Unexpected));
+}
+
+test "nonzero Codex child exit is an aborted managed session" {
+    try std.testing.expect(childTermAbortReason(.{ .Exited = 0 }) == null);
+    try std.testing.expectEqualStrings("child_exit_nonzero", childTermAbortReason(.{ .Exited = 1 }).?);
+    try std.testing.expectEqualStrings("child_exit_nonzero", childTermAbortReason(.{ .Exited = 2 }).?);
 }
 
 /// Open a TCP connection to the proxy and immediately close it. This


### PR DESCRIPTION
## Summary

- Treat nonzero Codex child exits as managed `session_aborted` instead of a normal `session_ended`.
- Add a stubbed sqlite-lock startup failure mode matching the observed `state_5.sqlite` / database locked error.
- Extend the Codex CLI UX smoke so sqlite-lock-shaped startup failures preserve stderr, avoid route-health mutation, keep status redacted, and do not write a normal child report.

## Validation

- `zig fmt --check src/adapters/codex/main.zig`
- `python3 -m py_compile scripts/test-stub-codex.py`
- `bash -n scripts/smoke-codex-cli-ux.sh`
- `zig build test`
- `zig build`
- `./scripts/smoke-codex-cli-ux.sh`
- `git diff --check`
- `just check-local`

Refs #315.
Linear: TIN-1634
