### PR TITLE
Add Codex transport reset fallback smoke

### DIFF
--- a/scripts/smoke-codex-provider-degraded.sh
+++ b/scripts/smoke-codex-provider-degraded.sh
@@ -344,6 +344,62 @@ PY
     fi
 }
 
+run_transport_fallback_case() {
+    local case_dir="$TMP/transport-fallback"
+    local portfile="$case_dir/upstream.port"
+    local uplog="$case_dir/upstream.log"
+    local ndjson="$case_dir/adapter.ndjson"
+    local adapter_stderr="$case_dir/adapter.stderr"
+    local stub_report="$case_dir/stub-codex.report"
+    local trace_file="$case_dir/trace.ndjson"
+    mkdir -p "$case_dir"
+    write_two_account_fixture "$case_dir"
+
+    OMUX_STUB_PORT=0 \
+      OMUX_STUB_PORTFILE="$portfile" \
+      OMUX_STUB_OK_BEFORE_429=99 \
+      OMUX_STUB_LOGFILE="$uplog" \
+      OMUX_STUB_ACCOUNT_RESET_JSON='{"acc-A-id":"before_response"}' \
+      python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$case_dir/upstream.stderr" &
+    local upstream_pid=$!
+    UPSTREAM_PIDS+=("$upstream_pid")
+    wait_for_port "$portfile"
+    local upstream_port
+    upstream_port="$(cat "$portfile" | tr -d '[:space:]')"
+    echo "smoke-codex-provider-degraded: transport-fallback stub pid=$upstream_pid port=$upstream_port max-1=reset max-2=200"
+
+    OMUX_CONFIG="$case_dir/oauth-mux.config.json" \
+      OMUX_STATE_DIR="$case_dir/state" \
+      OMUX_UPSTREAM_HOST="127.0.0.1:$upstream_port" \
+      OMUX_UPSTREAM_SCHEME="http" \
+      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_TRACE=1 \
+      OMUX_TRACE_FILE="$trace_file" \
+      OMUX_STUB_CODEX_TURNS=3 \
+      OMUX_STUB_CODEX_REPORT="$stub_report" \
+      "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$ndjson" 2>"$adapter_stderr" || {
+        echo "adapter exited nonzero in transport-fallback case" >&2
+        cat "$ndjson" >&2 || true
+        cat "$adapter_stderr" >&2 || true
+        exit 1
+    }
+
+    echo "smoke-codex-provider-degraded: transport-fallback assertions"
+    assert_grep "transport reset recorded upstream failure" '"kind":"proxy_upstream_failed".*"account":"codex:max-1"' "$ndjson"
+    assert_grep "transport reset retried fallback account" '"kind":"proxy_provider_same_turn_retry".*"from":"codex:max-1".*"to":"codex:max-2".*"reason":"provider_5xx"' "$ndjson"
+    assert_grep "transport fallback account returned 200" '"kind":"proxy_turn".*"account":"codex:max-2".*"status":200.*"classification":"ok"' "$ndjson"
+    assert_no_grep "transport fallback did not emit terminal provider unavailable" '"kind":"proxy_provider_retry_unavailable"' "$ndjson"
+    assert_no_grep "transport fallback did not leak route-repair body" 'oauth_mux_no_account_selectable' "$stub_report"
+    jq -e 'select(.name == "codex.proxy.upstream_failure" and .attributes.path_kind == "responses" and .attributes.raw_account_id_printed == false)' "$trace_file" >/dev/null
+    echo "  ✓ trace captured transport reset without raw account ids"
+    jq -e 'select(.response_classification == "transport_reset" and .account_id == "acc-A-id")' "$uplog" >/dev/null
+    echo "  ✓ upstream fixture reset the first account before response"
+    jq -e '([.turns[] | select(.status == 200)] | length == 3) and (.pid_stable == true)' "$stub_report" >/dev/null
+    echo "  ✓ stub-codex stayed in one process and saw all turns recover"
+    jq -e '[.accounts[] | select(.key == "codex:max-1#codex-max" and .last_probe_hint_class == "provider_degraded")] | length == 1' "$case_dir/state/health.json" >/dev/null
+    echo "  ✓ transport reset recorded provider-degraded route evidence"
+}
+
 run_upstream_interrupted_case() {
     local case_dir="$TMP/upstream-interrupted"
     local portfile="$case_dir/upstream.port"
@@ -448,6 +504,7 @@ run_client_disconnect_case() {
 run_fallback_case
 run_no_fallback_case
 run_transport_failure_case
+run_transport_fallback_case
 run_upstream_interrupted_case
 run_client_disconnect_case
 

--- a/scripts/test-stub-upstream.py
+++ b/scripts/test-stub-upstream.py
@@ -87,10 +87,18 @@ ALWAYS_STATUS = os.environ.get("OMUX_STUB_ALWAYS_STATUS", "")
 # status codes, e.g. {"acc-A-id":401}. Accounts not listed follow the normal
 # OK_BEFORE_429 flow. This lets smokes model a dead active account with a
 # healthy fallback account.
+# OMUX_STUB_ACCOUNT_RESET_JSON maps ChatGPT-Account-ID values to reset modes,
+# e.g. {"acc-A-id":"before_response"}. Matching accounts reset the connection
+# after the request body is read and before any response is written.
 try:
     ACCOUNT_STATUS = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_STATUS_JSON", "{}"))
 except json.JSONDecodeError:
     ACCOUNT_STATUS = {}
+
+try:
+    ACCOUNT_RESET = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_RESET_JSON", "{}"))
+except json.JSONDecodeError:
+    ACCOUNT_RESET = {}
 
 
 # Per-account request counter. Reset only on process restart.
@@ -200,6 +208,27 @@ class StubHandler(http.server.BaseHTTPRequestHandler):
             }
         return 429, body
 
+    def _reset_before_response_if_configured(self, path: str) -> bool:
+        acct = self._account_id()
+        if acct not in ACCOUNT_RESET:
+            return False
+        _log({
+            "path": path,
+            "method": self.command,
+            "account_id": acct,
+            "auth_prefix": self._auth_prefix(),
+            "status_returned": "reset_before_response",
+            "response_classification": "transport_reset",
+        })
+        try:
+            linger = struct.pack("ii", 1, 0)
+            self.connection.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, linger)
+        except OSError:
+            pass
+        self.close_connection = True
+        self.connection.close()
+        return True
+
     def _serve(self) -> None:
         path = urlparse(self.path).path
         if not path.startswith("/backend-api/codex"):
@@ -211,6 +240,8 @@ class StubHandler(http.server.BaseHTTPRequestHandler):
 
         body_bytes = self._read_body()
         _ = body_bytes  # request bodies are unused; we don't echo
+        if self._reset_before_response_if_configured(path):
+            return
 
         status, body = self._classify_for_account()
         if "_text" in body:


### PR DESCRIPTION
## Summary
- add an upstream-stub reset mode for account-specific connection resets before any response is written
- extend the provider-degraded smoke with a transport-reset fallback case
- assert reset-before-response on max-1 retries to max-2, all stub Codex turns return 200 in one process, and provider-degraded route evidence is recorded

## Validation
- python3 -m py_compile scripts/test-stub-upstream.py scripts/test-stub-codex.py
- bash -n scripts/smoke-codex-provider-degraded.sh
- ./scripts/smoke-codex-provider-degraded.sh
- git diff --check

Related: #311, TIN-1631