### PR TITLE
TIN-1631 Harden Codex upstream response stalls

### DIFF
--- a/scripts/smoke-codex-provider-degraded.sh
+++ b/scripts/smoke-codex-provider-degraded.sh
@@ -401,6 +401,64 @@ run_local_transport_retry_case() {
     echo "  ✓ route health was not polluted by recovered local retry"
 }
 
+run_upstream_header_stall_retry_case() {
+    local case_dir="$TMP/upstream-header-stall-retry"
+    local portfile="$case_dir/upstream.port"
+    local uplog="$case_dir/upstream.log"
+    local ndjson="$case_dir/adapter.ndjson"
+    local adapter_stderr="$case_dir/adapter.stderr"
+    local stub_report="$case_dir/stub-codex.report"
+    local trace_file="$case_dir/trace.ndjson"
+    mkdir -p "$case_dir"
+    write_one_account_fixture "$case_dir"
+
+    OMUX_STUB_PORT=0 \
+      OMUX_STUB_PORTFILE="$portfile" \
+      OMUX_STUB_OK_BEFORE_429=99 \
+      OMUX_STUB_LOGFILE="$uplog" \
+      OMUX_STUB_ACCOUNT_STALL_MS_JSON='{"acc-A-id":1000}' \
+      OMUX_STUB_ACCOUNT_STALL_COUNT_JSON='{"acc-A-id":1}' \
+      python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$case_dir/upstream.stderr" &
+    local upstream_pid=$!
+    UPSTREAM_PIDS+=("$upstream_pid")
+    wait_for_port "$portfile"
+    local upstream_port
+    upstream_port="$(cat "$portfile" | tr -d '[:space:]')"
+    echo "smoke-codex-provider-degraded: upstream-header-stall-retry stub pid=$upstream_pid port=$upstream_port first=max-1-stall second=max-1-200"
+
+    OMUX_CONFIG="$case_dir/oauth-mux.config.json" \
+      OMUX_STATE_DIR="$case_dir/state" \
+      OMUX_UPSTREAM_HOST="127.0.0.1:$upstream_port" \
+      OMUX_UPSTREAM_SCHEME="http" \
+      OMUX_PROXY_UPSTREAM_RESPONSE_TIMEOUT_MS=250 \
+      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_TRACE=1 \
+      OMUX_TRACE_FILE="$trace_file" \
+      OMUX_STUB_CODEX_TURNS=1 \
+      OMUX_STUB_CODEX_REPORT="$stub_report" \
+      "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$ndjson" 2>"$adapter_stderr" || {
+        echo "adapter exited nonzero in upstream-header-stall-retry case" >&2
+        cat "$ndjson" >&2 || true
+        cat "$adapter_stderr" >&2 || true
+        exit 1
+    }
+
+    echo "smoke-codex-provider-degraded: upstream-header-stall-retry assertions"
+    assert_grep "header stall recorded local retry" '"kind":"proxy_transport_local_retry".*"account":"codex:max-1".*"err":"ConnectionTimedOut".*"delivered_to_codex":false' "$ndjson"
+    assert_grep "header stall recovered on same account" '"kind":"proxy_transport_local_retry_recovered".*"account":"codex:max-1".*"status":200.*"classification":"ok"' "$ndjson"
+    assert_grep "same account returned 200 after header stall" '"kind":"proxy_turn".*"account":"codex:max-1".*"status":200.*"classification":"ok"' "$ndjson"
+    assert_no_grep "header stall did not mark upstream failed" '"kind":"proxy_upstream_failed"' "$ndjson"
+    assert_no_grep "header stall did not switch accounts" '"kind":"proxy_provider_same_turn_retry"|"kind":"proxy_same_turn_retry"|"kind":"proxy_provider_retry_unavailable"' "$ndjson"
+    jq -e 'select(.name == "codex.proxy.transport_local_retry" and .attributes.transport_error == "ConnectionTimedOut" and .attributes.raw_account_id_printed == false)' "$trace_file" >/dev/null
+    echo "  ✓ trace captured header-stall retry without raw account ids"
+    jq -s -e '[.[] | select(.response_classification == "transport_stall" and .account_id == "acc-A-id" and .stall_ms == 1000)] | length == 1' "$uplog" >/dev/null
+    echo "  ✓ upstream fixture stalled the first account once before headers"
+    jq -e '([.turns[] | select(.status == 200)] | length == 1) and (.pid_stable == true)' "$stub_report" >/dev/null
+    echo "  ✓ stub-codex stayed in one process and saw the turn recover"
+    jq -e '[.accounts[] | select(.last_probe_hint_class == "provider_degraded")] | length == 0' "$case_dir/state/health.json" >/dev/null
+    echo "  ✓ route health was not polluted by recovered header stall"
+}
+
 run_transport_fallback_case() {
     local case_dir="$TMP/transport-fallback"
     local portfile="$case_dir/upstream.port"
@@ -614,6 +672,7 @@ run_fallback_case
 run_no_fallback_case
 run_transport_failure_case
 run_local_transport_retry_case
+run_upstream_header_stall_retry_case
 run_transport_fallback_case
 run_upstream_interrupted_case
 run_client_disconnect_case

--- a/scripts/test-stub-upstream.py
+++ b/scripts/test-stub-upstream.py
@@ -92,6 +92,9 @@ ALWAYS_STATUS = os.environ.get("OMUX_STUB_ALWAYS_STATUS", "")
 # after the request body is read and before any response is written.
 # OMUX_STUB_ACCOUNT_RESET_COUNT_JSON optionally caps reset count per account,
 # e.g. {"acc-A-id":1}. When omitted, matching accounts reset every request.
+# OMUX_STUB_ACCOUNT_STALL_MS_JSON maps ChatGPT-Account-ID values to a millisecond
+# stall before response headers are written, e.g. {"acc-A-id":1000}.
+# OMUX_STUB_ACCOUNT_STALL_COUNT_JSON optionally caps stall count per account.
 try:
     ACCOUNT_STATUS = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_STATUS_JSON", "{}"))
 except json.JSONDecodeError:
@@ -106,6 +109,16 @@ try:
     ACCOUNT_RESET_COUNT = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_RESET_COUNT_JSON", "{}"))
 except json.JSONDecodeError:
     ACCOUNT_RESET_COUNT = {}
+
+try:
+    ACCOUNT_STALL_MS = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_STALL_MS_JSON", "{}"))
+except json.JSONDecodeError:
+    ACCOUNT_STALL_MS = {}
+
+try:
+    ACCOUNT_STALL_COUNT = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_STALL_COUNT_JSON", "{}"))
+except json.JSONDecodeError:
+    ACCOUNT_STALL_COUNT = {}
 
 
 # Per-account request counter. Reset only on process restart.
@@ -241,6 +254,29 @@ class StubHandler(http.server.BaseHTTPRequestHandler):
         self.connection.close()
         return True
 
+    def _stall_before_response_if_configured(self, path: str) -> None:
+        acct = self._account_id()
+        if acct not in ACCOUNT_STALL_MS:
+            return
+        if acct in ACCOUNT_STALL_COUNT:
+            remaining = int(ACCOUNT_STALL_COUNT.get(acct, 0))
+            if remaining <= 0:
+                return
+            ACCOUNT_STALL_COUNT[acct] = remaining - 1
+        stall_ms = int(ACCOUNT_STALL_MS.get(acct, 0))
+        if stall_ms <= 0:
+            return
+        _log({
+            "path": path,
+            "method": self.command,
+            "account_id": acct,
+            "auth_prefix": self._auth_prefix(),
+            "status_returned": "stall_before_response",
+            "response_classification": "transport_stall",
+            "stall_ms": stall_ms,
+        })
+        time.sleep(stall_ms / 1000)
+
     def _serve(self) -> None:
         path = urlparse(self.path).path
         if not path.startswith("/backend-api/codex"):
@@ -254,6 +290,7 @@ class StubHandler(http.server.BaseHTTPRequestHandler):
         _ = body_bytes  # request bodies are unused; we don't echo
         if self._reset_before_response_if_configured(path):
             return
+        self._stall_before_response_if_configured(path)
 
         status, body = self._classify_for_account()
         if "_text" in body:
@@ -314,7 +351,8 @@ class StubHandler(http.server.BaseHTTPRequestHandler):
 
 def main() -> int:
     LOGFILE.unlink(missing_ok=True)
-    httpd = http.server.HTTPServer(("127.0.0.1", PORT), StubHandler)
+    httpd = http.server.ThreadingHTTPServer(("127.0.0.1", PORT), StubHandler)
+    httpd.daemon_threads = True
     actual_port = httpd.server_address[1]
     PORTFILE.write_text(f"{actual_port}\n")
     print(f"stub-upstream: listening on 127.0.0.1:{actual_port}", file=sys.stderr, flush=True)

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -75,6 +75,8 @@ const UPSTREAM_BASE_PATH = "/backend-api/codex";
 const TRANSPORT_LOCAL_RETRY_BACKOFF_MS = [_]u64{ 150, 500 };
 const PROXY_IO_TIMEOUT_DEFAULT_MS: i32 = 30_000;
 const PROXY_IO_TIMEOUT_MAX_MS: i32 = 10 * 60 * 1000;
+const PROXY_UPSTREAM_RESPONSE_TIMEOUT_DEFAULT_MS: i32 = 30_000;
+const PROXY_UPSTREAM_RESPONSE_TIMEOUT_MAX_MS: i32 = 10 * 60 * 1000;
 
 pub const RouteState = enum {
     available,
@@ -112,15 +114,36 @@ fn upstreamScheme(allocator: std.mem.Allocator) []const u8 {
     }
 }
 
-fn configuredProxyIoTimeoutMs(allocator: std.mem.Allocator) i32 {
-    const raw = std.process.getEnvVarOwned(allocator, "OMUX_PROXY_IO_TIMEOUT_MS") catch {
-        return PROXY_IO_TIMEOUT_DEFAULT_MS;
-    };
+fn configuredPositiveTimeoutMs(
+    allocator: std.mem.Allocator,
+    env_name: []const u8,
+    default_ms: i32,
+    max_ms: i32,
+) i32 {
+    const raw = std.process.getEnvVarOwned(allocator, env_name) catch return default_ms;
     defer allocator.free(raw);
     const trimmed = std.mem.trim(u8, raw, " \t\r\n");
-    const parsed = std.fmt.parseInt(i32, trimmed, 10) catch return PROXY_IO_TIMEOUT_DEFAULT_MS;
-    if (parsed <= 0) return PROXY_IO_TIMEOUT_DEFAULT_MS;
-    return @min(parsed, PROXY_IO_TIMEOUT_MAX_MS);
+    const parsed = std.fmt.parseInt(i32, trimmed, 10) catch return default_ms;
+    if (parsed <= 0) return default_ms;
+    return @min(parsed, max_ms);
+}
+
+fn configuredProxyIoTimeoutMs(allocator: std.mem.Allocator) i32 {
+    return configuredPositiveTimeoutMs(
+        allocator,
+        "OMUX_PROXY_IO_TIMEOUT_MS",
+        PROXY_IO_TIMEOUT_DEFAULT_MS,
+        PROXY_IO_TIMEOUT_MAX_MS,
+    );
+}
+
+fn configuredProxyUpstreamResponseTimeoutMs(allocator: std.mem.Allocator) i32 {
+    return configuredPositiveTimeoutMs(
+        allocator,
+        "OMUX_PROXY_UPSTREAM_RESPONSE_TIMEOUT_MS",
+        PROXY_UPSTREAM_RESPONSE_TIMEOUT_DEFAULT_MS,
+        PROXY_UPSTREAM_RESPONSE_TIMEOUT_MAX_MS,
+    );
 }
 
 const ProxyIoWaitError = std.posix.PollError || error{ConnectionTimedOut};
@@ -133,6 +156,11 @@ fn waitForSocket(handle: std.posix.socket_t, events: i16, timeout_ms: i32) Proxy
     }};
     const ready = try std.posix.poll(&fds, timeout_ms);
     if (ready == 0) return error.ConnectionTimedOut;
+}
+
+fn waitForUpstreamResponseStart(http_req: *std.http.Client.Request, timeout_ms: i32) ProxyIoWaitError!void {
+    const connection = http_req.connection orelse return;
+    try waitForSocket(connection.stream.handle, @intCast(std.posix.POLL.IN), timeout_ms);
 }
 
 const TimedProxyStream = struct {
@@ -1470,6 +1498,7 @@ fn forwardAndStream(
         try http_req.writeAll(req.body);
         try http_req.finish();
     }
+    try waitForUpstreamResponseStart(&http_req, configuredProxyUpstreamResponseTimeoutMs(a));
     try http_req.wait();
 
     const status_u16: u16 = @intFromEnum(http_req.response.status);


### PR DESCRIPTION
## Summary

- add a bounded upstream response-start wait before the Codex proxy enters std.http.Client.wait()
- route response-header stalls through the existing local transport retry/recovery path
- add a provider-degraded smoke regression where the first upstream request stalls before headers, then the same account recovers without route-health pollution

Refs #311
Linear: TIN-1631

## Validation

- python3 -m py_compile scripts/test-stub-upstream.py
- bash -n scripts/smoke-codex-provider-degraded.sh
- zig fmt --check src/adapters/codex/wire_proxy.zig
- zig build
- ./scripts/smoke-codex-provider-degraded.sh
- zig build test
- just test
- git diff --check
- just release-windows-amd64