### PR TITLE
TIN-1631 Cover compact and memory transport fallback

### DIFF
--- a/scripts/smoke-codex-provider-degraded.sh
+++ b/scripts/smoke-codex-provider-degraded.sh
@@ -5,7 +5,9 @@
 # without emitting the route-repair no-account body, and treat downstream Codex
 # socket closes as local client disconnects rather than provider degradation.
 # Upstream interruptions after partial stream delivery should be recorded as
-# provider-degraded evidence, but must not trigger same-turn retry.
+# provider-degraded evidence, but must not trigger same-turn retry. The
+# transport fallback cases cover the main responses endpoint plus compact and
+# memory endpoints Codex uses around long-running sessions.
 
 set -euo pipefail
 
@@ -575,6 +577,69 @@ run_transport_fallback_case() {
     echo "  ✓ transport reset recorded provider-degraded route evidence"
 }
 
+run_endpoint_transport_fallback_case() {
+    local endpoint=$1
+    local path_kind=$2
+    local suffix=$3
+    local expected_upstream_path="/backend-api/codex/$endpoint"
+    local case_dir="$TMP/transport-fallback-$suffix"
+    local portfile="$case_dir/upstream.port"
+    local uplog="$case_dir/upstream.log"
+    local ndjson="$case_dir/adapter.ndjson"
+    local adapter_stderr="$case_dir/adapter.stderr"
+    local stub_report="$case_dir/stub-codex.report"
+    local trace_file="$case_dir/trace.ndjson"
+    mkdir -p "$case_dir"
+    write_two_account_fixture "$case_dir"
+
+    OMUX_STUB_PORT=0 \
+      OMUX_STUB_PORTFILE="$portfile" \
+      OMUX_STUB_OK_BEFORE_429=99 \
+      OMUX_STUB_LOGFILE="$uplog" \
+      OMUX_STUB_ACCOUNT_RESET_JSON='{"acc-A-id":"before_response"}' \
+      python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$case_dir/upstream.stderr" &
+    local upstream_pid=$!
+    UPSTREAM_PIDS+=("$upstream_pid")
+    wait_for_port "$portfile"
+    local upstream_port
+    upstream_port="$(cat "$portfile" | tr -d '[:space:]')"
+    echo "smoke-codex-provider-degraded: transport-fallback-$suffix stub pid=$upstream_pid port=$upstream_port max-1=reset max-2=200"
+
+    OMUX_CONFIG="$case_dir/oauth-mux.config.json" \
+      OMUX_STATE_DIR="$case_dir/state" \
+      OMUX_UPSTREAM_HOST="127.0.0.1:$upstream_port" \
+      OMUX_UPSTREAM_SCHEME="http" \
+      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_TRACE=1 \
+      OMUX_TRACE_FILE="$trace_file" \
+      OMUX_STUB_CODEX_TURNS=1 \
+      OMUX_STUB_CODEX_ENDPOINTS="$endpoint" \
+      OMUX_STUB_CODEX_REPORT="$stub_report" \
+      "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$ndjson" 2>"$adapter_stderr" || {
+        echo "adapter exited nonzero in transport-fallback-$suffix case" >&2
+        cat "$ndjson" >&2 || true
+        cat "$adapter_stderr" >&2 || true
+        exit 1
+    }
+
+    echo "smoke-codex-provider-degraded: transport-fallback-$suffix assertions"
+    assert_grep "$path_kind transport reset recorded upstream failure" '"kind":"proxy_upstream_failed".*"account":"codex:max-1"' "$ndjson"
+    assert_grep "$path_kind transport reset retried fallback account" '"kind":"proxy_provider_same_turn_retry".*"from":"codex:max-1".*"to":"codex:max-2".*"reason":"provider_5xx"' "$ndjson"
+    assert_grep "$path_kind fallback account returned 200" '"kind":"proxy_turn".*"account":"codex:max-2".*"method":"POST".*"path_kind":"'"$path_kind"'".*"status":200.*"classification":"ok"' "$ndjson"
+    assert_no_grep "$path_kind transport fallback did not emit terminal provider unavailable" '"kind":"proxy_provider_retry_unavailable"' "$ndjson"
+    assert_no_grep "$path_kind transport fallback did not leak route-repair body" 'oauth_mux_no_account_selectable' "$stub_report"
+    jq -e --arg path_kind "$path_kind" 'select(.name == "codex.proxy.upstream_failure" and .attributes.path_kind == $path_kind and .attributes.raw_account_id_printed == false)' "$trace_file" >/dev/null
+    echo "  ✓ trace captured $path_kind transport reset without raw account ids"
+    jq -s -e --arg path "$expected_upstream_path" '[.[] | select(.response_classification == "transport_reset" and .account_id == "acc-A-id" and .path == $path)] | length == 3' "$uplog" >/dev/null
+    echo "  ✓ upstream fixture reset max-1 on $expected_upstream_path during the bounded retry window"
+    jq -s -e --arg path "$expected_upstream_path" '[.[] | select(.account_id == "acc-B-id" and .status_returned == 200 and .path == $path)] | length == 1' "$uplog" >/dev/null
+    echo "  ✓ fallback account completed $expected_upstream_path"
+    jq -e --arg endpoint "$endpoint" '([.turns[] | select(.status == 200 and .endpoint == $endpoint)] | length == 1) and (.pid_stable == true)' "$stub_report" >/dev/null
+    echo "  ✓ stub-codex stayed in one process and saw $endpoint recover"
+    jq -e '[.accounts[] | select(.key == "codex:max-1#codex-max" and .last_probe_hint_class == "provider_degraded")] | length == 1' "$case_dir/state/health.json" >/dev/null
+    echo "  ✓ $path_kind transport reset recorded provider-degraded route evidence"
+}
+
 run_upstream_interrupted_case() {
     local case_dir="$TMP/upstream-interrupted"
     local portfile="$case_dir/upstream.port"
@@ -946,6 +1011,8 @@ run_local_transport_retry_case
 run_upstream_header_stall_retry_case
 run_upstream_partial_header_stall_retry_case
 run_transport_fallback_case
+run_endpoint_transport_fallback_case "responses/compact" "responses_compact" "compact"
+run_endpoint_transport_fallback_case "memories/trace_summarize" "memories_trace_summarize" "memory"
 run_upstream_interrupted_case
 run_upstream_body_idle_timeout_case
 run_upstream_body_idle_recovery_case

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -16,6 +16,10 @@ Env (set by the adapter):
 
 Env (set by the smoke harness):
   OMUX_STUB_CODEX_TURNS  — number of POST turns to send (default 5)
+  OMUX_STUB_CODEX_ENDPOINTS — optional comma-separated endpoint suffixes for
+                            each POST turn, relative to the managed base URL
+                            (default "responses"). The last endpoint is reused
+                            when turns exceed entries.
   OMUX_STUB_CODEX_PIDFILE — file to write our PID into (default
                             /tmp/omux-stub-codex.pid)
   OMUX_STUB_CODEX_REPORT  — JSON summary path (default
@@ -138,14 +142,28 @@ def _disconnect_turns() -> set[int]:
     return turns
 
 
+def _endpoint_for_turn(turn: int) -> str:
+    raw = os.environ.get("OMUX_STUB_CODEX_ENDPOINTS", "")
+    endpoints = [part.strip().lstrip("/") for part in raw.split(",") if part.strip()]
+    if not endpoints:
+        return "responses"
+    return endpoints[min(turn, len(endpoints) - 1)]
+
+
+def _path_for_turn(prefix: str, turn: int) -> tuple[str, str]:
+    endpoint = _endpoint_for_turn(turn)
+    return f"{prefix}/{endpoint}", endpoint
+
+
 def _request_parts(proxy_url: str, body: bytes, turn: int) -> tuple[str, bytes]:
     m = re.match(r"http://([^/]+)(/.*)$", proxy_url)
     if not m:
         print(f"stub-codex: cannot parse base_url={proxy_url}", file=sys.stderr)
         sys.exit(2)
     netloc, prefix = m.group(1), m.group(2)
+    path, _ = _path_for_turn(prefix, turn)
     headers = [
-        f"POST {prefix}/responses HTTP/1.1",
+        f"POST {path} HTTP/1.1",
         f"Host: {netloc}",
         "Content-Type: application/json",
         "User-Agent: stub-codex/0",
@@ -173,6 +191,7 @@ def _post(proxy_url: str, body: bytes, turn: int) -> tuple[int, str]:
         print(f"stub-codex: cannot parse base_url={proxy_url}", file=sys.stderr)
         sys.exit(2)
     netloc, prefix = m.group(1), m.group(2)
+    path, _ = _path_for_turn(prefix, turn)
     conn = http.client.HTTPConnection(netloc, timeout=15)
     headers = {
         "Content-Type": "application/json",
@@ -190,7 +209,7 @@ def _post(proxy_url: str, body: bytes, turn: int) -> tuple[int, str]:
     try:
         conn.request(
             "POST",
-            prefix + "/responses",
+            path,
             body=body,
             headers=headers,
         )
@@ -466,11 +485,12 @@ def main() -> int:
     disconnect_turns = _disconnect_turns()
     for i in range(turns):
         payload = json.dumps({"input": f"stub turn {i}"}).encode("utf-8")
+        endpoint = _endpoint_for_turn(i)
         if i in disconnect_turns:
             status, body = _post_and_disconnect(proxy_url, payload, i)
         else:
             status, body = _post(proxy_url, payload, i)
-        turn_results.append({"turn": i, "status": status, "body_head": body[:120]})
+        turn_results.append({"turn": i, "endpoint": endpoint, "status": status, "body_head": body[:120]})
         print(f"stub-codex: turn {i} -> {status}", file=sys.stderr, flush=True)
         time.sleep(turn_delay_ms / 1000)
 

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -1828,7 +1828,8 @@ fn pathKind(path: []const u8) []const u8 {
     if (std.mem.startsWith(u8, path, "/backend-api/models?")) return "models";
     if (std.mem.eql(u8, path, "/backend-api/codex/models")) return "models";
     if (std.mem.startsWith(u8, path, "/backend-api/codex/models?")) return "models";
-    if (std.mem.indexOf(u8, path, "/backend-api/codex/memories/trace_summarize") != null) return "memories_trace_summarize";
+    if (pathHasEndpointPrefix(path, "/backend-api/codex/memories/trace_summarize")) return "memories_trace_summarize";
+    if (pathHasEndpointPrefix(path, "/backend-api/memories/trace_summarize")) return "memories_trace_summarize";
     if (std.mem.indexOf(u8, path, "responses_websockets") != null) return "responses_websocket";
     if (std.mem.startsWith(u8, path, "/backend-api/codex/")) return "codex_other";
     return "unknown";
@@ -1842,6 +1843,9 @@ fn upstreamPathForRequest(a: std.mem.Allocator, path: []const u8) ![]const u8 {
         return try std.fmt.allocPrint(a, "/backend-api/codex{s}", .{path["/backend-api".len..]});
     }
     if (pathHasEndpointPrefix(path, "/backend-api/models")) {
+        return try std.fmt.allocPrint(a, "/backend-api/codex{s}", .{path["/backend-api".len..]});
+    }
+    if (pathHasEndpointPrefix(path, "/backend-api/memories/trace_summarize")) {
         return try std.fmt.allocPrint(a, "/backend-api/codex{s}", .{path["/backend-api".len..]});
     }
     return try a.dupe(u8, path);
@@ -2259,6 +2263,9 @@ test "pathKind redacts Codex endpoint paths into stable classes" {
     try std.testing.expectEqualStrings("models", pathKind("/backend-api/models?client_version=0.132.0"));
     try std.testing.expectEqualStrings("models", pathKind("/backend-api/codex/models?client_version=0.132.0"));
     try std.testing.expectEqualStrings("memories_trace_summarize", pathKind("/backend-api/codex/memories/trace_summarize"));
+    try std.testing.expectEqualStrings("memories_trace_summarize", pathKind("/backend-api/codex/memories/trace_summarize?after=1"));
+    try std.testing.expectEqualStrings("memories_trace_summarize", pathKind("/backend-api/memories/trace_summarize"));
+    try std.testing.expectEqualStrings("memories_trace_summarize", pathKind("/backend-api/memories/trace_summarize?after=1"));
     try std.testing.expectEqualStrings("codex_other", pathKind("/backend-api/codex/unknown/shape"));
     try std.testing.expectEqualStrings("unknown", pathKind("/not-codex"));
 }
@@ -2275,6 +2282,10 @@ test "upstreamPathForRequest maps built-in openai provider paths to Codex upstre
     const models = try upstreamPathForRequest(std.testing.allocator, "/backend-api/models?client_version=0.132.0");
     defer std.testing.allocator.free(models);
     try std.testing.expectEqualStrings("/backend-api/codex/models?client_version=0.132.0", models);
+
+    const memory = try upstreamPathForRequest(std.testing.allocator, "/backend-api/memories/trace_summarize?after=1");
+    defer std.testing.allocator.free(memory);
+    try std.testing.expectEqualStrings("/backend-api/codex/memories/trace_summarize?after=1", memory);
 
     const already_codex = try upstreamPathForRequest(std.testing.allocator, "/backend-api/codex/responses");
     defer std.testing.allocator.free(already_codex);


### PR DESCRIPTION
## Summary

- Map built-in OpenAI `/backend-api/memories/trace_summarize` requests to the Codex upstream namespace and stable `memories_trace_summarize` path kind.
- Extend the Codex smoke stub so tests can send compact and memory endpoint turns, not only responses turns.
- Add provider-degraded transport fallback smoke coverage for `/responses/compact` and `/memories/trace_summarize`.

## Validation

- `zig fmt --check src/adapters/codex/wire_proxy.zig`
- `python3 -m py_compile scripts/test-stub-codex.py`
- `bash -n scripts/smoke-codex-provider-degraded.sh`
- `just build`
- `./scripts/smoke-codex-provider-degraded.sh`
- `just test`
- `git diff --check`

## Tracker

TIN-1631 / #311