### PR TITLE
reauth: cookieless reauth engine (increment 1 — greenfield, 16/16 tests)

### DIFF
--- a/src/enroll/browser_launch.zig
+++ b/src/enroll/browser_launch.zig
@@ -1,0 +1,432 @@
+//! BrowserLauncher: COOKIELESS BROWSER LAUNCHER.
+//!
+//! Tier 1 (default, zero-dep): print "open a PRIVATE/incognito window" + the
+//!   authorize/verification URL (and non-secret user_code). Works over SSH, in
+//!   pipes, in CI — anywhere. This is the safe default.
+//!
+//! Tier 2 (opportunistic): if a chromium-family binary exists, spawn it against a
+//!   FRESH EPHEMERAL profile:
+//!       chrome --user-data-dir=<ephemeral tmp> --no-first-run --incognito <url>
+//!   The ephemeral profile dir is created before launch and deleted after the
+//!   browser exits, so no cookies/history persist (cookieless).
+//!
+//! Auto-detect Tier 2 -> fall back to Tier 1 if no browser is found.
+//!
+//! INJECTED SEAMS: `which` (binary detection), `spawn` (process), temp-dir
+//! create/delete, and `print` (output). Tests assert tier selection + the
+//! ephemeral-dir create/delete lifecycle and that argv carries NO secret, all
+//! WITHOUT touching the real filesystem, launching a real browser, or writing to
+//! real stdout. Imports only `std`.
+//!
+//! SECURITY: only the non-secret authorize/verification URL (and user_code) ever
+//! reaches argv. Access/refresh tokens never appear in argv or shell history.
+
+const std = @import("std");
+
+pub const BrowserTier = enum {
+    /// Print instructions; user opens their own private window.
+    tier1_print,
+    /// Spawn a chromium-family browser with an ephemeral profile.
+    tier2_ephemeral_chrome,
+};
+
+pub const BrowserLaunchError = error{
+    ProcessSpawnFailed,
+    TempDirCreationFailed,
+    PrintFailed,
+    OutOfMemory,
+};
+
+/// Result of a launch, so callers/tests can introspect what happened.
+pub const LaunchResult = struct {
+    tier: BrowserTier,
+    /// For Tier 2: the ephemeral profile dir that was created (and then deleted).
+    /// Null for Tier 1. Borrowed view into engine-owned memory; valid until the
+    /// LaunchResult is dropped (the dir itself is already deleted by launch()).
+    ephemeral_dir: ?[]const u8 = null,
+};
+
+// ── Injected seams ───────────────────────────────────────────────────────────
+
+/// Locate a binary on PATH (equivalent of `which`). Returns owned full path, or
+/// null if not found.
+pub const WhichFn = *const fn (
+    allocator: std.mem.Allocator,
+    ctx: *anyopaque,
+    binary: []const u8,
+) error{OutOfMemory}!?[]const u8;
+
+/// Spawn a process with the given argv. Returns the exit code. The real impl uses
+/// std.process.Child; tests record argv and return 0 without spawning.
+pub const SpawnFn = *const fn (
+    allocator: std.mem.Allocator,
+    ctx: *anyopaque,
+    argv: []const []const u8,
+) error{ SpawnFailed, OutOfMemory }!i32;
+
+/// Create a fresh ephemeral directory and return its owned path. Real impl makes a
+/// unique temp dir; tests track creation without touching disk.
+pub const MakeTempDirFn = *const fn (
+    allocator: std.mem.Allocator,
+    ctx: *anyopaque,
+) error{ TempDirCreationFailed, OutOfMemory }![]const u8;
+
+/// Delete a previously created ephemeral directory.
+pub const DeleteTempDirFn = *const fn (
+    ctx: *anyopaque,
+    path: []const u8,
+) void;
+
+/// Emit a line of instruction text to the operator. Injected so tests capture the
+/// output instead of writing to real stdout. REDACTION (if any) lives here.
+pub const PrintFn = *const fn (
+    ctx: *anyopaque,
+    line: []const u8,
+) error{PrintFailed}!void;
+
+pub const BrowserSeams = struct {
+    which: WhichFn,
+    spawn: SpawnFn,
+    make_temp_dir: MakeTempDirFn,
+    delete_temp_dir: DeleteTempDirFn,
+    print: PrintFn,
+
+    which_ctx: *anyopaque,
+    spawn_ctx: *anyopaque,
+    make_temp_dir_ctx: *anyopaque,
+    delete_temp_dir_ctx: *anyopaque,
+    print_ctx: *anyopaque,
+};
+
+/// Chromium-family binaries to probe, in preference order.
+pub const chromium_candidates = [_][]const u8{
+    "google-chrome",
+    "google-chrome-stable",
+    "chromium",
+    "chromium-browser",
+    "brave-browser",
+    "microsoft-edge",
+};
+
+pub const BrowserLauncher = struct {
+    allocator: std.mem.Allocator,
+    seams: BrowserSeams,
+    /// Non-secret authorize / verification URL. Safe for argv + display.
+    authorization_url: []const u8,
+    /// Optional non-secret user/device code (RFC 8628). Safe to display.
+    user_code: ?[]const u8 = null,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        seams: BrowserSeams,
+        authorization_url: []const u8,
+        user_code: ?[]const u8,
+    ) BrowserLauncher {
+        return .{
+            .allocator = allocator,
+            .seams = seams,
+            .authorization_url = authorization_url,
+            .user_code = user_code,
+        };
+    }
+
+    /// Probe for a chromium-family binary. Returns the owned path of the first
+    /// match, or null. Caller frees the returned path.
+    fn findChromium(self: *const BrowserLauncher) error{OutOfMemory}!?[]const u8 {
+        for (chromium_candidates) |candidate| {
+            const found = try self.seams.which(
+                self.allocator,
+                self.seams.which_ctx,
+                candidate,
+            );
+            if (found) |path| return path;
+        }
+        return null;
+    }
+
+    /// Decide which tier to use without launching anything.
+    pub fn detectTier(self: *const BrowserLauncher) error{OutOfMemory}!BrowserTier {
+        const path = try self.findChromium();
+        if (path) |p| {
+            self.allocator.free(p);
+            return .tier2_ephemeral_chrome;
+        }
+        return .tier1_print;
+    }
+
+    /// Launch: auto-detect tier, then either print (Tier 1) or spawn an ephemeral
+    /// chromium (Tier 2) and clean up its profile dir afterward.
+    pub fn launch(self: *const BrowserLauncher) BrowserLaunchError!LaunchResult {
+        const chromium_path = try self.findChromium();
+        if (chromium_path == null) {
+            try self.printInstructions();
+            return .{ .tier = .tier1_print, .ephemeral_dir = null };
+        }
+        const path = chromium_path.?;
+        defer self.allocator.free(path);
+
+        return self.launchEphemeralChrome(path);
+    }
+
+    fn printInstructions(self: *const BrowserLauncher) BrowserLaunchError!void {
+        try self.seams.print(self.seams.print_ctx, "Browser authorization required.");
+        try self.seams.print(self.seams.print_ctx, "Open a PRIVATE / INCOGNITO window and visit:");
+        try self.seams.print(self.seams.print_ctx, self.authorization_url);
+        if (self.user_code) |code| {
+            // user_code is NOT a secret (RFC 8628); safe to print.
+            const line = std.fmt.allocPrint(self.allocator, "Enter code: {s}", .{code}) catch
+                return error.OutOfMemory;
+            defer self.allocator.free(line);
+            try self.seams.print(self.seams.print_ctx, line);
+        }
+        try self.seams.print(self.seams.print_ctx, "Return here after authenticating.");
+    }
+
+    fn launchEphemeralChrome(self: *const BrowserLauncher, chrome_path: []const u8) BrowserLaunchError!LaunchResult {
+        // 1. Create the ephemeral profile dir.
+        const profile_dir = self.seams.make_temp_dir(
+            self.allocator,
+            self.seams.make_temp_dir_ctx,
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.TempDirCreationFailed => return error.TempDirCreationFailed,
+        };
+        // Always delete the ephemeral profile, even on spawn failure (cookieless).
+        defer self.seams.delete_temp_dir(self.seams.delete_temp_dir_ctx, profile_dir);
+
+        // 2. Build argv. `--user-data-dir=<dir>` is a single token so the path
+        //    cannot be mistaken for a positional arg. The ONLY URL/value passed is
+        //    the non-secret authorization URL.
+        const user_data_arg = std.fmt.allocPrint(
+            self.allocator,
+            "--user-data-dir={s}",
+            .{profile_dir},
+        ) catch return error.OutOfMemory;
+        defer self.allocator.free(user_data_arg);
+
+        var argv = std.ArrayList([]const u8).init(self.allocator);
+        defer argv.deinit();
+        argv.append(chrome_path) catch return error.OutOfMemory;
+        argv.append(user_data_arg) catch return error.OutOfMemory;
+        argv.append("--no-first-run") catch return error.OutOfMemory;
+        argv.append("--no-default-browser-check") catch return error.OutOfMemory;
+        argv.append("--incognito") catch return error.OutOfMemory;
+        argv.append(self.authorization_url) catch return error.OutOfMemory;
+
+        // 3. Spawn (blocks until the browser exits in the real impl).
+        _ = self.seams.spawn(
+            self.allocator,
+            self.seams.spawn_ctx,
+            argv.items,
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.SpawnFailed => return error.ProcessSpawnFailed,
+        };
+
+        // ephemeral_dir is reported back, but it has already been deleted by the
+        // defer above by the time the caller inspects it (lifecycle is complete).
+        return .{ .tier = .tier2_ephemeral_chrome, .ephemeral_dir = null };
+    }
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TESTS (no real browser, no real filesystem, no real stdout)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+/// Records seam interactions so tests can assert tier selection, the temp-dir
+/// create/delete lifecycle, captured output, and the exact argv (to prove no
+/// secret leaks).
+const Spy = struct {
+    chrome_present: bool,
+
+    // Temp-dir lifecycle bookkeeping.
+    temp_created: usize = 0,
+    temp_deleted: usize = 0,
+    live_temp_dir: ?[]const u8 = null,
+    fixed_temp_path: []const u8 = "/virtual/tmp/oauth-mux-XXXX",
+
+    // Spawn bookkeeping. argv slices are duped into `arena` so they survive.
+    spawned: bool = false,
+    captured_argv: std.ArrayList([]const u8),
+
+    // Captured printed lines.
+    printed: std.ArrayList([]const u8),
+
+    arena: std.mem.Allocator,
+
+    fn init(arena: std.mem.Allocator, chrome_present: bool) Spy {
+        return .{
+            .chrome_present = chrome_present,
+            .captured_argv = std.ArrayList([]const u8).init(arena),
+            .printed = std.ArrayList([]const u8).init(arena),
+            .arena = arena,
+        };
+    }
+
+    fn which(
+        allocator: std.mem.Allocator,
+        ctx: *anyopaque,
+        binary: []const u8,
+    ) error{OutOfMemory}!?[]const u8 {
+        const self: *Spy = @ptrCast(@alignCast(ctx));
+        if (!self.chrome_present) return null;
+        if (std.mem.eql(u8, binary, "google-chrome")) {
+            return try allocator.dupe(u8, "/usr/bin/google-chrome");
+        }
+        return null;
+    }
+
+    fn spawn(
+        allocator: std.mem.Allocator,
+        ctx: *anyopaque,
+        argv: []const []const u8,
+    ) error{ SpawnFailed, OutOfMemory }!i32 {
+        _ = allocator;
+        const self: *Spy = @ptrCast(@alignCast(ctx));
+        self.spawned = true;
+        for (argv) |arg| {
+            const dup = self.arena.dupe(u8, arg) catch return error.OutOfMemory;
+            self.captured_argv.append(dup) catch return error.OutOfMemory;
+        }
+        return 0;
+    }
+
+    fn makeTempDir(
+        allocator: std.mem.Allocator,
+        ctx: *anyopaque,
+    ) error{ TempDirCreationFailed, OutOfMemory }![]const u8 {
+        const self: *Spy = @ptrCast(@alignCast(ctx));
+        self.temp_created += 1;
+        const path = allocator.dupe(u8, self.fixed_temp_path) catch return error.OutOfMemory;
+        self.live_temp_dir = path;
+        return path;
+    }
+
+    fn deleteTempDir(ctx: *anyopaque, path: []const u8) void {
+        const self: *Spy = @ptrCast(@alignCast(ctx));
+        self.temp_deleted += 1;
+        // The path delivered to delete must be exactly the one we created.
+        if (self.live_temp_dir) |live| {
+            if (std.mem.eql(u8, live, path)) self.live_temp_dir = null;
+        }
+    }
+
+    fn print(ctx: *anyopaque, line: []const u8) error{PrintFailed}!void {
+        const self: *Spy = @ptrCast(@alignCast(ctx));
+        const dup = self.arena.dupe(u8, line) catch return error.PrintFailed;
+        self.printed.append(dup) catch return error.PrintFailed;
+    }
+
+    fn seams(self: *Spy) BrowserSeams {
+        return .{
+            .which = Spy.which,
+            .spawn = Spy.spawn,
+            .make_temp_dir = Spy.makeTempDir,
+            .delete_temp_dir = Spy.deleteTempDir,
+            .print = Spy.print,
+            .which_ctx = @ptrCast(self),
+            .spawn_ctx = @ptrCast(self),
+            .make_temp_dir_ctx = @ptrCast(self),
+            .delete_temp_dir_ctx = @ptrCast(self),
+            .print_ctx = @ptrCast(self),
+        };
+    }
+};
+
+const SECRET_TOKEN = "ACCESS_TOKEN_THAT_MUST_NEVER_REACH_ARGV";
+const AUTH_URL = "https://auth.example.com/device?user_code=WXYZ-7788";
+
+test "tier detection: chrome present -> Tier 2" {
+    var arena_inst = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_inst.deinit();
+    const arena = arena_inst.allocator();
+
+    var spy = Spy.init(arena, true);
+    const launcher = BrowserLauncher.init(arena, spy.seams(), AUTH_URL, "WXYZ-7788");
+
+    try testing.expectEqual(BrowserTier.tier2_ephemeral_chrome, try launcher.detectTier());
+}
+
+test "tier detection: chrome absent -> Tier 1" {
+    var arena_inst = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_inst.deinit();
+    const arena = arena_inst.allocator();
+
+    var spy = Spy.init(arena, false);
+    const launcher = BrowserLauncher.init(arena, spy.seams(), AUTH_URL, "WXYZ-7788");
+
+    try testing.expectEqual(BrowserTier.tier1_print, try launcher.detectTier());
+}
+
+test "Tier 2: ephemeral profile dir is created then removed, and spawned" {
+    var arena_inst = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_inst.deinit();
+    const arena = arena_inst.allocator();
+
+    var spy = Spy.init(arena, true);
+    const launcher = BrowserLauncher.init(arena, spy.seams(), AUTH_URL, "WXYZ-7788");
+
+    const result = try launcher.launch();
+
+    try testing.expectEqual(BrowserTier.tier2_ephemeral_chrome, result.tier);
+    try testing.expect(spy.spawned);
+    // Lifecycle: created exactly once, deleted exactly once, none left live.
+    try testing.expectEqual(@as(usize, 1), spy.temp_created);
+    try testing.expectEqual(@as(usize, 1), spy.temp_deleted);
+    try testing.expect(spy.live_temp_dir == null);
+}
+
+test "Tier 2: argv passes the ephemeral dir + auth URL but NEVER a secret" {
+    var arena_inst = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_inst.deinit();
+    const arena = arena_inst.allocator();
+
+    var spy = Spy.init(arena, true);
+    const launcher = BrowserLauncher.init(arena, spy.seams(), AUTH_URL, "WXYZ-7788");
+
+    _ = try launcher.launch();
+
+    var saw_user_data_dir = false;
+    var saw_auth_url = false;
+    for (spy.captured_argv.items) |arg| {
+        // The secret must appear in NO argv token (substring check, not equality).
+        try testing.expect(std.mem.indexOf(u8, arg, SECRET_TOKEN) == null);
+        if (std.mem.startsWith(u8, arg, "--user-data-dir=")) saw_user_data_dir = true;
+        if (std.mem.eql(u8, arg, AUTH_URL)) saw_auth_url = true;
+    }
+    try testing.expect(saw_user_data_dir);
+    try testing.expect(saw_auth_url);
+}
+
+test "Tier 1: prints incognito instructions + URL + user_code, no spawn, no temp dir" {
+    var arena_inst = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena_inst.deinit();
+    const arena = arena_inst.allocator();
+
+    var spy = Spy.init(arena, false);
+    const launcher = BrowserLauncher.init(arena, spy.seams(), AUTH_URL, "WXYZ-7788");
+
+    const result = try launcher.launch();
+
+    try testing.expectEqual(BrowserTier.tier1_print, result.tier);
+    try testing.expect(!spy.spawned);
+    try testing.expectEqual(@as(usize, 0), spy.temp_created);
+
+    // Must mention private/incognito, the URL, and the user_code.
+    var saw_incognito = false;
+    var saw_url = false;
+    var saw_code = false;
+    for (spy.printed.items) |line| {
+        if (std.mem.indexOf(u8, line, "INCOGNITO") != null or
+            std.mem.indexOf(u8, line, "PRIVATE") != null) saw_incognito = true;
+        if (std.mem.indexOf(u8, line, AUTH_URL) != null) saw_url = true;
+        if (std.mem.indexOf(u8, line, "WXYZ-7788") != null) saw_code = true;
+        // Never print a secret.
+        try testing.expect(std.mem.indexOf(u8, line, SECRET_TOKEN) == null);
+    }
+    try testing.expect(saw_incognito);
+    try testing.expect(saw_url);
+    try testing.expect(saw_code);
+}

--- a/src/enroll/device_code.zig
+++ b/src/enroll/device_code.zig
@@ -1,0 +1,508 @@
+//! DeviceCodeFlow: RFC 8628 OAuth 2.0 Device Authorization Grant.
+//!
+//! Flow:
+//!   1. POST device_authorization  -> {device_code, user_code, verification_uri, interval}
+//!   2. Display user_code + verification_uri  (NOT secrets; safe to display)
+//!   3. Poll the token endpoint with device_code until:
+//!        - success                  -> tokens (+ id_token)
+//!        - authorization_pending    -> wait `interval`, retry
+//!        - slow_down                -> increase interval, retry
+//!        - access_denied            -> typed error
+//!        - expired / timeout        -> typed error
+//!   4. Extract email + account_id (from id_token JWT or userinfo) for the gate.
+//!
+//! The device code itself is NOT a secret (it is bound to this client+grant and is
+//! safe to print). Only the resulting access/refresh tokens are secret.
+//!
+//! INJECTED SEAMS: device_authorize (HTTP), poll_token (HTTP), extract_identity,
+//! display_instructions, and a CLOCK/SLEEP seam so timeout + slow_down + backoff
+//! are testable with NO real waiting and NO real network. Imports only `std`.
+
+const std = @import("std");
+
+pub const DeviceCodeError = error{
+    AuthorizationDenied,
+    Timeout,
+    HttpFailed,
+    InvalidResponse,
+    IdentityExtractFailed,
+    OutOfMemory,
+};
+
+/// RFC 8628 §3.2 device authorization response. Slices are allocator-owned.
+pub const DeviceAuthResponse = struct {
+    device_code: []const u8,
+    user_code: []const u8,
+    verification_uri: []const u8,
+    verification_uri_complete: ?[]const u8 = null,
+    expires_in: i64 = 1800,
+    interval: i64 = 5,
+};
+
+/// RFC 8628 §3.5 token response (success). Slices are allocator-owned.
+pub const TokenExchangeResponse = struct {
+    access_token: []const u8,
+    token_type: []const u8 = "Bearer",
+    expires_in: ?i64 = null,
+    refresh_token: ?[]const u8 = null,
+    scope: ?[]const u8 = null,
+    /// JWT containing email + account_id claims (provider-dependent).
+    id_token: ?[]const u8 = null,
+};
+
+pub const IdentityInfo = struct {
+    email: []const u8,
+    account_id: []const u8,
+};
+
+/// Successful flow result. Caller owns all slices.
+pub const FlowResult = struct {
+    access_token: []const u8,
+    refresh_token: ?[]const u8,
+    expires_at: ?i64,
+    email: []const u8,
+    account_id: []const u8,
+};
+
+// ── Injected seams ───────────────────────────────────────────────────────────
+
+/// POST to the device_authorization endpoint.
+pub const DeviceAuthorizeFn = *const fn (
+    allocator: std.mem.Allocator,
+    ctx: *anyopaque,
+    device_auth_url: []const u8,
+    client_id: []const u8,
+    scope: []const u8,
+) error{ HttpFailed, InvalidResponse, OutOfMemory }!DeviceAuthResponse;
+
+/// Poll the token endpoint. RFC 8628 §3.5 error codes are surfaced as the
+/// pending/slow_down/denied errors; everything else collapses to HttpFailed /
+/// InvalidResponse.
+pub const PollTokenFn = *const fn (
+    allocator: std.mem.Allocator,
+    ctx: *anyopaque,
+    token_url: []const u8,
+    device_code: []const u8,
+    client_id: []const u8,
+) error{
+    HttpFailed,
+    InvalidResponse,
+    OutOfMemory,
+    AuthorizationPending,
+    SlowDown,
+    AuthorizationDenied,
+}!TokenExchangeResponse;
+
+/// Extract email + account_id from the id_token (JWT) or via userinfo introspection
+/// over the access_token. Returned slices are allocator-owned.
+pub const ExtractIdentityFn = *const fn (
+    allocator: std.mem.Allocator,
+    ctx: *anyopaque,
+    id_token: ?[]const u8,
+    access_token: []const u8,
+) error{ InvalidToken, OutOfMemory }!IdentityInfo;
+
+/// Display the (non-secret) user_code + verification URI to the operator.
+pub const DisplayInstructionsFn = *const fn (
+    allocator: std.mem.Allocator,
+    ctx: *anyopaque,
+    user_code: []const u8,
+    verification_uri: []const u8,
+    verification_uri_complete: ?[]const u8,
+) error{OutOfMemory}!void;
+
+/// CLOCK/SLEEP seam. Returns "now" in seconds and sleeps for `seconds`. Injected
+/// so tests can advance a virtual clock and never actually wait. The real impl
+/// wraps std.time.timestamp() / std.time.sleep().
+pub const ClockFn = *const fn (ctx: *anyopaque) i64;
+pub const SleepFn = *const fn (ctx: *anyopaque, seconds: i64) void;
+
+pub const DeviceCodeSeams = struct {
+    device_authorize: DeviceAuthorizeFn,
+    poll_token: PollTokenFn,
+    extract_identity: ExtractIdentityFn,
+    display_instructions: DisplayInstructionsFn,
+    clock: ClockFn,
+    sleep: SleepFn,
+
+    device_authorize_ctx: *anyopaque,
+    poll_token_ctx: *anyopaque,
+    extract_identity_ctx: *anyopaque,
+    display_instructions_ctx: *anyopaque,
+    clock_ctx: *anyopaque,
+    sleep_ctx: *anyopaque,
+};
+
+pub const DeviceCodeFlow = struct {
+    allocator: std.mem.Allocator,
+    seams: DeviceCodeSeams,
+    device_auth_url: []const u8,
+    token_url: []const u8,
+    client_id: []const u8,
+    scope: []const u8,
+    /// Overall deadline (seconds). The provider's expires_in clamps this lower.
+    timeout_s: i64 = 1800,
+    /// RFC 8628 §3.5: on slow_down, increase interval by at least 5s.
+    slow_down_increment_s: i64 = 5,
+    max_poll_interval_s: i64 = 120,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        seams: DeviceCodeSeams,
+        device_auth_url: []const u8,
+        token_url: []const u8,
+        client_id: []const u8,
+        scope: []const u8,
+    ) DeviceCodeFlow {
+        return .{
+            .allocator = allocator,
+            .seams = seams,
+            .device_auth_url = device_auth_url,
+            .token_url = token_url,
+            .client_id = client_id,
+            .scope = scope,
+        };
+    }
+
+    fn freeDeviceAuth(self: *const DeviceCodeFlow, da: DeviceAuthResponse) void {
+        self.allocator.free(da.device_code);
+        self.allocator.free(da.user_code);
+        self.allocator.free(da.verification_uri);
+        if (da.verification_uri_complete) |u| self.allocator.free(u);
+    }
+
+    fn freeTokenResp(self: *const DeviceCodeFlow, tr: TokenExchangeResponse) void {
+        self.allocator.free(tr.access_token);
+        self.allocator.free(tr.token_type);
+        if (tr.refresh_token) |rt| self.allocator.free(rt);
+        if (tr.scope) |s| self.allocator.free(s);
+        if (tr.id_token) |it| self.allocator.free(it);
+    }
+
+    /// Execute the device code flow end-to-end. On success returns owned tokens +
+    /// provider-confirmed identity. Caller owns all returned slices.
+    pub fn run(self: *const DeviceCodeFlow) DeviceCodeError!FlowResult {
+        // 1. Request device authorization.
+        const dev_auth = self.seams.device_authorize(
+            self.allocator,
+            self.seams.device_authorize_ctx,
+            self.device_auth_url,
+            self.client_id,
+            self.scope,
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.HttpFailed => return error.HttpFailed,
+            error.InvalidResponse => return error.InvalidResponse,
+        };
+        defer self.freeDeviceAuth(dev_auth);
+
+        // 2. Display the non-secret user_code + verification URI.
+        self.seams.display_instructions(
+            self.allocator,
+            self.seams.display_instructions_ctx,
+            dev_auth.user_code,
+            dev_auth.verification_uri,
+            dev_auth.verification_uri_complete,
+        ) catch return error.OutOfMemory;
+
+        // 3. Poll the token endpoint, honoring interval / slow_down / deadline.
+        const start = self.seams.clock(self.seams.clock_ctx);
+        const deadline = start + @min(self.timeout_s, dev_auth.expires_in);
+        var poll_interval = dev_auth.interval;
+
+        while (true) {
+            // Deadline check happens BEFORE sleeping so a zero-interval virtual
+            // clock can still time out deterministically.
+            if (self.seams.clock(self.seams.clock_ctx) >= deadline) {
+                return error.Timeout;
+            }
+
+            self.seams.sleep(self.seams.sleep_ctx, poll_interval);
+
+            const token_resp = self.seams.poll_token(
+                self.allocator,
+                self.seams.poll_token_ctx,
+                self.token_url,
+                dev_auth.device_code,
+                self.client_id,
+            ) catch |err| switch (err) {
+                error.AuthorizationPending => continue,
+                error.SlowDown => {
+                    poll_interval = @min(
+                        self.max_poll_interval_s,
+                        poll_interval + self.slow_down_increment_s,
+                    );
+                    continue;
+                },
+                error.AuthorizationDenied => return error.AuthorizationDenied,
+                error.OutOfMemory => return error.OutOfMemory,
+                error.HttpFailed => return error.HttpFailed,
+                error.InvalidResponse => return error.InvalidResponse,
+            };
+            // From here the token response is owned by us; free on every exit.
+            defer self.freeTokenResp(token_resp);
+
+            // 4. Extract identity for the confirm gate.
+            const identity = self.seams.extract_identity(
+                self.allocator,
+                self.seams.extract_identity_ctx,
+                token_resp.id_token,
+                token_resp.access_token,
+            ) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.InvalidToken => return error.IdentityExtractFailed,
+            };
+            // identity.email / identity.account_id are owned; on any failure below
+            // we must free them. There is no failure below, so they pass through.
+
+            const expires_at: ?i64 = if (token_resp.expires_in) |e|
+                self.seams.clock(self.seams.clock_ctx) + e
+            else
+                null;
+
+            return FlowResult{
+                .access_token = self.allocator.dupe(u8, token_resp.access_token) catch {
+                    self.allocator.free(identity.email);
+                    self.allocator.free(identity.account_id);
+                    return error.OutOfMemory;
+                },
+                .refresh_token = if (token_resp.refresh_token) |rt|
+                    (self.allocator.dupe(u8, rt) catch return error.OutOfMemory)
+                else
+                    null,
+                .expires_at = expires_at,
+                .email = identity.email,
+                .account_id = identity.account_id,
+            };
+        }
+    }
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TESTS (no network, no real sleeping)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+/// Drives the seams: a scripted poll sequence + a virtual clock that advances on
+/// each sleep, so timeouts are deterministic and instantaneous.
+const Harness = struct {
+    /// Poll responses to serve, in order. Each entry is an error code or success.
+    const PollStep = union(enum) {
+        pending,
+        slow_down,
+        denied,
+        success,
+    };
+    poll_script: []const PollStep,
+    poll_index: usize = 0,
+
+    /// Virtual clock (seconds). Advances by the slept amount on every sleep call.
+    now: i64 = 1000,
+    slept_total: i64 = 0,
+    sleep_calls: usize = 0,
+    /// Records the interval passed to each sleep, for backoff assertions.
+    last_sleep_interval: i64 = 0,
+
+    display_called: bool = false,
+    /// If true, the clock auto-advances even without sleeps (used to force timeout
+    /// while every poll says pending).
+    auto_advance_per_poll: i64 = 0,
+
+    fn deviceAuthorize(
+        allocator: std.mem.Allocator,
+        ctx: *anyopaque,
+        _: []const u8,
+        _: []const u8,
+        _: []const u8,
+    ) error{ HttpFailed, InvalidResponse, OutOfMemory }!DeviceAuthResponse {
+        _ = ctx;
+        return .{
+            .device_code = try allocator.dupe(u8, "DEVICE_CODE_SECRET_OK_TO_HOLD"),
+            .user_code = try allocator.dupe(u8, "WXYZ-7788"),
+            .verification_uri = try allocator.dupe(u8, "https://auth.example.com/device"),
+            .verification_uri_complete = try allocator.dupe(u8, "https://auth.example.com/device?user_code=WXYZ-7788"),
+            .expires_in = 600,
+            .interval = 5,
+        };
+    }
+
+    fn pollToken(
+        allocator: std.mem.Allocator,
+        ctx: *anyopaque,
+        _: []const u8,
+        _: []const u8,
+        _: []const u8,
+    ) error{
+        HttpFailed,
+        InvalidResponse,
+        OutOfMemory,
+        AuthorizationPending,
+        SlowDown,
+        AuthorizationDenied,
+    }!TokenExchangeResponse {
+        const self: *Harness = @ptrCast(@alignCast(ctx));
+        // If we ran off the end of the script, keep saying pending.
+        const step: PollStep = if (self.poll_index < self.poll_script.len)
+            self.poll_script[self.poll_index]
+        else
+            .pending;
+        self.poll_index += 1;
+
+        return switch (step) {
+            .pending => error.AuthorizationPending,
+            .slow_down => error.SlowDown,
+            .denied => error.AuthorizationDenied,
+            .success => .{
+                .access_token = try allocator.dupe(u8, "ACCESS_secret"),
+                .token_type = try allocator.dupe(u8, "Bearer"),
+                .expires_in = 3600,
+                .refresh_token = try allocator.dupe(u8, "REFRESH_secret"),
+                .scope = try allocator.dupe(u8, "openid email"),
+                .id_token = try allocator.dupe(u8, "header.payload.sig"),
+            },
+        };
+    }
+
+    fn extractIdentity(
+        allocator: std.mem.Allocator,
+        ctx: *anyopaque,
+        _: ?[]const u8,
+        _: []const u8,
+    ) error{ InvalidToken, OutOfMemory }!IdentityInfo {
+        _ = ctx;
+        return .{
+            .email = try allocator.dupe(u8, "dev@example.com"),
+            .account_id = try allocator.dupe(u8, "acct_dev_42"),
+        };
+    }
+
+    fn display(
+        _: std.mem.Allocator,
+        ctx: *anyopaque,
+        _: []const u8,
+        _: []const u8,
+        _: ?[]const u8,
+    ) error{OutOfMemory}!void {
+        const self: *Harness = @ptrCast(@alignCast(ctx));
+        self.display_called = true;
+    }
+
+    fn clock(ctx: *anyopaque) i64 {
+        const self: *Harness = @ptrCast(@alignCast(ctx));
+        // Auto-advance models wall time passing between deadline checks.
+        self.now += self.auto_advance_per_poll;
+        return self.now;
+    }
+
+    fn sleepVirtual(ctx: *anyopaque, seconds: i64) void {
+        const self: *Harness = @ptrCast(@alignCast(ctx));
+        self.now += seconds;
+        self.slept_total += seconds;
+        self.sleep_calls += 1;
+        self.last_sleep_interval = seconds;
+    }
+
+    fn seams(self: *Harness) DeviceCodeSeams {
+        return .{
+            .device_authorize = Harness.deviceAuthorize,
+            .poll_token = Harness.pollToken,
+            .extract_identity = Harness.extractIdentity,
+            .display_instructions = Harness.display,
+            .clock = Harness.clock,
+            .sleep = Harness.sleepVirtual,
+            .device_authorize_ctx = @ptrCast(self),
+            .poll_token_ctx = @ptrCast(self),
+            .extract_identity_ctx = @ptrCast(self),
+            .display_instructions_ctx = @ptrCast(self),
+            .clock_ctx = @ptrCast(self),
+            .sleep_ctx = @ptrCast(self),
+        };
+    }
+};
+
+fn freeResult(allocator: std.mem.Allocator, r: FlowResult) void {
+    allocator.free(r.access_token);
+    if (r.refresh_token) |rt| allocator.free(rt);
+    allocator.free(r.email);
+    allocator.free(r.account_id);
+}
+
+test "device_code: authorization_pending x2 then success yields token + identity" {
+    const allocator = testing.allocator;
+    var h = Harness{ .poll_script = &.{ .pending, .pending, .success } };
+    const flow = DeviceCodeFlow.init(
+        allocator,
+        h.seams(),
+        "https://auth.example.com/device_authorization",
+        "https://auth.example.com/token",
+        "client_abc",
+        "openid email",
+    );
+
+    const result = try flow.run();
+    defer freeResult(allocator, result);
+
+    try testing.expect(h.display_called);
+    try testing.expectEqualStrings("ACCESS_secret", result.access_token);
+    try testing.expectEqualStrings("REFRESH_secret", result.refresh_token.?);
+    try testing.expectEqualStrings("dev@example.com", result.email);
+    try testing.expectEqualStrings("acct_dev_42", result.account_id);
+    // Two pending polls => at least two sleeps before success.
+    try testing.expect(h.sleep_calls >= 3);
+}
+
+test "device_code: timeout returns typed Timeout error" {
+    const allocator = testing.allocator;
+    // Every poll says pending; auto-advance the clock 200s per deadline check so we
+    // blow past the 600s expires_in quickly and deterministically (no real wait).
+    var h = Harness{
+        .poll_script = &.{ .pending, .pending, .pending, .pending, .pending, .pending, .pending, .pending },
+        .auto_advance_per_poll = 200,
+    };
+    const flow = DeviceCodeFlow.init(
+        allocator,
+        h.seams(),
+        "https://auth.example.com/device_authorization",
+        "https://auth.example.com/token",
+        "client_abc",
+        "openid email",
+    );
+
+    try testing.expectError(error.Timeout, flow.run());
+}
+
+test "device_code: slow_down increases the poll interval (backoff respected)" {
+    const allocator = testing.allocator;
+    // pending(5s), slow_down(->10s), then success.
+    var h = Harness{ .poll_script = &.{ .pending, .slow_down, .success } };
+    const flow = DeviceCodeFlow.init(
+        allocator,
+        h.seams(),
+        "https://auth.example.com/device_authorization",
+        "https://auth.example.com/token",
+        "client_abc",
+        "openid email",
+    );
+
+    const result = try flow.run();
+    defer freeResult(allocator, result);
+
+    // After the slow_down, the next sleep interval must have grown from 5 to 10.
+    try testing.expectEqual(@as(i64, 10), h.last_sleep_interval);
+}
+
+test "device_code: access_denied returns typed AuthorizationDenied error" {
+    const allocator = testing.allocator;
+    var h = Harness{ .poll_script = &.{ .pending, .denied } };
+    const flow = DeviceCodeFlow.init(
+        allocator,
+        h.seams(),
+        "https://auth.example.com/device_authorization",
+        "https://auth.example.com/token",
+        "client_abc",
+        "openid email",
+    );
+
+    try testing.expectError(error.AuthorizationDenied, flow.run());
+}

--- a/src/enroll/reauth.zig
+++ b/src/enroll/reauth.zig
@@ -1,0 +1,446 @@
+//! ReauthOrchestrator: COOKIELESS REAUTH ENGINE
+//!
+//! Coordinates one of four enrollment flows to obtain a token + provider-confirmed
+//! identity, then runs an IDENTITY-CONFIRM gate, and only on confirm invokes a
+//! writeStore callback.
+//!
+//! All side-effecting work is behind INJECTED SEAMS (function pointers bundled in
+//! a small interface struct) so the engine is testable with NO network, NO real
+//! browser, and NO real file writes. The module imports only `std` to stay
+//! self-contained (no build_options / module graph).
+//!
+//! Flow dispatch is ENUM DISPATCH (a switch on a tagged enum), NOT a vtable.
+//!
+//! References: RFC 8628 (device), RFC 7636 (PKCE), RFC 8252 (loopback).
+
+const std = @import("std");
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PUBLIC TYPES
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The four enrollment flows. The orchestrator dispatches on this with a switch.
+pub const Flow = enum {
+    /// RFC 8628 device authorization grant. No PKCE, no loopback listener.
+    device_code,
+    /// RFC 8252 loopback redirect with PKCE (RFC 7636).
+    redirect_loopback,
+    /// Delegate to an upstream CLI (e.g. `codex login`) that owns the browser.
+    command_owned,
+    /// User pastes a personal access token / pre-minted credential.
+    pat_paste,
+};
+
+/// The provider-confirmed identity + token material produced by a flow.
+/// All slices are owned by the caller's allocator (the engine frees them on
+/// reject / store-failure, or returns ownership on success).
+pub const FlowOutcome = struct {
+    access_token: []const u8,
+    refresh_token: ?[]const u8 = null,
+    expires_at: ?i64 = null,
+    /// Provider-confirmed email (may be empty if the provider does not return one).
+    email: []const u8,
+    /// Provider-confirmed stable account identifier. This is the clone-dedup key.
+    account_id: []const u8,
+};
+
+/// Final successful enrollment result returned to the caller. Same shape as
+/// FlowOutcome; kept distinct so the public success type is named clearly.
+pub const EnrollmentResult = FlowOutcome;
+
+pub const IdentityConfirmDecision = enum { confirm, reject };
+
+/// Why the confirm gate decided as it did. Carried out of the prompt seam so the
+/// engine can map a rejection to a precise typed error without re-deriving it.
+pub const ConfirmReason = enum {
+    /// User (or policy) accepted the identity.
+    accepted,
+    /// User declined at the prompt.
+    user_declined,
+    /// account_id already enrolled for this provider (the max-4 clone lesson).
+    already_enrolled,
+    /// Provider identity did not match the intended provider:account.
+    identity_mismatch,
+};
+
+pub const ConfirmResult = struct {
+    decision: IdentityConfirmDecision,
+    reason: ConfirmReason,
+};
+
+pub const EnrollError = error{
+    FlowFailed,
+    /// Confirm gate returned reject because the user declined.
+    UserDeclined,
+    /// Confirm gate returned reject because account_id is already enrolled.
+    AlreadyEnrolled,
+    /// Confirm gate returned reject because the identity did not match intent.
+    IdentityMismatch,
+    /// The confirm seam itself errored (could not prompt).
+    ConfirmUnavailable,
+    StoreWriteFailed,
+    OutOfMemory,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SEAM INTERFACES (injected function pointers; no real I/O in the engine)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Run the selected flow. The concrete impl (device_code, loopback, ...) is bound
+/// at wire-up time. It must return an allocator-owned FlowOutcome. `flow_ctx` is an
+/// opaque pointer to flow-specific configuration (endpoints, client_id, ...).
+pub const RunFlowFn = *const fn (
+    allocator: std.mem.Allocator,
+    flow: Flow,
+    flow_ctx: *anyopaque,
+) error{ FlowFailed, OutOfMemory }!FlowOutcome;
+
+/// Identity-confirm gate. Given the provider-confirmed identity and the set of
+/// account_ids already enrolled for this provider, decide confirm/reject.
+///
+/// REDACTION happens at this seam (the prompt/log impl), NOT inside the engine —
+/// the engine passes the raw email/account_id through untouched.
+///
+/// `existing_account_ids` enables CLONE PREVENTION for `account add`: an impl can
+/// compare the confirmed account_id against the list and return
+/// `.already_enrolled` to block a duplicate enrollment.
+pub const ConfirmIdentityFn = *const fn (
+    allocator: std.mem.Allocator,
+    confirm_ctx: *anyopaque,
+    provider: []const u8,
+    email: []const u8,
+    account_id: []const u8,
+    existing_account_ids: []const []const u8,
+) error{ Unavailable, OutOfMemory }!ConfirmResult;
+
+/// Persist the enrollment. Invoked ONLY after the confirm gate returns `.confirm`.
+pub const WriteStoreFn = *const fn (
+    allocator: std.mem.Allocator,
+    store_ctx: *anyopaque,
+    provider: []const u8,
+    outcome: FlowOutcome,
+) error{ WriteFailed, OutOfMemory }!void;
+
+/// Spawn a child process and optionally capture stdout. Used by command_owned and
+/// by the browser launcher when wired together. Injected so tests never spawn.
+pub const ProcessSpawnFn = *const fn (
+    allocator: std.mem.Allocator,
+    spawn_ctx: *anyopaque,
+    argv: []const []const u8,
+) error{ SpawnFailed, OutOfMemory }!?[]const u8;
+
+/// The bundle of injected seams. Each seam carries its own opaque context pointer
+/// so callers can bind closures/state without globals.
+pub const Seams = struct {
+    run_flow: RunFlowFn,
+    confirm_identity: ConfirmIdentityFn,
+    write_store: WriteStoreFn,
+    process_spawn: ProcessSpawnFn,
+
+    flow_ctx: *anyopaque,
+    confirm_ctx: *anyopaque,
+    store_ctx: *anyopaque,
+    spawn_ctx: *anyopaque,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ORCHESTRATOR
+// ─────────────────────────────────────────────────────────────────────────────
+
+pub const ReauthOrchestrator = struct {
+    allocator: std.mem.Allocator,
+    seams: Seams,
+    /// Provider identity (e.g. "codex", "claude"). Borrowed; not owned.
+    provider: []const u8,
+    /// account_ids already enrolled for this provider. Borrowed; not owned.
+    /// Empty for first-time enrollment; populated for `account add` clone checks.
+    existing_account_ids: []const []const u8,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        seams: Seams,
+        provider: []const u8,
+        existing_account_ids: []const []const u8,
+    ) ReauthOrchestrator {
+        return .{
+            .allocator = allocator,
+            .seams = seams,
+            .provider = provider,
+            .existing_account_ids = existing_account_ids,
+        };
+    }
+
+    /// Free an outcome's owned slices. Used on the reject / store-failure paths.
+    fn freeOutcome(self: *const ReauthOrchestrator, outcome: FlowOutcome) void {
+        self.allocator.free(outcome.access_token);
+        if (outcome.refresh_token) |rt| self.allocator.free(rt);
+        self.allocator.free(outcome.email);
+        self.allocator.free(outcome.account_id);
+    }
+
+    /// Drive the full enrollment:
+    ///   run flow -> obtain token + identity -> confirm gate -> writeStore (on confirm)
+    ///
+    /// On success returns the EnrollmentResult (caller owns its slices).
+    /// On any rejection or failure, all token material is freed and a typed error
+    /// is returned WITHOUT calling writeStore.
+    pub fn begin(self: *const ReauthOrchestrator, flow: Flow) EnrollError!EnrollmentResult {
+        // 1. Run the selected flow (enum dispatch lives inside the injected runner;
+        //    the orchestrator itself stays flow-agnostic so the seam is a single
+        //    point of substitution in tests).
+        const outcome = self.seams.run_flow(
+            self.allocator,
+            flow,
+            self.seams.flow_ctx,
+        ) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.FlowFailed => return error.FlowFailed,
+        };
+
+        // 2. Identity-confirm gate. Existing account_ids are passed so the gate can
+        //    block clones (the max-4 lesson).
+        const confirmation = self.seams.confirm_identity(
+            self.allocator,
+            self.seams.confirm_ctx,
+            self.provider,
+            outcome.email,
+            outcome.account_id,
+            self.existing_account_ids,
+        ) catch |err| switch (err) {
+            error.OutOfMemory => {
+                self.freeOutcome(outcome);
+                return error.OutOfMemory;
+            },
+            error.Unavailable => {
+                self.freeOutcome(outcome);
+                return error.ConfirmUnavailable;
+            },
+        };
+
+        if (confirmation.decision == .reject) {
+            self.freeOutcome(outcome);
+            return switch (confirmation.reason) {
+                .already_enrolled => error.AlreadyEnrolled,
+                .identity_mismatch => error.IdentityMismatch,
+                // .accepted should never pair with a reject decision; treat as decline.
+                .user_declined, .accepted => error.UserDeclined,
+            };
+        }
+
+        // 3. Confirmed: persist. Only now does any store write happen.
+        self.seams.write_store(
+            self.allocator,
+            self.seams.store_ctx,
+            self.provider,
+            outcome,
+        ) catch |err| {
+            self.freeOutcome(outcome);
+            return switch (err) {
+                error.OutOfMemory => error.OutOfMemory,
+                error.WriteFailed => error.StoreWriteFailed,
+            };
+        };
+
+        return outcome;
+    }
+};
+
+/// Convenience: default clone-detection used by real confirm-gate impls. Returns
+/// true if `account_id` is already present in `existing_account_ids`. Kept here
+/// (not inside `begin`) so redaction/policy stays at the seam, but the dedup
+/// comparison logic is shared and testable.
+pub fn isAlreadyEnrolled(account_id: []const u8, existing_account_ids: []const []const u8) bool {
+    for (existing_account_ids) |existing| {
+        if (std.mem.eql(u8, existing, account_id)) return true;
+    }
+    return false;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TESTS (no network, no browser, no real file writes)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+/// A test double that records what the orchestrator did to it. Each seam closure
+/// recovers this struct from its opaque ctx pointer.
+const Recorder = struct {
+    /// What the flow seam should hand back.
+    flow_email: []const u8 = "user@example.com",
+    flow_account_id: []const u8 = "acct_NEW_001",
+    /// Confirm seam behavior.
+    confirm_decision: IdentityConfirmDecision = .confirm,
+    confirm_reason: ConfirmReason = .accepted,
+    /// Whether the confirm impl should run real clone detection against existing.
+    confirm_uses_clone_check: bool = false,
+    existing_for_check: []const []const u8 = &.{},
+
+    // Observations:
+    store_called: bool = false,
+    stored_account_id: ?[]const u8 = null,
+    confirm_saw_existing_len: usize = 0,
+
+    fn runFlow(
+        allocator: std.mem.Allocator,
+        flow: Flow,
+        flow_ctx: *anyopaque,
+    ) error{ FlowFailed, OutOfMemory }!FlowOutcome {
+        _ = flow;
+        const self: *Recorder = @ptrCast(@alignCast(flow_ctx));
+        return .{
+            .access_token = try allocator.dupe(u8, "ACCESS_TOKEN_VALUE"),
+            .refresh_token = try allocator.dupe(u8, "REFRESH_TOKEN_VALUE"),
+            .email = try allocator.dupe(u8, self.flow_email),
+            .account_id = try allocator.dupe(u8, self.flow_account_id),
+        };
+    }
+
+    fn confirm(
+        allocator: std.mem.Allocator,
+        confirm_ctx: *anyopaque,
+        provider: []const u8,
+        email: []const u8,
+        account_id: []const u8,
+        existing_account_ids: []const []const u8,
+    ) error{ Unavailable, OutOfMemory }!ConfirmResult {
+        _ = allocator;
+        _ = provider;
+        _ = email;
+        const self: *Recorder = @ptrCast(@alignCast(confirm_ctx));
+        self.confirm_saw_existing_len = existing_account_ids.len;
+
+        if (self.confirm_uses_clone_check and
+            isAlreadyEnrolled(account_id, existing_account_ids))
+        {
+            return .{ .decision = .reject, .reason = .already_enrolled };
+        }
+        return .{ .decision = self.confirm_decision, .reason = self.confirm_reason };
+    }
+
+    fn writeStore(
+        allocator: std.mem.Allocator,
+        store_ctx: *anyopaque,
+        provider: []const u8,
+        outcome: FlowOutcome,
+    ) error{ WriteFailed, OutOfMemory }!void {
+        _ = provider;
+        const self: *Recorder = @ptrCast(@alignCast(store_ctx));
+        self.store_called = true;
+        self.stored_account_id = try allocator.dupe(u8, outcome.account_id);
+    }
+
+    fn spawnNoop(
+        allocator: std.mem.Allocator,
+        spawn_ctx: *anyopaque,
+        argv: []const []const u8,
+    ) error{ SpawnFailed, OutOfMemory }!?[]const u8 {
+        _ = allocator;
+        _ = spawn_ctx;
+        _ = argv;
+        return null;
+    }
+};
+
+fn seamsFor(rec: *Recorder) Seams {
+    return .{
+        .run_flow = Recorder.runFlow,
+        .confirm_identity = Recorder.confirm,
+        .write_store = Recorder.writeStore,
+        .process_spawn = Recorder.spawnNoop,
+        .flow_ctx = @ptrCast(rec),
+        .confirm_ctx = @ptrCast(rec),
+        .store_ctx = @ptrCast(rec),
+        .spawn_ctx = @ptrCast(rec),
+    };
+}
+
+test "identity-confirm: confirm -> writeStore called and result owned" {
+    const allocator = testing.allocator;
+    var rec = Recorder{ .confirm_decision = .confirm, .confirm_reason = .accepted };
+
+    const orch = ReauthOrchestrator.init(allocator, seamsFor(&rec), "codex", &.{});
+    const result = try orch.begin(.device_code);
+    defer {
+        allocator.free(result.access_token);
+        if (result.refresh_token) |rt| allocator.free(rt);
+        allocator.free(result.email);
+        allocator.free(result.account_id);
+    }
+    defer if (rec.stored_account_id) |s| allocator.free(s);
+
+    try testing.expect(rec.store_called);
+    try testing.expectEqualStrings("acct_NEW_001", result.account_id);
+    try testing.expectEqualStrings("user@example.com", result.email);
+    try testing.expectEqualStrings("ACCESS_TOKEN_VALUE", result.access_token);
+    try testing.expectEqualStrings("acct_NEW_001", rec.stored_account_id.?);
+}
+
+test "identity-confirm: reject (user declined) -> writeStore NOT called, typed error" {
+    const allocator = testing.allocator;
+    var rec = Recorder{ .confirm_decision = .reject, .confirm_reason = .user_declined };
+
+    const orch = ReauthOrchestrator.init(allocator, seamsFor(&rec), "codex", &.{});
+    const err = orch.begin(.device_code);
+
+    try testing.expectError(error.UserDeclined, err);
+    try testing.expect(!rec.store_called);
+    // No leak: testing.allocator would fail teardown if the outcome wasn't freed.
+}
+
+test "account add clone: account_id matches existing -> flagged (AlreadyEnrolled), no write" {
+    const allocator = testing.allocator;
+    // The new flow returns an account_id that is ALREADY enrolled.
+    const existing = [_][]const u8{ "acct_OLD_A", "acct_CLONE_TARGET", "acct_OLD_B" };
+    var rec = Recorder{
+        .flow_account_id = "acct_CLONE_TARGET",
+        .confirm_uses_clone_check = true,
+        .existing_for_check = &existing,
+    };
+
+    const orch = ReauthOrchestrator.init(allocator, seamsFor(&rec), "codex", &existing);
+    const err = orch.begin(.device_code);
+
+    try testing.expectError(error.AlreadyEnrolled, err);
+    try testing.expect(!rec.store_called);
+    // The gate must have actually received the existing set (clone-prevention path).
+    try testing.expectEqual(@as(usize, 3), rec.confirm_saw_existing_len);
+}
+
+test "account add non-clone: distinct account_id passes clone check and writes" {
+    const allocator = testing.allocator;
+    const existing = [_][]const u8{ "acct_OLD_A", "acct_OLD_B" };
+    var rec = Recorder{
+        .flow_account_id = "acct_FRESH_999",
+        .confirm_uses_clone_check = true,
+        .existing_for_check = &existing,
+    };
+
+    const orch = ReauthOrchestrator.init(allocator, seamsFor(&rec), "codex", &existing);
+    const result = try orch.begin(.device_code);
+    defer {
+        allocator.free(result.access_token);
+        if (result.refresh_token) |rt| allocator.free(rt);
+        allocator.free(result.email);
+        allocator.free(result.account_id);
+    }
+    defer if (rec.stored_account_id) |s| allocator.free(s);
+
+    try testing.expect(rec.store_called);
+    try testing.expectEqualStrings("acct_FRESH_999", result.account_id);
+}
+
+test "identity-confirm: mismatch reason maps to IdentityMismatch error" {
+    const allocator = testing.allocator;
+    var rec = Recorder{ .confirm_decision = .reject, .confirm_reason = .identity_mismatch };
+
+    const orch = ReauthOrchestrator.init(allocator, seamsFor(&rec), "codex", &.{});
+    try testing.expectError(error.IdentityMismatch, orch.begin(.device_code));
+    try testing.expect(!rec.store_called);
+}
+
+test "isAlreadyEnrolled helper" {
+    const existing = [_][]const u8{ "a", "b", "c" };
+    try testing.expect(isAlreadyEnrolled("b", &existing));
+    try testing.expect(!isAlreadyEnrolled("z", &existing));
+    try testing.expect(!isAlreadyEnrolled("a", &.{}));
+}

--- a/src/enroll/tests.zig
+++ b/src/enroll/tests.zig
@@ -1,0 +1,20 @@
+//! EnrollModuleTests: test root for src/enroll/* modules
+//!
+//! This module imports all enroll-related modules and ensures their tests compile and run.
+
+const std = @import("std");
+
+const reauth = @import("reauth.zig");
+const device_code = @import("device_code.zig");
+const browser_launch = @import("browser_launch.zig");
+
+// Pull all test declarations into scope.
+comptime {
+    _ = reauth;
+    _ = device_code;
+    _ = browser_launch;
+}
+
+test {
+    std.testing.refAllDeclsRecursive(@This());
+}


### PR DESCRIPTION
Increment 1 of the cookieless callback reauth backend — the **engine**, as greenfield `src/enroll/` modules behind injected seams. **New files only**; zero edits to existing code (deliberately deconflicted from the parallel core work). Design: Linear doc *Cookieless callback reauth backend*.

## What
- **`reauth.zig`** — `ReauthOrchestrator` + `Flow` enum (`device_code`/`redirect_loopback`/`command_owned`/`pat_paste`), enum dispatch (not a vtable). The **identity-confirm gate**: only calls `writeStore` after the operator confirms the provider-returned email/account_id, and **prevents clones** (compares `account_id` vs existing accounts — the max-4 lesson). Redaction at the output seam.
- **`device_code.zig`** — RFC 8628 over injected `device_authorize`/`poll_token`/`extract_identity`/`clock`; honors `authorization_pending`/`slow_down`/`timeout`/`access_denied`.
- **`browser_launch.zig`** — cookieless launcher: **Tier 1** (print "use a PRIVATE/incognito window" + URL/code, zero-dep default) / **Tier 2** (ephemeral chromium `--user-data-dir`, created+deleted per job), auto-detect. Secret never appears in argv/URL.
- **`tests.zig`** — `refAllDeclsRecursive` root.

## Verified
`nix develop --command zig test src/enroll/tests.zig` → **All 16 tests passed** (leak-checked via `std.testing.allocator`). Reproduced independently on the latest `main` base (228a3ef). Self-contained: every module imports only `std` + sibling enroll files — no `build_options`, no existing `src/*`.

## To wire in (coordinated follow-ups, touch shared files)
1. `build.zig` test step:
```zig
const enroll_tests = b.addTest(.{ .root_source_file = b.path("src/enroll/tests.zig"), .target = target, .optimize = optimize });
const run_enroll_tests = b.addRunArtifact(enroll_tests);
b.step("test-enroll", "Run cookieless reauth engine tests").dependOn(&run_enroll_tests.step);
test_step.dependOn(&run_enroll_tests.step);
```
2. Real seam bindings: HTTP (mirror `oauth.zig:refreshToken`), `writeStore` (atomic `writeFileReplace`, 0600), `extract_identity` (id_token JWT email — note `auth.json` doesn't store email today), browser spawn (`std.process.Child`), interactive confirm prompt + redaction.
3. CLI verbs `oauth-mux account add` / `account replace` (TIN-1806).

Part of omux Foundations · reauth-backend-ui. Increment 2 = bind the seams + CLI.