### PR TITLE
TIN-1631 Harden buffered error body stalls

### DIFF
--- a/scripts/smoke-codex-provider-degraded.sh
+++ b/scripts/smoke-codex-provider-degraded.sh
@@ -738,6 +738,65 @@ run_upstream_body_idle_recovery_case() {
     echo "  ✓ route health was not polluted by a short body pause"
 }
 
+run_buffered_error_body_idle_timeout_case() {
+    local case_dir="$TMP/buffered-error-body-idle-timeout"
+    local portfile="$case_dir/upstream.port"
+    local uplog="$case_dir/upstream.log"
+    local ndjson="$case_dir/adapter.ndjson"
+    local adapter_stderr="$case_dir/adapter.stderr"
+    local stub_report="$case_dir/stub-codex.report"
+    local trace_file="$case_dir/trace.ndjson"
+    mkdir -p "$case_dir"
+    write_one_account_fixture "$case_dir"
+
+    OMUX_STUB_PORT=0 \
+      OMUX_STUB_PORTFILE="$portfile" \
+      OMUX_STUB_OK_BEFORE_429=0 \
+      OMUX_STUB_LOGFILE="$uplog" \
+      OMUX_STUB_ACCOUNT_BODY_STALL_MS_JSON='{"acc-A-id":1000}' \
+      OMUX_STUB_ACCOUNT_BODY_STALL_AFTER_BYTES_JSON='{"acc-A-id":0}' \
+      python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$case_dir/upstream.stderr" &
+    local upstream_pid=$!
+    UPSTREAM_PIDS+=("$upstream_pid")
+    wait_for_port "$portfile"
+    local upstream_port
+    upstream_port="$(cat "$portfile" | tr -d '[:space:]')"
+    echo "smoke-codex-provider-degraded: buffered-error-body-idle-timeout stub pid=$upstream_pid port=$upstream_port"
+
+    OMUX_CONFIG="$case_dir/oauth-mux.config.json" \
+      OMUX_STATE_DIR="$case_dir/state" \
+      OMUX_UPSTREAM_HOST="127.0.0.1:$upstream_port" \
+      OMUX_UPSTREAM_SCHEME="http" \
+      OMUX_PROXY_UPSTREAM_BODY_IDLE_TIMEOUT_MS=250 \
+      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_TRACE=1 \
+      OMUX_TRACE_FILE="$trace_file" \
+      OMUX_STUB_CODEX_TURNS=1 \
+      OMUX_STUB_CODEX_REPORT="$stub_report" \
+      "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$ndjson" 2>"$adapter_stderr" || {
+        echo "adapter exited nonzero in buffered-error-body-idle-timeout case" >&2
+        cat "$ndjson" >&2 || true
+        cat "$adapter_stderr" >&2 || true
+        exit 1
+    }
+
+    echo "smoke-codex-provider-degraded: buffered-error-body-idle-timeout assertions"
+    assert_grep "buffered error body timeout retried locally" '"kind":"proxy_transport_local_retry".*"account":"codex:max-1".*"err":"ConnectionTimedOut".*"delivered_to_codex":false' "$ndjson"
+    assert_grep "buffered error body timeout became upstream failure after bounded retries" '"kind":"proxy_upstream_failed".*"account":"codex:max-1".*"err":"ConnectionTimedOut"' "$ndjson"
+    assert_grep "buffered error body timeout delivered provider unavailable" '"kind":"proxy_provider_retry_unavailable".*"from":"codex:max-1".*"err":"ConnectionTimedOut".*"delivered_to_codex":true' "$ndjson"
+    assert_no_grep "incomplete 429 body did not become quota proof" '"kind":"quota_handoff_failed_no_account_selectable"|"classification":"quota_exhausted"' "$ndjson"
+    assert_no_grep "incomplete 429 body did not same-turn quota retry" '"kind":"proxy_same_turn_retry"' "$ndjson"
+    assert_no_grep "incomplete 429 body did not leak no-account body" 'oauth_mux_no_account_selectable' "$stub_report"
+    jq -e 'select(.name == "codex.proxy.upstream_failure" and .attributes.path_kind == "responses" and .attributes.transport_error == "ConnectionTimedOut" and .attributes.raw_account_id_printed == false)' "$trace_file" >/dev/null
+    echo "  ✓ trace captured buffered error body-idle timeout"
+    jq -s -e '[.[] | select(.response_classification == "transport_body_stall" and .account_id == "acc-A-id" and .status_returned == 429 and .stall_ms == 1000 and .bytes_before_stall == 0)] | length >= 1' "$uplog" >/dev/null
+    echo "  ✓ upstream fixture stalled 429 bodies before any body bytes"
+    jq -e '[.turns[] | select(.status == 503 and (.body_head | contains("oauth_mux_provider_unavailable")))] | length == 1' "$stub_report" >/dev/null
+    echo "  ✓ stub-codex saw provider-unavailable response, not the incomplete 429"
+    jq -e '[.accounts[] | select(.key == "codex:max-1#codex-max" and .last_probe_hint_class == "provider_degraded")] | length == 1' "$case_dir/state/health.json" >/dev/null
+    echo "  ✓ buffered error body timeout recorded provider-degraded route health"
+}
+
 run_client_disconnect_case() {
     local case_dir="$TMP/client-disconnect"
     local portfile="$case_dir/upstream.port"
@@ -890,6 +949,7 @@ run_transport_fallback_case
 run_upstream_interrupted_case
 run_upstream_body_idle_timeout_case
 run_upstream_body_idle_recovery_case
+run_buffered_error_body_idle_timeout_case
 run_client_disconnect_case
 run_buffered_error_client_disconnect_case
 run_local_client_stall_case

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -1708,7 +1708,13 @@ fn forwardAndStream(
     // before anything is written to Codex.
     if (status_u16 >= 400 and status_u16 < 600) {
         // Cap at 64 KiB — chatgpt.com's error JSON/HTML bodies are small.
-        const body = try http_req.reader().readAllAlloc(a, 64 * 1024);
+        const body_idle_timeout_ms = configuredProxyUpstreamBodyIdleTimeoutMs(a);
+        var upstream_body_reader = TimedUpstreamBodyReader{
+            .request = &http_req,
+            .timeout_ms = body_idle_timeout_ms,
+            .timeout_active = setUpstreamBodyIdleReadTimeoutIfSafe(&http_req, body_idle_timeout_ms),
+        };
+        const body = try upstream_body_reader.reader().readAllAlloc(a, 64 * 1024);
         const classification = classify(a, status_u16, body);
         return .{
             .status = status_u16,


### PR DESCRIPTION
## Summary
- apply upstream body-idle timeout to buffered 4xx/5xx body reads before Codex sees bytes
- prevent incomplete stalled 429 bodies from becoming false quota proof or no-account handoff failures
- add provider-degraded smoke coverage for stalled buffered error bodies

## Verification
- zig fmt --check src/adapters/codex/wire_proxy.zig
- bash -n scripts/smoke-codex-provider-degraded.sh
- just build
- ./scripts/smoke-codex-provider-degraded.sh
- just test
- git diff --check
- just release

Refs #311
Refs TIN-1631