### PR TITLE
TIN-1631 Contain responses websocket fallback

### DIFF
--- a/scripts/smoke-codex-acceptance.sh
+++ b/scripts/smoke-codex-acceptance.sh
@@ -145,6 +145,7 @@ OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_TRACE_FILE="$TRACE_FILE" \
   OMUX_STUB_CANONICAL_SESSION_HOME="$CANONICAL_SESSION_HOME" \
   OMUX_STUB_CODEX_WEBSOCKET_PROBE=1 \
+  OMUX_STUB_CODEX_WEBSOCKET_EXTRA_SUFFIX="/responses_websockets" \
   OMUX_STUB_CODEX_WEBSOCKET_RST_PROBE=1 \
   OMUX_STUB_CODEX_TURNS=3 \
   OMUX_STUB_CODEX_PIDFILE="$STUB_PIDFILE" \
@@ -201,6 +202,7 @@ assert_grep "runtime identity marks path printed" '"path_printed":true' "$NDJSON
 assert_grep "runtime identity records installed/local mismatch bit" '"installed_local_mismatch_detected":false' "$NDJSON"
 assert_grep "websocket upgrade got local HTTP fallback signal" '"kind":"proxy_unsupported_transport".*"transport":"websocket".*"method":"GET".*"path_kind":"responses".*"status":426.*"fallback_signal":"http_426".*"upstream_called":false.*"delivered_to_codex":true' "$NDJSON"
 assert_grep "plain responses GET got local HTTP fallback signal" '"kind":"proxy_unsupported_transport".*"transport":"responses_get".*"method":"GET".*"path_kind":"responses".*"status":426.*"fallback_signal":"http_426".*"upstream_called":false.*"delivered_to_codex":true' "$NDJSON"
+assert_grep "responses_websocket upgrade got local HTTP fallback signal" '"kind":"proxy_unsupported_transport".*"transport":"websocket".*"method":"GET".*"path_kind":"responses_websocket".*"status":426.*"fallback_signal":"http_426".*"upstream_called":false.*"delivered_to_codex":true' "$NDJSON"
 assert_grep "websocket client reset is not counted as delivered" '"kind":"proxy_unsupported_transport".*"transport":"websocket".*"status":426.*"delivered_to_codex":false.*"err":"(BrokenPipe|ConnectionResetByPeer|ConnectionTimedOut|EndOfStream)"' "$NDJSON"
 assert_no_grep "websocket client reset did not leak serveOne error" 'proxy: serveOne: (BrokenPipe|ConnectionResetByPeer|EndOfStream|ConnectionTimedOut)' "$ADAPTER_STDERR"
 if grep -q -E '"kind":"proxy_turn".*"method":"GET".*"path_kind":"responses".*"status":405.*"classification":"ok"' "$NDJSON"; then
@@ -209,6 +211,13 @@ if grep -q -E '"kind":"proxy_turn".*"method":"GET".*"path_kind":"responses".*"st
     exit 1
 else
     echo "  ✓ websocket upgrade was not misclassified as proxy_turn ok"
+fi
+if grep -q -E '"kind":"proxy_turn".*"method":"GET".*"path_kind":"responses_websocket".*"status":405.*"classification":"ok"' "$NDJSON"; then
+    echo "  ✗ responses_websocket upgrade was forwarded upstream and misclassified as ok" >&2
+    cat "$NDJSON" >&2
+    exit 1
+else
+    echo "  ✓ responses_websocket upgrade was not misclassified as proxy_turn ok"
 fi
 assert_grep "proxy_turn 200 ok"         '"kind":"proxy_turn".*"status":200.*"classification":"ok"' "$NDJSON"
 assert_grep "proxy_turn 429 quota_exhausted" '"kind":"proxy_turn".*"status":429.*"classification":"quota_exhausted"' "$NDJSON"

--- a/scripts/smoke-codex-status-summary.sh
+++ b/scripts/smoke-codex-status-summary.sh
@@ -126,6 +126,7 @@ EOF
 cat >"$BAD_405" <<'EOF'
 {"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
 {"kind":"proxy_turn","account":"codex:max-1","method":"GET","path_kind":"responses","status":405,"classification":"ok","body_class":"json_error","claim_level":"broker_owned","streamed":false,"delivered_to_codex":true}
+{"kind":"proxy_turn","account":"codex:max-1","method":"GET","path_kind":"responses_websocket","status":405,"classification":"ok","body_class":"json_error","claim_level":"broker_owned","streamed":false,"delivered_to_codex":true}
 {"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":false}
 EOF
 
@@ -421,7 +422,7 @@ if [[ "$(jq -r .verdict <<<"$BAD_405_SUMMARY")" != "transport_regression_405_mis
     echo "$BAD_405_SUMMARY" >&2
     exit 1
 fi
-if [[ "$(jq -r .responses_get_405_misclassified_ok <<<"$BAD_405_SUMMARY")" != "1" ]]; then
+if [[ "$(jq -r .responses_get_405_misclassified_ok <<<"$BAD_405_SUMMARY")" != "2" ]]; then
     echo "bad-405 regression count mismatch" >&2
     echo "$BAD_405_SUMMARY" >&2
     exit 1
@@ -433,7 +434,7 @@ if [[ "$(jq -r .verdict <<<"$BAD_405_NATIVE_SUMMARY")" != "transport_regression_
     echo "$BAD_405_NATIVE_SUMMARY" >&2
     exit 1
 fi
-if [[ "$(jq -r .responses_get_405_misclassified_ok <<<"$BAD_405_NATIVE_SUMMARY")" != "1" ]]; then
+if [[ "$(jq -r .responses_get_405_misclassified_ok <<<"$BAD_405_NATIVE_SUMMARY")" != "2" ]]; then
     echo "native bad-405 regression count mismatch" >&2
     echo "$BAD_405_NATIVE_SUMMARY" >&2
     exit 1

--- a/scripts/summarize-codex-status.py
+++ b/scripts/summarize-codex-status.py
@@ -377,7 +377,7 @@ def summarize(path: Path) -> dict[str, Any]:
         e
         for e in proxy_turns
         if e.get("method") == "GET"
-        and e.get("path_kind") == "responses"
+        and e.get("path_kind") in {"responses", "responses_websocket"}
         and e.get("status") == 405
         and e.get("classification") == "ok"
     ]

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -267,10 +267,10 @@ def _websocket_probe(proxy_url: str) -> dict:
         print(f"stub-codex: cannot parse base_url={proxy_url}", file=sys.stderr)
         sys.exit(2)
     netloc, prefix = m.group(1), m.group(2)
-    def run_get(label: str, headers: dict) -> dict:
+    def run_get(label: str, headers: dict, suffix: str = "/responses") -> dict:
         conn = http.client.HTTPConnection(netloc, timeout=15)
         try:
-            conn.request("GET", prefix + "/responses", headers=headers)
+            conn.request("GET", prefix + suffix, headers=headers)
             resp = conn.getresponse()
             body = resp.read().decode("utf-8", errors="replace")
             return {
@@ -336,6 +336,11 @@ def _websocket_probe(proxy_url: str) -> dict:
         run_get("websocket_upgrade", websocket_headers),
         run_get("responses_get_beta_only", beta_only_headers),
     ]
+    extra_suffix = os.environ.get("OMUX_STUB_CODEX_WEBSOCKET_EXTRA_SUFFIX")
+    if extra_suffix:
+        if not extra_suffix.startswith("/"):
+            extra_suffix = "/" + extra_suffix
+        variants.append(run_get("websocket_upgrade_extra_suffix", websocket_headers, extra_suffix))
     if os.environ.get("OMUX_STUB_CODEX_WEBSOCKET_RST_PROBE") == "1":
         variants.append(run_get_and_rst("websocket_upgrade_rst", websocket_headers))
     primary = variants[0]

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -1498,7 +1498,12 @@ fn isWebSocketUpgradeRequest(req: *const Request) bool {
 
 fn unsupportedResponsesGetTransport(req: *const Request) ?[]const u8 {
     if (!std.mem.eql(u8, req.method, "GET")) return null;
-    if (!std.mem.eql(u8, pathKind(req.path), "responses")) return null;
+    const kind = pathKind(req.path);
+    if (!std.mem.eql(u8, kind, "responses") and
+        !std.mem.eql(u8, kind, "responses_websocket"))
+    {
+        return null;
+    }
     if (isWebSocketUpgradeRequest(req)) return "websocket";
     return "responses_get";
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -10850,8 +10850,10 @@ fn summarizeProxyTurn(
     if (path_kind) |value| try incrementStringCount(allocator, &summary.proxy_turns_by_path_kind, value);
     if (body_class) |value| try incrementStringCount(allocator, &summary.proxy_turns_by_body_class, value);
 
+    const responses_get_path = stringEquals(path_kind, "responses") or
+        stringEquals(path_kind, "responses_websocket");
     if (stringEquals(jsonString(object.get("method")), "GET") and
-        stringEquals(path_kind, "responses") and
+        responses_get_path and
         status != null and status.? == 405 and
         stringEquals(classification, "ok"))
     {


### PR DESCRIPTION
## Summary
- classify GET /responses_websockets as unsupported local transport instead of proxying it upstream
- extend the Codex stub and acceptance smoke to cover the alternate WebSocket path kind
- update native and Python status summaries to flag responses_websocket 405 misclassification regressions

## Validation
- zig fmt --check src/adapters/codex/wire_proxy.zig src/main.zig
- python3 -m py_compile scripts/test-stub-codex.py scripts/summarize-codex-status.py
- bash -n scripts/smoke-codex-acceptance.sh scripts/smoke-codex-status-summary.sh
- just build
- ./scripts/smoke-codex-acceptance.sh
- ./scripts/smoke-codex-status-summary.sh
- just test
- git diff --check