### PR TITLE
Keep process gate visible when ps is denied

### DIFF
--- a/scripts/dogfood-process-snapshot.py
+++ b/scripts/dogfood-process-snapshot.py
@@ -68,6 +68,8 @@ def run_command(argv: list[str]) -> tuple[int, str, str]:
         return proc.returncode, proc.stdout, proc.stderr
     except FileNotFoundError as exc:
         return 127, "", str(exc)
+    except OSError as exc:
+        return 126, "", str(exc)
 
 
 def command_name(command: str) -> str:

--- a/scripts/smoke-dogfood-process-snapshot.sh
+++ b/scripts/smoke-dogfood-process-snapshot.sh
@@ -65,6 +65,17 @@ assert module.is_numeric_fd_tag("cwd") is False
 assert module.is_numeric_fd_tag("txt") is False
 assert module.is_numeric_fd_tag("mem") is False
 assert module.is_numeric_fd_tag("") is False
+
+original_subprocess_run = module.subprocess.run
+try:
+    module.subprocess.run = lambda *args, **kwargs: (_ for _ in ()).throw(PermissionError(1, "Operation not permitted", "ps"))
+    code, stdout, stderr = module.run_command(["ps"])
+    assert code == 126
+    assert stdout == ""
+    assert "Operation not permitted" in stderr
+finally:
+    module.subprocess.run = original_subprocess_run
+
 oauth_mux_codex_parent = {
     "command_name": "oauth-mux",
     "command": "/Users/test/bin/oauth-mux codex resume --last",


### PR DESCRIPTION
## Summary
- Convert process-probe OSError and permission denial into a typed command status instead of crashing the dogfood process snapshot.
- Keep capture preflight process-gate metadata present and fail-closed when sandboxed ps is denied.
- Add a regression assertion for PermissionError in the process snapshot smoke.

## Validation
- python3 -m py_compile scripts/dogfood-process-snapshot.py
- bash -n scripts/smoke-dogfood-process-snapshot.sh
- bash -n scripts/smoke-codex-capture-review.sh
- ./scripts/smoke-dogfood-process-snapshot.sh
- ./scripts/smoke-codex-capture-review.sh
- git diff --check

Related: TIN-1591, #176