### PR TITLE
TIN-1631 Clarify managed Codex resume boundary

### DIFF
--- a/docs/stay-afloat-wrappers.md
+++ b/docs/stay-afloat-wrappers.md
@@ -76,14 +76,15 @@ selectable account when a route that looked selectable at preflight is
 reclassified before the target starts. If no selectable account remains, it
 prints the refreshed mediation text and exits nonzero.
 
-For native Codex, prefer `codex managed` over a bare `stay-afloat launch -- codex`
-when you want the invocation and resume semantics to be explicit. It uses the
-same selected route boundary, injects the selected route-local `CODEX_HOME`,
-and can forward `resume --last --include-non-interactive` for sessions created
-in that store. Explicit `--resume <id>` is preflighted against that selected
-store before native Codex starts; missing ids fail with a redacted diagnostic
-instead of launching the wrong account. It still cannot import or rescue an
-unmanaged already-running Codex session.
+For native Codex route-local diagnostics, `codex managed` is clearer than a bare
+`stay-afloat launch -- codex`. It uses the same selected route boundary,
+injects the selected route-local `CODEX_HOME`, and can forward
+`resume --last --include-non-interactive` for sessions created in that store.
+Explicit `--resume <id>` is preflighted against that selected store before
+native Codex starts; missing ids fail with a redacted diagnostic instead of
+launching the wrong account. This is not canonical Codex resume authority. Use
+`oauth-mux codex resume ...` for the managed-frame path that bridges canonical
+session authority and checks canonical SQLite state.
 
 Use `stay-afloat observe --classify-exit-code <code>
 -- <command>` when oauth-mux should observe the child process boundary. The

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -988,6 +988,9 @@ expect_contains "$managed_plan" '"level":"managed_codex_process"' "managed-plan 
 expect_contains "$managed_plan" '"proof_status":"managed_launch_planning_only"' "managed-plan scopes proof to planning"
 expect_contains "$managed_plan" '"route_local_resume":true' "managed-plan reports route-local resume namespace"
 expect_contains "$managed_plan" '"resume_namespace":"selected_route_codex_home"' "managed-plan names selected CODEX_HOME namespace"
+expect_contains "$managed_plan" '"diagnostic_only":true' "managed-plan marks route-local resume check as diagnostic"
+expect_contains "$managed_plan" '"canonical_resume_authority_checked":false' "managed-plan does not claim canonical resume authority"
+expect_contains "$managed_plan" '"canonical_resume_entrypoint":"oauth-mux codex resume"' "managed-plan points canonical resume to first-class adapter"
 expect_contains "$managed_plan" '"selected":{"provider":"codex","account":"max-2","capability":"codex-max"' "managed-plan selects first live route"
 expect_contains "$managed_plan" '"prepared_fallback":true' "managed-plan reports prepared fallback"
 expect_contains "$managed_plan" '"path_printed":false' "managed-plan does not print CODEX_HOME path"
@@ -1002,6 +1005,8 @@ expect_contains "$managed_resume_plan" '"mode":"codex_managed_session_plan"' "ma
 expect_contains "$managed_resume_plan" '"requested":true' "managed --json reports resume request"
 expect_contains "$managed_resume_plan" '"resume_last":true' "managed --json reports resume-last"
 expect_contains "$managed_resume_plan" '"status":"resume_last_unchecked"' "managed --json leaves resume-last to native Codex"
+expect_contains "$managed_resume_plan" '"canonical_resume_authority_checked":false' "managed --json does not claim canonical resume authority"
+expect_contains "$managed_resume_plan" '"canonical_resume_entrypoint":"oauth-mux codex resume"' "managed --json points canonical resume to first-class adapter"
 expect_contains "$managed_resume_plan" '"include_non_interactive":true' "managed --json reports include-non-interactive"
 expect_contains "$managed_resume_plan" '"passthrough_arg_count":2' "managed --json counts forwarded Codex args without printing them"
 expect_not_contains "$managed_resume_plan" 'gpt-5.5' "managed --json does not print forwarded model arg"
@@ -1011,6 +1016,8 @@ expect_contains "$managed_resume_found" '"ok":true' "managed explicit resume pla
 expect_contains "$managed_resume_found" '"checked":true' "managed explicit resume plan checks selected route store"
 expect_contains "$managed_resume_found" '"found_in_selected_store":true' "managed explicit resume plan reports route-local match"
 expect_contains "$managed_resume_found" '"status":"found_in_selected_store"' "managed explicit resume plan reports found status"
+expect_contains "$managed_resume_found" '"diagnostic_only":true' "managed explicit resume plan marks route-local scan as diagnostic"
+expect_contains "$managed_resume_found" '"canonical_resume_authority_checked":false' "managed explicit resume plan does not claim canonical resume authority"
 expect_contains "$managed_resume_found" '"session_index_match":true' "managed explicit resume plan uses session index evidence"
 expect_contains "$managed_resume_found" '"resume_id_printed":false' "managed explicit resume plan suppresses resume id"
 expect_not_contains "$managed_resume_found" 'managed-good-session' "managed explicit resume plan does not print resume id value"
@@ -1019,6 +1026,7 @@ managed_resume_missing="$(PATH="$broker_session_bin:$PATH" OMUX_CONFIG="$broker_
 expect_contains "$managed_resume_missing" '"ok":false' "managed explicit resume plan fails when id is missing from selected route store"
 expect_contains "$managed_resume_missing" '"found_in_selected_store":false' "managed explicit resume plan reports missing route-local id"
 expect_contains "$managed_resume_missing" '"status":"not_found_in_selected_store"' "managed explicit resume plan reports missing status"
+expect_contains "$managed_resume_missing" '"canonical_resume_authority_checked":false' "managed explicit missing resume does not claim canonical resume authority"
 expect_contains "$managed_resume_missing" '"unmanaged_cross_route_resume":false' "managed explicit resume plan refuses cross-route import claim"
 expect_not_contains "$managed_resume_missing" 'missing-session' "managed explicit resume plan does not print missing resume id value"
 
@@ -1044,6 +1052,8 @@ if PATH="$broker_session_bin:$PATH" OMUX_E2E_MANAGED_OUT="$managed_should_not_ru
 fi
 managed_refusal="$(cat "$managed_refusal_out")"
 expect_contains "$managed_refusal" 'status: not_found_in_selected_store' "managed missing explicit resume reports route-local diagnostic"
+expect_contains "$managed_refusal" 'canonical_resume_authority_checked: false' "managed missing explicit resume text keeps canonical authority boundary explicit"
+expect_contains "$managed_refusal" 'canonical_resume_entrypoint: oauth-mux codex resume' "managed missing explicit resume text points to canonical entrypoint"
 expect_contains "$managed_refusal" 'resume_id_printed: false' "managed missing explicit resume suppresses id in text output"
 if [ -f "$managed_should_not_run" ]; then
   printf 'e2e assertion failed: managed explicit missing resume launched child unexpectedly\n' >&2

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1359,7 +1359,7 @@ pub fn printUsage(writer: anytype) !void {
         \\      Managed Codex readiness snapshot: install, policy, routes, and next actions.
         \\
         \\  codex managed-plan [--profile name] [--capability c] [--json]
-        \\      Plan a managed native Codex launch with route-local resume semantics.
+        \\      Plan a legacy route-local native Codex launch diagnostic.
         \\
         \\  codex managed [--profile name] [--capability c] [--resume id|--resume-last] [--include-non-interactive] [-- codex-args...]
         \\      Launch native Codex through stay-afloat route selection and selected CODEX_HOME.
@@ -1460,9 +1460,10 @@ pub fn printCodexUsage(writer: anytype) !void {
         \\Safety:
         \\  canary reads local readiness by default; --live contacts provider endpoints.
         \\  live-qa, revalidate-exhausted, probe-all, and canary --live run real provider probes.
-        \\  managed-plan only inspects readiness. managed launches native Codex under the
-        \\  selected route-local CODEX_HOME, so provider calls depend on the
-        \\  Codex child process and are not made during planning.
+        \\  managed-plan only inspects route-local launch readiness. managed launches
+        \\  native Codex under the selected route-local CODEX_HOME, so provider calls
+        \\  depend on the Codex child process and are not made during planning.
+        \\  For canonical Codex resume authority, use oauth-mux codex resume.
         \\  broker-smoke, broker-refresh-smoke, broker-401-smoke,
         \\  broker-quota-smoke, broker-session-smoke, and broker-run read a
         \\  selected Codex route secret and send it only to a broker-owned

--- a/src/main.zig
+++ b/src/main.zig
@@ -11135,6 +11135,8 @@ const CodexManagedResumeInspection = struct {
     explicit_id: bool = false,
     resume_last: bool = false,
     include_non_interactive: bool = false,
+    diagnostic_only: bool = true,
+    canonical_resume_authority_checked: bool = false,
     checked: bool = false,
     found: bool = false,
     selected_route_available: bool = false,
@@ -11148,6 +11150,7 @@ const CodexManagedResumeInspection = struct {
     path_printed: bool = false,
     status: []const u8 = "not_requested",
     diagnostic: []const u8 = "no resume id requested",
+    canonical_resume_entrypoint: []const u8 = "oauth-mux codex resume",
 };
 
 fn inspectCodexManagedResumeForArgs(allocator: std.mem.Allocator, args: cli.Command.CodexArgs) !CodexManagedResumeInspection {
@@ -11195,7 +11198,7 @@ fn inspectCodexManagedResume(
     if (!result.requested) return result;
     if (args.resume_last and args.resume_id == null) {
         result.status = "resume_last_unchecked";
-        result.diagnostic = "resume --last is resolved by native Codex inside the selected route-local CODEX_HOME";
+        result.diagnostic = "resume --last is resolved by native Codex inside the selected route-local CODEX_HOME; canonical resume authority is checked by oauth-mux codex resume --last";
         result.selected_route_available = selected_route != null;
         return result;
     }
@@ -11205,14 +11208,14 @@ fn inspectCodexManagedResume(
 
     const route = selected_route orelse {
         result.status = "selected_route_unavailable";
-        result.diagnostic = "no selectable route is available, so oauth-mux cannot check a route-local Codex resume id";
+        result.diagnostic = "no selectable route is available, so oauth-mux cannot check this route-local Codex resume diagnostic";
         return result;
     };
     result.selected_route_available = true;
 
     const store_dir = try codexManagedRouteConfigDir(allocator, cfg, route) orelse {
         result.status = "selected_route_missing_store";
-        result.diagnostic = "selected Codex route does not define a CODEX_HOME store for resume lookup";
+        result.diagnostic = "selected Codex route does not define a CODEX_HOME store for this route-local resume diagnostic";
         return result;
     };
     defer allocator.free(store_dir);
@@ -11236,10 +11239,10 @@ fn inspectCodexManagedResume(
     result.found = result.session_index_match or result.rollout_filename_match or result.state_store_match;
     if (result.found) {
         result.status = "found_in_selected_store";
-        result.diagnostic = "resume id was found in the selected route-local Codex store";
+        result.diagnostic = "resume id was found in the selected route-local Codex store; canonical resume authority is checked by oauth-mux codex resume";
     } else {
         result.status = "not_found_in_selected_store";
-        result.diagnostic = "resume id was not found in the selected route-local Codex store; choose the route that owns it or start a new managed session";
+        result.diagnostic = "resume id was not found in the selected route-local Codex store; use oauth-mux codex resume for canonical session authority or choose the route that owns this route-local store";
     }
     return result;
 }
@@ -11359,6 +11362,12 @@ fn writeCodexManagedResumeJson(writer: anytype, inspection: CodexManagedResumeIn
     try writer.writeAll(if (inspection.resume_last) "true" else "false");
     try writer.writeAll(",\"resume_id_provided\":");
     try writer.writeAll(if (inspection.explicit_id) "true" else "false");
+    try writer.writeAll(",\"diagnostic_only\":");
+    try writer.writeAll(if (inspection.diagnostic_only) "true" else "false");
+    try writer.writeAll(",\"canonical_resume_authority_checked\":");
+    try writer.writeAll(if (inspection.canonical_resume_authority_checked) "true" else "false");
+    try writer.writeAll(",\"canonical_resume_entrypoint\":");
+    try std.json.stringify(inspection.canonical_resume_entrypoint, .{}, writer);
     try writer.writeAll(",\"checked\":");
     try writer.writeAll(if (inspection.checked) "true" else "false");
     try writer.writeAll(",\"found_in_selected_store\":");
@@ -11393,10 +11402,13 @@ fn writeCodexManagedResumeRefusalText(writer: anytype, inspection: CodexManagedR
     try writer.writeAll("oauth-mux Codex managed resume diagnostic\n\n");
     try writer.print("  ok: false\n  status: {s}\n", .{inspection.status});
     try writer.print("  selected_route_available: {s}\n", .{if (inspection.selected_route_available) "true" else "false"});
+    try writer.writeAll("  diagnostic_only: true\n");
+    try writer.writeAll("  canonical_resume_authority_checked: false\n");
+    try writer.print("  canonical_resume_entrypoint: {s}\n", .{inspection.canonical_resume_entrypoint});
     try writer.writeAll("  resume_id_printed: false\n");
     try writer.writeAll("  path_printed: false\n");
     try writer.print("  diagnostic: {s}\n", .{inspection.diagnostic});
-    try writer.writeAll("  next: start a new managed session, or select the account whose route-local CODEX_HOME owns that session id\n");
+    try writer.writeAll("  next: use oauth-mux codex resume for canonical session authority, start a new managed session, or select the account whose route-local CODEX_HOME owns that session id\n");
 }
 
 fn writeCodexManagedPlanJson(
@@ -11472,7 +11484,7 @@ fn writeCodexManagedPlanText(
     try writer.writeAll("oauth-mux Codex managed session plan\n\n");
     if (profile) |value| try writer.print("  profile: {s}\n", .{value});
     if (capability) |value| try writer.print("  capability: {s}\n", .{value});
-    try writer.writeAll("  claim: planning-only managed_codex_process launch with route-local CODEX_HOME resume namespace\n");
+    try writer.writeAll("  claim: planning-only managed_codex_process launch with route-local CODEX_HOME diagnostic resume namespace\n");
     try writer.print("  session_start_ready: {s}\n", .{if (selected_index != null) "true" else "false"});
     try writer.print("  selectable_fallback_routes: {d}\n", .{fallback_count});
     try writer.print("  resume_requested: {s}\n", .{if (args.resume_id != null or args.resume_last) "true" else "false"});


### PR DESCRIPTION
## Summary
- mark legacy codex managed resume JSON/text as route-local diagnostic-only
- add canonical resume entrypoint and no-canonical-authority-check fields to prevent stale route-local scans from looking authoritative
- update stay-afloat wrapper docs and e2e assertions

## Validation
- zig fmt --check src/main.zig src/cli.zig
- bash -n scripts/e2e-local.sh
- just e2e-local
- just test
- git diff --check