### PR TITLE
TIN-1631 Classify buffered response disconnects

### DIFF
--- a/scripts/smoke-codex-provider-degraded.sh
+++ b/scripts/smoke-codex-provider-degraded.sh
@@ -618,6 +618,48 @@ run_client_disconnect_case() {
     echo "  ✓ route health was not polluted by downstream disconnect"
 }
 
+run_buffered_error_client_disconnect_case() {
+    local case_dir="$TMP/buffered-error-client-disconnect"
+    local portfile="$case_dir/upstream.port"
+    local ndjson="$case_dir/adapter.ndjson"
+    local adapter_stderr="$case_dir/adapter.stderr"
+    local stub_report="$case_dir/stub-codex.report"
+    mkdir -p "$case_dir"
+    write_one_account_fixture "$case_dir"
+
+    OMUX_STUB_PORT=0 \
+      OMUX_STUB_PORTFILE="$portfile" \
+      OMUX_STUB_ALWAYS_STATUS=503 \
+      python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$case_dir/upstream.stderr" &
+    local upstream_pid=$!
+    UPSTREAM_PIDS+=("$upstream_pid")
+    wait_for_port "$portfile"
+    local upstream_port
+    upstream_port="$(cat "$portfile" | tr -d '[:space:]')"
+    echo "smoke-codex-provider-degraded: buffered-error-client-disconnect stub pid=$upstream_pid port=$upstream_port"
+
+    OMUX_CONFIG="$case_dir/oauth-mux.config.json" \
+      OMUX_STATE_DIR="$case_dir/state" \
+      OMUX_UPSTREAM_HOST="127.0.0.1:$upstream_port" \
+      OMUX_UPSTREAM_SCHEME="http" \
+      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_STUB_CODEX_TURNS=1 \
+      OMUX_STUB_CODEX_DISCONNECT_TURNS=0 \
+      OMUX_STUB_CODEX_REPORT="$stub_report" \
+      "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$ndjson" 2>"$adapter_stderr" || {
+        echo "adapter exited nonzero in buffered-error-client-disconnect case" >&2
+        cat "$ndjson" >&2 || true
+        cat "$adapter_stderr" >&2 || true
+        exit 1
+    }
+
+    echo "smoke-codex-provider-degraded: buffered-error-client-disconnect assertions"
+    assert_grep "buffered error close classified as client disconnect" '"kind":"proxy_client_disconnected".*"account":"codex:max-1".*"status":503.*"err":"(BrokenPipe|ConnectionResetByPeer|EndOfStream|ConnectionTimedOut)".*"retry_attempted":true' "$ndjson"
+    assert_no_grep "buffered error close did not leak benign proxy write failure" 'proxy: serveOne: (BrokenPipe|ConnectionResetByPeer|EndOfStream|ConnectionTimedOut)' "$adapter_stderr"
+    jq -e '[.turns[] | select(.status == 0 and (.body_head | contains("client_disconnected_before_response")))] | length == 1' "$stub_report" >/dev/null
+    echo "  ✓ buffered error write failure was classified as downstream disconnect"
+}
+
 run_local_client_stall_case() {
     local case_dir="$TMP/local-client-stall"
     local portfile="$case_dir/upstream.port"
@@ -676,6 +718,7 @@ run_upstream_header_stall_retry_case
 run_transport_fallback_case
 run_upstream_interrupted_case
 run_client_disconnect_case
+run_buffered_error_client_disconnect_case
 run_local_client_stall_case
 
 echo

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -372,27 +372,44 @@ pub const Proxy = struct {
                     self.logEvent("proxy_observed_401_codex_handles", .{
                         .account = pending_failure_account orelse "",
                     });
-                    try writeBufferedStoredResponse(writer, pending_buffered.?);
+                    _ = try self.writeBufferedStoredResponseOrClientDisconnect(
+                        writer,
+                        req,
+                        pending_failure_account orelse "",
+                        pending_buffered.?,
+                        true,
+                    );
                 } else if (pending_kind != null and pending_kind.? == .provider_5xx) {
-                    self.logEvent("proxy_provider_retry_unavailable", .{
-                        .from = pending_failure_account orelse "",
-                        .err = pending_transport_error orelse @errorName(err),
-                        .attempted = attempted.items,
-                        .rejections = rejections.items,
-                        .delivered_to_codex = true,
-                    });
-                    self.traceProviderUnavailable(req, pending_failure_account orelse "", pending_transport_error orelse @errorName(err), rejections.items);
+                    var delivered_to_codex = true;
+                    const retry_err = pending_transport_error orelse @errorName(err);
+                    const retry_account = pending_failure_account orelse "";
                     if (pending_buffered) |buffered| {
-                        try writeBufferedStoredResponse(writer, buffered);
+                        delivered_to_codex = try self.writeBufferedStoredResponseOrClientDisconnect(
+                            writer,
+                            req,
+                            retry_account,
+                            buffered,
+                            true,
+                        );
                     } else {
-                        try writeProviderUnavailableResponse(
+                        delivered_to_codex = try self.writeProviderUnavailableResponseOrClientDisconnect(
                             a,
                             writer,
-                            pending_failure_account orelse "",
-                            pending_transport_error orelse @errorName(err),
+                            req,
+                            retry_account,
+                            retry_err,
                             rejections.items,
+                            true,
                         );
                     }
+                    self.logEvent("proxy_provider_retry_unavailable", .{
+                        .from = retry_account,
+                        .err = retry_err,
+                        .attempted = attempted.items,
+                        .rejections = rejections.items,
+                        .delivered_to_codex = delivered_to_codex,
+                    });
+                    self.traceProviderUnavailable(req, retry_account, retry_err, rejections.items, delivered_to_codex);
                 } else if (pending_kind != null and (pending_kind.? == .quota_exhausted or pending_kind.? == .rate_limited)) {
                     self.logEvent("proxy_same_turn_retry_unavailable", .{
                         .from = pending_failure_account orelse "",
@@ -543,7 +560,13 @@ pub const Proxy = struct {
 
             if (!should_retry) {
                 if (status_and_class.buffered_response) |buffered| {
-                    try writeBufferedStoredResponse(writer, buffered);
+                    if (!try self.writeBufferedStoredResponseOrClientDisconnect(
+                        writer,
+                        req,
+                        elected.id,
+                        buffered,
+                        false,
+                    )) break;
                 }
                 break;
             }
@@ -633,6 +656,64 @@ pub const Proxy = struct {
             }
             return status_and_class;
         }
+    }
+
+    fn writeBufferedStoredResponseOrClientDisconnect(
+        self: *Proxy,
+        writer: anytype,
+        req: Request,
+        account_id: []const u8,
+        response: BufferedResponse,
+        retry_attempted: bool,
+    ) !bool {
+        writeBufferedStoredResponse(writer, response) catch |err| {
+            if (isClientDisconnectWriteError(err)) {
+                self.logClientDisconnected(account_id, req, response.status, @errorName(err), 0, retry_attempted);
+                return false;
+            }
+            return err;
+        };
+        return true;
+    }
+
+    fn writeProviderUnavailableResponseOrClientDisconnect(
+        self: *Proxy,
+        allocator: std.mem.Allocator,
+        writer: anytype,
+        req: Request,
+        account_id: []const u8,
+        err_name: []const u8,
+        rejections: []const CandidateRejection,
+        retry_attempted: bool,
+    ) !bool {
+        writeProviderUnavailableResponse(allocator, writer, account_id, err_name, rejections) catch |err| {
+            if (isClientDisconnectWriteError(err)) {
+                self.logClientDisconnected(account_id, req, 503, @errorName(err), 0, retry_attempted);
+                return false;
+            }
+            return err;
+        };
+        return true;
+    }
+
+    fn logClientDisconnected(
+        self: *Proxy,
+        account_id: []const u8,
+        req: Request,
+        status: u16,
+        err_name: []const u8,
+        bytes_streamed: usize,
+        retry_attempted: bool,
+    ) void {
+        self.logEvent("proxy_client_disconnected", .{
+            .account = account_id,
+            .method = req.method,
+            .path_kind = pathKind(req.path),
+            .status = status,
+            .err = err_name,
+            .bytes_streamed = bytes_streamed,
+            .retry_attempted = retry_attempted,
+        });
     }
 
     fn logProxyTurn(
@@ -786,6 +867,7 @@ pub const Proxy = struct {
         account_id: []const u8,
         err: []const u8,
         rejections: []const CandidateRejection,
+        delivered_to_codex: bool,
     ) void {
         trace.append(self.allocator, "codex.proxy.provider_unavailable", .warn, &.{
             trace.string("provider", "codex"),
@@ -794,7 +876,7 @@ pub const Proxy = struct {
             trace.string("path_kind", pathKind(req.path)),
             trace.string("transport_error", err),
             trace.uint("rejections_total", @intCast(rejections.len)),
-            trace.boolean("delivered_to_codex", true),
+            trace.boolean("delivered_to_codex", delivered_to_codex),
             trace.boolean("token_material_printed", false),
             trace.boolean("raw_account_id_printed", false),
             trace.boolean("session_ids_printed", false),
@@ -1545,6 +1627,13 @@ fn isRetryablePreResponseTransportError(err: anyerror) bool {
         err == error.EndOfStream or
         err == error.HttpConnectionClosing or
         err == error.TlsConnectionTruncated;
+}
+
+fn isClientDisconnectWriteError(err: anyerror) bool {
+    return err == error.BrokenPipe or
+        err == error.ConnectionResetByPeer or
+        err == error.ConnectionTimedOut or
+        err == error.EndOfStream;
 }
 
 fn pathKind(path: []const u8) []const u8 {


### PR DESCRIPTION
## Summary
- classify downstream Codex disconnects while writing buffered upstream/local error responses as proxy_client_disconnected
- mark provider-unavailable delivery accurately when the buffered write never reaches Codex
- add a provider-degraded smoke regression for the 503 buffered-error disconnect path

## Validation
- zig fmt --check src/adapters/codex/wire_proxy.zig
- bash -n scripts/smoke-codex-provider-degraded.sh
- zig build
- ./scripts/smoke-codex-provider-degraded.sh
- zig build test
- just test
- git diff --check
- just release-windows-amd64

Refs #311 / TIN-1631