### PR TITLE
TIN-1631 Retry upstream request write resets

### DIFF
--- a/scripts/smoke-codex-provider-degraded.sh
+++ b/scripts/smoke-codex-provider-degraded.sh
@@ -452,6 +452,67 @@ run_local_transport_retry_case() {
     echo "  ✓ route health was not polluted by recovered local retry"
 }
 
+run_upstream_request_write_reset_retry_case() {
+    local case_dir="$TMP/upstream-request-write-reset-retry"
+    local portfile="$case_dir/upstream.port"
+    local uplog="$case_dir/upstream.log"
+    local ndjson="$case_dir/adapter.ndjson"
+    local adapter_stderr="$case_dir/adapter.stderr"
+    local stub_report="$case_dir/stub-codex.report"
+    local trace_file="$case_dir/trace.ndjson"
+    mkdir -p "$case_dir"
+    write_one_account_fixture "$case_dir"
+
+    OMUX_STUB_PORT=0 \
+      OMUX_STUB_PORTFILE="$portfile" \
+      OMUX_STUB_OK_BEFORE_429=99 \
+      OMUX_STUB_LOGFILE="$uplog" \
+      OMUX_STUB_ACCOUNT_CLOSE_DURING_REQUEST_JSON='{"acc-A-id":true}' \
+      OMUX_STUB_ACCOUNT_CLOSE_DURING_REQUEST_COUNT_JSON='{"acc-A-id":1}' \
+      python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$case_dir/upstream.stderr" &
+    local upstream_pid=$!
+    UPSTREAM_PIDS+=("$upstream_pid")
+    wait_for_port "$portfile"
+    local upstream_port
+    upstream_port="$(cat "$portfile" | tr -d '[:space:]')"
+    echo "smoke-codex-provider-degraded: upstream-request-write-reset-retry stub pid=$upstream_pid port=$upstream_port first=max-1-request-write-reset second=max-1-200"
+
+    OMUX_CONFIG="$case_dir/oauth-mux.config.json" \
+      OMUX_STATE_DIR="$case_dir/state" \
+      OMUX_UPSTREAM_HOST="127.0.0.1:$upstream_port" \
+      OMUX_UPSTREAM_SCHEME="http" \
+      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      OMUX_TRACE=1 \
+      OMUX_TRACE_FILE="$trace_file" \
+      OMUX_STUB_CODEX_TURNS=1 \
+      OMUX_STUB_CODEX_BODY_BYTES=8388608 \
+      OMUX_STUB_CODEX_REPORT="$stub_report" \
+      "$BIN" codex run --profile codex-max --isolated-session-store --json-status-file "$ndjson" 2>"$adapter_stderr" || {
+        echo "adapter exited nonzero in upstream-request-write-reset-retry case" >&2
+        cat "$ndjson" >&2 || true
+        cat "$adapter_stderr" >&2 || true
+        cat "$uplog" >&2 || true
+        exit 1
+    }
+
+    echo "smoke-codex-provider-degraded: upstream-request-write-reset-retry assertions"
+    assert_grep "request-write reset retried before delivery" '"kind":"proxy_transport_local_retry".*"account":"codex:max-1".*"err":"(BrokenPipe|ConnectionResetByPeer|UnexpectedWriteFailure)".*"delivered_to_codex":false' "$ndjson"
+    assert_grep "request-write reset recovered on same account" '"kind":"proxy_transport_local_retry_recovered".*"account":"codex:max-1".*"status":200.*"classification":"ok"' "$ndjson"
+    assert_grep "same account returned 200 after request-write reset" '"kind":"proxy_turn".*"account":"codex:max-1".*"status":200.*"classification":"ok"' "$ndjson"
+    assert_no_grep "request-write reset did not mark upstream failed" '"kind":"proxy_upstream_failed"' "$ndjson"
+    assert_no_grep "request-write reset did not switch accounts" '"kind":"proxy_provider_same_turn_retry"|"kind":"proxy_same_turn_retry"|"kind":"proxy_provider_retry_unavailable"' "$ndjson"
+    jq -e 'select(.name == "codex.proxy.transport_local_retry" and .attributes.path_kind == "responses" and (.attributes.transport_error == "BrokenPipe" or .attributes.transport_error == "ConnectionResetByPeer" or .attributes.transport_error == "UnexpectedWriteFailure") and .attributes.raw_account_id_printed == false)' "$trace_file" >/dev/null
+    echo "  ✓ trace captured request-write reset without raw account ids"
+    jq -s -e '[.[] | select(.response_classification == "transport_request_write_reset" and .account_id == "acc-A-id")] | length == 1' "$uplog" >/dev/null
+    echo "  ✓ upstream fixture reset once while the proxy wrote the request body"
+    jq -s -e '[.[] | select(.account_id == "acc-A-id" and .status_returned == 200)] | length == 1' "$uplog" >/dev/null
+    echo "  ✓ retry on the same account completed after request-write reset"
+    jq -e '([.turns[] | select(.status == 200 and .payload_bytes >= 8388608)] | length == 1) and (.pid_stable == true)' "$stub_report" >/dev/null
+    echo "  ✓ stub-codex stayed in one process and sent a large request body"
+    jq -e '[.accounts[] | select(.last_probe_hint_class == "provider_degraded")] | length == 0' "$case_dir/state/health.json" >/dev/null
+    echo "  ✓ route health was not polluted by recovered request-write reset"
+}
+
 run_upstream_header_stall_retry_case() {
     local case_dir="$TMP/upstream-header-stall-retry"
     local portfile="$case_dir/upstream.port"
@@ -1120,6 +1181,7 @@ run_no_fallback_case
 run_transport_failure_case
 run_tls_transport_failure_case
 run_local_transport_retry_case
+run_upstream_request_write_reset_retry_case
 run_upstream_header_stall_retry_case
 run_upstream_partial_header_stall_retry_case
 run_transport_fallback_case

--- a/scripts/test-stub-codex.py
+++ b/scripts/test-stub-codex.py
@@ -41,6 +41,9 @@ Env (set by the smoke harness):
                             Codex persisting refreshed ChatGPT tokens in the
                             managed overlay.
   OMUX_STUB_CODEX_TURN_DELAY_MS — optional delay between turns (default 50).
+  OMUX_STUB_CODEX_BODY_BYTES — optional approximate JSON request body size for
+                            each POST turn. Used to force proxy->upstream
+                            request writes across multiple socket writes.
   OMUX_STUB_CODEX_DISCONNECT_TURNS — optional comma-separated turn indexes that
                             should send the request then close the proxy socket
                             before reading the streamed response.
@@ -148,6 +151,18 @@ def _endpoint_for_turn(turn: int) -> str:
     if not endpoints:
         return "responses"
     return endpoints[min(turn, len(endpoints) - 1)]
+
+
+def _payload_for_turn(turn: int) -> bytes:
+    target_bytes = int(os.environ.get("OMUX_STUB_CODEX_BODY_BYTES", "0"))
+    if target_bytes <= 0:
+        return json.dumps({"input": f"stub turn {turn}"}).encode("utf-8")
+
+    payload = {"input": f"stub turn {turn}", "padding": ""}
+    base_len = len(json.dumps(payload).encode("utf-8"))
+    if target_bytes > base_len:
+        payload["padding"] = "x" * (target_bytes - base_len)
+    return json.dumps(payload).encode("utf-8")
 
 
 def _path_for_turn(prefix: str, turn: int) -> tuple[str, str]:
@@ -489,13 +504,19 @@ def main() -> int:
     turn_results: list[dict] = []
     disconnect_turns = _disconnect_turns()
     for i in range(turns):
-        payload = json.dumps({"input": f"stub turn {i}"}).encode("utf-8")
+        payload = _payload_for_turn(i)
         endpoint = _endpoint_for_turn(i)
         if i in disconnect_turns:
             status, body = _post_and_disconnect(proxy_url, payload, i)
         else:
             status, body = _post(proxy_url, payload, i)
-        turn_results.append({"turn": i, "endpoint": endpoint, "status": status, "body_head": body[:120]})
+        turn_results.append({
+            "turn": i,
+            "endpoint": endpoint,
+            "status": status,
+            "payload_bytes": len(payload),
+            "body_head": body[:120],
+        })
         print(f"stub-codex: turn {i} -> {status}", file=sys.stderr, flush=True)
         time.sleep(turn_delay_ms / 1000)
 

--- a/scripts/test-stub-upstream.py
+++ b/scripts/test-stub-upstream.py
@@ -31,6 +31,11 @@ Behavior (configurable via env):
                         a millisecond stall after writing a complete response
                         head and optional body prefix. Used to model upstream
                         body streams that stop making progress.
+  OMUX_STUB_ACCOUNT_CLOSE_DURING_REQUEST_JSON — maps ChatGPT-Account-ID values
+                        to a truthy value that makes the upstream close with
+                        TCP RST after request headers but before reading the
+                        request body. Used to model BrokenPipe/ConnectionReset
+                        while the proxy is still writing the upstream request.
 
 Per request:
   - Logs a JSON line with: ts, path, method, account_id (from
@@ -101,6 +106,11 @@ ALWAYS_STATUS = os.environ.get("OMUX_STUB_ALWAYS_STATUS", "")
 # after the request body is read and before any response is written.
 # OMUX_STUB_ACCOUNT_RESET_COUNT_JSON optionally caps reset count per account,
 # e.g. {"acc-A-id":1}. When omitted, matching accounts reset every request.
+# OMUX_STUB_ACCOUNT_CLOSE_DURING_REQUEST_JSON maps ChatGPT-Account-ID values to
+# a truthy value. Matching accounts reset the connection before the request body
+# is read, so the proxy sees a pre-response upstream write failure.
+# OMUX_STUB_ACCOUNT_CLOSE_DURING_REQUEST_COUNT_JSON optionally caps these closes
+# per account.
 # OMUX_STUB_ACCOUNT_STALL_MS_JSON maps ChatGPT-Account-ID values to a millisecond
 # stall before response headers are written, e.g. {"acc-A-id":1000}.
 # OMUX_STUB_ACCOUNT_STALL_COUNT_JSON optionally caps stall count per account.
@@ -131,6 +141,18 @@ try:
     ACCOUNT_RESET_COUNT = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_RESET_COUNT_JSON", "{}"))
 except json.JSONDecodeError:
     ACCOUNT_RESET_COUNT = {}
+
+try:
+    ACCOUNT_CLOSE_DURING_REQUEST = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_CLOSE_DURING_REQUEST_JSON", "{}"))
+except json.JSONDecodeError:
+    ACCOUNT_CLOSE_DURING_REQUEST = {}
+
+try:
+    ACCOUNT_CLOSE_DURING_REQUEST_COUNT = json.loads(
+        os.environ.get("OMUX_STUB_ACCOUNT_CLOSE_DURING_REQUEST_COUNT_JSON", "{}")
+    )
+except json.JSONDecodeError:
+    ACCOUNT_CLOSE_DURING_REQUEST_COUNT = {}
 
 try:
     ACCOUNT_STALL_MS = json.loads(os.environ.get("OMUX_STUB_ACCOUNT_STALL_MS_JSON", "{}"))
@@ -301,6 +323,34 @@ class StubHandler(http.server.BaseHTTPRequestHandler):
         self.connection.close()
         return True
 
+    def _close_during_request_if_configured(self, path: str) -> bool:
+        acct = self._account_id()
+        if acct not in ACCOUNT_CLOSE_DURING_REQUEST:
+            return False
+        if not ACCOUNT_CLOSE_DURING_REQUEST.get(acct):
+            return False
+        if acct in ACCOUNT_CLOSE_DURING_REQUEST_COUNT:
+            remaining = int(ACCOUNT_CLOSE_DURING_REQUEST_COUNT.get(acct, 0))
+            if remaining <= 0:
+                return False
+            ACCOUNT_CLOSE_DURING_REQUEST_COUNT[acct] = remaining - 1
+        _log({
+            "path": path,
+            "method": self.command,
+            "account_id": acct,
+            "auth_prefix": self._auth_prefix(),
+            "status_returned": "close_during_request",
+            "response_classification": "transport_request_write_reset",
+        })
+        try:
+            linger = struct.pack("ii", 1, 0)
+            self.connection.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, linger)
+        except OSError:
+            pass
+        self.close_connection = True
+        self.connection.close()
+        return True
+
     def _stall_before_response_if_configured(self, path: str) -> None:
         acct = self._account_id()
         if acct not in ACCOUNT_STALL_MS:
@@ -448,6 +498,9 @@ class StubHandler(http.server.BaseHTTPRequestHandler):
             self.send_header("Content-Length", "0")
             self.send_header("Connection", "close")
             self.end_headers()
+            return
+
+        if self._close_during_request_if_configured(path):
             return
 
         body_bytes = self._read_body()

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -1808,6 +1808,7 @@ fn isRetryablePreResponseTransportError(err: anyerror) bool {
         err == error.TemporaryNameServerFailure or
         err == error.NameServerFailure or
         err == error.UnknownHostName or
+        err == error.UnexpectedWriteFailure or
         err == error.EndOfStream or
         err == error.HttpConnectionClosing or
         err == error.TlsInitializationFailed or
@@ -2538,6 +2539,7 @@ test "pre-response transport retry classifier covers transient network failures"
     try std.testing.expect(isRetryablePreResponseTransportError(error.ConnectionRefused));
     try std.testing.expect(isRetryablePreResponseTransportError(error.NetworkUnreachable));
     try std.testing.expect(isRetryablePreResponseTransportError(error.UnknownHostName));
+    try std.testing.expect(isRetryablePreResponseTransportError(error.UnexpectedWriteFailure));
     try std.testing.expect(isRetryablePreResponseTransportError(error.TlsInitializationFailed));
     try std.testing.expect(isRetryablePreResponseTransportError(error.TlsAlert));
     try std.testing.expect(isRetryablePreResponseTransportError(error.TlsFailure));


### PR DESCRIPTION
## Summary
- treat std.http pre-response upstream write failures as retryable transport errors
- add a stub upstream mode that resets while oauth-mux is still writing the upstream request body
- add provider-degraded smoke coverage proving recovery on the same account without marking route health degraded or switching accounts

## Validation
- zig fmt --check src/adapters/codex/wire_proxy.zig
- python3 -m py_compile scripts/test-stub-codex.py scripts/test-stub-upstream.py
- bash -n scripts/smoke-codex-provider-degraded.sh
- just build
- ./scripts/smoke-codex-provider-degraded.sh
- just test
- git diff --check