### PR TITLE
TIN-1631 Harden Codex partial-header stalls

### DIFF
--- a/scripts/smoke-codex-provider-degraded.sh
+++ b/scripts/smoke-codex-provider-degraded.sh
@@ -459,6 +459,64 @@ run_upstream_header_stall_retry_case() {
     echo "  ✓ route health was not polluted by recovered header stall"
 }
 
+run_upstream_partial_header_stall_retry_case() {
+    local case_dir="$TMP/upstream-partial-header-stall-retry"
+    local portfile="$case_dir/upstream.port"
+    local uplog="$case_dir/upstream.log"
+    local ndjson="$case_dir/adapter.ndjson"
+    local adapter_stderr="$case_dir/adapter.stderr"
+    local stub_report="$case_dir/stub-codex.report"
+    local trace_file="$case_dir/trace.ndjson"
+    mkdir -p "$case_dir"
+    write_one_account_fixture "$case_dir"
+
+    OMUX_STUB_PORT=0 \
+      OMUX_STUB_PORTFILE="$portfile" \
+      OMUX_STUB_OK_BEFORE_429=99 \
+      OMUX_STUB_LOGFILE="$uplog" \
+      OMUX_STUB_ACCOUNT_PARTIAL_HEADER_STALL_MS_JSON='{"acc-A-id":1000}' \
+      OMUX_STUB_ACCOUNT_PARTIAL_HEADER_STALL_COUNT_JSON='{"acc-A-id":1}' \
+      python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$case_dir/upstream.stderr" &
+    local upstream_pid=$!
+    UPSTREAM_PIDS+=("$upstream_pid")
+    wait_for_port "$portfile"
+    local upstream_port
+    upstream_port="$(cat "$portfile" | tr -d '[:space:]')"
+    echo "smoke-codex-provider-degraded: upstream-partial-header-stall-retry stub pid=$upstream_pid port=$upstream_port first=max-1-partial-header-stall second=max-1-200"
+
+    OMUX_CONFIG="$case_dir/oauth-mux.config.json" \
+      OMUX_STATE_DIR="$case_dir/state" \
+      OMUX_UPSTREAM_HOST="127.0.0.1:$upstream_port" \
+      OMUX_UPSTREAM_SCHEME="http" \
+      OMUX_PROXY_UPSTREAM_RESPONSE_TIMEOUT_MS=250 \
+      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_TRACE=1 \
+      OMUX_TRACE_FILE="$trace_file" \
+      OMUX_STUB_CODEX_TURNS=1 \
+      OMUX_STUB_CODEX_REPORT="$stub_report" \
+      "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$ndjson" 2>"$adapter_stderr" || {
+        echo "adapter exited nonzero in upstream-partial-header-stall-retry case" >&2
+        cat "$ndjson" >&2 || true
+        cat "$adapter_stderr" >&2 || true
+        exit 1
+    }
+
+    echo "smoke-codex-provider-degraded: upstream-partial-header-stall-retry assertions"
+    assert_grep "partial header stall recorded local retry" '"kind":"proxy_transport_local_retry".*"account":"codex:max-1".*"err":"ConnectionTimedOut".*"delivered_to_codex":false' "$ndjson"
+    assert_grep "partial header stall recovered on same account" '"kind":"proxy_transport_local_retry_recovered".*"account":"codex:max-1".*"status":200.*"classification":"ok"' "$ndjson"
+    assert_grep "same account returned 200 after partial header stall" '"kind":"proxy_turn".*"account":"codex:max-1".*"status":200.*"classification":"ok"' "$ndjson"
+    assert_no_grep "partial header stall did not mark upstream failed" '"kind":"proxy_upstream_failed"' "$ndjson"
+    assert_no_grep "partial header stall did not switch accounts" '"kind":"proxy_provider_same_turn_retry"|"kind":"proxy_same_turn_retry"|"kind":"proxy_provider_retry_unavailable"' "$ndjson"
+    jq -e 'select(.name == "codex.proxy.transport_local_retry" and .attributes.transport_error == "ConnectionTimedOut" and .attributes.raw_account_id_printed == false)' "$trace_file" >/dev/null
+    echo "  ✓ trace captured partial-header retry without raw account ids"
+    jq -s -e '[.[] | select(.response_classification == "transport_partial_header_stall" and .account_id == "acc-A-id" and .stall_ms == 1000)] | length == 1' "$uplog" >/dev/null
+    echo "  ✓ upstream fixture stalled once after partial headers"
+    jq -e '([.turns[] | select(.status == 200)] | length == 1) and (.pid_stable == true)' "$stub_report" >/dev/null
+    echo "  ✓ stub-codex stayed in one process and saw the turn recover"
+    jq -e '[.accounts[] | select(.last_probe_hint_class == "provider_degraded")] | length == 0' "$case_dir/state/health.json" >/dev/null
+    echo "  ✓ route health was not polluted by recovered partial-header stall"
+}
+
 run_transport_fallback_case() {
     local case_dir="$TMP/transport-fallback"
     local portfile="$case_dir/upstream.port"
@@ -715,6 +773,7 @@ run_no_fallback_case
 run_transport_failure_case
 run_local_transport_retry_case
 run_upstream_header_stall_retry_case
+run_upstream_partial_header_stall_retry_case
 run_transport_fallback_case
 run_upstream_interrupted_case
 run_client_disconnect_case

--- a/scripts/test-stub-upstream.py
+++ b/scripts/test-stub-upstream.py
@@ -22,6 +22,11 @@ Behavior (configurable via env):
                         of a 200 response body, then reset the connection.
                         Used to model upstream network interruption after a
                         partial streaming response reached the proxy.
+  OMUX_STUB_ACCOUNT_PARTIAL_HEADER_STALL_MS_JSON — maps ChatGPT-Account-ID
+                        values to a millisecond stall after writing partial
+                        response headers but before completing the response
+                        head. Used to model upstream connections that become
+                        readable, then stop before a complete HTTP response.
 
 Per request:
   - Logs a JSON line with: ts, path, method, account_id (from
@@ -95,6 +100,11 @@ ALWAYS_STATUS = os.environ.get("OMUX_STUB_ALWAYS_STATUS", "")
 # OMUX_STUB_ACCOUNT_STALL_MS_JSON maps ChatGPT-Account-ID values to a millisecond
 # stall before response headers are written, e.g. {"acc-A-id":1000}.
 # OMUX_STUB_ACCOUNT_STALL_COUNT_JSON optionally caps stall count per account.
+# OMUX_STUB_ACCOUNT_PARTIAL_HEADER_STALL_MS_JSON maps ChatGPT-Account-ID values
+# to a millisecond stall after partial response headers are written, e.g.
+# {"acc-A-id":1000}.
+# OMUX_STUB_ACCOUNT_PARTIAL_HEADER_STALL_COUNT_JSON optionally caps partial
+# header stalls per account.
 try:
     ACCOUNT_STATUS = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_STATUS_JSON", "{}"))
 except json.JSONDecodeError:
@@ -119,6 +129,16 @@ try:
     ACCOUNT_STALL_COUNT = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_STALL_COUNT_JSON", "{}"))
 except json.JSONDecodeError:
     ACCOUNT_STALL_COUNT = {}
+
+try:
+    ACCOUNT_PARTIAL_HEADER_STALL_MS = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_PARTIAL_HEADER_STALL_MS_JSON", "{}"))
+except json.JSONDecodeError:
+    ACCOUNT_PARTIAL_HEADER_STALL_MS = {}
+
+try:
+    ACCOUNT_PARTIAL_HEADER_STALL_COUNT = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_PARTIAL_HEADER_STALL_COUNT_JSON", "{}"))
+except json.JSONDecodeError:
+    ACCOUNT_PARTIAL_HEADER_STALL_COUNT = {}
 
 
 # Per-account request counter. Reset only on process restart.
@@ -277,6 +297,55 @@ class StubHandler(http.server.BaseHTTPRequestHandler):
         })
         time.sleep(stall_ms / 1000)
 
+    def _partial_header_stall_if_configured(
+        self,
+        path: str,
+        status: int,
+        payload: bytes,
+        content_type: str,
+    ) -> bool:
+        acct = self._account_id()
+        if acct not in ACCOUNT_PARTIAL_HEADER_STALL_MS:
+            return False
+        if acct in ACCOUNT_PARTIAL_HEADER_STALL_COUNT:
+            remaining = int(ACCOUNT_PARTIAL_HEADER_STALL_COUNT.get(acct, 0))
+            if remaining <= 0:
+                return False
+            ACCOUNT_PARTIAL_HEADER_STALL_COUNT[acct] = remaining - 1
+        stall_ms = int(ACCOUNT_PARTIAL_HEADER_STALL_MS.get(acct, 0))
+        if stall_ms <= 0:
+            return False
+
+        partial_head = (
+            f"HTTP/1.1 {status} Stub\r\n"
+            f"Content-Type: {content_type}\r\n"
+        ).encode("utf-8")
+        remaining_head = (
+            f"Content-Length: {len(payload)}\r\n"
+            "Connection: close\r\n"
+            "\r\n"
+        ).encode("utf-8")
+
+        _log({
+            "path": path,
+            "method": self.command,
+            "account_id": acct,
+            "auth_prefix": self._auth_prefix(),
+            "status_returned": "partial_header_stall",
+            "response_classification": "transport_partial_header_stall",
+            "stall_ms": stall_ms,
+            "final_status": status,
+        })
+        try:
+            self.connection.sendall(partial_head)
+            time.sleep(stall_ms / 1000)
+            self.connection.sendall(remaining_head)
+            self.connection.sendall(payload)
+        except OSError:
+            pass
+        self.close_connection = True
+        return True
+
     def _serve(self) -> None:
         path = urlparse(self.path).path
         if not path.startswith("/backend-api/codex"):
@@ -300,6 +369,9 @@ class StubHandler(http.server.BaseHTTPRequestHandler):
         else:
             payload = json.dumps(body).encode("utf-8")
             ct = "application/json"
+
+        if self._partial_header_stall_if_configured(path, status, payload, ct):
+            return
 
         if status == 200 and TRUNCATE_200_AFTER_BYTES > 0 and TRUNCATE_200_AFTER_BYTES < len(payload):
             self.send_response(status)
@@ -362,6 +434,8 @@ def main() -> int:
     print(f"stub-upstream: 200_body_repeat={BODY_REPEAT}", file=sys.stderr, flush=True)
     print(f"stub-upstream: truncate_200_after_bytes={TRUNCATE_200_AFTER_BYTES}", file=sys.stderr, flush=True)
     print(f"stub-upstream: 429_type={ERROR_TYPE}", file=sys.stderr, flush=True)
+    if ACCOUNT_PARTIAL_HEADER_STALL_MS:
+        print("stub-upstream: partial_header_stall accounts configured", file=sys.stderr, flush=True)
     if ALWAYS_STATUS:
         print(f"stub-upstream: always_status={ALWAYS_STATUS} (overrides classification)", file=sys.stderr, flush=True)
     try:

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -63,6 +63,7 @@
 //!     runtime claim level.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const broker_types = @import("../../broker/types.zig");
 const account_pool_mod = @import("../../broker/account_pool.zig");
 const health_mod = @import("../../health.zig");
@@ -146,9 +147,9 @@ fn configuredProxyUpstreamResponseTimeoutMs(allocator: std.mem.Allocator) i32 {
     );
 }
 
-const ProxyIoWaitError = std.posix.PollError || error{ConnectionTimedOut};
+const ProxyIoWaitError = std.posix.PollError || error{ ConnectionTimedOut, ConnectionResetByPeer };
 
-fn waitForSocket(handle: std.posix.socket_t, events: i16, timeout_ms: i32) ProxyIoWaitError!void {
+fn pollSocket(handle: std.posix.socket_t, events: i16, timeout_ms: i32) ProxyIoWaitError!i16 {
     var fds = [_]std.posix.pollfd{.{
         .fd = handle,
         .events = events,
@@ -156,11 +157,76 @@ fn waitForSocket(handle: std.posix.socket_t, events: i16, timeout_ms: i32) Proxy
     }};
     const ready = try std.posix.poll(&fds, timeout_ms);
     if (ready == 0) return error.ConnectionTimedOut;
+    if (fds[0].revents & events == 0 and fds[0].revents & (std.posix.POLL.ERR | std.posix.POLL.NVAL | std.posix.POLL.HUP) != 0) {
+        return error.ConnectionResetByPeer;
+    }
+    return fds[0].revents;
 }
 
-fn waitForUpstreamResponseStart(http_req: *std.http.Client.Request, timeout_ms: i32) ProxyIoWaitError!void {
+fn waitForSocket(handle: std.posix.socket_t, events: i16, timeout_ms: i32) ProxyIoWaitError!void {
+    _ = try pollSocket(handle, events, timeout_ms);
+}
+
+fn waitForUpstreamResponseStart(http_req: *std.http.Client.Request, timeout_ms: i32) ProxyIoWaitError!i16 {
+    const connection = http_req.connection orelse return 0;
+    return try pollSocket(connection.stream.handle, @intCast(std.posix.POLL.IN), timeout_ms);
+}
+
+fn setSocketReceiveTimeoutMs(handle: std.posix.socket_t, timeout_ms: i32) std.posix.SetSockOptError!void {
+    if (builtin.os.tag == .windows) {
+        var timeout: u32 = @intCast(@max(timeout_ms, 0));
+        try std.posix.setsockopt(
+            handle,
+            std.posix.SOL.SOCKET,
+            std.posix.SO.RCVTIMEO,
+            std.mem.asBytes(&timeout),
+        );
+        return;
+    }
+
+    var timeout = std.posix.timeval{
+        .sec = @intCast(@divTrunc(timeout_ms, 1000)),
+        .usec = @intCast(@rem(timeout_ms, 1000) * 1000),
+    };
+    try std.posix.setsockopt(
+        handle,
+        std.posix.SOL.SOCKET,
+        std.posix.SO.RCVTIMEO,
+        std.mem.asBytes(&timeout),
+    );
+}
+
+fn setUpstreamResponseReadTimeout(http_req: *std.http.Client.Request, timeout_ms: i32) std.posix.SetSockOptError!void {
     const connection = http_req.connection orelse return;
-    try waitForSocket(connection.stream.handle, @intCast(std.posix.POLL.IN), timeout_ms);
+    try setSocketReceiveTimeoutMs(connection.stream.handle, timeout_ms);
+}
+
+fn clearUpstreamResponseReadTimeout(http_req: *std.http.Client.Request) void {
+    setUpstreamResponseReadTimeout(http_req, 0) catch {};
+}
+
+fn waitForUpstreamResponseHeaders(http_req: *std.http.Client.Request, timeout_ms: i32) !void {
+    const revents = try waitForUpstreamResponseStart(http_req, timeout_ms);
+    const can_set_deadline = revents & (std.posix.POLL.ERR | std.posix.POLL.NVAL | std.posix.POLL.HUP) == 0;
+    if (can_set_deadline) {
+        try setUpstreamResponseReadTimeout(http_req, timeout_ms);
+    }
+
+    const started_ns = std.time.nanoTimestamp();
+    http_req.wait() catch |err| {
+        if (err == error.ConnectionTimedOut) return error.ConnectionTimedOut;
+        if (err == error.UnexpectedReadFailure) {
+            const timeout_ns = @as(i128, timeout_ms) * std.time.ns_per_ms;
+            const slack_ns = 50 * std.time.ns_per_ms;
+            if (std.time.nanoTimestamp() - started_ns + slack_ns >= timeout_ns) {
+                return error.ConnectionTimedOut;
+            }
+        }
+        return err;
+    };
+    if (can_set_deadline) {
+        clearUpstreamResponseReadTimeout(http_req);
+    }
 }
 
 const TimedProxyStream = struct {
@@ -1580,8 +1646,7 @@ fn forwardAndStream(
         try http_req.writeAll(req.body);
         try http_req.finish();
     }
-    try waitForUpstreamResponseStart(&http_req, configuredProxyUpstreamResponseTimeoutMs(a));
-    try http_req.wait();
+    try waitForUpstreamResponseHeaders(&http_req, configuredProxyUpstreamResponseTimeoutMs(a));
 
     const status_u16: u16 = @intFromEnum(http_req.response.status);
 


### PR DESCRIPTION
## Summary
- bound upstream response-head parsing after the socket first becomes readable, so partial HTTP headers cannot pin the managed Codex proxy
- keep recovered partial-header stalls on the existing local transport retry path with delivered_to_codex:false and no route-health pollution
- add a deterministic upstream fixture and provider-degraded smoke regression for partial-header stalls

Refs #311.

## Validation
- python3 -m py_compile scripts/test-stub-upstream.py
- bash -n scripts/smoke-codex-provider-degraded.sh
- zig fmt --check src/adapters/codex/wire_proxy.zig
- just build
- ./scripts/smoke-codex-provider-degraded.sh
- just test
- just release
- git diff --check