### PR TITLE
TIN-1631 Fix WebSocket fallback delivery accounting

### DIFF
--- a/scripts/smoke-codex-acceptance.sh
+++ b/scripts/smoke-codex-acceptance.sh
@@ -145,6 +145,7 @@ OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_TRACE_FILE="$TRACE_FILE" \
   OMUX_STUB_CANONICAL_SESSION_HOME="$CANONICAL_SESSION_HOME" \
   OMUX_STUB_CODEX_WEBSOCKET_PROBE=1 \
+  OMUX_STUB_CODEX_WEBSOCKET_RST_PROBE=1 \
   OMUX_STUB_CODEX_TURNS=3 \
   OMUX_STUB_CODEX_PIDFILE="$STUB_PIDFILE" \
   OMUX_STUB_CODEX_REPORT="$STUB_REPORT" \
@@ -172,6 +173,17 @@ assert_grep() {
     fi
 }
 
+assert_no_grep() {
+    local label=$1 pattern=$2 file=$3
+    if grep -q -E "$pattern" "$file"; then
+        echo "  ✗ $label (unexpected match for: $pattern)" >&2
+        cat "$file" >&2
+        return 1
+    else
+        echo "  ✓ $label"
+    fi
+}
+
 echo "smoke-codex-acceptance: assertions"
 
 assert_grep "session_started"           '"kind":"session_started"'           "$NDJSON"
@@ -189,6 +201,8 @@ assert_grep "runtime identity marks path printed" '"path_printed":true' "$NDJSON
 assert_grep "runtime identity records installed/local mismatch bit" '"installed_local_mismatch_detected":false' "$NDJSON"
 assert_grep "websocket upgrade got local HTTP fallback signal" '"kind":"proxy_unsupported_transport".*"transport":"websocket".*"method":"GET".*"path_kind":"responses".*"status":426.*"fallback_signal":"http_426".*"upstream_called":false.*"delivered_to_codex":true' "$NDJSON"
 assert_grep "plain responses GET got local HTTP fallback signal" '"kind":"proxy_unsupported_transport".*"transport":"responses_get".*"method":"GET".*"path_kind":"responses".*"status":426.*"fallback_signal":"http_426".*"upstream_called":false.*"delivered_to_codex":true' "$NDJSON"
+assert_grep "websocket client reset is not counted as delivered" '"kind":"proxy_unsupported_transport".*"transport":"websocket".*"status":426.*"delivered_to_codex":false.*"err":"(BrokenPipe|ConnectionResetByPeer|ConnectionTimedOut|EndOfStream)"' "$NDJSON"
+assert_no_grep "websocket client reset did not leak serveOne error" 'proxy: serveOne: (BrokenPipe|ConnectionResetByPeer|EndOfStream|ConnectionTimedOut)' "$ADAPTER_STDERR"
 if grep -q -E '"kind":"proxy_turn".*"method":"GET".*"path_kind":"responses".*"status":405.*"classification":"ok"' "$NDJSON"; then
     echo "  ✗ websocket upgrade was forwarded as plain GET and misclassified as ok" >&2
     cat "$NDJSON" >&2
@@ -254,8 +268,9 @@ if jq -e '.websocket_probe.checked == true
           and .websocket_probe.body_has_unsupported_transport == true
           and .websocket_probe.path_printed == false
           and .websocket_probe.token_material_printed == false
-          and (.websocket_probe.variants | length) == 2
-          and all(.websocket_probe.variants[]; .status == 426 and .body_has_unsupported_transport == true and .path_printed == false and .token_material_printed == false)' "$STUB_REPORT" >/dev/null; then
+          and ([.websocket_probe.variants[] | select(.label == "websocket_upgrade" and .status == 426 and .body_has_unsupported_transport == true and .path_printed == false and .token_material_printed == false)] | length) == 1
+          and ([.websocket_probe.variants[] | select(.label == "responses_get_beta_only" and .status == 426 and .body_has_unsupported_transport == true and .path_printed == false and .token_material_printed == false)] | length) == 1
+          and ([.websocket_probe.variants[] | select(.label == "websocket_upgrade_rst" and .status == 0 and .client_closed_before_response == true and .path_printed == false and .token_material_printed == false)] | length) == 1' "$STUB_REPORT" >/dev/null; then
     echo "  ✓ child saw typed local WebSocket fallback response"
 else
     echo "  ✗ child WebSocket probe did not see local fallback response" >&2

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -45,6 +45,9 @@ Env (set by the smoke harness):
                             the proxy loop is not pinned by a half-open local socket.
   OMUX_STUB_CODEX_WEBSOCKET_PROBE — optional "1" to send a Codex-shaped
                             WebSocket upgrade GET before normal POST turns.
+  OMUX_STUB_CODEX_WEBSOCKET_RST_PROBE — optional "1" to send an additional
+                            WebSocket upgrade GET and reset the socket before
+                            reading the managed proxy's response.
   OMUX_STUB_CODEX_FAIL_MODE — optional startup failure mode. "sqlite_locked"
                             emits Codex's sqlite lock startup error and exits 1.
   The report records argv after the stub binary so CLI forwarding smokes can
@@ -261,6 +264,29 @@ def _websocket_probe(proxy_url: str) -> dict:
         finally:
             conn.close()
 
+    def run_get_and_rst(label: str, headers: dict) -> dict:
+        host, port_s = netloc.rsplit(":", 1)
+        sock = socket.create_connection((host, int(port_s)), timeout=15)
+        try:
+            lines = [
+                f"GET {prefix}/responses HTTP/1.1",
+                f"Host: {netloc}",
+            ]
+            lines.extend(f"{name}: {value}" for name, value in headers.items())
+            sock.sendall(("\r\n".join(lines) + "\r\n\r\n").encode("utf-8"))
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+        finally:
+            sock.close()
+        time.sleep(0.05)
+        return {
+            "label": label,
+            "status": 0,
+            "body_has_unsupported_transport": False,
+            "client_closed_before_response": True,
+            "path_printed": False,
+            "token_material_printed": False,
+        }
+
     websocket_headers = {
         "Connection": "keep-alive, Upgrade",
         "Upgrade": "websocket",
@@ -291,6 +317,8 @@ def _websocket_probe(proxy_url: str) -> dict:
         run_get("websocket_upgrade", websocket_headers),
         run_get("responses_get_beta_only", beta_only_headers),
     ]
+    if os.environ.get("OMUX_STUB_CODEX_WEBSOCKET_RST_PROBE") == "1":
+        variants.append(run_get_and_rst("websocket_upgrade_rst", websocket_headers))
     primary = variants[0]
     return {
         "checked": True,

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -442,29 +442,14 @@ pub const Proxy = struct {
         };
 
         if (unsupportedResponsesGetTransport(&req)) |transport| {
-            self.logEvent("proxy_unsupported_transport", .{
-                .transport = transport,
-                .method = req.method,
-                .path_kind = pathKind(req.path),
-                .status = 426,
-                .fallback_signal = "http_426",
-                .upstream_called = false,
-                .delivered_to_codex = true,
-            });
-            trace.append(self.allocator, "codex.proxy.unsupported_transport", .warn, &.{
-                trace.string("provider", "codex"),
-                trace.string("transport", transport),
-                trace.string("method", req.method),
-                trace.string("path_kind", pathKind(req.path)),
-                trace.uint("status", 426),
-                trace.string("fallback_signal", "http_426"),
-                trace.boolean("upstream_called", false),
-                trace.boolean("delivered_to_codex", true),
-                trace.boolean("token_material_printed", false),
-                trace.boolean("raw_account_id_printed", false),
-                trace.boolean("session_ids_printed", false),
-            });
-            try writeUnsupportedWebSocketResponse(writer);
+            var delivered_to_codex = true;
+            var write_error: ?[]const u8 = null;
+            writeUnsupportedWebSocketResponse(writer) catch |err| {
+                if (!isClientDisconnectWriteError(err)) return err;
+                delivered_to_codex = false;
+                write_error = @errorName(err);
+            };
+            self.logUnsupportedTransport(req, transport, delivered_to_codex, write_error);
             return;
         }
 
@@ -833,6 +818,39 @@ pub const Proxy = struct {
             .err = err_name,
             .bytes_streamed = bytes_streamed,
             .retry_attempted = retry_attempted,
+        });
+    }
+
+    fn logUnsupportedTransport(
+        self: *Proxy,
+        req: Request,
+        transport: []const u8,
+        delivered_to_codex: bool,
+        write_error: ?[]const u8,
+    ) void {
+        self.logEvent("proxy_unsupported_transport", .{
+            .transport = transport,
+            .method = req.method,
+            .path_kind = pathKind(req.path),
+            .status = 426,
+            .fallback_signal = "http_426",
+            .upstream_called = false,
+            .delivered_to_codex = delivered_to_codex,
+            .err = write_error,
+        });
+        trace.append(self.allocator, "codex.proxy.unsupported_transport", .warn, &.{
+            trace.string("provider", "codex"),
+            trace.string("transport", transport),
+            trace.string("method", req.method),
+            trace.string("path_kind", pathKind(req.path)),
+            trace.uint("status", 426),
+            trace.string("fallback_signal", "http_426"),
+            trace.boolean("upstream_called", false),
+            trace.boolean("delivered_to_codex", delivered_to_codex),
+            trace.string("write_error", write_error orelse "none"),
+            trace.boolean("token_material_printed", false),
+            trace.boolean("raw_account_id_printed", false),
+            trace.boolean("session_ids_printed", false),
         });
     }
 


### PR DESCRIPTION
## Summary
- log unsupported WebSocket / responses GET transport delivery after the 426 write completes
- classify client-reset write failures as not delivered instead of pre-claiming delivery
- add a stub Codex reset probe and acceptance regression for the unsupported transport path

## Verification
- zig fmt --check src/adapters/codex/wire_proxy.zig
- python3 -m py_compile scripts/test-stub-codex.py
- bash -n scripts/smoke-codex-acceptance.sh
- zig build
- ./scripts/smoke-codex-acceptance.sh
- zig build test
- git diff --check

Refs #311