### PR TITLE
TIN-1631 Classify no-account disconnects

### DIFF
--- a/scripts/smoke-codex-all-exhausted.sh
+++ b/scripts/smoke-codex-all-exhausted.sh
@@ -97,6 +97,7 @@ OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_TRACE_ID="cccccccccccccccccccccccccccccccc" \
   OMUX_SPAN_ID="dddddddddddddddd" \
   OMUX_STUB_CODEX_TURNS=5 \
+  OMUX_STUB_CODEX_DISCONNECT_TURNS=2 \
   OMUX_STUB_CODEX_REPORT="$STUB_REPORT" \
   "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$NDJSON" 2>"$ADAPTER_STDERR" || {
     echo "adapter exited nonzero" >&2
@@ -127,6 +128,14 @@ assert_grep "proxy_same_turn_retry fired" '"kind":"proxy_same_turn_retry"' "$NDJ
 assert_grep "fallback quota 429 was not delivered before no-account failure" '"kind":"proxy_turn".*"account":"codex:max-2".*"status":429.*"delivered_to_codex":false' "$NDJSON"
 assert_grep "same-turn retry unavailable after all accounts exhausted" '"kind":"proxy_same_turn_retry_unavailable"' "$NDJSON"
 assert_grep "proxy_no_account_selectable event fired" '"kind":"proxy_no_account_selectable"' "$NDJSON"
+assert_grep "no-account response disconnect classified as client disconnect" '"kind":"proxy_client_disconnected".*"status":503.*"err":"(BrokenPipe|ConnectionResetByPeer|EndOfStream|ConnectionTimedOut)".*"retry_attempted":true' "$NDJSON"
+if grep -q -E 'proxy: serveOne: (BrokenPipe|ConnectionResetByPeer|EndOfStream|ConnectionTimedOut)' "$ADAPTER_STDERR"; then
+    echo "  ✗ no-account disconnect leaked benign proxy close" >&2
+    cat "$ADAPTER_STDERR" >&2
+    exit 1
+else
+    echo "  ✓ no-account disconnect did not leak benign proxy close"
+fi
 
 jq -e 'select(.name == "codex.managed.overlay" and .attributes.auth_authority == "mux_owned_overlay" and .attributes.config_paths_printed == false)' "$TRACE_FILE" >/dev/null
 echo "  ✓ trace captured managed overlay without config paths"
@@ -185,5 +194,5 @@ fi
 assert_grep "session_ended final_claim_level broker_owned" '"kind":"session_ended".*"final_claim_level":"broker_owned"' "$NDJSON"
 
 echo
-echo "smoke-codex-all-exhausted: all 12 assertions passed."
+echo "smoke-codex-all-exhausted: all assertions passed."
 echo "  full ndjson: $NDJSON"

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -1772,12 +1772,14 @@ fn proxyThreadMain(p: *wire_proxy.Proxy, shutdown: *std.atomic.Value(bool)) void
 fn isBenignProxyConnectionClose(err: anyerror) bool {
     return err == error.BrokenPipe or
         err == error.ConnectionResetByPeer or
+        err == error.ConnectionTimedOut or
         err == error.EndOfStream;
 }
 
 test "proxy thread suppresses expected localhost connection close errors" {
     try std.testing.expect(isBenignProxyConnectionClose(error.BrokenPipe));
     try std.testing.expect(isBenignProxyConnectionClose(error.ConnectionResetByPeer));
+    try std.testing.expect(isBenignProxyConnectionClose(error.ConnectionTimedOut));
     try std.testing.expect(isBenignProxyConnectionClose(error.EndOfStream));
     try std.testing.expect(!isBenignProxyConnectionClose(error.Unexpected));
 }

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -534,14 +534,26 @@ pub const Proxy = struct {
                         .rejections = rejections.items,
                     });
                     self.traceNoAccountSelectable(req, pending_kind, attempted.items, rejections.items);
-                    try writeNoAccountSelectableResponse(a, writer, self.profile, rejections.items);
+                    _ = try self.writeNoAccountSelectableResponseOrClientDisconnect(
+                        a,
+                        writer,
+                        req,
+                        pending_failure_account orelse "",
+                        rejections.items,
+                    );
                 } else {
                     self.logEvent("proxy_no_account_selectable", .{
                         .attempted = attempted.items,
                         .rejections = rejections.items,
                     });
                     self.traceNoAccountSelectable(req, pending_kind, attempted.items, rejections.items);
-                    try writeNoAccountSelectableResponse(a, writer, self.profile, rejections.items);
+                    _ = try self.writeNoAccountSelectableResponseOrClientDisconnect(
+                        a,
+                        writer,
+                        req,
+                        pending_failure_account orelse "",
+                        rejections.items,
+                    );
                 }
                 return;
             };
@@ -794,6 +806,24 @@ pub const Proxy = struct {
         writeProviderUnavailableResponse(allocator, writer, account_id, err_name, rejections) catch |err| {
             if (isClientDisconnectWriteError(err)) {
                 self.logClientDisconnected(account_id, req, 503, @errorName(err), 0, retry_attempted);
+                return false;
+            }
+            return err;
+        };
+        return true;
+    }
+
+    fn writeNoAccountSelectableResponseOrClientDisconnect(
+        self: *Proxy,
+        allocator: std.mem.Allocator,
+        writer: anytype,
+        req: Request,
+        account_id: []const u8,
+        rejections: []const CandidateRejection,
+    ) !bool {
+        writeNoAccountSelectableResponse(allocator, writer, self.profile, rejections) catch |err| {
+            if (isClientDisconnectWriteError(err)) {
+                self.logClientDisconnected(account_id, req, 503, @errorName(err), 0, true);
                 return false;
             }
             return err;


### PR DESCRIPTION
Refs #311

Scope:
- classify Codex disconnects while oauth-mux is writing the no-account-selectable 503 as proxy_client_disconnected
- include local ConnectionTimedOut in top-level benign proxy close suppression
- extend the all-exhausted smoke so a Codex-side disconnect on the terminal repair response is recorded without leaking proxy: serveOne diagnostics

Why:
The no-account terminal path still used a plain response write, unlike buffered and provider-unavailable responses. A local disconnect there could escape as noisy proxy loop output instead of the existing structured client-disconnect event.

Validation:
- zig fmt --check src/adapters/codex/wire_proxy.zig src/adapters/codex/main.zig
- bash -n scripts/smoke-codex-all-exhausted.sh
- zig build
- ./scripts/smoke-codex-all-exhausted.sh
- zig build test
- just test
- git diff --check