### PR TITLE
TIN-1631 Harden Codex body-idle stalls

### DIFF
--- a/scripts/smoke-codex-provider-degraded.sh
+++ b/scripts/smoke-codex-provider-degraded.sh
@@ -626,6 +626,118 @@ run_upstream_interrupted_case() {
     echo "  ✓ interrupted upstream stream recorded provider-degraded route health"
 }
 
+run_upstream_body_idle_timeout_case() {
+    local case_dir="$TMP/upstream-body-idle-timeout"
+    local portfile="$case_dir/upstream.port"
+    local uplog="$case_dir/upstream.log"
+    local ndjson="$case_dir/adapter.ndjson"
+    local adapter_stderr="$case_dir/adapter.stderr"
+    local stub_report="$case_dir/stub-codex.report"
+    local trace_file="$case_dir/trace.ndjson"
+    mkdir -p "$case_dir"
+    write_one_account_fixture "$case_dir"
+
+    OMUX_STUB_PORT=0 \
+      OMUX_STUB_PORTFILE="$portfile" \
+      OMUX_STUB_OK_BEFORE_429=99 \
+      OMUX_STUB_LOGFILE="$uplog" \
+      OMUX_STUB_200_BODY_REPEAT=4096 \
+      OMUX_STUB_ACCOUNT_BODY_STALL_MS_JSON='{"acc-A-id":1000}' \
+      OMUX_STUB_ACCOUNT_BODY_STALL_AFTER_BYTES_JSON='{"acc-A-id":128}' \
+      OMUX_STUB_ACCOUNT_BODY_STALL_COUNT_JSON='{"acc-A-id":1}' \
+      python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$case_dir/upstream.stderr" &
+    local upstream_pid=$!
+    UPSTREAM_PIDS+=("$upstream_pid")
+    wait_for_port "$portfile"
+    local upstream_port
+    upstream_port="$(cat "$portfile" | tr -d '[:space:]')"
+    echo "smoke-codex-provider-degraded: upstream-body-idle-timeout stub pid=$upstream_pid port=$upstream_port"
+
+    OMUX_CONFIG="$case_dir/oauth-mux.config.json" \
+      OMUX_STATE_DIR="$case_dir/state" \
+      OMUX_UPSTREAM_HOST="127.0.0.1:$upstream_port" \
+      OMUX_UPSTREAM_SCHEME="http" \
+      OMUX_PROXY_UPSTREAM_BODY_IDLE_TIMEOUT_MS=250 \
+      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_TRACE=1 \
+      OMUX_TRACE_FILE="$trace_file" \
+      OMUX_STUB_CODEX_TURNS=1 \
+      OMUX_STUB_CODEX_REPORT="$stub_report" \
+      "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$ndjson" 2>"$adapter_stderr" || {
+        echo "adapter exited nonzero in upstream-body-idle-timeout case" >&2
+        cat "$ndjson" >&2 || true
+        cat "$adapter_stderr" >&2 || true
+        exit 1
+    }
+
+    echo "smoke-codex-provider-degraded: upstream-body-idle-timeout assertions"
+    jq -e 'select(.kind == "proxy_stream_interrupted" and .account == "codex:max-1" and .status == 200 and .err == "ConnectionTimedOut" and .bytes_streamed > 0 and .delivered_to_codex == true and .retry_attempted == false)' "$ndjson" >/dev/null
+    echo "  ✓ idle upstream body classified as interrupted"
+    assert_no_grep "idle upstream body did not same-turn retry" '"kind":"proxy_provider_same_turn_retry"|"kind":"proxy_same_turn_retry"|"kind":"proxy_provider_retry_unavailable"' "$ndjson"
+    assert_no_grep "idle upstream body did not become pre-response failure" '"kind":"proxy_upstream_failed"' "$ndjson"
+    jq -e 'select(.name == "codex.proxy.upstream_failure" and .attributes.path_kind == "responses" and .attributes.transport_error == "ConnectionTimedOut" and .attributes.raw_account_id_printed == false)' "$trace_file" >/dev/null
+    echo "  ✓ trace captured body-idle timeout"
+    jq -s -e '[.[] | select(.response_classification == "transport_body_stall" and .account_id == "acc-A-id" and .stall_ms == 1000 and .bytes_before_stall == 128)] | length == 1' "$uplog" >/dev/null
+    echo "  ✓ upstream fixture stalled the body after partial delivery"
+    jq -e '[.turns[] | select(.status == 200 and (.body_head | contains("response.created")))] | length == 1' "$stub_report" >/dev/null
+    echo "  ✓ stub-codex saw partial 200 stream"
+    jq -e '[.accounts[] | select(.key == "codex:max-1#codex-max" and .last_probe_hint_class == "provider_degraded")] | length == 1' "$case_dir/state/health.json" >/dev/null
+    echo "  ✓ idle upstream body recorded provider-degraded route health"
+}
+
+run_upstream_body_idle_recovery_case() {
+    local case_dir="$TMP/upstream-body-idle-recovery"
+    local portfile="$case_dir/upstream.port"
+    local uplog="$case_dir/upstream.log"
+    local ndjson="$case_dir/adapter.ndjson"
+    local adapter_stderr="$case_dir/adapter.stderr"
+    local stub_report="$case_dir/stub-codex.report"
+    mkdir -p "$case_dir"
+    write_one_account_fixture "$case_dir"
+
+    OMUX_STUB_PORT=0 \
+      OMUX_STUB_PORTFILE="$portfile" \
+      OMUX_STUB_OK_BEFORE_429=99 \
+      OMUX_STUB_LOGFILE="$uplog" \
+      OMUX_STUB_200_BODY_REPEAT=8 \
+      OMUX_STUB_ACCOUNT_BODY_STALL_MS_JSON='{"acc-A-id":100}' \
+      OMUX_STUB_ACCOUNT_BODY_STALL_AFTER_BYTES_JSON='{"acc-A-id":128}' \
+      OMUX_STUB_ACCOUNT_BODY_STALL_COUNT_JSON='{"acc-A-id":1}' \
+      python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$case_dir/upstream.stderr" &
+    local upstream_pid=$!
+    UPSTREAM_PIDS+=("$upstream_pid")
+    wait_for_port "$portfile"
+    local upstream_port
+    upstream_port="$(cat "$portfile" | tr -d '[:space:]')"
+    echo "smoke-codex-provider-degraded: upstream-body-idle-recovery stub pid=$upstream_pid port=$upstream_port"
+
+    OMUX_CONFIG="$case_dir/oauth-mux.config.json" \
+      OMUX_STATE_DIR="$case_dir/state" \
+      OMUX_UPSTREAM_HOST="127.0.0.1:$upstream_port" \
+      OMUX_UPSTREAM_SCHEME="http" \
+      OMUX_PROXY_UPSTREAM_BODY_IDLE_TIMEOUT_MS=1000 \
+      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_STUB_CODEX_TURNS=1 \
+      OMUX_STUB_CODEX_REPORT="$stub_report" \
+      "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$ndjson" 2>"$adapter_stderr" || {
+        echo "adapter exited nonzero in upstream-body-idle-recovery case" >&2
+        cat "$ndjson" >&2 || true
+        cat "$adapter_stderr" >&2 || true
+        exit 1
+    }
+
+    echo "smoke-codex-provider-degraded: upstream-body-idle-recovery assertions"
+    assert_grep "body stall below idle timeout completed normally" '"kind":"proxy_turn".*"account":"codex:max-1".*"status":200.*"classification":"ok"' "$ndjson"
+    assert_no_grep "short body stall did not mark stream interrupted" '"kind":"proxy_stream_interrupted"' "$ndjson"
+    assert_no_grep "short body stall did not mark upstream failed" '"kind":"proxy_upstream_failed"' "$ndjson"
+    jq -s -e '[.[] | select(.response_classification == "transport_body_stall_completed" and .account_id == "acc-A-id" and .stall_ms == 100 and .bytes_before_stall == 128 and .completed == true)] | length == 1' "$uplog" >/dev/null
+    echo "  ✓ upstream fixture resumed before the idle deadline"
+    jq -e '[.turns[] | select(.status == 200 and (.body_head | contains("response.created")))] | length == 1' "$stub_report" >/dev/null
+    echo "  ✓ stub-codex saw the completed 200 stream"
+    jq -e '[.accounts[] | select(.last_probe_hint_class == "provider_degraded")] | length == 0' "$case_dir/state/health.json" >/dev/null
+    echo "  ✓ route health was not polluted by a short body pause"
+}
+
 run_client_disconnect_case() {
     local case_dir="$TMP/client-disconnect"
     local portfile="$case_dir/upstream.port"
@@ -776,6 +888,8 @@ run_upstream_header_stall_retry_case
 run_upstream_partial_header_stall_retry_case
 run_transport_fallback_case
 run_upstream_interrupted_case
+run_upstream_body_idle_timeout_case
+run_upstream_body_idle_recovery_case
 run_client_disconnect_case
 run_buffered_error_client_disconnect_case
 run_local_client_stall_case

--- a/scripts/test-stub-upstream.py
+++ b/scripts/test-stub-upstream.py
@@ -27,6 +27,10 @@ Behavior (configurable via env):
                         response headers but before completing the response
                         head. Used to model upstream connections that become
                         readable, then stop before a complete HTTP response.
+  OMUX_STUB_ACCOUNT_BODY_STALL_MS_JSON — maps ChatGPT-Account-ID values to
+                        a millisecond stall after writing a complete response
+                        head and optional body prefix. Used to model upstream
+                        body streams that stop making progress.
 
 Per request:
   - Logs a JSON line with: ts, path, method, account_id (from
@@ -105,6 +109,14 @@ ALWAYS_STATUS = os.environ.get("OMUX_STUB_ALWAYS_STATUS", "")
 # {"acc-A-id":1000}.
 # OMUX_STUB_ACCOUNT_PARTIAL_HEADER_STALL_COUNT_JSON optionally caps partial
 # header stalls per account.
+# OMUX_STUB_ACCOUNT_BODY_STALL_MS_JSON maps ChatGPT-Account-ID values to a
+# millisecond stall after response headers have been sent, e.g.
+# {"acc-A-id":1000}.
+# OMUX_STUB_ACCOUNT_BODY_STALL_AFTER_BYTES_JSON maps ChatGPT-Account-ID values
+# to the number of response body bytes to write before stalling. Omitted means
+# stall before the first body byte.
+# OMUX_STUB_ACCOUNT_BODY_STALL_COUNT_JSON optionally caps body stalls per
+# account.
 try:
     ACCOUNT_STATUS = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_STATUS_JSON", "{}"))
 except json.JSONDecodeError:
@@ -139,6 +151,21 @@ try:
     ACCOUNT_PARTIAL_HEADER_STALL_COUNT = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_PARTIAL_HEADER_STALL_COUNT_JSON", "{}"))
 except json.JSONDecodeError:
     ACCOUNT_PARTIAL_HEADER_STALL_COUNT = {}
+
+try:
+    ACCOUNT_BODY_STALL_MS = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_BODY_STALL_MS_JSON", "{}"))
+except json.JSONDecodeError:
+    ACCOUNT_BODY_STALL_MS = {}
+
+try:
+    ACCOUNT_BODY_STALL_AFTER_BYTES = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_BODY_STALL_AFTER_BYTES_JSON", "{}"))
+except json.JSONDecodeError:
+    ACCOUNT_BODY_STALL_AFTER_BYTES = {}
+
+try:
+    ACCOUNT_BODY_STALL_COUNT = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_BODY_STALL_COUNT_JSON", "{}"))
+except json.JSONDecodeError:
+    ACCOUNT_BODY_STALL_COUNT = {}
 
 
 # Per-account request counter. Reset only on process restart.
@@ -346,6 +373,74 @@ class StubHandler(http.server.BaseHTTPRequestHandler):
         self.close_connection = True
         return True
 
+    def _body_stall_if_configured(
+        self,
+        path: str,
+        status: int,
+        payload: bytes,
+        content_type: str,
+    ) -> bool:
+        acct = self._account_id()
+        if acct not in ACCOUNT_BODY_STALL_MS:
+            return False
+        if acct in ACCOUNT_BODY_STALL_COUNT:
+            remaining = int(ACCOUNT_BODY_STALL_COUNT.get(acct, 0))
+            if remaining <= 0:
+                return False
+            ACCOUNT_BODY_STALL_COUNT[acct] = remaining - 1
+        stall_ms = int(ACCOUNT_BODY_STALL_MS.get(acct, 0))
+        if stall_ms <= 0:
+            return False
+
+        after_bytes = int(ACCOUNT_BODY_STALL_AFTER_BYTES.get(acct, 0))
+        after_bytes = max(0, min(after_bytes, len(payload)))
+
+        _log({
+            "path": path,
+            "method": self.command,
+            "account_id": acct,
+            "auth_prefix": self._auth_prefix(),
+            "status_returned": status,
+            "response_classification": "transport_body_stall",
+            "stall_ms": stall_ms,
+            "bytes_before_stall": after_bytes,
+            "final_status": status,
+            "completed": False,
+        })
+
+        completed = False
+        try:
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(payload)))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            if after_bytes > 0:
+                self.wfile.write(payload[:after_bytes])
+            self.wfile.flush()
+            time.sleep(stall_ms / 1000)
+            self.wfile.write(payload[after_bytes:])
+            self.wfile.flush()
+            completed = True
+        except OSError:
+            pass
+
+        self.close_connection = True
+        if completed:
+            _log({
+                "path": path,
+                "method": self.command,
+                "account_id": acct,
+                "auth_prefix": self._auth_prefix(),
+                "status_returned": status,
+                "response_classification": "transport_body_stall_completed",
+                "stall_ms": stall_ms,
+                "bytes_before_stall": after_bytes,
+                "final_status": status,
+                "completed": completed,
+            })
+        return True
+
     def _serve(self) -> None:
         path = urlparse(self.path).path
         if not path.startswith("/backend-api/codex"):
@@ -371,6 +466,9 @@ class StubHandler(http.server.BaseHTTPRequestHandler):
             ct = "application/json"
 
         if self._partial_header_stall_if_configured(path, status, payload, ct):
+            return
+
+        if self._body_stall_if_configured(path, status, payload, ct):
             return
 
         if status == 200 and TRUNCATE_200_AFTER_BYTES > 0 and TRUNCATE_200_AFTER_BYTES < len(payload):
@@ -436,6 +534,8 @@ def main() -> int:
     print(f"stub-upstream: 429_type={ERROR_TYPE}", file=sys.stderr, flush=True)
     if ACCOUNT_PARTIAL_HEADER_STALL_MS:
         print("stub-upstream: partial_header_stall accounts configured", file=sys.stderr, flush=True)
+    if ACCOUNT_BODY_STALL_MS:
+        print("stub-upstream: body_stall accounts configured", file=sys.stderr, flush=True)
     if ALWAYS_STATUS:
         print(f"stub-upstream: always_status={ALWAYS_STATUS} (overrides classification)", file=sys.stderr, flush=True)
     try:

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -78,6 +78,8 @@ const PROXY_IO_TIMEOUT_DEFAULT_MS: i32 = 30_000;
 const PROXY_IO_TIMEOUT_MAX_MS: i32 = 10 * 60 * 1000;
 const PROXY_UPSTREAM_RESPONSE_TIMEOUT_DEFAULT_MS: i32 = 30_000;
 const PROXY_UPSTREAM_RESPONSE_TIMEOUT_MAX_MS: i32 = 10 * 60 * 1000;
+const PROXY_UPSTREAM_BODY_IDLE_TIMEOUT_DEFAULT_MS: i32 = 10 * 60 * 1000;
+const PROXY_UPSTREAM_BODY_IDLE_TIMEOUT_MAX_MS: i32 = 60 * 60 * 1000;
 
 pub const RouteState = enum {
     available,
@@ -144,6 +146,15 @@ fn configuredProxyUpstreamResponseTimeoutMs(allocator: std.mem.Allocator) i32 {
         "OMUX_PROXY_UPSTREAM_RESPONSE_TIMEOUT_MS",
         PROXY_UPSTREAM_RESPONSE_TIMEOUT_DEFAULT_MS,
         PROXY_UPSTREAM_RESPONSE_TIMEOUT_MAX_MS,
+    );
+}
+
+fn configuredProxyUpstreamBodyIdleTimeoutMs(allocator: std.mem.Allocator) i32 {
+    return configuredPositiveTimeoutMs(
+        allocator,
+        "OMUX_PROXY_UPSTREAM_BODY_IDLE_TIMEOUT_MS",
+        PROXY_UPSTREAM_BODY_IDLE_TIMEOUT_DEFAULT_MS,
+        PROXY_UPSTREAM_BODY_IDLE_TIMEOUT_MAX_MS,
     );
 }
 
@@ -228,6 +239,49 @@ fn waitForUpstreamResponseHeaders(http_req: *std.http.Client.Request, timeout_ms
         clearUpstreamResponseReadTimeout(http_req);
     }
 }
+
+fn setUpstreamBodyIdleReadTimeoutIfSafe(http_req: *std.http.Client.Request, timeout_ms: i32) bool {
+    const connection = http_req.connection orelse return false;
+    const revents = pollSocket(connection.stream.handle, @intCast(std.posix.POLL.IN), 0) catch |err| switch (err) {
+        error.ConnectionTimedOut => 0,
+        error.ConnectionResetByPeer => return false,
+        else => return false,
+    };
+    if (revents & (std.posix.POLL.ERR | std.posix.POLL.NVAL | std.posix.POLL.HUP) != 0) return false;
+    setSocketReceiveTimeoutMs(connection.stream.handle, timeout_ms) catch return false;
+    return true;
+}
+
+fn timeoutLikelyElapsed(started_ns: i128, timeout_ms: i32) bool {
+    const timeout_ns = @as(i128, timeout_ms) * std.time.ns_per_ms;
+    const slack_ns = 50 * std.time.ns_per_ms;
+    return std.time.nanoTimestamp() - started_ns + slack_ns >= timeout_ns;
+}
+
+const TimedUpstreamBodyReader = struct {
+    request: *std.http.Client.Request,
+    timeout_ms: i32,
+    timeout_active: bool,
+
+    pub const ReadError = std.http.Client.Request.ReadError;
+    pub const Reader = std.io.Reader(*TimedUpstreamBodyReader, ReadError, read);
+
+    pub fn reader(self: *TimedUpstreamBodyReader) Reader {
+        return .{ .context = self };
+    }
+
+    pub fn read(self: *TimedUpstreamBodyReader, buffer: []u8) ReadError!usize {
+        if (buffer.len == 0) return 0;
+        const started_ns = std.time.nanoTimestamp();
+        return self.request.read(buffer) catch |err| {
+            if (err == error.ConnectionTimedOut) return error.ConnectionTimedOut;
+            if (self.timeout_active and err == error.UnexpectedReadFailure and timeoutLikelyElapsed(started_ns, self.timeout_ms)) {
+                return error.ConnectionTimedOut;
+            }
+            return err;
+        };
+    }
+};
 
 const TimedProxyStream = struct {
     stream: std.net.Stream,
@@ -1670,7 +1724,13 @@ fn forwardAndStream(
     }
 
     const classification = classify(a, status_u16, &.{});
-    const stream_outcome = writeStreamedResponse(client_writer, http_req.response, http_req.reader());
+    const body_idle_timeout_ms = configuredProxyUpstreamBodyIdleTimeoutMs(a);
+    var upstream_body_reader = TimedUpstreamBodyReader{
+        .request = &http_req,
+        .timeout_ms = body_idle_timeout_ms,
+        .timeout_active = setUpstreamBodyIdleReadTimeoutIfSafe(&http_req, body_idle_timeout_ms),
+    };
+    const stream_outcome = writeStreamedResponse(client_writer, http_req.response, upstream_body_reader.reader());
     return .{
         .status = status_u16,
         .classification = classification,


### PR DESCRIPTION
## Summary
- Adds an upstream body-idle deadline for managed Codex streaming responses after response headers have been committed to Codex.
- Classifies post-delivery idle timeouts as proxy_stream_interrupted with delivered_to_codex=true and retry_attempted=false, avoiding duplicate same-turn retries.
- Extends the upstream stub and provider-degraded smoke with long body-stall and short body-pause regression cases.

Refs #311

## Validation
- python3 -m py_compile scripts/test-stub-upstream.py
- bash -n scripts/smoke-codex-provider-degraded.sh
- zig fmt --check src/adapters/codex/wire_proxy.zig
- just build
- ./scripts/smoke-codex-provider-degraded.sh
- just test
- git diff --check
- just release