### PR TITLE
Codex: default managed profile and capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,11 @@ oauth-mux route explain --profile codex-max --capability codex-max
 oauth-mux codex resume
 ```
 
+Managed `oauth-mux codex` launch/resume reads `defaults.profile` and
+`defaults.capability` when they are configured. Existing Codex Max configs also
+fall back to the conventional `codex-max` profile, so explicit profile flags are
+needed only for diagnostics, alternate profiles, or scripted proof.
+
 If a route needs upstream auth, run the labeled handoff reported by
 `route explain`, for example:
 

--- a/examples/codex-max.config.json
+++ b/examples/codex-max.config.json
@@ -3,6 +3,8 @@
   "defaults": {
     "provider": "codex",
     "strategy": "health-weighted",
+    "profile": "codex-max",
+    "capability": "codex-max",
     "shell": "fish"
   },
   "providers": {

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -561,6 +561,37 @@ const ManagedCapabilityResolution = union(enum) {
     ambiguous,
 };
 
+const ManagedLaunchDefaults = struct {
+    profile: ?[]const u8 = null,
+    capability: ?[]const u8 = null,
+};
+
+fn resolveManagedLaunchDefaults(
+    cfg: config_mod.Config,
+    explicit_profile: ?[]const u8,
+    explicit_capability: ?[]const u8,
+) ManagedLaunchDefaults {
+    const config_profile = cfg.defaults.profile;
+    var profile: ?[]const u8 = explicit_profile orelse config_profile;
+    if (profile == null and cfg.profiles.map.get("codex-max") != null) profile = "codex-max";
+
+    var capability: ?[]const u8 = explicit_capability;
+    if (capability == null) {
+        if (explicit_profile == null) {
+            capability = cfg.defaults.capability;
+        } else if (config_profile) |default_profile| {
+            if (std.mem.eql(u8, explicit_profile.?, default_profile)) {
+                capability = cfg.defaults.capability;
+            }
+        }
+    }
+
+    return .{
+        .profile = profile,
+        .capability = capability,
+    };
+}
+
 fn managedRouteCapability(
     cfg: config_mod.Config,
     explicit_capability: ?[]const u8,
@@ -1149,7 +1180,8 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     };
     defer parsed.deinit();
 
-    const route_capability = switch (managedRouteCapability(parsed.value, opts.capability, opts.profile)) {
+    const launch_defaults = resolveManagedLaunchDefaults(parsed.value, opts.profile, opts.capability);
+    const route_capability = switch (managedRouteCapability(parsed.value, launch_defaults.capability, launch_defaults.profile)) {
         .capability => |capability| capability,
         .none => null,
         .ambiguous => {
@@ -1163,7 +1195,7 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     defer server.deinit();
     var route_health = health_mod.HealthStore.load(allocator, .{});
     defer route_health.deinit();
-    broker_loader.populatePoolFromRouteHealthScoped(&server.pool, parsed.value, opts.profile, route_capability, &route_health) catch {
+    broker_loader.populatePoolFromRouteHealthScoped(&server.pool, parsed.value, launch_defaults.profile, route_capability, &route_health) catch {
         try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "pool_populate_failed", "config_health_load", "PoolPopulateFailed", session_started_emitted);
         return RunError.PoolPopulateFailed;
     };
@@ -1177,7 +1209,7 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
             allocator,
             parsed.value,
             &route_health,
-            opts.profile,
+            launch_defaults.profile,
             route_capability,
             opts.account,
             initial_selectable_routes,
@@ -1188,7 +1220,7 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         if (revalidation.changedRouteHealth()) {
             server.pool.deinit();
             server.pool = broker.AccountPool.init(allocator);
-            broker_loader.populatePoolFromRouteHealthScoped(&server.pool, parsed.value, opts.profile, route_capability, &route_health) catch {
+            broker_loader.populatePoolFromRouteHealthScoped(&server.pool, parsed.value, launch_defaults.profile, route_capability, &route_health) catch {
                 try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "pool_populate_failed", "codex_auto_revalidation", "PoolPopulateFailed", session_started_emitted);
                 return RunError.PoolPopulateFailed;
             };
@@ -1217,7 +1249,7 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         try stderr.print("oauth-mux codex: --account {s} not in profile\n", .{pin});
         try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "no_account_selectable", "route_election", "NoAccountSelectable", session_started_emitted);
         return RunError.NoAccountSelectable;
-    } else server.pool.elect(opts.profile, route_capability, &.{}) catch |e| switch (e) {
+    } else server.pool.elect(launch_defaults.profile, route_capability, &.{}) catch |e| switch (e) {
         broker_types.BrokerError.NoAccountSelectable => {
             try stderr.writeAll("oauth-mux codex: no selectable account in profile\n");
             try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "no_account_selectable", "route_election", "NoAccountSelectable", session_started_emitted);
@@ -1256,7 +1288,7 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         return e;
     };
     defer proxy.deinit();
-    proxy.profile = opts.profile;
+    proxy.profile = launch_defaults.profile;
     proxy.capability = route_capability;
     const proxy_port = proxy.port();
     try launch_timer.mark(status_writer, emit_status, "proxy_bind");
@@ -1277,7 +1309,7 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         opts.isolated_session_store,
     );
     defer codex_home.deinit(allocator);
-    traceManagedOverlay(allocator, elected.id, opts.profile, proxy_port, &codex_home);
+    traceManagedOverlay(allocator, elected.id, launch_defaults.profile, proxy_port, &codex_home);
     try launch_timer.mark(status_writer, emit_status, "overlay_creation");
 
     const resume_request = detectResumeRequest(opts.forward_argv);
@@ -1406,10 +1438,10 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     if (status_file_path) |path| try env_map.put("OMUX_STATUS_FILE", path);
     const account_only = elected.id[std.mem.indexOfScalar(u8, elected.id, ':').? + 1 ..];
     try env_map.put("OMUX_ACTIVE_ACCOUNT", account_only);
-    if (opts.profile) |p| try env_map.put("OMUX_ACTIVE_PROFILE", p);
+    if (launch_defaults.profile) |p| try env_map.put("OMUX_ACTIVE_PROFILE", p);
     try launch_timer.mark(status_writer, emit_status, "env_build");
 
-    traceManagedSessionStart(allocator, elected.id, opts.profile, opts.forward_argv.len, resume_request.mode, &codex_home);
+    traceManagedSessionStart(allocator, elected.id, launch_defaults.profile, opts.forward_argv.len, resume_request.mode, &codex_home);
 
     // 8. Spawn codex as child with inherited stdio (so the user gets
     // the real codex TUI). The adapter stays alive in parent.
@@ -3051,6 +3083,96 @@ test "RunOptions defaults" {
     try std.testing.expect(!opts.json_status);
     try std.testing.expect(opts.json_status_file == null);
     try std.testing.expectEqual(@as(usize, 0), opts.forward_argv.len);
+}
+
+test "resolveManagedLaunchDefaults prefers explicit args, config defaults, then codex-max profile" {
+    const cfg_json =
+        \\{
+        \\  "version": 1,
+        \\  "defaults": {
+        \\    "profile": "codex-mini",
+        \\    "capability": "codex-mini"
+        \\  },
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": { "priority": 20, "secret": { "backend": "file", "path": "/tmp/a" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "codex-max": { "providers": ["codex:max-1#codex-max"] },
+        \\    "codex-mini": { "providers": ["codex:max-1#codex-mini"] }
+        \\  }
+        \\}
+    ;
+    var parsed = try config_mod.loadFromBytes(std.testing.allocator, cfg_json);
+    defer parsed.deinit();
+
+    const from_config = resolveManagedLaunchDefaults(parsed.value, null, null);
+    try std.testing.expectEqualStrings("codex-mini", from_config.profile.?);
+    try std.testing.expectEqualStrings("codex-mini", from_config.capability.?);
+
+    const explicit = resolveManagedLaunchDefaults(parsed.value, "codex-max", "codex-max");
+    try std.testing.expectEqualStrings("codex-max", explicit.profile.?);
+    try std.testing.expectEqualStrings("codex-max", explicit.capability.?);
+
+    const default_profile_explicit = resolveManagedLaunchDefaults(parsed.value, "codex-mini", null);
+    try std.testing.expectEqualStrings("codex-mini", default_profile_explicit.profile.?);
+    try std.testing.expectEqualStrings("codex-mini", default_profile_explicit.capability.?);
+
+    const switched_profile = resolveManagedLaunchDefaults(parsed.value, "codex-max", null);
+    try std.testing.expectEqualStrings("codex-max", switched_profile.profile.?);
+    try std.testing.expect(switched_profile.capability == null);
+}
+
+test "resolveManagedLaunchDefaults preserves bare codex behavior for existing configs" {
+    const cfg_json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": { "priority": 20, "secret": { "backend": "file", "path": "/tmp/a" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "codex-max": { "providers": ["codex:max-1#codex-max"] }
+        \\  }
+        \\}
+    ;
+    var parsed = try config_mod.loadFromBytes(std.testing.allocator, cfg_json);
+    defer parsed.deinit();
+
+    const defaults = resolveManagedLaunchDefaults(parsed.value, null, null);
+    try std.testing.expectEqualStrings("codex-max", defaults.profile.?);
+    try std.testing.expect(defaults.capability == null);
+
+    const non_codex_json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": { "priority": 20, "secret": { "backend": "file", "path": "/tmp/a" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "custom": { "providers": ["codex:max-1#codex-custom"] }
+        \\  }
+        \\}
+    ;
+    var non_codex = try config_mod.loadFromBytes(std.testing.allocator, non_codex_json);
+    defer non_codex.deinit();
+
+    const empty = resolveManagedLaunchDefaults(non_codex.value, null, null);
+    try std.testing.expect(empty.profile == null);
+    try std.testing.expect(empty.capability == null);
 }
 
 test "managedRouteCapability infers unique profile capability and rejects ambiguous profiles" {

--- a/src/config.zig
+++ b/src/config.zig
@@ -16,6 +16,8 @@ pub const Config = struct {
 pub const Defaults = struct {
     provider: ?[]const u8 = null,
     strategy: ?[]const u8 = null,
+    profile: ?[]const u8 = null,
+    capability: ?[]const u8 = null,
     shell: ?[]const u8 = null,
     daemon: bool = false,
 };
@@ -130,6 +132,13 @@ pub fn validate(cfg: Config, writer: anytype) !void {
     if (cfg.defaults.strategy) |strategy_name| {
         if (cfg.strategies.map.get(strategy_name) == null) {
             try writer.print("config error: defaults.strategy references unknown strategy '{s}'\n", .{strategy_name});
+            ok = false;
+        }
+    }
+
+    if (cfg.defaults.profile) |profile_name| {
+        if (cfg.profiles.map.get(profile_name) == null) {
+            try writer.print("config error: defaults.profile references unknown profile '{s}'\n", .{profile_name});
             ok = false;
         }
     }
@@ -709,6 +718,44 @@ test "loadFromBytes minimal config" {
     try std.testing.expectEqualStrings("CLAUDE_TOKEN", work.secret.variable.?);
 }
 
+test "loadFromBytes accepts managed launch defaults" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "defaults": {
+        \\    "provider": "codex",
+        \\    "profile": "codex-max",
+        \\    "capability": "codex-max"
+        \\  },
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": {
+        \\          "secret": { "backend": "env", "variable": "CODEX_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "codex-max": { "providers": ["codex:max-1#codex-max"] }
+        \\  },
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    try std.testing.expectEqualStrings("codex", parsed.value.defaults.provider.?);
+    try std.testing.expectEqualStrings("codex-max", parsed.value.defaults.profile.?);
+    try std.testing.expectEqualStrings("codex-max", parsed.value.defaults.capability.?);
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try validate(parsed.value, out.writer());
+    try std.testing.expectEqual(@as(usize, 0), out.items.len);
+}
+
 test "loadFromBytes provider definition override" {
     const json =
         \\{
@@ -907,6 +954,38 @@ test "validate rejects unknown profile account" {
     defer out.deinit();
     try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
     try std.testing.expect(std.mem.indexOf(u8, out.items, "unknown account 'codex:max-2'") != null);
+}
+
+test "validate rejects unknown default profile" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "defaults": {
+        \\    "profile": "missing"
+        \\  },
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": {
+        \\          "secret": { "backend": "env", "variable": "CODEX_AUTH" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "codex-max": { "providers": ["codex:max-1#codex-max"] }
+        \\  },
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "defaults.profile references unknown profile 'missing'") != null);
 }
 
 test "validate accepts capability profile route" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -8874,6 +8874,8 @@ fn writeCodexMaxStarterConfig(allocator: std.mem.Allocator, writer: anytype, sto
         \\  "defaults": {
         \\    "provider": "codex",
         \\    "strategy": "health-weighted",
+        \\    "profile": "codex-max",
+        \\    "capability": "codex-max",
         \\    "shell": "fish"
         \\  },
         \\  "providers": {


### PR DESCRIPTION
## Summary

- add `defaults.profile` / `defaults.capability` to config so managed Codex can infer the launch profile/capability without repeated flags
- make `oauth-mux codex` and `oauth-mux codex resume` resolve explicit args first, then config defaults, then the conventional `codex-max` profile for older configs
- update generated/example Codex Max configs and README UX text

Refs #339.

## Validation

- `nix develop --command zig build test`
- `nix develop --command just smoke-codex-cli-ux-local`
- `nix develop --command just codex-max-config-candidate /tmp/oauth-mux-codex-max-defaults-check.json` + generated config validation
- `nix develop --command just check-local`