### PR TITLE
Surface Codex transport recovery in status summaries

### DIFF
--- a/scripts/smoke-codex-status-summary.sh
+++ b/scripts/smoke-codex-status-summary.sh
@@ -23,6 +23,8 @@ AUTH_FALLBACK_CHAIN="$TMP/auth-fallback-chain.ndjson"
 INCOMPLETE="$TMP/incomplete.ndjson"
 SIGNALED="$TMP/signaled.ndjson"
 PRE_SPAWN="$TMP/pre-spawn.ndjson"
+TRANSPORT_RECOVERY="$TMP/transport-recovery.ndjson"
+BAD_405="$TMP/bad-405.ndjson"
 
 cat >"$BROKERED" <<'EOF'
 {"kind":"launch_timing","phase":"config_health_load","duration_ms":4,"elapsed_ms":4,"path_printed":false,"token_material_printed":false,"session_id_printed":false}
@@ -101,6 +103,21 @@ EOF
 cat >"$PRE_SPAWN" <<'EOF'
 {"kind":"launch_timing","phase":"config_health_load","duration_ms":3,"elapsed_ms":3,"path_printed":false,"token_material_printed":false,"session_id_printed":false}
 {"kind":"session_aborted","adapter":"codex","reason":"no_account_selectable","phase":"route_election","error":"NoAccountSelectable","exit_code":-1,"term_kind":null,"term_code":null,"signal_name":null,"final_claim_level":"none","synthetic_swap_observed":false,"pre_spawn":true,"child_spawned":false,"path_printed":false,"token_material_printed":false,"session_id_printed":false}
+EOF
+
+cat >"$TRANSPORT_RECOVERY" <<'EOF'
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"proxy_upstream_failed","account":"codex:max-1","err":"ConnectionResetByPeer"}
+{"kind":"proxy_provider_same_turn_retry","from":"codex:max-1","to":"codex:max-2","reason":"provider_5xx","dropped":"x-codex-turn-state"}
+{"kind":"proxy_turn","account":"codex:max-2","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true,"delivered_to_codex":true}
+{"kind":"proxy_turn","account":"codex:max-2","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true,"delivered_to_codex":true}
+{"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":true}
+EOF
+
+cat >"$BAD_405" <<'EOF'
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"proxy_turn","account":"codex:max-1","method":"GET","path_kind":"responses","status":405,"classification":"ok","body_class":"json_error","claim_level":"broker_owned","streamed":false,"delivered_to_codex":true}
+{"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":false}
 EOF
 
 BROKERED_SUMMARY="$(python3 "$ROOT/scripts/summarize-codex-status.py" "$BROKERED" --require-brokered)"
@@ -308,6 +325,69 @@ fi
 if [[ "$(jq -r .terminal_event.term_kind <<<"$PRE_SPAWN_SUMMARY")" != "null" ]]; then
     echo "pre-spawn artifact should not fake a child term kind" >&2
     echo "$PRE_SPAWN_SUMMARY" >&2
+    exit 1
+fi
+
+TRANSPORT_RECOVERY_SUMMARY="$(python3 "$ROOT/scripts/summarize-codex-status.py" "$TRANSPORT_RECOVERY" --require-brokered)"
+if [[ "$(jq -r .verdict <<<"$TRANSPORT_RECOVERY_SUMMARY")" != "transport_fallback_recovered" ]]; then
+    echo "transport-recovery verdict mismatch" >&2
+    echo "$TRANSPORT_RECOVERY_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .transport_failure_observed <<<"$TRANSPORT_RECOVERY_SUMMARY")" != "true" ]]; then
+    echo "transport-recovery should report transport failure evidence" >&2
+    echo "$TRANSPORT_RECOVERY_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .transport_recovery_observed <<<"$TRANSPORT_RECOVERY_SUMMARY")" != "true" ]]; then
+    echo "transport-recovery should report recovery" >&2
+    echo "$TRANSPORT_RECOVERY_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .upstream_failure_events <<<"$TRANSPORT_RECOVERY_SUMMARY")" != "1" ]]; then
+    echo "transport-recovery upstream failure count mismatch" >&2
+    echo "$TRANSPORT_RECOVERY_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .provider_same_turn_retry_events <<<"$TRANSPORT_RECOVERY_SUMMARY")" != "1" ]]; then
+    echo "transport-recovery provider retry count mismatch" >&2
+    echo "$TRANSPORT_RECOVERY_SUMMARY" >&2
+    exit 1
+fi
+
+TRANSPORT_RECOVERY_NATIVE_SUMMARY="$("$ROOT/zig-out/bin/oauth-mux" codex status-latest --status-file "$TRANSPORT_RECOVERY" --json)"
+if [[ "$(jq -r .verdict <<<"$TRANSPORT_RECOVERY_NATIVE_SUMMARY")" != "transport_fallback_recovered" ]]; then
+    echo "native transport-recovery verdict mismatch" >&2
+    echo "$TRANSPORT_RECOVERY_NATIVE_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .transport_recovery_observed <<<"$TRANSPORT_RECOVERY_NATIVE_SUMMARY")" != "true" ]]; then
+    echo "native transport-recovery should report recovery" >&2
+    echo "$TRANSPORT_RECOVERY_NATIVE_SUMMARY" >&2
+    exit 1
+fi
+
+BAD_405_SUMMARY="$(python3 "$ROOT/scripts/summarize-codex-status.py" "$BAD_405" --require-brokered)"
+if [[ "$(jq -r .verdict <<<"$BAD_405_SUMMARY")" != "transport_regression_405_misclassified" ]]; then
+    echo "bad-405 verdict mismatch" >&2
+    echo "$BAD_405_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .responses_get_405_misclassified_ok <<<"$BAD_405_SUMMARY")" != "1" ]]; then
+    echo "bad-405 regression count mismatch" >&2
+    echo "$BAD_405_SUMMARY" >&2
+    exit 1
+fi
+
+BAD_405_NATIVE_SUMMARY="$("$ROOT/zig-out/bin/oauth-mux" codex status-latest --status-file "$BAD_405" --json)"
+if [[ "$(jq -r .verdict <<<"$BAD_405_NATIVE_SUMMARY")" != "transport_regression_405_misclassified" ]]; then
+    echo "native bad-405 verdict mismatch" >&2
+    echo "$BAD_405_NATIVE_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .responses_get_405_misclassified_ok <<<"$BAD_405_NATIVE_SUMMARY")" != "1" ]]; then
+    echo "native bad-405 regression count mismatch" >&2
+    echo "$BAD_405_NATIVE_SUMMARY" >&2
     exit 1
 fi
 

--- a/scripts/summarize-codex-status.py
+++ b/scripts/summarize-codex-status.py
@@ -249,6 +249,54 @@ def find_auth_fallback_sequence(events: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def find_transport_recovery_sequence(events: list[dict[str, Any]]) -> dict[str, Any]:
+    failure_event: dict[str, Any] | None = None
+    retry_event: dict[str, Any] | None = None
+    recovery_turn: dict[str, Any] | None = None
+
+    for idx, event in enumerate(events):
+        if event.get("kind") != "proxy_upstream_failed":
+            continue
+        failure_event = event
+        failure_account = event.get("account")
+
+        for later in events[idx + 1 :]:
+            kind = later.get("kind")
+            if kind == "proxy_provider_same_turn_retry":
+                retry_event = later
+                continue
+            if kind != "proxy_turn" or later.get("status") != 200:
+                continue
+            if retry_event is not None and later.get("account") == retry_event.get("to"):
+                recovery_turn = later
+                break
+            if failure_account is not None and later.get("account") != failure_account:
+                recovery_turn = later
+                break
+        break
+
+    if failure_event is None:
+        return {
+            "observed": False,
+            "reason": "no proxy_upstream_failed event",
+        }
+    if recovery_turn is None:
+        return {
+            "observed": False,
+            "reason": "upstream failure without successful fallback turn",
+            "failure": failure_event,
+            "retry": retry_event,
+        }
+    return {
+        "observed": True,
+        "failure": failure_event,
+        "retry": retry_event,
+        "fallback_account": recovery_turn.get("account"),
+        "fallback_status": recovery_turn.get("status"),
+        "fallback_path_kind": recovery_turn.get("path_kind"),
+    }
+
+
 def summarize(path: Path) -> dict[str, Any]:
     events = load_events(path)
     proxy_turns = [e for e in events if e.get("kind") == "proxy_turn"]
@@ -267,6 +315,7 @@ def summarize(path: Path) -> dict[str, Any]:
     fallback = find_fallback_sequence(events)
     quota_failure = find_quota_handoff_failure(events)
     auth_fallback = find_auth_fallback_sequence(events)
+    transport_recovery = find_transport_recovery_sequence(events)
     auth_health_events = [e for e in events if e.get("kind") == "auth_health_observed"]
     auth_unauthorized_turns = [
         e
@@ -284,6 +333,27 @@ def summarize(path: Path) -> dict[str, Any]:
         for e in proxy_turns
         if e.get("status") == 429 and e.get("classification") == "quota_exhausted"
     ]
+    bad_responses_get_405 = [
+        e
+        for e in proxy_turns
+        if e.get("method") == "GET"
+        and e.get("path_kind") == "responses"
+        and e.get("status") == 405
+        and e.get("classification") == "ok"
+    ]
+    unsupported_transport_events = [e for e in events if e.get("kind") == "proxy_unsupported_transport"]
+    upstream_failure_events = [e for e in events if e.get("kind") == "proxy_upstream_failed"]
+    provider_retry_events = [e for e in events if e.get("kind") == "proxy_provider_same_turn_retry"]
+    provider_retry_unavailable_events = [e for e in events if e.get("kind") == "proxy_provider_retry_unavailable"]
+    stream_interrupted_events = [e for e in events if e.get("kind") == "proxy_stream_interrupted"]
+    client_disconnected_events = [e for e in events if e.get("kind") == "proxy_client_disconnected"]
+    transport_failure_observed = bool(
+        bad_responses_get_405
+        or unsupported_transport_events
+        or upstream_failure_events
+        or provider_retry_unavailable_events
+        or stream_interrupted_events
+    )
 
     brokered_session = (
         session_started.get("claim_level") == "broker_owned"
@@ -327,6 +397,24 @@ def summarize(path: Path) -> dict[str, Any]:
     elif auth_fallback.get("observed"):
         verdict = "auth_fallback_sequence_observed"
         next_action = "continue_managed_dogfood"
+    elif bad_responses_get_405:
+        verdict = "transport_regression_405_misclassified"
+        next_action = "contain_reconnect_get_transport"
+    elif transport_recovery.get("observed"):
+        verdict = "transport_fallback_recovered"
+        next_action = "continue_managed_dogfood"
+    elif provider_retry_unavailable_events or upstream_failure_events:
+        verdict = "transport_failure_unavailable"
+        next_action = "inspect_transport_failure_and_route_capacity"
+    elif unsupported_transport_events:
+        verdict = "transport_unsupported_contained"
+        next_action = "continue_managed_dogfood"
+    elif stream_interrupted_events:
+        verdict = "stream_interrupted_partial"
+        next_action = "inspect_provider_stream_stability"
+    elif client_disconnected_events:
+        verdict = "client_disconnected"
+        next_action = "continue_managed_dogfood"
     elif brokered_session and auth_failure_observed and not terminal_event_observed:
         verdict = "brokered_incomplete_auth_failed"
         next_action = "inspect_incomplete_run"
@@ -363,6 +451,16 @@ def summarize(path: Path) -> dict[str, Any]:
         "auth_health_quota_claim_observed": any(e.get("quota_claim") is True for e in auth_health_events),
         "quota_event_observed": bool(quota_turns),
         "quota_handoff_observed": bool(fallback.get("observed")),
+        "transport_failure_observed": transport_failure_observed,
+        "transport_recovery_observed": bool(transport_recovery.get("observed")),
+        "transport_recovery_sequence": transport_recovery,
+        "unsupported_transport_events": len(unsupported_transport_events),
+        "upstream_failure_events": len(upstream_failure_events),
+        "provider_same_turn_retry_events": len(provider_retry_events),
+        "provider_retry_unavailable_events": len(provider_retry_unavailable_events),
+        "stream_interrupted_events": len(stream_interrupted_events),
+        "client_disconnected_events": len(client_disconnected_events),
+        "responses_get_405_misclassified_ok": len(bad_responses_get_405),
         "quota_handoff_failed_reason": quota_failure.get("reason")
         if quota_failure.get("observed")
         else None,

--- a/src/main.zig
+++ b/src/main.zig
@@ -10500,6 +10500,15 @@ const CodexStatusSummary = struct {
     auth_health_quota_claim_observed: bool = false,
     quota_event_observed: bool = false,
     quota_handoff_observed: bool = false,
+    transport_failure_observed: bool = false,
+    transport_recovery_observed: bool = false,
+    unsupported_transport_events: u64 = 0,
+    upstream_failure_events: u64 = 0,
+    provider_same_turn_retry_events: u64 = 0,
+    provider_retry_unavailable_events: u64 = 0,
+    stream_interrupted_events: u64 = 0,
+    client_disconnected_events: u64 = 0,
+    responses_get_405_misclassified_ok: u64 = 0,
     quota_handoff_failed_reason: ?[]const u8 = null,
     user_visible_failure_likely: bool = false,
     terminal_event_observed: bool = false,
@@ -10567,9 +10576,15 @@ const CodexStatusScanState = struct {
     auth_retry_seen: bool = false,
     ok_turns: u64 = 0,
     auth_recovered_observed: bool = false,
+    upstream_failure_seen: bool = false,
+    upstream_failure_account: ?[]const u8 = null,
+    provider_retry_after_upstream_failure: bool = false,
+    provider_retry_to: ?[]const u8 = null,
 
     fn deinit(self: *CodexStatusScanState, allocator: std.mem.Allocator) void {
         if (self.quota_account) |value| allocator.free(value);
+        if (self.upstream_failure_account) |value| allocator.free(value);
+        if (self.provider_retry_to) |value| allocator.free(value);
     }
 };
 
@@ -10672,6 +10687,30 @@ fn summarizeCodexStatusFile(allocator: std.mem.Allocator, path: []const u8) !Cod
                 if (scan.auth_seen) scan.auth_retry_seen = true;
             } else if (std.mem.eql(u8, k, "proxy_auth_retry_unavailable")) {
                 summary.auth_retry_unavailable_events += 1;
+            } else if (std.mem.eql(u8, k, "proxy_unsupported_transport")) {
+                summary.unsupported_transport_events += 1;
+                summary.transport_failure_observed = true;
+            } else if (std.mem.eql(u8, k, "proxy_upstream_failed")) {
+                summary.upstream_failure_events += 1;
+                summary.transport_failure_observed = true;
+                if (!scan.upstream_failure_seen) {
+                    scan.upstream_failure_seen = true;
+                    scan.upstream_failure_account = try dupeJsonString(allocator, object.get("account"));
+                }
+            } else if (std.mem.eql(u8, k, "proxy_provider_same_turn_retry")) {
+                summary.provider_same_turn_retry_events += 1;
+                if (scan.upstream_failure_seen) {
+                    scan.provider_retry_after_upstream_failure = true;
+                    if (jsonString(object.get("to"))) |to| try replaceOptionalString(allocator, &scan.provider_retry_to, to);
+                }
+            } else if (std.mem.eql(u8, k, "proxy_provider_retry_unavailable")) {
+                summary.provider_retry_unavailable_events += 1;
+                summary.transport_failure_observed = true;
+            } else if (std.mem.eql(u8, k, "proxy_stream_interrupted")) {
+                summary.stream_interrupted_events += 1;
+                summary.transport_failure_observed = true;
+            } else if (std.mem.eql(u8, k, "proxy_client_disconnected")) {
+                summary.client_disconnected_events += 1;
             } else if (std.mem.eql(u8, k, "proxy_same_turn_retry_unavailable")) {
                 summary.same_turn_retry_unavailable_events += 1;
                 if (scan.quota_seen and summary.quota_handoff_failed_reason == null) {
@@ -10719,6 +10758,24 @@ fn summarizeCodexStatusFile(allocator: std.mem.Allocator, path: []const u8) !Cod
         summary.next_action = "repair_route_health_or_add_fallback_account";
     } else if (scan.auth_recovered_observed and summary.auth_same_turn_retry_events > 0) {
         summary.verdict = "auth_fallback_sequence_observed";
+        summary.next_action = "continue_managed_dogfood";
+    } else if (summary.responses_get_405_misclassified_ok != 0) {
+        summary.verdict = "transport_regression_405_misclassified";
+        summary.next_action = "contain_reconnect_get_transport";
+    } else if (summary.transport_recovery_observed) {
+        summary.verdict = "transport_fallback_recovered";
+        summary.next_action = "continue_managed_dogfood";
+    } else if (summary.provider_retry_unavailable_events != 0 or summary.upstream_failure_events != 0) {
+        summary.verdict = "transport_failure_unavailable";
+        summary.next_action = "inspect_transport_failure_and_route_capacity";
+    } else if (summary.unsupported_transport_events != 0) {
+        summary.verdict = "transport_unsupported_contained";
+        summary.next_action = "continue_managed_dogfood";
+    } else if (summary.stream_interrupted_events != 0) {
+        summary.verdict = "stream_interrupted_partial";
+        summary.next_action = "inspect_provider_stream_stability";
+    } else if (summary.client_disconnected_events != 0) {
+        summary.verdict = "client_disconnected";
         summary.next_action = "continue_managed_dogfood";
     } else if (summary.brokered_session_observed and scan.auth_seen and !summary.terminal_event_observed) {
         summary.verdict = "brokered_incomplete_auth_failed";
@@ -10782,6 +10839,15 @@ fn summarizeProxyTurn(
     if (path_kind) |value| try incrementStringCount(allocator, &summary.proxy_turns_by_path_kind, value);
     if (body_class) |value| try incrementStringCount(allocator, &summary.proxy_turns_by_body_class, value);
 
+    if (stringEquals(jsonString(object.get("method")), "GET") and
+        stringEquals(path_kind, "responses") and
+        status != null and status.? == 405 and
+        stringEquals(classification, "ok"))
+    {
+        summary.responses_get_405_misclassified_ok += 1;
+        summary.transport_failure_observed = true;
+    }
+
     const is_auth = (status != null and status.? == 401) or stringEquals(classification, "auth_unauthorized");
     if (is_auth) {
         summary.auth_unauthorized_turns += 1;
@@ -10802,6 +10868,18 @@ fn summarizeProxyTurn(
     if (status != null and status.? == 200) {
         scan.ok_turns += 1;
         if (scan.auth_seen and scan.auth_retry_seen) scan.auth_recovered_observed = true;
+        if (scan.upstream_failure_seen and account != null) {
+            const recovered_via_retry = scan.provider_retry_after_upstream_failure and
+                scan.provider_retry_to != null and
+                std.mem.eql(u8, scan.provider_retry_to.?, account.?);
+            const recovered_via_different_account = if (scan.upstream_failure_account) |failed_account|
+                !std.mem.eql(u8, failed_account, account.?)
+            else
+                false;
+            if (recovered_via_retry or recovered_via_different_account) {
+                summary.transport_recovery_observed = true;
+            }
+        }
         if (scan.quota_seen and scan.retry_after_quota and account != null) {
             const quota_account = scan.quota_account;
             if (quota_account == null or !std.mem.eql(u8, quota_account.?, account.?)) {
@@ -10900,6 +10978,17 @@ fn writeCodexStatusSummaryJson(writer: anytype, summary: CodexStatusSummary) !vo
     try writer.writeAll(if (summary.quota_event_observed) "true" else "false");
     try writer.writeAll(",\"quota_handoff_observed\":");
     try writer.writeAll(if (summary.quota_handoff_observed) "true" else "false");
+    try writer.writeAll(",\"transport_failure_observed\":");
+    try writer.writeAll(if (summary.transport_failure_observed) "true" else "false");
+    try writer.writeAll(",\"transport_recovery_observed\":");
+    try writer.writeAll(if (summary.transport_recovery_observed) "true" else "false");
+    try writer.print(",\"unsupported_transport_events\":{d}", .{summary.unsupported_transport_events});
+    try writer.print(",\"upstream_failure_events\":{d}", .{summary.upstream_failure_events});
+    try writer.print(",\"provider_same_turn_retry_events\":{d}", .{summary.provider_same_turn_retry_events});
+    try writer.print(",\"provider_retry_unavailable_events\":{d}", .{summary.provider_retry_unavailable_events});
+    try writer.print(",\"stream_interrupted_events\":{d}", .{summary.stream_interrupted_events});
+    try writer.print(",\"client_disconnected_events\":{d}", .{summary.client_disconnected_events});
+    try writer.print(",\"responses_get_405_misclassified_ok\":{d}", .{summary.responses_get_405_misclassified_ok});
     try writer.writeAll(",\"quota_handoff_failed_reason\":");
     try writeOptionalJsonString(writer, summary.quota_handoff_failed_reason);
     try writer.writeAll(",\"user_visible_failure_likely\":");
@@ -10967,6 +11056,8 @@ fn writeCodexStatusSummaryText(writer: anytype, summary: CodexStatusSummary) !vo
     try writer.print("  selected_account: {s}\n", .{summary.selected_account orelse "null"});
     try writer.print("  quota_event_observed: {s}\n", .{if (summary.quota_event_observed) "true" else "false"});
     try writer.print("  quota_handoff_observed: {s}\n", .{if (summary.quota_handoff_observed) "true" else "false"});
+    try writer.print("  transport_failure_observed: {s}\n", .{if (summary.transport_failure_observed) "true" else "false"});
+    try writer.print("  transport_recovery_observed: {s}\n", .{if (summary.transport_recovery_observed) "true" else "false"});
     try writer.print("  proxy_turns: {d}\n", .{summary.proxy_turns});
     if (summary.launch_timing_events != 0) {
         try writer.print("  launch_timing_events: {d}\n", .{summary.launch_timing_events});
@@ -18238,6 +18329,65 @@ test "Codex status summary preserves child signal terminal evidence" {
     try std.testing.expectEqualStrings("signal", summary.terminal_term_kind.?);
     try std.testing.expectEqual(@as(i64, 9), summary.terminal_term_code.?);
     try std.testing.expectEqualStrings("SIGKILL", summary.terminal_signal_name.?);
+}
+
+test "Codex status summary reports transport fallback recovery" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+
+    const status_path = try std.fs.path.join(std.testing.allocator, &.{ root, "status.ndjson" });
+    defer std.testing.allocator.free(status_path);
+
+    var file = try tmp.dir.createFile("status.ndjson", .{});
+    defer file.close();
+    try file.writeAll(
+        \\{"kind":"session_started","claim_level":"broker_owned","selected_account":"codex:max-1","session_authority":"canonical_bridge"}
+        \\{"kind":"proxy_upstream_failed","account":"codex:max-1","err":"ConnectionResetByPeer"}
+        \\{"kind":"proxy_provider_same_turn_retry","from":"codex:max-1","to":"codex:max-2","reason":"provider_5xx"}
+        \\{"kind":"proxy_turn","account":"codex:max-2","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","delivered_to_codex":true}
+        \\{"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":true}
+        \\
+    );
+
+    var summary = try summarizeCodexStatusFile(std.testing.allocator, status_path);
+    defer summary.deinit();
+
+    try std.testing.expect(summary.brokered_session_observed);
+    try std.testing.expect(summary.transport_failure_observed);
+    try std.testing.expect(summary.transport_recovery_observed);
+    try std.testing.expectEqual(@as(u64, 1), summary.upstream_failure_events);
+    try std.testing.expectEqual(@as(u64, 1), summary.provider_same_turn_retry_events);
+    try std.testing.expectEqualStrings("transport_fallback_recovered", summary.verdict);
+}
+
+test "Codex status summary flags historical responses GET 405 ok regression" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+
+    const status_path = try std.fs.path.join(std.testing.allocator, &.{ root, "status.ndjson" });
+    defer std.testing.allocator.free(status_path);
+
+    var file = try tmp.dir.createFile("status.ndjson", .{});
+    defer file.close();
+    try file.writeAll(
+        \\{"kind":"session_started","claim_level":"broker_owned","selected_account":"codex:max-1","session_authority":"canonical_bridge"}
+        \\{"kind":"proxy_turn","account":"codex:max-1","method":"GET","path_kind":"responses","status":405,"classification":"ok","body_class":"json_error","delivered_to_codex":true}
+        \\{"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":false}
+        \\
+    );
+
+    var summary = try summarizeCodexStatusFile(std.testing.allocator, status_path);
+    defer summary.deinit();
+
+    try std.testing.expect(summary.transport_failure_observed);
+    try std.testing.expectEqual(@as(u64, 1), summary.responses_get_405_misclassified_ok);
+    try std.testing.expectEqualStrings("transport_regression_405_misclassified", summary.verdict);
 }
 
 // Pull in all module tests


### PR DESCRIPTION
## Summary
- teach Python and native Codex status summarizers to report transport failure/recovery evidence explicitly
- add verdicts for recovered transport fallback, terminal transport failure, contained unsupported transport, interrupted streams, client disconnects, and historical GET responses 405 misclassification
- add status-summary smoke fixtures for recovered transport reset and the old 405-as-ok regression

## Validation
- python3 -m py_compile scripts/summarize-codex-status.py
- bash -n scripts/smoke-codex-status-summary.sh
- zig build
- ./scripts/smoke-codex-status-summary.sh
- zig build test
- just test
- git diff --check

Related: #311, TIN-1631