### PR TITLE
Harden Codex proxy local socket deadlines

### DIFF
--- a/scripts/smoke-codex-provider-degraded.sh
+++ b/scripts/smoke-codex-provider-degraded.sh
@@ -560,6 +560,56 @@ run_client_disconnect_case() {
     echo "  ✓ route health was not polluted by downstream disconnect"
 }
 
+run_local_client_stall_case() {
+    local case_dir="$TMP/local-client-stall"
+    local portfile="$case_dir/upstream.port"
+    local ndjson="$case_dir/status.ndjson"
+    local trace_file="$case_dir/trace.ndjson"
+    local adapter_stderr="$case_dir/adapter.stderr"
+    local stub_report="$case_dir/stub-report.json"
+    mkdir -p "$case_dir"
+    write_one_account_fixture "$case_dir"
+
+    OMUX_STUB_PORT=0 \
+      OMUX_STUB_PORTFILE="$portfile" \
+      OMUX_STUB_OK_BEFORE_429=99 \
+      python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$case_dir/upstream.stderr" &
+    local upstream_pid=$!
+    UPSTREAM_PIDS+=("$upstream_pid")
+    wait_for_port "$portfile"
+    local upstream_port
+    upstream_port="$(cat "$portfile" | tr -d '[:space:]')"
+    echo "smoke-codex-provider-degraded: local-client-stall stub pid=$upstream_pid port=$upstream_port"
+
+    OMUX_CONFIG="$case_dir/oauth-mux.config.json" \
+      OMUX_STATE_DIR="$case_dir/state" \
+      OMUX_UPSTREAM_HOST="127.0.0.1:$upstream_port" \
+      OMUX_UPSTREAM_SCHEME="http" \
+      OMUX_PROXY_IO_TIMEOUT_MS=250 \
+      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_TRACE=1 \
+      OMUX_TRACE_FILE="$trace_file" \
+      OMUX_STUB_CODEX_TURNS=1 \
+      OMUX_STUB_CODEX_PARTIAL_STALL_MS=3000 \
+      OMUX_STUB_CODEX_REPORT="$stub_report" \
+      "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$ndjson" 2>"$adapter_stderr" || {
+        echo "adapter exited nonzero in local-client-stall case" >&2
+        cat "$ndjson" >&2 || true
+        cat "$adapter_stderr" >&2 || true
+        exit 1
+    }
+
+    echo "smoke-codex-provider-degraded: local-client-stall assertions"
+    assert_grep "partial request timed out locally" '"kind":"proxy_request_parse_error","err":"ConnectionTimedOut"' "$ndjson"
+    assert_grep "queued valid turn still completed" '"kind":"proxy_turn".*"account":"codex:max-1".*"status":200.*"classification":"ok"' "$ndjson"
+    assert_no_grep "local stall did not record upstream failure" '"kind":"proxy_upstream_failed"' "$ndjson"
+    assert_no_grep "adapter stderr suppresses local timeout" 'proxy: serveOne: ConnectionTimedOut' "$adapter_stderr"
+    jq -e '.partial_stall.enabled == true and .partial_stall.hold_ms == 3000 and .duration_s < 2.0' "$stub_report" >/dev/null
+    echo "  ✓ half-open local socket did not pin the proxy loop"
+    jq -e '[.accounts[] | select(.last_probe_hint_class == "provider_degraded")] | length == 0' "$case_dir/state/health.json" >/dev/null
+    echo "  ✓ route health was not polluted by local client stall"
+}
+
 run_fallback_case
 run_no_fallback_case
 run_transport_failure_case
@@ -567,6 +617,7 @@ run_local_transport_retry_case
 run_transport_fallback_case
 run_upstream_interrupted_case
 run_client_disconnect_case
+run_local_client_stall_case
 
 echo
 echo "smoke-codex-provider-degraded: all assertions passed."

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -40,6 +40,9 @@ Env (set by the smoke harness):
   OMUX_STUB_CODEX_DISCONNECT_TURNS — optional comma-separated turn indexes that
                             should send the request then close the proxy socket
                             before reading the streamed response.
+  OMUX_STUB_CODEX_PARTIAL_STALL_MS — optional millisecond hold for a deliberately
+                            incomplete request before normal turns. Used to prove
+                            the proxy loop is not pinned by a half-open local socket.
   OMUX_STUB_CODEX_WEBSOCKET_PROBE — optional "1" to send a Codex-shaped
                             WebSocket upgrade GET before normal POST turns.
   OMUX_STUB_CODEX_FAIL_MODE — optional startup failure mode. "sqlite_locked"
@@ -57,6 +60,7 @@ import re
 import socket
 import struct
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -204,6 +208,32 @@ def _post_and_disconnect(proxy_url: str, body: bytes, turn: int) -> tuple[int, s
     finally:
         sock.close()
     return 0, "client_disconnected_before_response"
+
+
+def _start_partial_stall(proxy_url: str, hold_ms: int) -> dict:
+    if hold_ms <= 0:
+        return {"enabled": False}
+    m = re.match(r"http://([^/]+)(/.*)$", proxy_url)
+    if not m:
+        print(f"stub-codex: cannot parse base_url={proxy_url}", file=sys.stderr)
+        sys.exit(2)
+    netloc, prefix = m.group(1), m.group(2)
+    host, port_s = netloc.rsplit(":", 1)
+    sock = socket.create_connection((host, int(port_s)), timeout=15)
+    partial = (
+        f"POST {prefix}/responses HTTP/1.1\r\n"
+        f"Host: {netloc}\r\n"
+        "Content-Type: application/json\r\n"
+        "Content-Length: 2\r\n"
+    ).encode("utf-8")
+    sock.sendall(partial)
+
+    def close_later() -> None:
+        time.sleep(hold_ms / 1000)
+        sock.close()
+
+    threading.Thread(target=close_later, daemon=True).start()
+    return {"enabled": True, "hold_ms": hold_ms}
 
 
 def _websocket_probe(proxy_url: str) -> dict:
@@ -392,6 +422,10 @@ def main() -> int:
     sqlite_env = _sqlite_env_report()
     auth_rewrite = _rewrite_auth_json(codex_home)
     websocket_probe = _websocket_probe(proxy_url)
+    partial_stall = _start_partial_stall(
+        proxy_url,
+        int(os.environ.get("OMUX_STUB_CODEX_PARTIAL_STALL_MS", "0")),
+    )
 
     started_at = time.time()
     print(
@@ -431,6 +465,7 @@ def main() -> int:
         "sqlite_env": sqlite_env,
         "auth_rewrite": auth_rewrite,
         "websocket_probe": websocket_probe,
+        "partial_stall": partial_stall,
     }
     report_path.write_text(json.dumps(report, indent=2))
     print(f"stub-codex: pid_stable={report['pid_stable']} turns={turns}", file=sys.stderr, flush=True)

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -73,6 +73,8 @@ const DEFAULT_UPSTREAM_HOST = "chatgpt.com";
 const DEFAULT_UPSTREAM_SCHEME = "https";
 const UPSTREAM_BASE_PATH = "/backend-api/codex";
 const TRANSPORT_LOCAL_RETRY_BACKOFF_MS = [_]u64{ 150, 500 };
+const PROXY_IO_TIMEOUT_DEFAULT_MS: i32 = 30_000;
+const PROXY_IO_TIMEOUT_MAX_MS: i32 = 10 * 60 * 1000;
 
 pub const RouteState = enum {
     available,
@@ -109,6 +111,59 @@ fn upstreamScheme(allocator: std.mem.Allocator) []const u8 {
         return allocator.dupe(u8, DEFAULT_UPSTREAM_SCHEME) catch DEFAULT_UPSTREAM_SCHEME;
     }
 }
+
+fn configuredProxyIoTimeoutMs(allocator: std.mem.Allocator) i32 {
+    const raw = std.process.getEnvVarOwned(allocator, "OMUX_PROXY_IO_TIMEOUT_MS") catch {
+        return PROXY_IO_TIMEOUT_DEFAULT_MS;
+    };
+    defer allocator.free(raw);
+    const trimmed = std.mem.trim(u8, raw, " \t\r\n");
+    const parsed = std.fmt.parseInt(i32, trimmed, 10) catch return PROXY_IO_TIMEOUT_DEFAULT_MS;
+    if (parsed <= 0) return PROXY_IO_TIMEOUT_DEFAULT_MS;
+    return @min(parsed, PROXY_IO_TIMEOUT_MAX_MS);
+}
+
+const ProxyIoWaitError = std.posix.PollError || error{ConnectionTimedOut};
+
+fn waitForSocket(handle: std.posix.socket_t, events: i16, timeout_ms: i32) ProxyIoWaitError!void {
+    var fds = [_]std.posix.pollfd{.{
+        .fd = handle,
+        .events = events,
+        .revents = 0,
+    }};
+    const ready = try std.posix.poll(&fds, timeout_ms);
+    if (ready == 0) return error.ConnectionTimedOut;
+}
+
+const TimedProxyStream = struct {
+    stream: std.net.Stream,
+    timeout_ms: i32,
+
+    pub const ReadError = std.net.Stream.ReadError || ProxyIoWaitError;
+    pub const WriteError = std.net.Stream.WriteError || ProxyIoWaitError;
+    pub const Reader = std.io.Reader(TimedProxyStream, ReadError, read);
+    pub const Writer = std.io.Writer(TimedProxyStream, WriteError, write);
+
+    pub fn reader(self: TimedProxyStream) Reader {
+        return .{ .context = self };
+    }
+
+    pub fn writer(self: TimedProxyStream) Writer {
+        return .{ .context = self };
+    }
+
+    pub fn read(self: TimedProxyStream, buffer: []u8) ReadError!usize {
+        if (buffer.len == 0) return 0;
+        try waitForSocket(self.stream.handle, @intCast(std.posix.POLL.IN), self.timeout_ms);
+        return self.stream.read(buffer);
+    }
+
+    pub fn write(self: TimedProxyStream, bytes: []const u8) WriteError!usize {
+        if (bytes.len == 0) return 0;
+        try waitForSocket(self.stream.handle, @intCast(std.posix.POLL.OUT), self.timeout_ms);
+        return self.stream.write(bytes);
+    }
+};
 
 pub const Proxy = struct {
     allocator: std.mem.Allocator,
@@ -213,12 +268,16 @@ pub const Proxy = struct {
     pub fn serveOne(self: *Proxy) !void {
         var conn = try self.server.accept();
         defer conn.stream.close();
-        try self.handleConnection(conn);
+        const stream = TimedProxyStream{
+            .stream = conn.stream,
+            .timeout_ms = configuredProxyIoTimeoutMs(self.allocator),
+        };
+        try self.handleConnection(stream);
     }
 
-    fn handleConnection(self: *Proxy, conn: std.net.Server.Connection) !void {
-        const reader = conn.stream.reader();
-        const writer = conn.stream.writer();
+    fn handleConnection(self: *Proxy, stream: TimedProxyStream) !void {
+        const reader = stream.reader();
+        const writer = stream.writer();
 
         var arena = std.heap.ArenaAllocator.init(self.allocator);
         defer arena.deinit();


### PR DESCRIPTION
## Summary
- add bounded read/write waits around accepted local Codex proxy sockets
- keep half-open local requests from pinning the single proxy loop
- add a smoke regression where a partial local request stalls while a valid turn queues behind it

## Validation
- python3 -m py_compile scripts/test-stub-codex.py
- bash -n scripts/smoke-codex-provider-degraded.sh
- zig fmt --check src/adapters/codex/wire_proxy.zig
- zig build
- ./scripts/smoke-codex-provider-degraded.sh
- zig build test
- just test
- git diff --check
- just release-windows-amd64

Fixes part of #311.