### PR TITLE
Detect locked Codex sqlite authority before resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ What works today:
 - Native Codex chooser/session authority bridge, including canonical
   `state_5.sqlite*` and `logs_2.sqlite*` when present, with managed Codex using
   Codex's built-in `openai` provider namespace so the native and managed resume
-  pickers enumerate the same session rows.
+  pickers enumerate the same session rows. Managed resume also reports
+  canonical `state_5.sqlite` lock contention before child spawn instead of
+  forking or bypassing Codex's session authority.
 - Root-partitioned Codex config passthrough for user settings such as
   `[features]`, legacy `experimental_*`, MCP servers, approval/sandbox policy,
   profiles, model defaults, and non-managed provider definitions.

--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -137,6 +137,16 @@ session ids, SQL rows, token material, or provider response bodies, and it
 does not mutate SQLite. Any cleanup of canonical Codex SQLite state remains an
 explicit operator action that must be backed up and reversible.
 
+Implementation update, 2026-05-27: managed resume checks canonical SQLite lock
+contention before spawning Codex. In canonical bridge mode, `oauth-mux codex
+resume...` probes the SQLite lock byte range on `state_5.sqlite` when present.
+If another process holds the lock, oauth-mux emits a redacted
+`sqlite_authority_check` with `db_basename:"state_5.sqlite"`,
+`sqlite_error_class:"database_locked"`, `sqlite_error_code:5`, then aborts
+pre-spawn with `reason:"session_authority_locked"`. The adapter does not kill
+other Codex processes, rewrite session state, or fall back to an overlay-local
+SQLite database.
+
 Implementation update, 2026-05-10: managed launch no longer runs broad
 `repairRefreshableCodexAuthFailures()` before child spawn. Network refresh is
 deferred to actual credential materialization for the selected/fallback route,
@@ -549,6 +559,10 @@ oauth-mux evidence. Frame shapes are stable under broker `surface_version:
 // terminal status frame when the parent can run cleanup
 { "kind": "session_aborted", "adapter": "codex", "reason": "child_wait_error", "exit_code": -1, "final_claim_level": "broker_owned", "synthetic_swap_observed": false, "wait_error": "..." }
 { "kind": "session_aborted", "adapter": "codex", "reason": "child_signal", "exit_code": -1, "term_kind": "signal", "term_code": 9, "signal_name": "SIGKILL", "final_claim_level": "broker_owned", "synthetic_swap_observed": false }
+
+// canonical SQLite authority lock contention before child spawn
+{ "kind": "sqlite_authority_check", "mode": "resume", "sqlite_authority": "canonical_env", "ok": false, "diagnostic": "database_locked", "db_basename": "state_5.sqlite", "next_action": "close_or_wait_for_other_codex_process_then_retry", "sqlite_error_class": "database_locked", "sqlite_error_code": 5, "path_printed": false, "token_material_printed": false, "session_id_printed": false }
+{ "kind": "session_aborted", "adapter": "codex", "reason": "session_authority_locked", "phase": "sqlite_authority_check", "error": "SqliteStateLocked", "exit_code": -1, "term_kind": null, "term_code": null, "signal_name": null, "final_claim_level": "none", "synthetic_swap_observed": false, "pre_spawn": true, "child_spawned": false, "path_printed": false, "token_material_printed": false, "session_id_printed": false }
 ```
 
 These frames are the only structured surface the adapter publishes. The

--- a/docs/spec/harness-session-authority-bridge-2026-05-05.md
+++ b/docs/spec/harness-session-authority-bridge-2026-05-05.md
@@ -163,6 +163,13 @@ chooser authority when present; otherwise the legacy entries above remain the
 fallback authority set. Add new entries only with evidence that native Codex
 requires them for chooser/resume parity.
 
+For canonical Codex SQLite authority, managed resume may probe SQLite's
+standard lock byte range on `state_5.sqlite` before child spawn. A held lock is
+reported as redacted `session_authority_locked` / `database_locked` status with
+the database basename only. oauth-mux must not kill the lock holder, rewrite the
+canonical database, or create an overlay-local SQLite authority to bypass the
+lock.
+
 ### 2.4 Cache, Log, and Runtime State
 
 Local state that may be large, private, or not required for session continuity:

--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -41,6 +41,10 @@ STATE_DIR="$TMP/state"
 CANONICAL_SESSION_HOME="$TMP/canonical-codex"
 
 cleanup() {
+    if [[ -n "${SQLITE_LOCK_PID:-}" ]]; then
+        kill "$SQLITE_LOCK_PID" 2>/dev/null || true
+        wait "$SQLITE_LOCK_PID" 2>/dev/null || true
+    fi
     rm -rf "$TMP"
 }
 trap cleanup EXIT
@@ -460,6 +464,85 @@ if grep -q -E 'managed-good-session|'"$BAD_AUTHORITY_HOME" "$BAD_AUTHORITY_NDJSO
     cat "$BAD_AUTHORITY_STDERR" >&2
     exit 1
 fi
+
+echo "smoke-codex-cli-ux: locked canonical sqlite authority fails before spawn"
+SQLITE_AUTH_LOCK_NDJSON="$TMP/sqlite-authority-lock/status.ndjson"
+SQLITE_AUTH_LOCK_STDERR="$TMP/sqlite-authority-lock.stderr"
+SQLITE_AUTH_LOCK_REPORT="$TMP/sqlite-authority-lock.report"
+SQLITE_AUTH_LOCK_HEALTH_BEFORE="$TMP/sqlite-authority-lock.health.before"
+SQLITE_LOCK_READY="$TMP/sqlite-authority-lock.ready"
+SQLITE_LOCK_RELEASE="$TMP/sqlite-authority-lock.release"
+mkdir -p "$(dirname "$SQLITE_AUTH_LOCK_NDJSON")"
+cp "$STATE_DIR/health.json" "$SQLITE_AUTH_LOCK_HEALTH_BEFORE"
+python3 - "$CANONICAL_SESSION_HOME/state_5.sqlite" "$SQLITE_LOCK_READY" "$SQLITE_LOCK_RELEASE" <<'PY' &
+import fcntl
+import os
+import pathlib
+import sys
+import time
+
+db = pathlib.Path(sys.argv[1])
+ready = pathlib.Path(sys.argv[2])
+release = pathlib.Path(sys.argv[3])
+fd = os.open(db, os.O_RDWR)
+fcntl.lockf(fd, fcntl.LOCK_EX | fcntl.LOCK_NB, 512, 0x40000000, os.SEEK_SET)
+ready.write_text("ready\n", encoding="utf-8")
+try:
+    while not release.exists():
+        time.sleep(0.05)
+finally:
+    os.close(fd)
+PY
+SQLITE_LOCK_PID=$!
+for _ in $(seq 1 100); do
+    if [[ -e "$SQLITE_LOCK_READY" ]]; then
+        break
+    fi
+    if ! kill -0 "$SQLITE_LOCK_PID" 2>/dev/null; then
+        echo "  ✗ sqlite lock helper exited before ready" >&2
+        wait "$SQLITE_LOCK_PID" || true
+        exit 1
+    fi
+    sleep 0.05
+done
+if [[ ! -e "$SQLITE_LOCK_READY" ]]; then
+    echo "  ✗ sqlite lock helper did not become ready" >&2
+    exit 1
+fi
+if OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+     OMUX_STATE_DIR="$STATE_DIR" \
+     OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+     CODEX_HOME="$CANONICAL_SESSION_HOME" \
+     OMUX_CODEX_SESSION_HOME="$CANONICAL_SESSION_HOME" \
+     OMUX_CODEX_CONFIG_HOME="$CANONICAL_SESSION_HOME" \
+     OMUX_STUB_CODEX_REPORT="$SQLITE_AUTH_LOCK_REPORT" \
+     "$BIN" codex --profile codex-max --json-status-file "$SQLITE_AUTH_LOCK_NDJSON" resume 2>"$SQLITE_AUTH_LOCK_STDERR"; then
+    echo "  ✗ locked sqlite authority unexpectedly launched" >&2
+    exit 1
+fi
+touch "$SQLITE_LOCK_RELEASE"
+wait "$SQLITE_LOCK_PID"
+SQLITE_LOCK_PID=""
+assert_grep "sqlite authority lock diagnostic" '"kind":"sqlite_authority_check".*"ok":false.*"diagnostic":"database_locked".*"db_basename":"state_5.sqlite".*"sqlite_error_class":"database_locked".*"sqlite_error_code":5' "$SQLITE_AUTH_LOCK_NDJSON"
+assert_grep "sqlite authority lock terminal status" '"kind":"session_aborted".*"reason":"session_authority_locked".*"phase":"sqlite_authority_check".*"pre_spawn":true.*"child_spawned":false' "$SQLITE_AUTH_LOCK_NDJSON"
+assert_grep "sqlite authority lock stderr" 'canonical Codex sqlite state is locked' "$SQLITE_AUTH_LOCK_STDERR"
+if [[ -e "$SQLITE_AUTH_LOCK_REPORT" ]]; then
+    echo "  ✗ locked sqlite authority launched stub unexpectedly" >&2
+    cat "$SQLITE_AUTH_LOCK_REPORT" >&2
+    exit 1
+fi
+if ! cmp -s "$STATE_DIR/health.json" "$SQLITE_AUTH_LOCK_HEALTH_BEFORE"; then
+    echo "  ✗ locked sqlite authority mutated route health" >&2
+    diff -u "$SQLITE_AUTH_LOCK_HEALTH_BEFORE" "$STATE_DIR/health.json" >&2 || true
+    exit 1
+fi
+if grep -q -E 'managed-good-session|'"$CANONICAL_SESSION_HOME" "$SQLITE_AUTH_LOCK_NDJSON" "$SQLITE_AUTH_LOCK_STDERR"; then
+    echo "  ✗ locked sqlite authority leaked path or session id" >&2
+    cat "$SQLITE_AUTH_LOCK_NDJSON" >&2
+    cat "$SQLITE_AUTH_LOCK_STDERR" >&2
+    exit 1
+fi
+echo "  ✓ locked canonical sqlite authority fails before child spawn"
 
 echo "smoke-codex-cli-ux: sqlite lock shaped child startup failure records abort"
 SQLITE_LOCK_NDJSON="$TMP/sqlite-lock/status.ndjson"

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -27,6 +27,7 @@
 //! `oauth-mux codex run` default path.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const broker = @import("../../broker/mod.zig");
 const broker_types = @import("../../broker/types.zig");
 const broker_loader = @import("../../broker_loader.zig");
@@ -67,6 +68,7 @@ pub const RunError = error{
     NoAccountSelectable,
     NoCodexHome,
     SessionAuthorityUnavailable,
+    SessionAuthorityLocked,
     ConfigOverrideUnavailable,
     CodexShimRecursion,
 };
@@ -366,6 +368,21 @@ const AuthWritebackObservation = struct {
 const ManagedAuthHealthObservation = struct {
     recorded: bool = false,
     reason: []const u8 = "not_observed",
+};
+
+const SqliteAuthorityLockObservation = struct {
+    checked: bool = false,
+    ok: bool = true,
+    diagnostic: []const u8 = "not_checked",
+    sqlite_authority: CodexSqliteAuthorityMode = .isolated_overlay,
+    db_basename: []const u8 = "state_5.sqlite",
+    sqlite_error_class: ?[]const u8 = null,
+    sqlite_error_code: ?u8 = null,
+    next_action: []const u8 = "none",
+
+    fn locked(self: SqliteAuthorityLockObservation) bool {
+        return self.checked and !self.ok;
+    }
 };
 
 const FinalSessionStatus = struct {
@@ -1286,6 +1303,17 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         return RunError.ConfigOverrideUnavailable;
     }
 
+    const sqlite_lock_check = try checkResumeSqliteAuthorityLock(allocator, &codex_home, resume_request);
+    if (emit_status and sqlite_lock_check.checked) {
+        try writeSqliteAuthorityCheckStatus(status_writer, sqlite_lock_check);
+    }
+    try launch_timer.mark(status_writer, emit_status, "sqlite_authority_check");
+    if (sqlite_lock_check.locked()) {
+        try stderr.writeAll("oauth-mux codex: canonical Codex sqlite state is locked by another Codex process; close or wait for that process, then retry\n");
+        try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "session_authority_locked", "sqlite_authority_check", "SqliteStateLocked", session_started_emitted);
+        return RunError.SessionAuthorityLocked;
+    }
+
     var resume_preflight = ResumePreflightObservation{};
     defer resume_preflight.deinit();
     if (resume_request.mode == .explicit) {
@@ -1471,6 +1499,126 @@ fn openStatusFile(path: []const u8) !std.fs.File {
         try std.fs.cwd().makePath(dir);
     }
     return try std.fs.cwd().createFile(path, .{ .mode = 0o600, .truncate = true });
+}
+
+fn checkResumeSqliteAuthorityLock(
+    allocator: std.mem.Allocator,
+    codex_home: *const SessionCodexHome,
+    resume_request: ResumeRequest,
+) !SqliteAuthorityLockObservation {
+    var observation = SqliteAuthorityLockObservation{
+        .sqlite_authority = codex_home.sqlite_authority,
+    };
+    if (!resume_request.requested()) {
+        observation.diagnostic = "not_resume";
+        return observation;
+    }
+    if (codex_home.sqlite_authority != .canonical_env) {
+        observation.diagnostic = "not_canonical_sqlite_authority";
+        return observation;
+    }
+    const authority_home = codex_home.authority_home orelse {
+        observation.diagnostic = "missing_authority_home";
+        return observation;
+    };
+
+    const db_path = try std.fs.path.join(allocator, &.{ authority_home, observation.db_basename });
+    defer allocator.free(db_path);
+
+    var file = std.fs.openFileAbsolute(db_path, .{ .mode = .read_write }) catch |e| switch (e) {
+        error.FileNotFound => {
+            observation.diagnostic = "state_db_absent";
+            return observation;
+        },
+        error.AccessDenied => {
+            observation.checked = true;
+            observation.diagnostic = "state_db_probe_unavailable";
+            observation.next_action = "retry_without_lock_probe_or_check_file_permissions";
+            return observation;
+        },
+        else => {
+            observation.checked = true;
+            observation.diagnostic = "state_db_probe_unavailable";
+            observation.next_action = "retry_or_inspect_codex_state";
+            return observation;
+        },
+    };
+    defer file.close();
+
+    observation.checked = true;
+    const probe = try probeSqliteLockBytes(file);
+    switch (probe) {
+        .clear => {
+            observation.ok = true;
+            observation.diagnostic = "clear";
+        },
+        .locked => {
+            observation.ok = false;
+            observation.diagnostic = "database_locked";
+            observation.sqlite_error_class = "database_locked";
+            observation.sqlite_error_code = 5;
+            observation.next_action = "close_or_wait_for_other_codex_process_then_retry";
+        },
+        .unsupported => {
+            observation.ok = true;
+            observation.diagnostic = "lock_probe_unsupported";
+            observation.next_action = "retry_if_codex_reports_database_locked";
+        },
+    }
+    return observation;
+}
+
+const SqliteLockProbeResult = enum {
+    clear,
+    locked,
+    unsupported,
+};
+
+fn probeSqliteLockBytes(file: std.fs.File) !SqliteLockProbeResult {
+    if (builtin.os.tag == .windows or builtin.os.tag == .wasi) {
+        return .unsupported;
+    }
+
+    const sqlite_pending_byte: u64 = 0x40000000;
+    const sqlite_lock_span: u64 = 512;
+    var lock = std.mem.zeroes(std.c.Flock);
+    lock.type = @intCast(std.c.F.WRLCK);
+    lock.whence = @intCast(std.c.SEEK.SET);
+    lock.start = @intCast(sqlite_pending_byte);
+    lock.len = @intCast(sqlite_lock_span);
+
+    _ = std.posix.fcntl(file.handle, std.c.F.SETLK, @intFromPtr(&lock)) catch |e| switch (e) {
+        error.Locked => return .locked,
+        error.FileBusy => return .locked,
+        error.LockedRegionLimitExceeded,
+        error.DeadLock,
+        error.PermissionDenied,
+        error.ProcessFdQuotaExceeded,
+        => return .unsupported,
+        else => return e,
+    };
+    lock.type = @intCast(std.c.F.UNLCK);
+    _ = std.posix.fcntl(file.handle, std.c.F.SETLK, @intFromPtr(&lock)) catch {};
+    return .clear;
+}
+
+fn writeSqliteAuthorityCheckStatus(writer: anytype, check: SqliteAuthorityLockObservation) !void {
+    try writer.print(
+        "{{\"kind\":\"sqlite_authority_check\",\"mode\":\"resume\",\"sqlite_authority\":\"{s}\",\"ok\":{any},\"diagnostic\":\"{s}\",\"db_basename\":\"{s}\",\"next_action\":\"{s}\",\"sqlite_error_class\":",
+        .{ check.sqlite_authority.toString(), check.ok, check.diagnostic, check.db_basename, check.next_action },
+    );
+    if (check.sqlite_error_class) |class| {
+        try std.json.stringify(class, .{}, writer);
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"sqlite_error_code\":");
+    if (check.sqlite_error_code) |code| {
+        try writer.print("{d}", .{code});
+    } else {
+        try writer.writeAll("null");
+    }
+    try writer.writeAll(",\"path_printed\":false,\"token_material_printed\":false,\"session_id_printed\":false}\n");
 }
 
 fn writeManagedPreSpawnAbortStatus(


### PR DESCRIPTION
## Summary

- Add a managed-resume pre-spawn probe for canonical Codex `state_5.sqlite` lock contention.
- Emit redacted `sqlite_authority_check` status with `db_basename`, sqlite code 5, and explicit retry action when the lock is held.
- Abort pre-spawn with `reason:"session_authority_locked"` without killing other Codex processes, mutating route health, or creating an overlay-local sqlite authority.
- Extend the CLI UX smoke with a real POSIX byte-range lock holder on the SQLite lock region.
- Document the new session-authority lock behavior in README/specs.

## Validation

- `zig fmt --check src/adapters/codex/main.zig`
- `bash -n scripts/smoke-codex-cli-ux.sh`
- `python3 -m py_compile scripts/test-stub-codex.py`
- `git diff --check`
- `zig build test`
- `zig build`
- `./scripts/smoke-codex-cli-ux.sh`
- `just check-local`
- `just release-windows-amd64`

Closes #315.
Linear: TIN-1634
