### PR TITLE
docs: concurrent-session OAuth refresh-token race — incident, design contract, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,49 @@ Still research or open:
 - Unmanaged bare-`codex` daemon hot-swap.
 - Non-Codex provider stay-afloat proof.
 - Long-window soak and negative permutation cassette coverage.
+- Cross-process serialization of single-use OAuth refresh-token rotation (see
+  "Known failure" below).
+
+## Known failure: concurrent Codex sessions & rotating OAuth refresh tokens
+
+If you run many parallel Codex sessions against the same ChatGPT/Codex account and
+see any of:
+
+```
+Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.
+token_revoked
+HTTP 401  https://chatgpt.com/backend-api/codex/responses
+https://chatgpt.com/backend-api/codex/responses/compact
+already used. Please log out and sign in again.
+```
+
+you are hitting single-use **rotating** OAuth refresh tokens under concurrency.
+Each successful refresh invalidates the token it consumed; upstream Codex guards
+refresh only in-process plus an unlocked file backend, so independent processes
+race the refresh — the first rotates, every other refresher gets `token_revoked`
+(upstream class `openai/codex#10332`; oauth-mux specs track it as
+`openai/codex#9634`). `oauth-mux` today runs **per-session in-process proxies with
+no shared daemon** (see "There is no hidden daemon dependency for the current Codex
+path." above), and the broker's read → refresh → write path holds no cross-process
+lock, so even brokered multi-session launches can still double-spend one rotating
+token. The error URL is `chatgpt.com` because the broker proxies upstream to
+ChatGPT — it does **not** prove direct/native mode; the *refresh* POST that rotates
+the token actually targets `auth.openai.com/oauth/token`.
+
+This is an `oauth-mux`-owned serialization defect, not just a Codex bug: it hampers
+any agent-laced harness workflow, including a single harness fanning out sessions.
+The remediation is (1) a cross-process, per-`provider:account` refresh lock so N
+concurrent refreshers collapse to one rotation plus N-1 no-op re-reads, and (2) an
+adapter-agnostic serial re-enrollment / re-login surface so a revoked account is
+re-authed exactly once across sessions. Full root cause + repro:
+`docs/incidents/2026-05-31-codex-refresh-token-race.md`; design + acceptance plan:
+`docs/spec/codex-refresh-serialization-contract-2026-05-31.md`.
+
+The proposed acceptance gate (to be implemented with the fix) is a deterministic,
+no-spend, failing-then-passing proof: a unit test (`zig build test`) that spawns N
+concurrent refreshers against a stubbed OAuth **token endpoint** and asserts one
+POST / zero `token_revoked` once serialized, plus a cross-process smoke
+(`just smoke-codex-refresh-race`) pointing two sessions at one shared account.
 
 ## Lifecycle
 

--- a/docs/incidents/2026-05-31-codex-refresh-token-race.md
+++ b/docs/incidents/2026-05-31-codex-refresh-token-race.md
@@ -1,0 +1,302 @@
+# Concurrent Codex sessions double-spend single-use OAuth refresh tokens → `token_revoked` / "refresh token already used"
+
+> This file is the canonical write-up. It is also the body for the GitHub issue
+> of the same name, kept in-repo so the failure signature is committed, diffable,
+> and search-indexed alongside the fix.
+
+**Labels:** `bug` · `oauth` · `auth` · `refresh-token` · `token-rotation` ·
+`concurrency` · `race-condition` · `mutex` · `serialization` · `codex` ·
+`chatgpt` · `token_revoked` · `multi-session` · `enterprise`
+
+**Search keywords:** refresh token already used · token_revoked · refresh token
+rotation race · concurrent Codex sessions · "Please log out and sign in again" ·
+single-use refresh token · OAuth double-spend · parallel agent sessions ·
+`chatgpt.com/backend-api/codex/responses` 401 · multi-process refresh lock ·
+`openai/codex#10332` · `openai/codex#9634`
+
+---
+
+## TL;DR
+
+If you run **multiple concurrent Codex / ChatGPT sessions that share one OAuth
+account** and you see any of:
+
+```
+Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.
+token_revoked
+HTTP 401  POST https://chatgpt.com/backend-api/codex/responses
+HTTP 401  POST https://chatgpt.com/backend-api/codex/responses/compact
+already used. Please log out and sign in again.
+```
+
+…this is a **rotating (single-use) OAuth refresh-token double-spend race**. Two
+or more processes read the same `refresh_token`, each POSTs it to the OAuth token
+endpoint, the server rotates on the first and **revokes** the rest. It is the
+same upstream failure class as **`openai/codex#10332`** (oauth-mux's own specs
+track the class as `openai/codex#9634`).
+
+`oauth-mux` treats this as an **OAuth mutual-exclusion / semaphore serialization
+concern it intends to own**, because it breaks enterprise agent-laced harness
+workflows even for a single harness fanning out multiple sessions. This issue
+documents the behavior, a **provable, test-verifiable reproduction**, and the
+fix.
+
+> **The error URL does not prove direct/native mode.** The
+> `chatgpt.com/backend-api/codex/responses` URL appears because `oauth-mux`
+> **proxies upstream to `chatgpt.com`** (`src/adapters/codex/wire_proxy.zig:73-75`).
+> Routing through the broker produces the same upstream URL. What matters is the
+> refresh-token rotation race, not the URL. Note also that the *refresh* POST
+> that actually rotates the token goes to a **different** endpoint — the OAuth
+> token endpoint `https://auth.openai.com/oauth/token`
+> (`src/provider_schema.zig:721`), not `chatgpt.com`.
+
+---
+
+## Expected vs Actual
+
+**Expected:** N concurrent sessions sharing one OAuth account perform **at most
+one** refresh-token rotation. The first refresh rotates the token; every other
+session observes the freshly rotated token (or waits for the in-flight refresh)
+and continues. No session is revoked.
+
+**Actual:** N concurrent sessions each independently detect the access token is
+near expiry, each read the **same** `refresh_token` from the shared `auth.json`,
+and each POST it to the OAuth token endpoint. The server accepts the **first**
+(rotating/invalidating that refresh token) and returns `token_revoked` / HTTP 401
+/ "refresh token already used" to the **rest**. Affected sessions die mid-run and
+demand a full re-login.
+
+---
+
+## Environment / trigger conditions
+
+- 10+ parallel Codex sessions against ChatGPT accounts; broker seeded with
+  per-account stores under `~/.local/share/oauth-mux/codex/<acct>/auth.json`
+  (`src/main.zig:16591-16608` — `codexStoreRoot` / `codexAccountDir`).
+- Upstream Codex has only an **in-process** refresh guard plus a file auth
+  backend with **no cross-process lock**, so independent processes race the
+  refresh (matches `openai/codex#10332`).
+- `oauth-mux` today uses **per-session in-process proxies with no shared daemon**
+  (`README.md:257`). N concurrent `oauth-mux codex` invocations = N independent
+  OS processes, each with its own materializer pointed at the **same** per-account
+  `auth.json`, with **no `flock`/`O_EXCL`/mutex** around the read → refresh →
+  write path.
+
+A second, lab-specific trigger (out of `oauth-mux` scope) compounded the
+2026-05-31 incident: a home-manager `sops-nix` mechanism materialized a **stale**
+snapshot of `~/.codex/auth.json` over the live rotating token on every switch
+(disabled at the lab layer). That is **not** the `oauth-mux`-owned defect; the
+refresh race below reproduces independently of it.
+
+---
+
+## Root cause (oauth-mux-owned, cited to file:line)
+
+OAuth refresh tokens here are **single-use / rotating**: a successful refresh
+invalidates the refresh token it was issued against and returns a new one. Any
+second use of the old token is rejected.
+
+### The unguarded critical section
+
+`refreshCodexAccountAuthFile` — `src/broker_loader.zig:362-390`:
+
+1. `readFileAlloc(path)` (`:372`) — read the current `refresh_token`.
+2. `parseCodexAuthRefreshMaterial` (`:375-377`) — extract `refresh_token`.
+3. `oauth.refreshToken(allocator, token_url, refresh_token, client_id)` (`:381`)
+   — network POST to `def.auth.token_endpoint` (`:380`;
+   codex = `https://auth.openai.com/oauth/token`, `src/provider_schema.zig:721`)
+   that **rotates / invalidates** the supplied refresh token server-side
+   (`src/oauth.zig:18`).
+4. `buildRefreshedCodexAuthJson` → `writeFileReplace(path, …)` (`:385-387`).
+
+**No lock is held across `:372 → :387`.** Two processes whose access tokens both
+crossed the `exp - 300s` boundary (`refreshCodexAuthState`, `:398-404`) each read
+the **same** `refresh_token` at `:372` and each POST it at `:381`. The server
+accepts the first (rotates) and returns 401 to the rest.
+
+Reached per outbound request via the proxy: `materialize_chatgpt`
+(`src/adapters/codex/wire_proxy.zig:562`) → `materializeChatgpt`
+(`src/broker_loader.zig:641-695`, read `:683` / refresh `:687` / re-read `:688`)
+→ `refreshCodexAuthBeforeMaterialize` (`:406-424`) → `refreshCodexAccountAuthFile`.
+The same `refreshCodexAccountAuthFile` is also called by the preflight sweep
+`repairRefreshableCodexAuthFailures` (`:107`, call site `:138`).
+
+### `writeFileReplace` is atomicity, NOT mutual exclusion
+
+`src/broker_loader.zig:552-580`: writes to a **random** `path.tmp-<rand>` with
+`.exclusive = true` (O_EXCL on the unique tmp name only — never contended),
+`fsync`, then `rename` over `path`. This guarantees readers never see a torn
+file, but it is **last-writer-wins** and does **not** serialize the network POST
+at `oauth.zig:18`. The contended resource is the POST, which `writeFileReplace`
+does not gate.
+
+### Second double-spend channel: child-preserved auth
+
+`shouldPreserveChildAuth` (`src/adapters/codex/wire_proxy.zig:1645-1654`) returns
+true when inbound `ChatGPT-Account-ID` matches the elected account and
+`Authorization` is non-empty; `setOutboundAuthHeaders` (`:1616-1643`) then
+**forwards the child's own bearer** (`:1627-1628`) instead of substituting the
+broker's elected token (`:1637-1638`). The Codex child has its own in-process
+refresh and **its own unlocked file backend**, so it can rotate the shared token
+out-of-band while another `oauth-mux` process is mid-refresh on the same account
+(`proxy_preserved_child_auth` / `same_account_child_refresh`, `:584-589`). So even
+brokered multi-session can double-spend.
+
+### The fix primitive already exists in-tree — it just isn't applied here
+
+`oauth-mux` already ships a per-account exclusive file lock keyed exactly right,
+but wired only to the **interactive repair** flow, not the silent refresh path:
+
+- `repair_state.acquireRepairLock` — `src/repair_state.zig:362-397`
+  (`createFileAbsolute` with `.lock = .exclusive`, keyed `<provider>-<account>.lock`;
+  path helpers `:438-454`); probe `probeRepairLock` `:399-418`. Callers:
+  `src/main.zig:2897`, `:5168`, `src/runtime.zig:156`.
+- In-process-only `std.Thread.Mutex` (`src/main.zig:14421`, `:14617`) — **useless
+  across the N session processes.**
+
+A repository search confirms **zero** `flock` / `O_EXCL` / `LOCK_EX` / `fcntl` /
+cross-process `Mutex` in the refresh + write path of `src/oauth.zig` or
+`src/broker_loader.zig`. The per-account mutex the specs promise
+(`docs/spec/broker-mcp-contract-2026-05-03.md:283`,
+`docs/spec/codex-adapter-contract-2026-05-03.md:501`, both citing
+`openai/codex#9634`) exists only as prose. That is the defect.
+
+---
+
+## Repro (provable, test-verifiable, no spend) — proposed acceptance gate
+
+> ⚠️ The reproduction below is the **proposed acceptance gate to be implemented
+> alongside the fix**. It does not exist in the tree yet. It is specified
+> precisely so the failing-then-passing proof lands in the same PR(s) as the fix.
+
+### What must be stubbed (and what must NOT)
+
+The refresh POST that rotates the token targets the **OAuth token endpoint**
+(`def.auth.token_endpoint` → `https://auth.openai.com/oauth/token`,
+`src/provider_schema.zig:721`), **not** the `chatgpt.com/backend-api/codex/responses`
+proxy upstream that `scripts/test-stub-upstream.py` simulates. A no-spend repro
+must therefore override the provider definition's **`token_endpoint`** to a local
+stub — exactly the seam the existing test
+`"materializeChatgpt refuses stale codex token when refresh fails"` already uses
+(`src/broker_loader.zig:936-990`, which sets `"token_endpoint": "://invalid"` at
+`:959`). Extending `test-stub-upstream.py` would **not** intercept the refresh and
+would not exercise the race.
+
+Also note: `oauth.refreshToken` returns only `error.RefreshDenied` on a non-200
+and **discards the response body** (`src/oauth.zig:55-57`). The literal upstream
+strings (`token_revoked`, "refresh token already used…") never flow through
+oauth-mux's own output from this path, so the discoverable strings must be
+**emitted by the test/stub print lines and the stub's 401 body** — they are the
+search-indexed proof, not incidental log output.
+
+### Unit test (primary proof) — new block beside the refresh unit tests (`src/broker_loader.zig:865-1014`)
+
+An in-process stub OAuth **token endpoint** (no network, no spend) holding
+`consumed: ?[]const u8`. On `grant_type=refresh_token`:
+- token == current & not consumed → mark consumed, rotate, return **200** with the
+  rotated token;
+- token already consumed → return **HTTP 401** body
+  `{"error":"token_revoked","error_description":"Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again."}`.
+
+Seed one `auth.json` with an **expired** access JWT (`exp <= now + 300`, so
+`refreshCodexAuthState == .needed`, `:398-404`) and a known `refresh_token`. Point
+the codex provider def `token_endpoint` at the stub. Spawn **N=8** threads each
+calling `refreshCodexAccountAuthFile`.
+
+> Caveat to validate during implementation: an N-thread test exercises the
+> cross-process lock only if the fix uses an OS file lock (Zig `.lock = .exclusive`
+> → `flock`), which contends across independent open-file-descriptions within one
+> process too. Confirm this holds on the target platform rather than assuming it.
+
+Distinctive output markers (hardcoded in the test, for discoverability):
+
+```
+# reproduces TODAY (lock absent): assert revoked_count >= 1 && stub.post_count > 1
+REFRESH-RACE-REPRO: detected token_revoked
+REFRESH-RACE-REPRO: upstream said "refresh token already used. Please log out and sign in again."
+REFRESH-RACE-REPRO: server refresh_token POST count = 8 (expected 1 under serialization)
+
+# passes WITH serialization (lock present): assert stub.post_count == 1 && revoked_count == 0
+REFRESH-RACE-FIXED: 8 concurrent refreshers, 1 token-endpoint POST, 0 token_revoked
+REFRESH-RACE-FIXED: serialized via per-account flock (provider:account)
+REFRESH-RACE-FIXED: all 8 sessions converged on one rotated refresh_token
+```
+
+Test name carries the searchable strings, e.g.
+`test "refresh race: concurrent refreshers do not double-spend single-use token (token_revoked / refresh token already used)"`.
+Run via `zig build test` (`build.zig:31-38`; `just test`).
+
+### No-spend cross-process smoke — proposed `scripts/smoke-codex-refresh-race.sh` / `just smoke-codex-refresh-race`
+
+Closest existing assets to reuse:
+- `scripts/smoke-codex-cassette-replay.sh:246-248` already drives
+  `POST /oauth/token → 401` with body code `redacted_refresh_reused` — the nearest
+  working pattern for stubbing the **token endpoint** with a refresh-reuse 401.
+- `scripts/smoke-codex-concurrent-sessions.sh` is the concurrency harness, but it
+  deliberately uses **distinct** accounts (which is exactly why it does not catch
+  this) — the new smoke must point **both** session entries at **one shared**
+  account store.
+- `scripts/test-stub-upstream.py` already supports forcing 401 via
+  `OMUX_STUB_ALWAYS_STATUS` (`:98`) and `OMUX_STUB_ACCOUNT_STATUS_JSON` (`:100`),
+  but (a) it is the `/responses` upstream, not the token endpoint, and (b) it has
+  no `token_revoked` body / revoke-after-first-refresh mode. The smoke needs a
+  **token-endpoint** stub with a stateful "revoke after first refresh" mode.
+
+- **Failing variant** (lock off): token-endpoint stub log shows **≥2** refresh
+  POSTs of the same token; ≥1 session emits a `token_revoked` frame. Terminal:
+  `refresh-race smoke: REPRODUCED token_revoked double-spend (N refresh POSTs > 1).`
+- **Passing variant** (lock on): exactly **1** refresh POST; both sessions succeed;
+  `jq -r '.tokens.refresh_token' <store>/auth.json` shows one rotated token; zero
+  `token_revoked` frames. Terminal: `all <k> assertions passed.`
+
+---
+
+## Proposed fix (summary; full design in the contract doc)
+
+Full design + acceptance plan:
+`docs/spec/codex-refresh-serialization-contract-2026-05-31.md`.
+
+1. **Cross-process refresh serialization (the OAuth semaphore).** Add a blocking
+   per-`provider:account` exclusive file lock around the read → refresh → write
+   critical section in `refreshCodexAccountAuthFile` (`broker_loader.zig:362-390`),
+   with a **double-checked re-read** under the lock (re-run `refreshCodexAuthState`;
+   if a peer already rotated, skip the POST). Reuse the existing
+   `repair_state.acquireRepairLock` idiom (`repair_state.zig:362-454`) so refresh
+   and interactive repair contend on the same domain. Kernel `flock` auto-releases
+   on process death (no stale-lock GC). Collapses N refreshes into 1 POST + (N-1)
+   no-ops.
+2. **Close the child channel.** For accounts oauth-mux owns (`config_dir != null`,
+   `broker_loader.zig:122,415`), make `shouldPreserveChildAuth`
+   (`wire_proxy.zig:1645-1654`) return `false` so the broker is the sole refresher.
+3. **Adapter-agnostic serial re-login.** When refresh is impossible (already
+   revoked), a serialized, user-mediated re-enrollment surface (CLI + optional
+   loopback callback + minimal `127.0.0.1` web UI) re-auths each `provider:account`
+   exactly once across sessions, on the same lock. See the contract doc.
+
+Rejected: a mandatory shared broker daemon (contradicts the per-session/no-daemon
+model, `README.md:257`) and a hand-rolled sentinel file (SIGKILL-orphan / TTL
+liabilities the kernel `flock` avoids).
+
+---
+
+## References
+
+- Upstream class: `openai/codex#10332` (incident error signature);
+  `openai/codex#9634` (cited by the in-repo specs).
+- Per-session / no-daemon model: `README.md:257`.
+- Unguarded refresh critical section: `src/broker_loader.zig:362-390` (POST `:381`,
+  token URL `:380` → `src/provider_schema.zig:721`); `src/oauth.zig:18`,
+  `:55-57` (body discarded, returns `error.RefreshDenied`).
+- Atomic-but-not-locked write: `src/broker_loader.zig:552-580`.
+- Materialize path: `src/adapters/codex/wire_proxy.zig:562`;
+  `src/broker_loader.zig:641-695`, `:406-424`, `:398-404`; preflight sweep
+  `repairRefreshableCodexAuthFailures` `:107`/`:138`.
+- Child double-spend channel: `src/adapters/codex/wire_proxy.zig:1645-1654`,
+  `:1616-1643`, `:584-589`.
+- Existing lock idiom to reuse: `src/repair_state.zig:362-397`, `:438-454`;
+  readiness `src/runtime.zig:156-158`.
+- Account store path (matches incident): `src/main.zig:16591-16608`.
+- Test/smoke scaffolding: `build.zig:31-38`; refresh unit tests
+  `src/broker_loader.zig:865-1014` (token-endpoint override seam at `:936-990`,
+  `:959`); `scripts/smoke-codex-concurrent-sessions.sh`;
+  `scripts/smoke-codex-cassette-replay.sh:246-248`; `scripts/test-stub-upstream.py:98-160`.

--- a/docs/spec/broker-mcp-contract-2026-05-03.md
+++ b/docs/spec/broker-mcp-contract-2026-05-03.md
@@ -277,10 +277,19 @@ the new handle.
 - Returns: `{ "credential_handle": "...", "exp_unix": 1788000123 }`
 - Errors: `refresh_failed` with typed reason (`refresh_token_expired`, `refresh_token_reused`, `refresh_token_invalidated`, `provider_5xx`, `policy_denied`).
 
-Refresh-token rotation per OAuth 2.1 §4.3.1 is enforced here: the broker
+Refresh-token rotation per OAuth 2.1 §4.3.1 is handled here: the broker
 holds a per-account mutex around refresh so two concurrent adapters can't
 race a refresh-token reuse fault (the failure mode tracked in
 `openai/codex#9634`).
+
+> **Status (2026-05-31): designed, NOT yet implemented.** The refresh write
+> path (`src/broker_loader.zig:362-390`) currently holds **no** lock — the
+> per-account mutex above is the *target* contract, not live behavior. The
+> 2026-05-31 `token_revoked` incident is the proof it is not yet enforced.
+> Tracked by GH #336 / TIN-1591; design in
+> `codex-refresh-serialization-contract-2026-05-31.md`. Note also that this
+> mutex alone does **not** deliver Level-3 never-halt — cross-capability
+> degradation is a separate gap (GH #339 / TIN-1811).
 
 ### 2.4 Quota and observability
 

--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -504,6 +504,11 @@ serializes per-account; if a second adapter requests refresh while one is
 in flight, the broker returns the result of the in-flight call (not a
 fresh attempt). Adapters must accept that policy without retry.
 
+> **Status (2026-05-31): this serialization is DESIGNED, not yet implemented.**
+> `src/broker_loader.zig:362-390` refreshes with no lock today; the
+> 2026-05-31 incident is the proof. Tracked by GH #336 / TIN-1591
+> (`codex-refresh-serialization-contract-2026-05-31.md`).
+
 ## 8. Adapter CLI Surface
 
 ```

--- a/docs/spec/codex-refresh-serialization-contract-2026-05-31.md
+++ b/docs/spec/codex-refresh-serialization-contract-2026-05-31.md
@@ -1,0 +1,520 @@
+# Codex Refresh Serialization & Adapter-Agnostic Re-Login — Design Contract
+
+Status: Draft (2026-05-31)
+Owner: oauth-mux
+Incident anchor: `docs/incidents/2026-05-31-codex-refresh-token-race.md` (host `neo`, 10+ parallel Codex sessions → `token_revoked` / "refresh token already used")
+Upstream class: `openai/codex#10332` (incident signature); `openai/codex#9634` (cited by `docs/spec/broker-mcp-contract-2026-05-03.md:283`, `docs/spec/codex-adapter-contract-2026-05-03.md:501`)
+
+---
+
+## 1. Context & Problem
+
+### 1.1 The race class, precisely
+
+OAuth refresh tokens are single-use/rotating: a successful refresh invalidates the
+refresh token it consumed and returns a new one. Critical section in
+`refreshCodexAccountAuthFile` (`src/broker_loader.zig:362-390`):
+
+1. `readFileAlloc(path)` — read current `refresh_token` (`:372`).
+2. `parseCodexAuthRefreshMaterial` — extract it (`:375-377`).
+3. `oauth.refreshToken(...)` — network POST to `def.auth.token_endpoint` (`:380`;
+   codex = `https://auth.openai.com/oauth/token`, `src/provider_schema.zig:721`)
+   that **rotates/invalidates** the supplied refresh token server-side
+   (`src/oauth.zig:18`).
+4. `buildRefreshedCodexAuthJson` → `writeFileReplace(path, …)` (`:385-387`).
+
+No lock is held across `:372 → :387`. Two processes whose access-token `exp` both
+crossed the `exp - 300` boundary (`refreshCodexAuthState`, `:398-404`, `:426-428`)
+read the same `refresh_token` at `:372` and each POST it at `:381`. OpenAI accepts
+the first (rotates) and returns 401 `token_revoked` to the rest.
+
+`writeFileReplace` (`:552-580`) writes to `path.tmp-<rand>` with `.exclusive=true`
+(O_EXCL on the unique tmp name only), `fsync`, then `rename`. That guarantees
+**write atomicity** (no torn file, last-writer-wins byte image) — it is **not** a
+refresh mutex. The contended resource is the network POST at `:381`.
+
+The materializer is invoked **per outbound request**
+(`src/adapters/codex/wire_proxy.zig:562`), so the window is hit repeatedly across
+the session fleet. The same `refreshCodexAccountAuthFile` is also called by the
+preflight sweep `repairRefreshableCodexAuthFailures` (`:107`, call `:138`).
+
+> **Routing note.** The proxy's *upstream* is `chatgpt.com`
+> (`wire_proxy.zig:73-75`), so request errors read `chatgpt.com/backend-api/codex/responses`
+> even when fully brokered — that does **not** prove direct mode. The *refresh*
+> POST that rotates the token is a separate endpoint (`auth.openai.com/oauth/token`).
+
+### 1.2 Why oauth-mux can amplify it
+
+oauth-mux uses **per-session in-process proxies, no shared daemon**
+(`README.md:257`; per-session proxy+materializer bind at
+`src/adapters/codex/main.zig:1247-1257`). N concurrent `oauth-mux codex`
+invocations = N independent OS processes, each with its own materializer, all
+pointed at the same per-account `auth.json`, with no `flock`/`O_EXCL`/mutex around
+the read → refresh → write path. Additionally, `shouldPreserveChildAuth`
+(`wire_proxy.zig:1645-1654`) lets the Codex child forward and rotate the shared
+token out-of-band (`:584-589`), a second uncoordinated writer.
+
+### 1.3 The spec/reality gap — and the in-tree primitive
+
+The specs already *promise* a per-account refresh mutex (broker-contract §2.3,
+codex-adapter-contract §7.2, citing `openai/codex#9634`), but a repo-wide search
+finds **zero** `flock`/`O_EXCL`/`LOCK_EX`/`fcntl`/cross-process `Mutex` in
+`src/oauth.zig` or the refresh path of `src/broker_loader.zig`. The in-process
+`std.Thread.Mutex` (`src/main.zig:14421`, `:14617`) is useless across processes.
+
+The locking primitive **already ships in-tree**: `repair_state.acquireRepairLock`
+(`src/repair_state.zig:362-397`) — a per-account exclusive file lock keyed
+`provider:account`, with path helpers (`lockPath`/`sanitizedLockFileName`/
+`ensureParentDir`, `:438-454`). It is wired only to interactive repair
+(`src/main.zig:2897,5168`, `src/runtime.zig:156`), never to the silent
+`exp - 300` refresh. The fix applies the existing idiom to the refresh path.
+
+### 1.4 Out of scope (lab-owned)
+
+The 2026-05-31 incident was compounded by a home-manager `sops-nix` mechanism that
+materialized a stale `~/.codex/auth.json` over the live token on every switch
+(disabled at the lab layer). Not an oauth-mux defect; the race below reproduces
+independently.
+
+---
+
+## 2. Goals / Non-Goals
+
+**Goals**
+
+1. Eliminate the double-spend of single-use refresh tokens across concurrent
+   oauth-mux processes (and threads), collapsing N concurrent refreshes into
+   **1 POST + (N-1) no-ops**.
+2. Keep the fix **below the adapter** (keyed on `provider:account` + store path),
+   so single-harness multi-session benefits too.
+3. Close the child-rotation channel so the Codex child cannot rotate the shared
+   token out from under oauth-mux.
+4. Provide an **adapter-agnostic serial re-login** surface (enrollment / callback /
+   web UI + CLI) for the revoked-token case, serialized on the same domain.
+5. Ship **provable, test-verifiable, search-discoverable** evidence: a
+   deterministic, no-spend repro that fails today and passes after the fix,
+   emitting the literal incident strings.
+
+**Non-Goals**
+
+- A mandatory shared broker daemon (stays optional; correctness must not depend on
+  it; `README.md:257`, broker-contract `daemon_hosts_broker:false`).
+- Fixing the lab sops-nix materialization (lab-owned, already disabled).
+- Silent browser/device login without operator consent
+  (`docs/spec/in-agent-reauth-handoff-contract-2026-05-14.md` §1/§7).
+
+---
+
+## 3. Design A — Cross-Process Refresh Serialization (the OAuth semaphore)
+
+### 3.1 Approach comparison
+
+| | (1) Advisory per-account file lock + double-checked re-read | (2) Shared broker daemon owns refresh | (3) Hand-rolled "in-progress" sentinel |
+|---|---|---|---|
+| Cross-process correct | Yes (kernel `flock`, OS-arbitrated) | Yes | Yes |
+| Matches per-session/no-daemon arch | Yes — drop-in | No — new always-on service/socket/lifecycle | Yes |
+| Reuses in-tree code | Yes — `acquireRepairLock` idiom, same key | No | Partial |
+| Avoids double-refresh | Yes (re-read under lock) | Yes (single owner) | Yes |
+| Crash / stale-lock safety | High — `flock` released on fd close/death; no sentinel to GC | Daemon crash = outage | Lower — SIGKILL orphans sentinel; needs TTL/PID reaping |
+| Blast radius / LOC | Smallest | Largest | Medium |
+
+### 3.2 Recommendation: Approach (1)
+
+Advisory per-account exclusive file lock (blocking for the silent refresh waiter)
+with a **double-checked re-read** under the lock. Rationale: no architectural
+change; the primitive/key/path/parent-dir-creation already exist and are tested in
+`src/repair_state.zig:362-454`; kernel `flock` auto-releases on process death (no
+stale-lock GC — the decisive edge over (3)); "wait & re-read" falls out for free.
+Approach (2) is the right *long-term* shape only if oauth-mux grows a real broker
+daemon; out of scope here.
+
+### 3.3 Lock semantics
+
+- **Key domain:** `provider:account` (matching `repair_state.lockPath`), not
+  per-session, not per-overlay-path. Guarded state = the per-account `auth.json`.
+- **Lock location:** reuse the **repair-lock domain** so refresh and interactive
+  repair are mutually exclusive (a session cannot silently refresh while a repair
+  re-login is mid-flight). A sibling `auth-locks/<provider>-<account>.lock` under
+  `runtimeDir` is acceptable if a distinct domain is preferred.
+- **Acquisition mode:** silent refresh waiter uses **blocking**
+  (`lock_nonblocking = false`) with a **bounded wait** (~10s → degrade to
+  `SecretUnavailable` rather than hang). Interactive repair keeps the existing
+  `lock_nonblocking = true` / fail-fast `RepairInProgress` semantics.
+- **Double-checked locking:** after acquiring, re-`readFileAlloc` and re-run
+  `refreshCodexAuthState` (`:398-404`). If `exp > now + 300` → `.not_needed` →
+  return without POSTing. Collapses N→1 and guarantees POSTing the *current* token.
+
+### 3.4 Exact change points
+
+**Change 1 (PRIMARY) — `src/broker_loader.zig`.** Wrap the critical section in
+`refreshCodexAccountAuthFile` (`:362-390`): acquire a blocking exclusive
+per-account lock before the read at `:372`, hold through `writeFileReplace` at
+`:387`. After acquiring, re-read and re-evaluate `refreshCodexAuthState`; if a
+peer already rotated, return (no-op).
+
+```zig
+fn refreshCodexAccountAuthFile(allocator, cfg, provider, account, acct_cfg) !void {
+    // NEW: blocking exclusive per-account lock (key = provider:account), bounded wait.
+    var lock = try acquireAccountAuthLock(allocator, provider, account, .blocking);
+    defer lock.deinit();
+
+    const path = try accountAuthMaterialPath(allocator, acct_cfg);
+    defer allocator.free(path);
+
+    // NEW: double-checked locking — re-read & re-evaluate under the lock.
+    const bytes = try readFileAlloc(allocator, path);
+    defer allocator.free(bytes);
+    if (refreshCodexAuthState(allocator, bytes) != .needed) return; // peer rotated → no-op
+
+    // ... unchanged :375-387: parse, token_url, oauth.refreshToken, build, writeFileReplace ...
+}
+```
+
+- `acquireAccountAuthLock` is a ~15-line clone of `acquireRepairLock`
+  (`src/repair_state.zig:362-397`) with `lock_nonblocking = false` + bounded retry,
+  reusing `lockPath`/`sanitizedLockFileName`/`ensureParentDir` (`:438-454`). Add it
+  beside `acquireRepairLock` so refresh and repair share one domain.
+- Both callers inherit the lock with no change: `refreshCodexAuthBeforeMaterialize`
+  (`:421`) and the preflight sweep `repairRefreshableCodexAuthFailures` (`:138`).
+- The outer `materializeChatgpt` (`:683-694`) need not also lock; its re-read at
+  `:688` observes the rotated file once Change 1 lands.
+
+**Change 2 (SECONDARY) — `src/adapters/codex/wire_proxy.zig`.** Change 1 alone
+leaves the Codex child as a second uncoordinated writer. For accounts oauth-mux
+owns (`acct_cfg.config_dir != null` — the predicate already gating refresh at
+`broker_loader.zig:122,415`), add a guard at the top of `shouldPreserveChildAuth`
+(`:1645-1654`) returning `false`. The child then always receives the
+broker-substituted token (`:1637-1638`) and never rotates the shared token;
+oauth-mux is the sole refresher. Unmanaged default-store accounts
+(`config_dir == null`, `broker_loader.zig:120-122`) keep child-refresh behavior.
+
+### 3.5 Crash-safety, staleness, Darwin
+
+- **Crash-safety:** `flock` releases on fd close and process death (SIGKILL
+  included). The lock *file* may persist but the *lock* does not — strictly safer
+  than a hand-rolled sentinel.
+- **Staleness:** the re-read inside the lock POSTs only the current token.
+- **Darwin:** Zig `std.fs.File` `.lock = .exclusive` → `flock(LOCK_EX)`, supported
+  on local APFS/HFS+ (store under `~/.local/share` / `XDG_DATA_HOME`). Advisory,
+  whole-file, auto-released; no `fcntl` byte-range subtleties. Already exercised on
+  this platform by `repair_state` and `src/trace.zig:187-193`.
+- **Validate during implementation:** the unit test (§5.1) relies on `flock`
+  contending across independent open-file-descriptions **within one process**
+  (threads). This is the expected POSIX semantic but is a property of the chosen
+  primitive — confirm it on the target platform rather than assuming.
+
+---
+
+## 4. Design B — Adapter-Agnostic Enrollment / Callback / Serial Re-Login
+
+### 4.1 Where this sits
+
+Design A serializes the *silent* refresh. Design B is the *interactive* sibling:
+when refresh is impossible (`token_revoked` / 401), an operator/harness performs a
+fresh provider login. That re-login serializes on the **same `provider:account`
+lock**, so N concurrent revocations produce exactly **one** login flow and (N-1)
+waiters that re-read the freshly written store. It is bounded by the consent
+contract (`in-agent-reauth-handoff-contract-2026-05-14.md:18-21`): oauth-mux MUST
+NOT silently run browser/device login. The web UI / callback is an
+operator-facing, user-mediated surface that lowers activation cost and serializes
+the existing `oauth-mux codex login-device` handoff.
+
+### 4.2 Adapter-agnostic interface
+
+oauth-mux already has a provider-neutral account/secret model (`src/config.zig`),
+a declarative `ProviderDefinition` (`src/provider_schema.zig:31-77,231-241`), and a
+neutral store-path resolver (`src/paths.zig`). The Codex-hardcoded parts are
+`broker_loader.materializeChatgpt` (`:641-695`) and the `ProviderKind` switches in
+`src/provider.zig`. Add a small Zig vtable capturing exactly what re-login needs —
+new file `src/enroll/reauth_adapter.zig`:
+
+```zig
+pub const ReauthAdapter = struct {
+    provider: []const u8,            // "codex", "claude", "figma", ...
+    flow: LoginFlow,
+    vtable: *const VTable,
+
+    pub const LoginFlow = enum {
+        device_code,       // codex login --device-auth (poll; no loopback)
+        redirect_loopback, // OAuth authz-code + PKCE → http://127.0.0.1:<port>/callback
+        command_owned,     // claude auth login (CLI owns the flow; we isolate the dir)
+        pat_paste,         // figma PAT paste (no OAuth)
+    };
+
+    pub const VTable = struct {
+        storePath:         *const fn (Ctx, Alloc, account: []const u8) anyerror![]u8,
+        loginHandoff:      *const fn (Ctx, Alloc, account: []const u8) anyerror!Handoff, // argv+env, never auto-run
+        buildAuthorizeUrl: ?*const fn (Ctx, Alloc, redirect_uri: []const u8, pkce: Pkce) anyerror![]u8 = null,
+        exchangeCode:      ?*const fn (Ctx, Alloc, code: []const u8, pkce: Pkce, redirect_uri: []const u8) anyerror!CredentialBytes = null,
+        writeStore:        *const fn (Ctx, Alloc, account: []const u8, cred: CredentialBytes) anyerror!void, // → writeFileReplace, lock held
+        livenessSummary:   *const fn (Ctx, Alloc, account: []const u8) anyerror!Liveness, // no-spend, redacted
+    };
+};
+```
+
+`buildAuthorizeUrl`/`exchangeCode` are **optional** — only `redirect_loopback`
+adapters implement them. Codex is `device_code` (`src/main.zig:8565-8584`) and
+needs no loopback; its proven flow is untouched. Registration is a comptime table
+parallel to `provider_schema.builtin_providers` (`:231-241`), new file
+`src/enroll/reauth_registry.zig`.
+
+### 4.3 Serialized re-login queue / semaphore
+
+Add to `src/repair_state.zig` a single primitive used by **both** silent refresh
+(Design A, NONBLOCKING) and interactive reauth (Design B, BLOCKING):
+
+```zig
+pub fn acquireAccountAuthLock(alloc, provider, account, mode: enum { nonblocking, blocking }) !AuthLock
+```
+
+Body is the existing `createFileAbsolute(..., .lock = .exclusive,
+.lock_nonblocking = (mode == .nonblocking))` (`:371-379`) with `lockPath` keyed
+`<provider>-<account>.lock` (`:438-444`). One lock for refresh AND reauth: a
+revoked-token reauth writing a brand-new `auth.json` must not race a peer
+mid-silent-refresh.
+
+Single-flight via double-checked liveness (the interactive analogue of §3.3):
+
+```
+acquireAccountAuthLock(provider, account, .blocking)   // wait my turn
+defer lock.release()
+cred = readStore(account)                              // re-read AFTER lock
+if livenessSummary(cred) == .live: return .already_repaired_by_peer  // (K-1) waiters exit here
+// else: I am the elected re-login driver
+run interactive login flow (device | redirect | command | pat)
+writeStore(account, new_cred)                          // atomic, lock held
+```
+
+For the daemon/web-UI case (single long-lived process), add a per-`provider:account`
+in-process `std.Thread.Mutex` *plus* the on-disk lock (so UI and a stray CLI
+session still serialize), with a per-account `ReauthJob` state machine
+single-flighted by an in-process map. New file `src/enroll/reauth_queue.zig`.
+
+### 4.4 Loopback callback handler (redirect_loopback only)
+
+New file `src/enroll/callback_server.zig`:
+
+```
+bind loopback 127.0.0.1:0 (ephemeral port); redirect_uri = http://127.0.0.1:<port>/callback
+state = random 32B; pkce = S256(verifier); authorize_url = adapter.buildAuthorizeUrl(...)
+→ hand authorize_url to operator (print/open)   [MEDIATED, not auto-opened by default]
+serve exactly ONE /callback:
+    validate state (CSRF) else 400; extract code
+    cred = adapter.exchangeCode(code, pkce, redirect_uri)
+    --- LOCK BOUNDARY (same provider:account auth lock, held by the ReauthJob) ---
+    adapter.writeStore(account, cred)   // broker_loader.writeFileReplace, atomic
+    respond 200 "You may close this tab."; signal ReauthJob complete
+```
+
+Properties: loopback-only, ephemeral port, one-shot; `state` + PKCE mandatory; the
+`writeStore` happens while the account lock is held (acquired by the owning
+`ReauthJob` before the listener opens), so a concurrent silent refresh cannot
+interleave with the reauth publish. Codex needs no callback server (device flow
+polls; `codex login --device-auth` writes `auth.json`, then the `ReauthJob`
+re-reads/validates under lock).
+
+### 4.5 `ReauthJob` state machine
+
+```
+revocation → detected (token_revoked / refresh-already-used / 401)
+  → queued (waiting on acquireAccountAuthLock(.blocking))
+  → rechecking_liveness (re-read under lock)
+        ├─ live → repaired (peer fixed it; release lock)
+        └─ dead → awaiting_consent (show handoff / authorize_url)
+             → login_in_flight (device poll | loopback callback | CLI)
+             → writing (writeStore under lock, atomic)
+             → verifying (livenessSummary, no-spend)
+                  ├─ live → repaired
+                  └─ not-live → failed(reason)
+```
+
+`awaiting_consent`/`login_in_flight` carry a TTL (~300s); on timeout the lock
+releases and the job goes `failed(timeout)` so a walked-away operator cannot hold
+the account lock forever. State labels are redaction-safe.
+
+### 4.6 Minimal web UI + CLI equivalent
+
+**Web UI** — a tiny `127.0.0.1`-only server-rendered surface (static HTML + thin
+JSON API), `src/enroll/web_ui.zig`, started by `oauth-mux reauth ui`:
+
+| Route | Purpose | Backed by |
+|---|---|---|
+| `GET /` | Account list + per-account liveness + **Re-login** button on rows needing action | `accounts list --json` + `routeReadiness` (`runtime.zig:145-161`) |
+| `POST /reauth/{provider}/{account}` | Enqueue a `ReauthJob` (single-flight); returns job id + state | `reauth_queue` |
+| `GET /reauth/{provider}/{account}` | Poll job state | `ReauthJob` |
+| `GET /callback` | OAuth loopback target (redirect_loopback only) | `callback_server` |
+| `GET /healthz` | UI liveness | — |
+
+Clicking **Re-login** on an account whose job already exists **joins** it
+(single-flight is the UI manifestation of serialization). The human always
+completes the upstream login.
+
+**Headless / CLI equivalent** — same state machine, no HTTP, under the existing
+dispatch (`src/cli.zig`):
+
+```bash
+oauth-mux accounts list --json
+oauth-mux reauth start --provider codex --account max-1 --json   # serialized re-login (blocks on lock, double-checks)
+oauth-mux reauth wait  --provider codex --account max-1 --timeout 300 --json
+oauth-mux reauth drain --provider codex --json                   # batch, serialized one account at a time
+```
+
+### 4.7 Integration with preflight / route / health and OMUX_*
+
+- `routeReadiness` already returns `.repair_in_progress` when `probeRepairLock`
+  sees a held lock (`src/runtime.zig:156-158`). Extend the probe to recognize the
+  account-auth lock, so while a `ReauthJob` holds it, `doctor runtime` /
+  `route explain` / `codex preflight` report `reauth_in_progress` and other
+  sessions wait rather than stampede.
+- `codex preflight` already splits `agent_safe` / `user_mediated` /
+  `spend_confirmed` next-actions; re-login slots into `user_mediated_next_actions`
+  as the existing `oauth-mux codex login-device <account>` handoff, optionally
+  annotated with `reauth_job_id` / `reauth_ui_url`.
+- Add provider-neutral env keys parallel to the existing `OMUX_*` child env
+  (`src/adapters/codex/main.zig:1403-1409`): `OMUX_REAUTH_UI_URL`,
+  `OMUX_REAUTH_LOCK_DIR`, `OMUX_REAUTH_JOB`. The `OMUX_CODEX_*` namespace is
+  untouched.
+- When the optional daemon runs it hosts `reauth_queue` + the web UI for
+  cross-session single-flight; absent it, the on-disk `flock` still serializes —
+  the daemon is an optimization, not a correctness dependency.
+
+---
+
+## 5. Test & Verification Plan (all no-spend; to be implemented with the fix)
+
+> The unit/smoke artifacts below **do not exist yet**; they are the acceptance
+> gate to land alongside the fix. Two correctness facts drive their shape:
+> (1) the refresh POST hits the **token endpoint** (`auth.openai.com/oauth/token`),
+> stubbed by overriding the provider def `token_endpoint` — the seam the existing
+> test `src/broker_loader.zig:936-990` uses (`"token_endpoint": "://invalid"` at
+> `:959`) — **not** the `chatgpt.com` responses upstream
+> (`scripts/test-stub-upstream.py`); and (2) `oauth.refreshToken` discards the
+> response body and returns only `error.RefreshDenied` (`src/oauth.zig:55-57`), so
+> the literal incident strings must be emitted by the **test/stub print lines and
+> the stub's 401 body**, not assumed to flow through oauth-mux output.
+
+### 5.1 Unit test (primary proof) — beside `src/broker_loader.zig:865-1014`
+
+In-process stub **token endpoint** (no network) holding `consumed: ?[]const u8`.
+On `grant_type=refresh_token`: token == current & unconsumed → mark consumed,
+rotate, **200** with rotated token; already consumed → **401** body
+`{"error":"token_revoked","error_description":"Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again."}`.
+
+Seed one `auth.json` with an **expired** access JWT (`exp <= now + 300`) and a
+known `refresh_token`; point the codex provider def `token_endpoint` at the stub;
+spawn **N=8** threads each calling `refreshCodexAccountAuthFile`.
+
+```
+# reproduces TODAY (lock absent): assert revoked_count >= 1 && stub.post_count > 1
+REFRESH-RACE-REPRO: detected token_revoked
+REFRESH-RACE-REPRO: upstream said "refresh token already used. Please log out and sign in again."
+REFRESH-RACE-REPRO: server refresh_token POST count = 8 (expected 1 under serialization)
+
+# passes WITH serialization: assert stub.post_count == 1 && revoked_count == 0
+REFRESH-RACE-FIXED: 8 concurrent refreshers, 1 token-endpoint POST, 0 token_revoked
+REFRESH-RACE-FIXED: serialized via per-account flock (provider:account)
+REFRESH-RACE-FIXED: all 8 sessions converged on one rotated refresh_token
+```
+
+Test name carries the searchable strings. Run: `just test` → `zig build test`
+(`build.zig:31-38`).
+
+### 5.2 No-spend cross-process smoke — `scripts/smoke-codex-refresh-race.sh`, `just smoke-codex-refresh-race`
+
+Reuse the closest existing assets:
+- `scripts/smoke-codex-cassette-replay.sh:246-248` already does
+  `POST /oauth/token → 401` (`redacted_refresh_reused`) — the working pattern for
+  stubbing the **token endpoint**.
+- `scripts/smoke-codex-concurrent-sessions.sh` is the concurrency harness but uses
+  **distinct** accounts; the new smoke points **both** session entries at **one
+  shared** account store and seeds it with an **expired** access JWT so
+  `refreshCodexAuthState == .needed`.
+- A **token-endpoint** stub with a stateful "revoke after first refresh" mode
+  returning a `token_revoked` body (the existing `scripts/test-stub-upstream.py`
+  can force 401 via `OMUX_STUB_ALWAYS_STATUS`/`OMUX_STUB_ACCOUNT_STATUS_JSON` but
+  is the `/responses` upstream and lacks a `token_revoked` body — it is **not** the
+  endpoint to stub here).
+
+- **Failing variant** (lock off): token-endpoint stub log shows ≥2 refresh POSTs of
+  the same token; ≥1 session emits `token_revoked`. Terminal:
+  `refresh-race smoke: REPRODUCED token_revoked double-spend (N refresh POSTs > 1).`
+- **Passing variant** (lock on): exactly 1 refresh POST; both sessions succeed;
+  `jq -r '.tokens.refresh_token'` shows one rotated token; zero `token_revoked`.
+  Terminal: `all <k> assertions passed.`
+
+### 5.3 Design B acceptance tests
+
+- `reauth_queue` unit: two threads `enqueue(codex, max-1)` → exactly one reaches
+  `login_in_flight`, the other resolves `already_repaired_by_peer`.
+- `repair_state` unit: A holds `acquireAccountAuthLock(.blocking)`; B's
+  `.nonblocking` returns the in-progress error; B's `.blocking` resolves only after
+  A releases.
+- `callback_server` unit: bad `state` → 400, no `writeStore`; good `state`+`code` →
+  `writeStore` called once, file replaced atomically (temp dir via
+  `OMUX_REAUTH_LOCK_DIR`).
+- `just smoke-codex-reauth-serialized`: two sessions on one account; token-endpoint
+  stub returns 401 after first refresh. Failing baseline asserts the second session
+  emits `token_revoked`; passing runs `oauth-mux reauth start` (device login stubbed)
+  and asserts both sessions serialize on one fresh token.
+
+### 5.4 Why these exact strings
+
+`token_revoked`; `Your access token could not be refreshed because your refresh
+token was already used. Please log out and sign in again.`; `already used. Please
+log out and sign in again.`; URL `https://chatgpt.com/backend-api/codex/responses(/compact)`
+— appear in unit markers, smoke assertions, test names, the incident doc, and the
+README "Known failure" subsection. Anyone searching those errors (and
+`openai/codex#10332` / `#9634`) lands on this repo and its committed proof.
+
+---
+
+## 6. Rollout / Migration
+
+1. **Design A behind a default-ON flag.** Implement `acquireAccountAuthLock` in
+   `repair_state.zig`; wrap `refreshCodexAccountAuthFile`. Gate the lock on
+   `OMUX_REFRESH_LOCK` (default `on`) **only** so the failing repro variant can
+   disable it; production never runs `off`. Ship the §5.1 unit test in the same
+   change.
+2. **Change 2 (`shouldPreserveChildAuth`) immediately after**, gated on
+   `config_dir != null`; verify with the same-account child-refresh smoke
+   (`scripts/smoke-codex-child-refresh.sh`) extended to assert the child no longer
+   rotates the managed-store token.
+3. **Discoverability docs in the same PR(s):** a "Known failure" subsection in
+   `README.md` (under "Still research or open") carrying the literal error strings
+   + `openai/codex#10332`/`#9634`; this contract doc cross-linked from
+   `docs/README.md` (Specs) and the incident doc
+   (`docs/incidents/2026-05-31-codex-refresh-token-race.md`). File the GitHub issue
+   separately so the strings are indexed.
+4. **Design B incrementally, additively** (no behavior change until verbs are
+   invoked): (a) share `acquireAccountAuthLock`; teach `routeReadiness` to probe
+   the account-auth lock; (b) `src/enroll/` package
+   (`reauth_adapter.zig`, `reauth_registry.zig`, `reauth_queue.zig`,
+   `codex_reauth.zig`); (c) CLI verbs `reauth {start,wait,drain}` + `OMUX_REAUTH_*`
+   env; (d) `callback_server.zig` + `web_ui.zig` + `reauth ui` last.
+5. **Migration:** no on-disk `auth.json` format change; new lockfiles auto-created/
+   auto-released; unmanaged default-store accounts unchanged; daemon optional. Roll
+   out per-host; the lock is local to each host's account store.
+
+---
+
+### File:line index for implementers
+
+- `src/broker_loader.zig:362-390` `refreshCodexAccountAuthFile` — PRIMARY lock site.
+- `src/broker_loader.zig:398-404,426-428` `refreshCodexAuthState` — `exp<=now+300`.
+- `src/broker_loader.zig:406-424` `refreshCodexAuthBeforeMaterialize` (`:415`
+  `config_dir`; `:421` caller).
+- `src/broker_loader.zig:107`/`:138` `repairRefreshableCodexAuthFailures` — preflight sweep, inherits lock.
+- `src/broker_loader.zig:552-580` `writeFileReplace` — atomic publish; stays inside lock.
+- `src/broker_loader.zig:641-695` `materializeChatgpt` — read `:683`/refresh `:687`/re-read `:688`.
+- `src/broker_loader.zig:936-990` existing token-endpoint override test seam (`:959`).
+- `src/oauth.zig:18` `refreshToken` (`:55-57` discards body → `error.RefreshDenied`); token URL via `def.auth.token_endpoint`.
+- `src/provider_schema.zig:83` `token_endpoint` field; `:721` codex `auth.openai.com/oauth/token`.
+- `src/repair_state.zig:362-397` `acquireRepairLock` + `:438-454` path helpers; `:399-418` `probeRepairLock`.
+- `src/adapters/codex/wire_proxy.zig:1645-1654` `shouldPreserveChildAuth` / `:1616-1643` `setOutboundAuthHeaders` (`:1627-1628` forward-child vs `:1637-1638` substitute); `:73-75` upstream host; `:562` per-request materialize; `:584-589` `proxy_preserved_child_auth`.
+- `src/adapters/codex/main.zig:1247-1257` per-session proxy bind; `:1403-1409` child env; `:8565-8584` device-login dispatch.
+- `src/main.zig:16591-16608` `codexStoreRoot`/`codexAccountDir`; `:2897,5168` repair-lock callers; `:14421,14617` in-process mutex.
+- `src/runtime.zig:145-161` `routeReadiness` (`:156-158` lock probe).
+- `src/cli.zig` enroll/codex dispatch (add `reauth` verbs); `src/paths.zig` path/runtime dirs.
+- `build.zig:31-38` `zig build test`.
+- `scripts/smoke-codex-concurrent-sessions.sh`, `scripts/smoke-codex-child-refresh.sh`, `scripts/smoke-codex-cassette-replay.sh:246-248`, `scripts/test-stub-upstream.py:98-160`.
+- Specs: `broker-mcp-contract-2026-05-03.md` §1.2/§2.3 (`:283`); `codex-adapter-contract-2026-05-03.md` §7.2 (`:501`); `in-agent-reauth-handoff-contract-2026-05-14.md`; `account-enrollment-agent-contract-2026-05-01.md`; `future-adapter-roadmap-2026-05-10.md`.

--- a/docs/spec/codex-refresh-serialization-contract-2026-05-31.md
+++ b/docs/spec/codex-refresh-serialization-contract-2026-05-31.md
@@ -1,9 +1,19 @@
 # Codex Refresh Serialization & Adapter-Agnostic Re-Login — Design Contract
 
-Status: Draft (2026-05-31)
+Status: **Draft design (2026-05-31). Implementation pending (TIN-1591); the acceptance tests do not exist yet — they are the gate to land alongside the fix.**
 Owner: oauth-mux
 Incident anchor: `docs/incidents/2026-05-31-codex-refresh-token-race.md` (host `neo`, 10+ parallel Codex sessions → `token_revoked` / "refresh token already used")
 Upstream class: `openai/codex#10332` (incident signature); `openai/codex#9634` (cited by `docs/spec/broker-mcp-contract-2026-05-03.md:283`, `docs/spec/codex-adapter-contract-2026-05-03.md:501`)
+
+> **Scope boundary (never-halt):** refresh serialization fixes the token-rotation
+> *race*. It does **not** by itself deliver Level-3 `next_turn_seamless`
+> ("account A exhausts and account B continues"). The 2026-05-31 brick proved a
+> second, independent gap: the route selector is capability-scoped and will not
+> degrade `codex-max → codex-mini` (or wait out quota) when a capability
+> saturates — it halts with `NoAccountSelectable` even when a live route exists.
+> That cross-capability degradation is tracked separately as **GH #339 / TIN-1811**
+> (omux Foundations · resilience-never-halt). A dead/exhausted account must never
+> halt work; one live route is enough.
 
 ---
 


### PR DESCRIPTION
Docs-only. Documents and designs the fix for the concurrent-session OAuth
refresh-token double-spend race (closes the documentation half of #336).

## What

- `docs/incidents/2026-05-31-codex-refresh-token-race.md` — discoverable incident
  write-up: exact error strings, `file:line` root cause, no-spend repro spec.
- `docs/spec/codex-refresh-serialization-contract-2026-05-31.md` — design contract:
  Design A (cross-process per-`provider:account` refresh lock, reusing the existing
  `repair_state.acquireRepairLock` idiom + double-checked re-read) and Design B
  (adapter-agnostic serial re-enrollment / loopback callback / minimal web UI),
  plus the test/verification plan and rollout.
- `README.md` — "Known failure" section (search-indexed error strings).

## Why

N concurrent sessions sharing one account each read the same single-use rotating
`refresh_token` and POST it to `auth.openai.com/oauth/token`; the server rotates on
the first and returns `token_revoked` to the rest. The read→refresh→write path
(`src/broker_loader.zig:362-390`) holds no cross-process lock, and
`shouldPreserveChildAuth` lets the Codex child rotate the shared token too. Same
upstream class as `openai/codex#10332` (specs cite `#9634`).

## Not in this PR

The implementation (the flock + the failing-then-passing concurrency test) and the
re-enrollment surface land in follow-ups, tracked from the design contract. The
repro/test sections are written as a **proposed acceptance gate**, not as currently
runnable proof.

Refs #336.