### PR TITLE
Harden Codex transport retry recovery

### DIFF
--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -325,6 +325,18 @@ For every forwarded request, the proxy:
    needed; the proxy speaks plaintext to the locally-bound app-server and
    speaks plain TLS to chatgpt.com.)
 
+Pre-response transport failures are handled before route-health mutation.
+For transient failures such as `BrokenPipe`, `ConnectionResetByPeer`,
+`ConnectionRefused`, `NetworkUnreachable`, resolver failures, or early EOF
+before any upstream response bytes have reached Codex, the proxy retries the
+same request on the same elected account with a short bounded backoff. If that
+local retry recovers, it emits `proxy_transport_local_retry` and
+`proxy_transport_local_retry_recovered`, returns the successful response to
+Codex, and does not mark the route provider-degraded. If the local retry window
+does not recover, the existing provider-degraded fallback path applies. The
+failed route is also blocked in the in-session pool for the same short retry
+window so later turns do not keep re-electing the route that just failed.
+
 ### 4.3 Response classification
 
 For every response from upstream, before returning bytes to the

--- a/scripts/smoke-codex-provider-degraded.sh
+++ b/scripts/smoke-codex-provider-degraded.sh
@@ -344,6 +344,63 @@ PY
     fi
 }
 
+run_local_transport_retry_case() {
+    local case_dir="$TMP/local-transport-retry"
+    local portfile="$case_dir/upstream.port"
+    local uplog="$case_dir/upstream.log"
+    local ndjson="$case_dir/adapter.ndjson"
+    local adapter_stderr="$case_dir/adapter.stderr"
+    local stub_report="$case_dir/stub-codex.report"
+    local trace_file="$case_dir/trace.ndjson"
+    mkdir -p "$case_dir"
+    write_one_account_fixture "$case_dir"
+
+    OMUX_STUB_PORT=0 \
+      OMUX_STUB_PORTFILE="$portfile" \
+      OMUX_STUB_OK_BEFORE_429=99 \
+      OMUX_STUB_LOGFILE="$uplog" \
+      OMUX_STUB_ACCOUNT_RESET_JSON='{"acc-A-id":"before_response"}' \
+      OMUX_STUB_ACCOUNT_RESET_COUNT_JSON='{"acc-A-id":1}' \
+      python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$case_dir/upstream.stderr" &
+    local upstream_pid=$!
+    UPSTREAM_PIDS+=("$upstream_pid")
+    wait_for_port "$portfile"
+    local upstream_port
+    upstream_port="$(cat "$portfile" | tr -d '[:space:]')"
+    echo "smoke-codex-provider-degraded: local-transport-retry stub pid=$upstream_pid port=$upstream_port first=max-1-reset second=max-1-200"
+
+    OMUX_CONFIG="$case_dir/oauth-mux.config.json" \
+      OMUX_STATE_DIR="$case_dir/state" \
+      OMUX_UPSTREAM_HOST="127.0.0.1:$upstream_port" \
+      OMUX_UPSTREAM_SCHEME="http" \
+      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_TRACE=1 \
+      OMUX_TRACE_FILE="$trace_file" \
+      OMUX_STUB_CODEX_TURNS=1 \
+      OMUX_STUB_CODEX_REPORT="$stub_report" \
+      "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$ndjson" 2>"$adapter_stderr" || {
+        echo "adapter exited nonzero in local-transport-retry case" >&2
+        cat "$ndjson" >&2 || true
+        cat "$adapter_stderr" >&2 || true
+        exit 1
+    }
+
+    echo "smoke-codex-provider-degraded: local-transport-retry assertions"
+    assert_grep "local retry recorded first transport failure" '"kind":"proxy_transport_local_retry".*"account":"codex:max-1".*"delivered_to_codex":false' "$ndjson"
+    assert_grep "local retry recovered on same account" '"kind":"proxy_transport_local_retry_recovered".*"account":"codex:max-1".*"status":200.*"classification":"ok"' "$ndjson"
+    assert_grep "same account returned 200 after local retry" '"kind":"proxy_turn".*"account":"codex:max-1".*"status":200.*"classification":"ok"' "$ndjson"
+    assert_no_grep "local retry did not mark upstream failed" '"kind":"proxy_upstream_failed"' "$ndjson"
+    assert_no_grep "local retry did not switch accounts" '"kind":"proxy_provider_same_turn_retry"|"kind":"proxy_same_turn_retry"|"kind":"proxy_provider_retry_unavailable"' "$ndjson"
+    jq -e 'select(.name == "codex.proxy.transport_local_retry" and .attributes.path_kind == "responses" and .attributes.raw_account_id_printed == false)' "$trace_file" >/dev/null
+    echo "  ✓ trace captured local transport retry without raw account ids"
+    jq -e 'select(.name == "codex.proxy.transport_local_retry_recovered" and .attributes.status == 200)' "$trace_file" >/dev/null
+    echo "  ✓ trace captured local transport recovery"
+    jq -e '([.turns[] | select(.status == 200)] | length == 1) and (.pid_stable == true)' "$stub_report" >/dev/null
+    echo "  ✓ stub-codex stayed in one process and saw the turn recover"
+    jq -e '[.accounts[] | select(.last_probe_hint_class == "provider_degraded")] | length == 0' "$case_dir/state/health.json" >/dev/null
+    echo "  ✓ route health was not polluted by recovered local retry"
+}
+
 run_transport_fallback_case() {
     local case_dir="$TMP/transport-fallback"
     local portfile="$case_dir/upstream.port"
@@ -392,8 +449,10 @@ run_transport_fallback_case() {
     assert_no_grep "transport fallback did not leak route-repair body" 'oauth_mux_no_account_selectable' "$stub_report"
     jq -e 'select(.name == "codex.proxy.upstream_failure" and .attributes.path_kind == "responses" and .attributes.raw_account_id_printed == false)' "$trace_file" >/dev/null
     echo "  ✓ trace captured transport reset without raw account ids"
-    jq -e 'select(.response_classification == "transport_reset" and .account_id == "acc-A-id")' "$uplog" >/dev/null
-    echo "  ✓ upstream fixture reset the first account before response"
+    jq -s -e '[.[] | select(.response_classification == "transport_reset" and .account_id == "acc-A-id")] | length == 3' "$uplog" >/dev/null
+    echo "  ✓ upstream fixture reset the first account only during the bounded retry window"
+    jq -s -e '[.[] | select(.account_id == "acc-B-id" and .status_returned == 200)] | length == 3' "$uplog" >/dev/null
+    echo "  ✓ later turns stayed on fallback while max-1 was provider-degraded"
     jq -e '([.turns[] | select(.status == 200)] | length == 3) and (.pid_stable == true)' "$stub_report" >/dev/null
     echo "  ✓ stub-codex stayed in one process and saw all turns recover"
     jq -e '[.accounts[] | select(.key == "codex:max-1#codex-max" and .last_probe_hint_class == "provider_degraded")] | length == 1' "$case_dir/state/health.json" >/dev/null
@@ -504,6 +563,7 @@ run_client_disconnect_case() {
 run_fallback_case
 run_no_fallback_case
 run_transport_failure_case
+run_local_transport_retry_case
 run_transport_fallback_case
 run_upstream_interrupted_case
 run_client_disconnect_case

--- a/scripts/smoke-codex-status-summary.sh
+++ b/scripts/smoke-codex-status-summary.sh
@@ -24,6 +24,7 @@ INCOMPLETE="$TMP/incomplete.ndjson"
 SIGNALED="$TMP/signaled.ndjson"
 PRE_SPAWN="$TMP/pre-spawn.ndjson"
 TRANSPORT_RECOVERY="$TMP/transport-recovery.ndjson"
+LOCAL_TRANSPORT_RECOVERY="$TMP/local-transport-recovery.ndjson"
 BAD_405="$TMP/bad-405.ndjson"
 
 cat >"$BROKERED" <<'EOF'
@@ -112,6 +113,14 @@ cat >"$TRANSPORT_RECOVERY" <<'EOF'
 {"kind":"proxy_turn","account":"codex:max-2","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true,"delivered_to_codex":true}
 {"kind":"proxy_turn","account":"codex:max-2","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true,"delivered_to_codex":true}
 {"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":true}
+EOF
+
+cat >"$LOCAL_TRANSPORT_RECOVERY" <<'EOF'
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"proxy_transport_local_retry","account":"codex:max-1","method":"POST","path_kind":"responses","err":"ConnectionResetByPeer","attempt":1,"max_attempts":2,"backoff_ms":150,"delivered_to_codex":false}
+{"kind":"proxy_transport_local_retry_recovered","account":"codex:max-1","method":"POST","path_kind":"responses","attempts":1,"status":200,"classification":"ok","delivered_to_codex":true}
+{"kind":"proxy_turn","account":"codex:max-1","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true,"delivered_to_codex":true}
+{"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":false}
 EOF
 
 cat >"$BAD_405" <<'EOF'
@@ -364,6 +373,45 @@ fi
 if [[ "$(jq -r .transport_recovery_observed <<<"$TRANSPORT_RECOVERY_NATIVE_SUMMARY")" != "true" ]]; then
     echo "native transport-recovery should report recovery" >&2
     echo "$TRANSPORT_RECOVERY_NATIVE_SUMMARY" >&2
+    exit 1
+fi
+
+LOCAL_TRANSPORT_RECOVERY_SUMMARY="$(python3 "$ROOT/scripts/summarize-codex-status.py" "$LOCAL_TRANSPORT_RECOVERY" --require-brokered)"
+if [[ "$(jq -r .verdict <<<"$LOCAL_TRANSPORT_RECOVERY_SUMMARY")" != "transport_local_retry_recovered" ]]; then
+    echo "local-transport-recovery verdict mismatch" >&2
+    echo "$LOCAL_TRANSPORT_RECOVERY_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .transport_failure_observed <<<"$LOCAL_TRANSPORT_RECOVERY_SUMMARY")" != "true" ]]; then
+    echo "local-transport-recovery should report transport failure evidence" >&2
+    echo "$LOCAL_TRANSPORT_RECOVERY_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .transport_recovery_observed <<<"$LOCAL_TRANSPORT_RECOVERY_SUMMARY")" != "true" ]]; then
+    echo "local-transport-recovery should report recovery" >&2
+    echo "$LOCAL_TRANSPORT_RECOVERY_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .transport_local_retry_events <<<"$LOCAL_TRANSPORT_RECOVERY_SUMMARY")" != "1" ]]; then
+    echo "local-transport-recovery retry count mismatch" >&2
+    echo "$LOCAL_TRANSPORT_RECOVERY_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .transport_local_retry_recovered_events <<<"$LOCAL_TRANSPORT_RECOVERY_SUMMARY")" != "1" ]]; then
+    echo "local-transport-recovery recovered count mismatch" >&2
+    echo "$LOCAL_TRANSPORT_RECOVERY_SUMMARY" >&2
+    exit 1
+fi
+
+LOCAL_TRANSPORT_RECOVERY_NATIVE_SUMMARY="$("$ROOT/zig-out/bin/oauth-mux" codex status-latest --status-file "$LOCAL_TRANSPORT_RECOVERY" --json)"
+if [[ "$(jq -r .verdict <<<"$LOCAL_TRANSPORT_RECOVERY_NATIVE_SUMMARY")" != "transport_local_retry_recovered" ]]; then
+    echo "native local-transport-recovery verdict mismatch" >&2
+    echo "$LOCAL_TRANSPORT_RECOVERY_NATIVE_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .transport_local_retry_events <<<"$LOCAL_TRANSPORT_RECOVERY_NATIVE_SUMMARY")" != "1" ]]; then
+    echo "native local-transport-recovery retry count mismatch" >&2
+    echo "$LOCAL_TRANSPORT_RECOVERY_NATIVE_SUMMARY" >&2
     exit 1
 fi
 

--- a/scripts/summarize-codex-status.py
+++ b/scripts/summarize-codex-status.py
@@ -297,6 +297,45 @@ def find_transport_recovery_sequence(events: list[dict[str, Any]]) -> dict[str, 
     }
 
 
+def find_local_transport_recovery_sequence(events: list[dict[str, Any]]) -> dict[str, Any]:
+    retry_event: dict[str, Any] | None = None
+    recovered_event: dict[str, Any] | None = None
+
+    for idx, event in enumerate(events):
+        if event.get("kind") != "proxy_transport_local_retry":
+            continue
+        retry_event = event
+        retry_account = event.get("account")
+
+        for later in events[idx + 1 :]:
+            if later.get("kind") == "proxy_transport_local_retry_recovered":
+                if retry_account is None or later.get("account") == retry_account:
+                    recovered_event = later
+                    break
+        break
+
+    if retry_event is None:
+        return {
+            "observed": False,
+            "reason": "no proxy_transport_local_retry event",
+        }
+    if recovered_event is None:
+        return {
+            "observed": False,
+            "reason": "local transport retry without recovery event",
+            "retry": retry_event,
+        }
+    return {
+        "observed": True,
+        "retry": retry_event,
+        "recovered": recovered_event,
+        "account": recovered_event.get("account"),
+        "status": recovered_event.get("status"),
+        "path_kind": recovered_event.get("path_kind"),
+        "attempts": recovered_event.get("attempts"),
+    }
+
+
 def summarize(path: Path) -> dict[str, Any]:
     events = load_events(path)
     proxy_turns = [e for e in events if e.get("kind") == "proxy_turn"]
@@ -316,6 +355,7 @@ def summarize(path: Path) -> dict[str, Any]:
     quota_failure = find_quota_handoff_failure(events)
     auth_fallback = find_auth_fallback_sequence(events)
     transport_recovery = find_transport_recovery_sequence(events)
+    local_transport_recovery = find_local_transport_recovery_sequence(events)
     auth_health_events = [e for e in events if e.get("kind") == "auth_health_observed"]
     auth_unauthorized_turns = [
         e
@@ -342,6 +382,10 @@ def summarize(path: Path) -> dict[str, Any]:
         and e.get("classification") == "ok"
     ]
     unsupported_transport_events = [e for e in events if e.get("kind") == "proxy_unsupported_transport"]
+    local_transport_retry_events = [e for e in events if e.get("kind") == "proxy_transport_local_retry"]
+    local_transport_retry_recovered_events = [
+        e for e in events if e.get("kind") == "proxy_transport_local_retry_recovered"
+    ]
     upstream_failure_events = [e for e in events if e.get("kind") == "proxy_upstream_failed"]
     provider_retry_events = [e for e in events if e.get("kind") == "proxy_provider_same_turn_retry"]
     provider_retry_unavailable_events = [e for e in events if e.get("kind") == "proxy_provider_retry_unavailable"]
@@ -350,6 +394,7 @@ def summarize(path: Path) -> dict[str, Any]:
     transport_failure_observed = bool(
         bad_responses_get_405
         or unsupported_transport_events
+        or local_transport_retry_events
         or upstream_failure_events
         or provider_retry_unavailable_events
         or stream_interrupted_events
@@ -400,6 +445,9 @@ def summarize(path: Path) -> dict[str, Any]:
     elif bad_responses_get_405:
         verdict = "transport_regression_405_misclassified"
         next_action = "contain_reconnect_get_transport"
+    elif local_transport_recovery.get("observed"):
+        verdict = "transport_local_retry_recovered"
+        next_action = "continue_managed_dogfood"
     elif transport_recovery.get("observed"):
         verdict = "transport_fallback_recovered"
         next_action = "continue_managed_dogfood"
@@ -452,9 +500,13 @@ def summarize(path: Path) -> dict[str, Any]:
         "quota_event_observed": bool(quota_turns),
         "quota_handoff_observed": bool(fallback.get("observed")),
         "transport_failure_observed": transport_failure_observed,
-        "transport_recovery_observed": bool(transport_recovery.get("observed")),
+        "transport_recovery_observed": bool(transport_recovery.get("observed"))
+        or bool(local_transport_recovery.get("observed")),
         "transport_recovery_sequence": transport_recovery,
+        "transport_local_recovery_sequence": local_transport_recovery,
         "unsupported_transport_events": len(unsupported_transport_events),
+        "transport_local_retry_events": len(local_transport_retry_events),
+        "transport_local_retry_recovered_events": len(local_transport_retry_recovered_events),
         "upstream_failure_events": len(upstream_failure_events),
         "provider_same_turn_retry_events": len(provider_retry_events),
         "provider_retry_unavailable_events": len(provider_retry_unavailable_events),

--- a/scripts/test-stub-upstream.py
+++ b/scripts/test-stub-upstream.py
@@ -90,6 +90,8 @@ ALWAYS_STATUS = os.environ.get("OMUX_STUB_ALWAYS_STATUS", "")
 # OMUX_STUB_ACCOUNT_RESET_JSON maps ChatGPT-Account-ID values to reset modes,
 # e.g. {"acc-A-id":"before_response"}. Matching accounts reset the connection
 # after the request body is read and before any response is written.
+# OMUX_STUB_ACCOUNT_RESET_COUNT_JSON optionally caps reset count per account,
+# e.g. {"acc-A-id":1}. When omitted, matching accounts reset every request.
 try:
     ACCOUNT_STATUS = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_STATUS_JSON", "{}"))
 except json.JSONDecodeError:
@@ -99,6 +101,11 @@ try:
     ACCOUNT_RESET = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_RESET_JSON", "{}"))
 except json.JSONDecodeError:
     ACCOUNT_RESET = {}
+
+try:
+    ACCOUNT_RESET_COUNT = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_RESET_COUNT_JSON", "{}"))
+except json.JSONDecodeError:
+    ACCOUNT_RESET_COUNT = {}
 
 
 # Per-account request counter. Reset only on process restart.
@@ -212,6 +219,11 @@ class StubHandler(http.server.BaseHTTPRequestHandler):
         acct = self._account_id()
         if acct not in ACCOUNT_RESET:
             return False
+        if acct in ACCOUNT_RESET_COUNT:
+            remaining = int(ACCOUNT_RESET_COUNT.get(acct, 0))
+            if remaining <= 0:
+                return False
+            ACCOUNT_RESET_COUNT[acct] = remaining - 1
         _log({
             "path": path,
             "method": self.command,

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -72,6 +72,7 @@ const core_types = @import("../../types.zig");
 const DEFAULT_UPSTREAM_HOST = "chatgpt.com";
 const DEFAULT_UPSTREAM_SCHEME = "https";
 const UPSTREAM_BASE_PATH = "/backend-api/codex";
+const TRANSPORT_LOCAL_RETRY_BACKOFF_MS = [_]u64{ 150, 500 };
 
 pub const RouteState = enum {
     available,
@@ -397,11 +398,12 @@ pub const Proxy = struct {
             // fixed. We don't transform the body.
 
             // ── 4. Forward to upstream + stream/buffer response ────
-            const status_and_class = forwardAndStream(a, req, out_headers, writer) catch |err| {
+            const status_and_class = self.forwardAndStreamWithLocalTransportRetry(a, req, out_headers, writer, elected.id) catch |err| {
                 appendRejection(a, &rejections, elected.id, .provider_degraded, @errorName(err)) catch {};
                 self.logEvent("proxy_upstream_failed", .{ .account = elected.id, .err = @errorName(err) });
                 self.traceUpstreamFailure(req, elected.id, @errorName(err));
                 self.recordDurableRouteState(elected.id, .provider_degraded, 503, 60);
+                self.pool.markProviderDegraded(elected.id, std.time.timestamp() + 60) catch {};
                 pending_failure_kind = .provider_5xx;
                 pending_failure_account = elected.id;
                 pending_transport_error = @errorName(err);
@@ -438,6 +440,7 @@ pub const Proxy = struct {
                 });
                 self.traceUpstreamFailure(req, elected.id, err_name);
                 self.recordDurableRouteState(elected.id, .provider_degraded, 503, 60);
+                self.pool.markProviderDegraded(elected.id, std.time.timestamp() + 60) catch {};
                 final_account = elected.id;
                 break;
             }
@@ -472,6 +475,76 @@ pub const Proxy = struct {
         if (final_account) |account| {
             if (self.previous_account) |old| self.allocator.free(old);
             self.previous_account = self.allocator.dupe(u8, account) catch null;
+        }
+    }
+
+    fn forwardAndStreamWithLocalTransportRetry(
+        self: *Proxy,
+        a: std.mem.Allocator,
+        req: Request,
+        out_headers: HeaderList,
+        client_writer: anytype,
+        account_id: []const u8,
+    ) !StatusAndClassification {
+        var retry_index: usize = 0;
+        while (true) {
+            const status_and_class = forwardAndStream(a, req, out_headers, client_writer) catch |err| {
+                if (!isRetryablePreResponseTransportError(err) or retry_index >= TRANSPORT_LOCAL_RETRY_BACKOFF_MS.len) {
+                    return err;
+                }
+
+                retry_index += 1;
+                const backoff_ms = TRANSPORT_LOCAL_RETRY_BACKOFF_MS[retry_index - 1];
+                self.logEvent("proxy_transport_local_retry", .{
+                    .account = account_id,
+                    .method = req.method,
+                    .path_kind = pathKind(req.path),
+                    .err = @errorName(err),
+                    .attempt = retry_index,
+                    .max_attempts = TRANSPORT_LOCAL_RETRY_BACKOFF_MS.len,
+                    .backoff_ms = backoff_ms,
+                    .delivered_to_codex = false,
+                });
+                trace.append(self.allocator, "codex.proxy.transport_local_retry", .warn, &.{
+                    trace.string("provider", "codex"),
+                    trace.string("method", req.method),
+                    trace.string("path_kind", pathKind(req.path)),
+                    trace.string("transport_error", @errorName(err)),
+                    trace.uint("attempt", @intCast(retry_index)),
+                    trace.uint("max_attempts", @intCast(TRANSPORT_LOCAL_RETRY_BACKOFF_MS.len)),
+                    trace.uint("backoff_ms", backoff_ms),
+                    trace.boolean("delivered_to_codex", false),
+                    trace.boolean("token_material_printed", false),
+                    trace.boolean("raw_account_id_printed", false),
+                    trace.boolean("session_ids_printed", false),
+                });
+                std.time.sleep(backoff_ms * std.time.ns_per_ms);
+                continue;
+            };
+
+            if (retry_index > 0) {
+                self.logEvent("proxy_transport_local_retry_recovered", .{
+                    .account = account_id,
+                    .method = req.method,
+                    .path_kind = pathKind(req.path),
+                    .attempts = retry_index,
+                    .status = status_and_class.status,
+                    .classification = @tagName(status_and_class.classification.kind),
+                    .delivered_to_codex = status_and_class.stream_outcome.kind != .client_disconnected,
+                });
+                trace.append(self.allocator, "codex.proxy.transport_local_retry_recovered", .info, &.{
+                    trace.string("provider", "codex"),
+                    trace.string("method", req.method),
+                    trace.string("path_kind", pathKind(req.path)),
+                    trace.uint("attempts", @intCast(retry_index)),
+                    trace.uint("status", status_and_class.status),
+                    trace.string("classification", @tagName(status_and_class.classification.kind)),
+                    trace.boolean("token_material_printed", false),
+                    trace.boolean("raw_account_id_printed", false),
+                    trace.boolean("session_ids_printed", false),
+                });
+            }
+            return status_and_class;
         }
     }
 
@@ -714,6 +787,7 @@ fn retryAfterSeconds(now_unix: i64, resets_at: ?i64, kind: broker_types.QuotaKin
     const reset = resets_at orelse return switch (kind) {
         .quota_exhausted => 7 * 24 * 60 * 60,
         .rate_limited => 60,
+        .provider_5xx => 60,
         else => null,
     };
     if (reset <= now_unix) return 0;
@@ -741,7 +815,8 @@ fn applyClassificationWithStore(
             try pool.markRateLimited(account_id, until);
         },
         .auth_unauthorized => try pool.markUnauthorized(account_id),
-        .tier_insufficient, .provider_5xx => {
+        .provider_5xx => try pool.markProviderDegraded(account_id, now_unix + 60),
+        .tier_insufficient => {
             // Recorded for telemetry only; no pool mutation.
         },
     }
@@ -1367,6 +1442,21 @@ fn forwardAndStream(
         .streamed = true,
         .stream_outcome = stream_outcome,
     };
+}
+
+fn isRetryablePreResponseTransportError(err: anyerror) bool {
+    return err == error.BrokenPipe or
+        err == error.ConnectionResetByPeer or
+        err == error.ConnectionRefused or
+        err == error.ConnectionTimedOut or
+        err == error.NetworkUnreachable or
+        err == error.HostLacksNetworkAddresses or
+        err == error.TemporaryNameServerFailure or
+        err == error.NameServerFailure or
+        err == error.UnknownHostName or
+        err == error.EndOfStream or
+        err == error.HttpConnectionClosing or
+        err == error.TlsConnectionTruncated;
 }
 
 fn pathKind(path: []const u8) []const u8 {
@@ -2067,6 +2157,15 @@ test "provider_5xx retries same turn and records provider-degraded route state" 
     try std.testing.expectEqual(RouteState.provider_degraded, routeStateFromClassification(.provider_5xx));
 }
 
+test "pre-response transport retry classifier covers transient network failures" {
+    try std.testing.expect(isRetryablePreResponseTransportError(error.BrokenPipe));
+    try std.testing.expect(isRetryablePreResponseTransportError(error.ConnectionResetByPeer));
+    try std.testing.expect(isRetryablePreResponseTransportError(error.ConnectionRefused));
+    try std.testing.expect(isRetryablePreResponseTransportError(error.NetworkUnreachable));
+    try std.testing.expect(isRetryablePreResponseTransportError(error.UnknownHostName));
+    try std.testing.expect(!isRetryablePreResponseTransportError(error.OutOfMemory));
+}
+
 test "classify 429 + usage_limit_reached -> quota_exhausted with resets_at" {
     const body =
         \\{"error":{"type":"usage_limit_reached","plan_type":"pro","resets_at":1788000000}}
@@ -2209,6 +2308,36 @@ test "quota evidence is recorded before same-turn retry election" {
     // the selected route has durable quota evidence and is blocked in-pool.
     const elected = try pool.elect(null, null, &.{});
     try std.testing.expectEqualStrings("codex:max-2", elected.id);
+}
+
+test "provider 5xx evidence blocks in-session route until retry window" {
+    var pool = account_pool_mod.AccountPool.init(std.testing.allocator);
+    defer pool.deinit();
+    try pool.add(.{ .id = "codex:max-1", .selectable = true, .liveness = .live, .availability = .available });
+    try pool.add(.{ .id = "codex:max-2", .selectable = true, .liveness = .live, .availability = .available });
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+
+    const now: i64 = 1_788_000_000;
+    try applyClassificationWithStore(&pool, &store, "codex:max-1", .{
+        .kind = .provider_5xx,
+    }, now, "codex-max");
+
+    const recorded = store.accounts.get("codex:max-1#codex-max") orelse {
+        return error.ExpectedProviderEvidence;
+    };
+    try std.testing.expectEqual(@as(?u16, 500), recorded.last_http_status);
+    try std.testing.expectEqual(@as(?u32, 60), recorded.last_probe_retry_after_s);
+    try std.testing.expectEqual(health_mod.ProbeHintClass.provider_degraded, recorded.last_probe_hint_class.?);
+    try std.testing.expectEqual(core_types.MuxDecision.try_next_provider, recorded.last_probe_decision.?);
+
+    const elected = try pool.elect(null, null, &.{});
+    try std.testing.expectEqualStrings("codex:max-2", elected.id);
+
+    pool.refreshTimeBased(now + 60);
+    const recovered = try pool.elect(null, null, &.{});
+    try std.testing.expectEqualStrings("codex:max-1", recovered.id);
 }
 
 test "successful managed proxy turn records capability route health" {

--- a/src/broker/account_pool.zig
+++ b/src/broker/account_pool.zig
@@ -103,6 +103,26 @@ pub const AccountPool = struct {
         return types.BrokerError.AccountNotFound;
     }
 
+    /// Mark a route as provider-degraded for a short retry window. This is not
+    /// credential death; the account can become selectable again once the
+    /// transport/provider window passes.
+    pub fn markProviderDegraded(
+        self: *AccountPool,
+        account_id: []const u8,
+        retry_after_at: i64,
+    ) types.BrokerError!void {
+        for (self.accounts.items) |*a| {
+            if (std.mem.eql(u8, a.id, account_id)) {
+                a.liveness = .degraded;
+                a.availability = .cooldown;
+                a.next_eligible_at = retry_after_at;
+                a.selectable = false;
+                return;
+            }
+        }
+        return types.BrokerError.AccountNotFound;
+    }
+
     /// Mark an account as authorization-failed (401). Becomes
     /// non-selectable; recovery requires either credential refresh
     /// (Phase 3) or operator re-enrollment.
@@ -129,6 +149,7 @@ pub const AccountPool = struct {
                     // Reset to available; selectability flag follows.
                     a.availability = .available;
                     a.next_eligible_at = null;
+                    if (a.liveness == .degraded) a.liveness = .live;
                     if (a.liveness != .dead) a.selectable = true;
                 }
             }
@@ -246,6 +267,33 @@ test "AccountPool markQuotaExhausted blocks selection until reset" {
     for (pool.accounts.items) |entry| {
         if (std.mem.eql(u8, entry.id, "codex:max-1")) {
             try std.testing.expect(entry.selectable);
+            try std.testing.expectEqual(Availability.available, entry.availability);
+            found_max1_available = true;
+        }
+    }
+    try std.testing.expect(found_max1_available);
+}
+
+test "AccountPool markProviderDegraded blocks selection until retry window" {
+    var pool = AccountPool.init(std.testing.allocator);
+    defer pool.deinit();
+    try pool.add(.{ .id = "codex:max-1", .selectable = true, .liveness = .live, .availability = .available });
+    try pool.add(.{ .id = "codex:max-2", .selectable = true, .liveness = .live, .availability = .available });
+
+    try pool.markProviderDegraded("codex:max-1", 1_800_000_060);
+    const elected = try pool.elect(null, null, &.{});
+    try std.testing.expectEqualStrings("codex:max-2", elected.id);
+
+    pool.refreshTimeBased(1_800_000_059);
+    const before_window = try pool.elect(null, null, &.{});
+    try std.testing.expectEqualStrings("codex:max-2", before_window.id);
+
+    pool.refreshTimeBased(1_800_000_060);
+    var found_max1_available = false;
+    for (pool.accounts.items) |entry| {
+        if (std.mem.eql(u8, entry.id, "codex:max-1")) {
+            try std.testing.expect(entry.selectable);
+            try std.testing.expectEqual(Liveness.live, entry.liveness);
             try std.testing.expectEqual(Availability.available, entry.availability);
             found_max1_available = true;
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -10503,6 +10503,8 @@ const CodexStatusSummary = struct {
     transport_failure_observed: bool = false,
     transport_recovery_observed: bool = false,
     unsupported_transport_events: u64 = 0,
+    transport_local_retry_events: u64 = 0,
+    transport_local_retry_recovered_events: u64 = 0,
     upstream_failure_events: u64 = 0,
     provider_same_turn_retry_events: u64 = 0,
     provider_retry_unavailable_events: u64 = 0,
@@ -10690,6 +10692,12 @@ fn summarizeCodexStatusFile(allocator: std.mem.Allocator, path: []const u8) !Cod
             } else if (std.mem.eql(u8, k, "proxy_unsupported_transport")) {
                 summary.unsupported_transport_events += 1;
                 summary.transport_failure_observed = true;
+            } else if (std.mem.eql(u8, k, "proxy_transport_local_retry")) {
+                summary.transport_local_retry_events += 1;
+                summary.transport_failure_observed = true;
+            } else if (std.mem.eql(u8, k, "proxy_transport_local_retry_recovered")) {
+                summary.transport_local_retry_recovered_events += 1;
+                summary.transport_recovery_observed = true;
             } else if (std.mem.eql(u8, k, "proxy_upstream_failed")) {
                 summary.upstream_failure_events += 1;
                 summary.transport_failure_observed = true;
@@ -10762,6 +10770,9 @@ fn summarizeCodexStatusFile(allocator: std.mem.Allocator, path: []const u8) !Cod
     } else if (summary.responses_get_405_misclassified_ok != 0) {
         summary.verdict = "transport_regression_405_misclassified";
         summary.next_action = "contain_reconnect_get_transport";
+    } else if (summary.transport_local_retry_recovered_events != 0) {
+        summary.verdict = "transport_local_retry_recovered";
+        summary.next_action = "continue_managed_dogfood";
     } else if (summary.transport_recovery_observed) {
         summary.verdict = "transport_fallback_recovered";
         summary.next_action = "continue_managed_dogfood";
@@ -10983,6 +10994,8 @@ fn writeCodexStatusSummaryJson(writer: anytype, summary: CodexStatusSummary) !vo
     try writer.writeAll(",\"transport_recovery_observed\":");
     try writer.writeAll(if (summary.transport_recovery_observed) "true" else "false");
     try writer.print(",\"unsupported_transport_events\":{d}", .{summary.unsupported_transport_events});
+    try writer.print(",\"transport_local_retry_events\":{d}", .{summary.transport_local_retry_events});
+    try writer.print(",\"transport_local_retry_recovered_events\":{d}", .{summary.transport_local_retry_recovered_events});
     try writer.print(",\"upstream_failure_events\":{d}", .{summary.upstream_failure_events});
     try writer.print(",\"provider_same_turn_retry_events\":{d}", .{summary.provider_same_turn_retry_events});
     try writer.print(",\"provider_retry_unavailable_events\":{d}", .{summary.provider_retry_unavailable_events});
@@ -11058,6 +11071,9 @@ fn writeCodexStatusSummaryText(writer: anytype, summary: CodexStatusSummary) !vo
     try writer.print("  quota_handoff_observed: {s}\n", .{if (summary.quota_handoff_observed) "true" else "false"});
     try writer.print("  transport_failure_observed: {s}\n", .{if (summary.transport_failure_observed) "true" else "false"});
     try writer.print("  transport_recovery_observed: {s}\n", .{if (summary.transport_recovery_observed) "true" else "false"});
+    if (summary.transport_local_retry_events != 0) {
+        try writer.print("  transport_local_retry_events: {d}\n", .{summary.transport_local_retry_events});
+    }
     try writer.print("  proxy_turns: {d}\n", .{summary.proxy_turns});
     if (summary.launch_timing_events != 0) {
         try writer.print("  launch_timing_events: {d}\n", .{summary.launch_timing_events});
@@ -18361,6 +18377,39 @@ test "Codex status summary reports transport fallback recovery" {
     try std.testing.expectEqual(@as(u64, 1), summary.upstream_failure_events);
     try std.testing.expectEqual(@as(u64, 1), summary.provider_same_turn_retry_events);
     try std.testing.expectEqualStrings("transport_fallback_recovered", summary.verdict);
+}
+
+test "Codex status summary reports local transport retry recovery" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+
+    const status_path = try std.fs.path.join(std.testing.allocator, &.{ root, "status.ndjson" });
+    defer std.testing.allocator.free(status_path);
+
+    var file = try tmp.dir.createFile("status.ndjson", .{});
+    defer file.close();
+    try file.writeAll(
+        \\{"kind":"session_started","claim_level":"broker_owned","selected_account":"codex:max-1","session_authority":"canonical_bridge"}
+        \\{"kind":"proxy_transport_local_retry","account":"codex:max-1","method":"POST","path_kind":"responses","err":"ConnectionResetByPeer","attempt":1,"max_attempts":2,"backoff_ms":150,"delivered_to_codex":false}
+        \\{"kind":"proxy_transport_local_retry_recovered","account":"codex:max-1","method":"POST","path_kind":"responses","attempts":1,"status":200,"classification":"ok","delivered_to_codex":true}
+        \\{"kind":"proxy_turn","account":"codex:max-1","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","delivered_to_codex":true}
+        \\{"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":false}
+        \\
+    );
+
+    var summary = try summarizeCodexStatusFile(std.testing.allocator, status_path);
+    defer summary.deinit();
+
+    try std.testing.expect(summary.brokered_session_observed);
+    try std.testing.expect(summary.transport_failure_observed);
+    try std.testing.expect(summary.transport_recovery_observed);
+    try std.testing.expectEqual(@as(u64, 1), summary.transport_local_retry_events);
+    try std.testing.expectEqual(@as(u64, 1), summary.transport_local_retry_recovered_events);
+    try std.testing.expectEqual(@as(u64, 0), summary.upstream_failure_events);
+    try std.testing.expectEqualStrings("transport_local_retry_recovered", summary.verdict);
 }
 
 test "Codex status summary flags historical responses GET 405 ok regression" {


### PR DESCRIPTION
## Summary
- retries pre-response transport failures on the same Codex account with a short bounded backoff before mutating route health
- blocks provider-degraded routes in the in-session account pool for the retry window so later turns do not keep re-electing a just-failed route
- surfaces local transport retry/recovery in Python and native `status-latest` summaries, with regression smokes and contract docs

## Validation
- `python3 -m py_compile scripts/test-stub-upstream.py scripts/summarize-codex-status.py`
- `bash -n scripts/smoke-codex-provider-degraded.sh`
- `bash -n scripts/smoke-codex-status-summary.sh`
- `zig build`
- `./scripts/smoke-codex-status-summary.sh`
- `./scripts/smoke-codex-provider-degraded.sh`
- `zig build test`
- `just test`
- `git diff --check`