### PR TITLE
Clear Codex auth-dead health after login

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -486,6 +486,12 @@ oauth-mux codex login-device max-1
 oauth-mux stay-afloat refresh --profile codex-max --capability codex-max --json
 ```
 
+For Codex OAuth handoffs, use a fresh incognito Chrome window per account when
+entering the device code. Do not reuse an already-signed-in browser profile:
+many operators have personal, work, startup, and family Google/OpenAI sessions
+active at once, and the wrong profile can silently enroll a duplicate or
+unexpected account.
+
 `stay-afloat refresh` is a named one-shot execute tick. It refreshes route
 evidence after user-mediated login and clears the pending prompt when the route
 becomes selectable. Use `stay-afloat handoff clear ... --json` only to dismiss a
@@ -717,7 +723,9 @@ login, plan token, file key, or consent gate without guessing.
 6. Run `oauth-mux enroll plan <provider> --json` before adding an N+1 account.
 7. For Codex N+1, run
    `oauth-mux enroll codex --account <name> --confirm-enroll --json`, then the
-   returned `oauth-mux codex login-device <name>` handoff.
+   returned `oauth-mux codex login-device <name>` handoff. Enter the device code
+   in a new incognito Chrome window and choose the intended OpenAI account
+   explicitly.
 8. For Claude N+1, run
    `oauth-mux enroll claude --account <name> --confirm-enroll --json`, then the
    returned `env CLAUDE_CONFIG_DIR=... claude auth login` handoff.

--- a/docs/spec/in-agent-reauth-handoff-contract-2026-05-14.md
+++ b/docs/spec/in-agent-reauth-handoff-contract-2026-05-14.md
@@ -100,6 +100,15 @@ The command is displayable. It is not agent-executable by default. A future
 permission broker may approve execution, but that approval must be explicit and
 auditable.
 
+Browser/device OAuth handoffs should use a fresh browser context for every
+account. The preferred operator flow is `login-device` plus a new incognito
+Chrome window for the device URL, with the one-time code copied locally rather
+than printed into chat. That avoids ambient Google/OpenAI profile cookies,
+personal/work/startup/family account bleed-through, and accidental clone-account
+enrollment. oauth-mux still treats the browser approval as user-mediated; agents
+may open the fresh browser context only when explicitly asked by the user or a
+permission broker.
+
 Some upstream-owned providers do not have an oauth-mux executable repair
 command yet. In those cases `command` remains `null` and
 `handoff_plan_command` points to a no-spend planning command the agent can show
@@ -144,6 +153,11 @@ spend-confirmed actions:
 Agents must not collapse those arrays. A login-device action repairs upstream
 auth state; it is not a provider-spend revalidation and it is not a daemon
 hot-swap.
+
+For Codex, prefer `login-device` over ordinary browser login when multiple
+Chrome profiles or Google Workspace identities are present. Open
+`https://auth.openai.com/codex/device` in a new incognito Chrome window for each
+route-specific account handoff and choose the intended account explicitly.
 
 ### Claude
 

--- a/src/health.zig
+++ b/src/health.zig
@@ -299,6 +299,52 @@ pub const HealthStore = struct {
         health.last_probe_decision = decision;
     }
 
+    pub fn recordAuthRefresh(self: *HealthStore, provider_name: []const u8, account_name: []const u8) void {
+        const base_key = accountKey(provider_name, account_name);
+        if (self.accounts.getPtr(base_key.slice())) |health| {
+            if (livenessIsDead(health.liveness)) resetAfterAuthRefresh(self, health, base_key.slice());
+        } else {
+            const health = self.getOrCreate(base_key.slice()) catch return;
+            resetAfterAuthRefresh(self, health, base_key.slice());
+        }
+
+        var prefix = base_key;
+        prefix.appendByte('#');
+        var it = self.accounts.iterator();
+        while (it.next()) |entry| {
+            if (!std.mem.startsWith(u8, entry.key_ptr.*, prefix.slice())) continue;
+            if (!livenessIsDead(entry.value_ptr.liveness)) continue;
+            resetAfterAuthRefresh(self, entry.value_ptr, entry.key_ptr.*);
+        }
+    }
+
+    fn resetAfterAuthRefresh(self: *HealthStore, health: *AccountHealth, key: []const u8) void {
+        const now = std.time.timestamp();
+        health.score.score += self.config.success_bonus;
+        health.score.successes += 1;
+        health.score.clamp();
+        health.score.last_updated = now;
+        health.circuit = .closed;
+        health.consecutive_failures = 0;
+        health.rate_limited_until = null;
+        health.quota_exhausted_until = null;
+        health.last_http_status = null;
+        health.liveness = .{ .live = .{ .availability = .available } };
+        health.last_probe_source = .credential_validation;
+        health.last_probe_observed_at = now;
+        health.last_probe_retry_after_s = null;
+        health.last_probe_hint_class = .none;
+        health.last_probe_decision = .use_this;
+        log.info("health: {s} auth refreshed, clearing auth-dead route health", .{key});
+    }
+
+    fn livenessIsDead(liveness: types.CredentialLiveness) bool {
+        return switch (liveness) {
+            .dead => true,
+            .live, .degraded => false,
+        };
+    }
+
     pub fn recordFailure(self: *HealthStore, key: []const u8, kind: FailureKind) void {
         const health = self.getOrCreate(key) catch return;
         const now = std.time.timestamp();
@@ -1056,6 +1102,39 @@ test "HealthStore account decisions dominate capability route decisions" {
         types.MuxDecision.try_next_account,
         store.muxDecisionFor("codex", "max-1", "codex-max"),
     );
+}
+
+test "HealthStore auth refresh clears auth-dead account without erasing quota routes" {
+    var store = HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+
+    store.recordHttpStatus("codex:max-1", 401, null);
+    store.recordCapabilityHttpStatus("codex", "max-1", "codex-max", 429, 7200);
+    store.recordHttpStatus("codex:max-1#codex-mini", 401, null);
+
+    store.recordAuthRefresh("codex", "max-1");
+
+    try std.testing.expectEqual(
+        types.MuxDecision.try_next_account,
+        store.muxDecisionFor("codex", "max-1", "codex-max"),
+    );
+    try std.testing.expectEqual(
+        types.MuxDecision.use_this,
+        store.muxDecisionFor("codex", "max-1", "codex-mini"),
+    );
+
+    const base = store.accounts.get("codex:max-1").?;
+    try std.testing.expectEqual(ProbeEvidenceSource.credential_validation, base.last_probe_source.?);
+    try std.testing.expectEqual(types.MuxDecision.use_this, base.last_probe_decision.?);
+
+    const quota_route = store.accounts.get("codex:max-1#codex-max").?;
+    switch (quota_route.liveness) {
+        .live => |live| switch (live.availability) {
+            .quota_exhausted => {},
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
 }
 
 test "effectiveHealthForRouteSelection recovers only expired transient degradation" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -3174,7 +3174,9 @@ fn executeCodexLoginDeviceRepair(
     const config_dir = account.config_dir orelse return false;
     const expanded = try paths.expandTilde(allocator, config_dir);
     defer allocator.free(expanded);
-    return try runCodexCli(allocator, expanded, &.{ "login", "--device-auth" });
+    const ok = try runCodexCli(allocator, expanded, &.{ "login", "--device-auth" });
+    if (ok) recordCodexLoginSuccess(allocator, route.account);
+    return ok;
 }
 
 fn collectRepairPlanRoutes(
@@ -8972,6 +8974,7 @@ fn runCodex(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Cod
             const dir = try codexAccountDir(allocator, root, account);
             defer allocator.free(dir);
             if (!try runCodexCli(allocator, dir, &.{"login"})) return error.CodexCommandFailed;
+            recordCodexLoginSuccess(allocator, account);
         },
         .login_device => {
             const account = singleCodexAccount(args) orelse return error.MissingAccount;
@@ -8979,6 +8982,7 @@ fn runCodex(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Cod
             const dir = try codexAccountDir(allocator, root, account);
             defer allocator.free(dir);
             if (!try runCodexCli(allocator, dir, &.{ "login", "--device-auth" })) return error.CodexCommandFailed;
+            recordCodexLoginSuccess(allocator, account);
         },
         .login_status => {
             const account = singleCodexAccount(args) orelse return error.MissingAccount;
@@ -9006,6 +9010,13 @@ fn runCodex(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Cod
         .broker_401_smoke => try runCodexBroker401Smoke(allocator, writer, args),
         .broker_quota_smoke => try runCodexBrokerQuotaSmoke(allocator, writer, args),
     }
+}
+
+fn recordCodexLoginSuccess(allocator: std.mem.Allocator, account: []const u8) void {
+    var store = health_mod.HealthStore.load(allocator, .{});
+    defer store.deinit();
+    store.recordAuthRefresh("codex", account);
+    store.persist();
 }
 
 fn runCodexOnboard(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.CodexArgs, root: []const u8) !void {


### PR DESCRIPTION
## Summary

- Clear stale auth-dead route health after successful `oauth-mux codex login` / `login-device` handoffs.
- Preserve quota/tier/provider evidence while allowing freshly reauthenticated accounts to become selectable again.
- Document fresh incognito/device-auth browser context for route-specific OAuth handoffs to avoid profile/account bleed-through.

## Dogfood

- Installed the patched binary into `~/.local/bin/oauth-mux` without installing the Codex shim.
- Recovered local dogfood from stale `token_revoked` health after max-1 reauth; `codex preflight --profile codex-max --capability codex-max --json` now reports `ok:true` and selects `codex:max-1#codex-max`.
- max-2 device flow was opened in a fresh incognito Chrome window but timed out without browser approval, so max-2 remains blocked.

## Validation

- `nix develop --command zig build test`
- `nix develop --command zig build`
- `nix develop --command just smoke-codex-cli-ux-local`
- `nix develop --command just check-local`
