### PR TITLE
reauth: operator web UI (TIN-1808 — greenfield, 29/29, anti-rebinding + redaction)

### DIFF
--- a/src/enroll/web_ui.zig
+++ b/src/enroll/web_ui.zig
@@ -1,0 +1,666 @@
+const std = @import("std");
+
+// ────────────────────────────────────────────────────────────────────────────
+// MINIMAL SEAM INTERFACES FOR WEB UI
+// These are defined locally and SELF-CONTAINED. Integration with real
+// reauth engine (src/enroll/reauth.zig) is a coordinated follow-up (PR #344).
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Per-account health row data (already redacted by the seam provider).
+/// Only fields safe for UI/JSON output (no raw tokens, no raw account_id).
+pub const AccountHealth = struct {
+    provider: []const u8,
+    account: []const u8,
+    /// Route-state label: "available", "rate_limited", "quota_exhausted",
+    /// "tier_insufficient", "auth_permanently_failed", "credential_unavailable",
+    /// "revalidation_needed"
+    route_state: []const u8,
+    /// Masked email hint (e.g. "j***@example.com"), or null if unavailable.
+    email_hint_masked: ?[]const u8 = null,
+    /// Whether a reauth job is currently in-flight for this account.
+    reauth_in_progress: bool = false,
+};
+
+/// Reauth state machine label.
+pub const ReauthState = enum {
+    pending,
+    awaiting_device_code,
+    awaiting_user_confirmation,
+    in_progress,
+    success,
+    failed,
+
+    pub fn toString(self: ReauthState) []const u8 {
+        return switch (self) {
+            .pending => "pending",
+            .awaiting_device_code => "awaiting_device_code",
+            .awaiting_user_confirmation => "awaiting_user_confirmation",
+            .in_progress => "in_progress",
+            .success => "success",
+            .failed => "failed",
+        };
+    }
+};
+
+/// Job handle returned by enqueueReauth.
+pub const ReauthJobHandle = struct {
+    job_id: []const u8,
+    handoff: []const u8, // device code+URL or authorize URL
+};
+
+/// Seam interface: pure function pointers injected at runtime.
+pub const Seams = struct {
+    /// List all accounts with their health (no-spend, already redacted).
+    listAccounts: *const fn (allocator: std.mem.Allocator) std.mem.Allocator.Error![]AccountHealth,
+
+    /// Enqueue or join a reauth job for provider:account.
+    enqueueReauth: *const fn (allocator: std.mem.Allocator, provider: []const u8, account: []const u8) std.mem.Allocator.Error!ReauthJobHandle,
+
+    /// Poll reauth state for provider:account.
+    pollReauth: *const fn (allocator: std.mem.Allocator, provider: []const u8, account: []const u8) std.mem.Allocator.Error!ReauthState,
+
+    /// Current unix timestamp (seconds).
+    now: *const fn () i64,
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// HTTP REQUEST/RESPONSE TYPES
+// ────────────────────────────────────────────────────────────────────────────
+
+pub const HttpMethod = enum {
+    GET,
+    POST,
+    pub fn fromString(s: []const u8) ?HttpMethod {
+        if (std.mem.eql(u8, s, "GET")) return .GET;
+        if (std.mem.eql(u8, s, "POST")) return .POST;
+        return null;
+    }
+};
+
+pub const Response = struct {
+    status: u16,
+    content_type: []const u8,
+    body: []const u8,
+    allocator: std.mem.Allocator,
+
+    pub fn deinit(self: Response) void {
+        self.allocator.free(self.body);
+    }
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// HTML / JSON RENDERING
+// ────────────────────────────────────────────────────────────────────────────
+
+fn renderAccountHealthHtml(allocator: std.mem.Allocator, accounts: []const AccountHealth) std.mem.Allocator.Error![]const u8 {
+    var buf = std.ArrayList(u8).init(allocator);
+    defer buf.deinit();
+
+    try buf.appendSlice(
+        \\<!DOCTYPE html>
+        \\<html lang="en">
+        \\<head>
+        \\  <meta charset="UTF-8">
+        \\  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        \\  <title>oauth-mux Operator Console</title>
+        \\  <style>
+        \\    * { margin: 0; padding: 0; box-sizing: border-box; }
+        \\    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: #f5f5f5; padding: 20px; }
+        \\    .container { max-width: 1200px; margin: 0 auto; background: white; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.1); padding: 40px; }
+        \\    h1 { color: #333; margin-bottom: 30px; }
+        \\    .account-grid { display: grid; gap: 20px; }
+        \\    .account-card { border: 1px solid #e0e0e0; border-radius: 6px; padding: 20px; transition: all 0.2s; }
+        \\    .account-card:hover { box-shadow: 0 4px 12px rgba(0,0,0,0.08); }
+        \\    .account-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px; }
+        \\    .account-title { font-size: 18px; font-weight: 600; color: #1a1a1a; }
+        \\    .account-subtitle { color: #666; font-size: 14px; margin-top: 4px; }
+        \\    .route-state { display: inline-block; padding: 4px 12px; border-radius: 4px; font-size: 12px; font-weight: 600; }
+        \\    .route-state.available { background: #c8e6c9; color: #2e7d32; }
+        \\    .route-state.rate_limited { background: #fff3cd; color: #856404; }
+        \\    .route-state.quota_exhausted { background: #fff3cd; color: #856404; }
+        \\    .route-state.revalidation_needed { background: #fff3cd; color: #856404; }
+        \\    .route-state.tier_insufficient { background: #ffccbc; color: #d84315; }
+        \\    .route-state.auth_permanently_failed { background: #ffcdd2; color: #c62828; }
+        \\    .route-state.credential_unavailable { background: #ffcdd2; color: #c62828; }
+        \\    .account-actions { margin-top: 15px; display: flex; gap: 10px; }
+        \\    button { padding: 8px 16px; border: none; border-radius: 4px; font-size: 14px; cursor: pointer; font-weight: 500; transition: all 0.2s; }
+        \\    .btn-primary { background: #1976d2; color: white; }
+        \\    .btn-primary:hover { background: #1565c0; }
+        \\    .btn-primary:disabled { background: #ccc; cursor: not-allowed; }
+        \\    .spinner { display: inline-block; width: 14px; height: 14px; border: 2px solid #ccc; border-top: 2px solid #1976d2; border-radius: 50%; animation: spin 0.6s linear infinite; }
+        \\    @keyframes spin { to { transform: rotate(360deg); } }
+        \\    .status-badge { display: inline-block; margin-left: 8px; }
+        \\    .reauth-hint { color: #856404; font-size: 13px; margin-left: 8px; }
+        \\    .empty-state { text-align: center; color: #999; padding: 40px 20px; }
+        \\  </style>
+        \\</head>
+        \\<body>
+        \\  <div class="container">
+        \\    <h1>oauth-mux Operator Console</h1>
+        \\    <div class="account-grid">
+    );
+
+    // REDACTION: the rendered board emits ONLY allow-listed fields:
+    //   - provider (label)
+    //   - email_hint_masked (masked hint)
+    //   - route_state (label)
+    //   - reauth_in_progress (boolean-derived UI state)
+    // The raw account_id (acc.account) is NEVER rendered as visible text. The
+    // re-login action targets the row's *index* (a non-identifying selector);
+    // the POST handler resolves index -> account server-side via the seam list.
+    for (accounts, 0..) |acc, idx| {
+        try buf.writer().print(
+            \\      <div class="account-card">
+            \\        <div class="account-header">
+            \\          <div>
+            \\            <div class="account-title">{s}</div>
+            \\            <div class="account-subtitle">{s}</div>
+            \\          </div>
+            \\          <span class="route-state {s}">{s}</span>
+            \\        </div>
+            , .{
+                acc.provider,
+                if (acc.email_hint_masked) |hint| hint else "(email unavailable)",
+                acc.route_state,
+                acc.route_state,
+            }
+        );
+
+        if (acc.reauth_in_progress) {
+            try buf.appendSlice(
+                \\        <div class="status-badge" data-reauth="in_progress">
+                \\          <span class="spinner"></span> Re-login in progress &mdash; complete it in a PRIVATE / INCOGNITO window.
+                \\        </div>
+            );
+        } else if (!std.mem.eql(u8, acc.route_state, "available")) {
+            // Confirm-identity reminder is server-rendered so the operator sees
+            // the intended provider + masked identity before driving re-login,
+            // and is reminded to use a private/incognito window (cookieless).
+            try buf.writer().print(
+                \\        <div class="account-actions">
+                \\          <button class="btn-primary" onclick="startReauth('{s}', {d})">Re-login</button>
+                \\          <span class="reauth-hint">Confirm identity <strong>{s}:{s}</strong> and use a PRIVATE / INCOGNITO window.</span>
+                \\        </div>
+                , .{
+                    acc.provider,
+                    idx,
+                    acc.provider,
+                    if (acc.email_hint_masked) |hint| hint else "(email unavailable)",
+                }
+            );
+        }
+
+        try buf.appendSlice("      </div>\n");
+    }
+
+    if (accounts.len == 0) {
+        try buf.appendSlice(
+            \\      <div class="empty-state">
+            \\        <p>No accounts configured.</p>
+            \\      </div>
+        );
+    }
+
+    try buf.appendSlice(
+        \\    </div>
+        \\  </div>
+        \\  <script>
+        \\    // The "selector" is a non-identifying row index; the server resolves
+        \\    // it back to the real account. The raw account id never reaches the DOM.
+        \\    async function startReauth(provider, selector) {
+        \\      try {
+        \\        const response = await fetch(`/reauth/${provider}/${selector}`, { method: 'POST' });
+        \\        const data = await response.json();
+        \\        if (data.job_id && data.handoff) {
+        \\          alert(`Use a PRIVATE / INCOGNITO window for ${provider}.\n\n${data.handoff}`);
+        \\          pollReauth(provider, selector);
+        \\        }
+        \\      } catch (e) {
+        \\        console.error('Reauth failed:', e);
+        \\      }
+        \\    }
+        \\    function pollReauth(provider, selector) {
+        \\      const interval = setInterval(async () => {
+        \\        try {
+        \\          const response = await fetch(`/reauth/${provider}/${selector}`);
+        \\          const data = await response.json();
+        \\          if (data.state === 'success' || data.state === 'failed') {
+        \\            clearInterval(interval);
+        \\            location.reload();
+        \\          }
+        \\        } catch (e) {
+        \\          console.error('Poll failed:', e);
+        \\        }
+        \\      }, 2000);
+        \\    }
+        \\    // ~2s board-level health poll on the single status endpoint.
+        \\    let lastBoard = null;
+        \\    setInterval(async () => {
+        \\      try {
+        \\        const response = await fetch('/api/accounts');
+        \\        const text = await response.text();
+        \\        if (lastBoard !== null && lastBoard !== text) location.reload();
+        \\        lastBoard = text;
+        \\      } catch (e) {
+        \\        console.error('Board poll failed:', e);
+        \\      }
+        \\    }, 2000);
+        \\  </script>
+        \\</body>
+        \\</html>
+    );
+
+    return try buf.toOwnedSlice();
+}
+
+fn renderAccountsJson(allocator: std.mem.Allocator, accounts: []const AccountHealth) std.mem.Allocator.Error![]const u8 {
+    var buf = std.ArrayList(u8).init(allocator);
+    defer buf.deinit();
+
+    try buf.appendSlice("[");
+    for (accounts, 0..) |acc, idx| {
+        if (idx > 0) try buf.appendSlice(",");
+        try buf.appendSlice("{\"provider\":");
+        try std.json.stringify(acc.provider, .{}, buf.writer());
+        try buf.appendSlice(",\"route_state\":");
+        try std.json.stringify(acc.route_state, .{}, buf.writer());
+        try buf.appendSlice(",\"email_hint_masked\":");
+        if (acc.email_hint_masked) |hint| {
+            try std.json.stringify(hint, .{}, buf.writer());
+        } else {
+            try buf.appendSlice("null");
+        }
+        try buf.appendSlice(",\"reauth_in_progress\":");
+        try buf.appendSlice(if (acc.reauth_in_progress) "true" else "false");
+        try buf.appendSlice("}");
+    }
+    try buf.appendSlice("]");
+
+    return try buf.toOwnedSlice();
+}
+// ────────────────────────────────────────────────────────────────────────────
+// ROUTE HANDLERS
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Check if Host header is loopback-only.
+///
+/// ANTI-DNS-REBINDING: the host portion (everything before an optional ":port")
+/// must be EXACTLY "127.0.0.1" or "localhost". A prefix match is deliberately
+/// NOT used, because "127.0.0.1.evil.com" / "localhost.evil.com" would slip
+/// past a startsWith() check and resolve to an attacker-controlled address.
+fn isLoopbackHost(host_header: []const u8) bool {
+    if (host_header.len == 0) return false;
+
+    // Split off an optional ":port" suffix. IPv6 literals are intentionally
+    // unsupported here: this surface binds the IPv4 loopback only.
+    const host = if (std.mem.indexOfScalar(u8, host_header, ':')) |colon|
+        host_header[0..colon]
+    else
+        host_header;
+
+    if (std.mem.eql(u8, host, "127.0.0.1")) return true;
+    if (std.mem.eql(u8, host, "localhost")) return true;
+    return false;
+}
+
+/// Handle GET / (account health board).
+fn handleGetRoot(allocator: std.mem.Allocator, seams: Seams) std.mem.Allocator.Error!Response {
+    const accounts = try seams.listAccounts(allocator);
+    defer allocator.free(accounts);
+
+    const html = try renderAccountHealthHtml(allocator, accounts);
+
+    return Response{
+        .status = 200,
+        .content_type = "text/html; charset=utf-8",
+        .body = html,
+        .allocator = allocator,
+    };
+}
+
+/// Handle GET /api/accounts (JSON account list).
+fn handleGetApiAccounts(allocator: std.mem.Allocator, seams: Seams) std.mem.Allocator.Error!Response {
+    const accounts = try seams.listAccounts(allocator);
+    defer allocator.free(accounts);
+
+    const json = try renderAccountsJson(allocator, accounts);
+
+    return Response{
+        .status = 200,
+        .content_type = "application/json",
+        .body = json,
+        .allocator = allocator,
+    };
+}
+
+/// A parsed /reauth/{provider}/{selector} path. `selector` is either a numeric
+/// row index (from the board) or a literal account token (documented route for
+/// the coordinated follow-up). `selector_is_index` records which form was seen.
+const ReauthTarget = struct {
+    provider: []const u8,
+    selector: []const u8,
+    selector_is_index: bool,
+};
+
+fn jsonError(allocator: std.mem.Allocator, status: u16, comptime err: []const u8) std.mem.Allocator.Error!Response {
+    return Response{
+        .status = status,
+        .content_type = "application/json",
+        .body = try allocator.dupe(u8, "{\"error\":\"" ++ err ++ "\"}"),
+        .allocator = allocator,
+    };
+}
+
+/// Parse /reauth/{provider}/{selector}. Returns null on malformed input.
+fn parseReauthPath(path: []const u8) ?ReauthTarget {
+    const prefix = "/reauth/";
+    if (!std.mem.startsWith(u8, path, prefix)) return null;
+
+    const remaining = path[prefix.len..];
+    const slash = std.mem.indexOfScalar(u8, remaining, '/') orelse return null;
+
+    const provider = remaining[0..slash];
+    const selector = remaining[slash + 1 ..];
+    if (provider.len == 0 or selector.len == 0) return null;
+    // A selector that still contains a slash is not a single path segment.
+    if (std.mem.indexOfScalar(u8, selector, '/') != null) return null;
+
+    const is_index = blk: {
+        _ = std.fmt.parseInt(usize, selector, 10) catch break :blk false;
+        break :blk true;
+    };
+
+    return .{ .provider = provider, .selector = selector, .selector_is_index = is_index };
+}
+
+/// Resolve a parsed target to the (provider, account) pair the seams expect.
+/// When the selector is a numeric index, it is looked up against the seam
+/// account list so the raw account id never needs to traverse the UI/DOM.
+/// The returned account is owned by `account_list` (do not free separately).
+fn resolveReauthTarget(
+    target: ReauthTarget,
+    account_list: []const AccountHealth,
+) ?[]const u8 {
+    if (!target.selector_is_index) return target.selector;
+
+    const idx = std.fmt.parseInt(usize, target.selector, 10) catch return null;
+    if (idx >= account_list.len) return null;
+    const row = account_list[idx];
+    if (!std.mem.eql(u8, row.provider, target.provider)) return null;
+    return row.account;
+}
+
+/// Handle POST /reauth/{provider}/{selector} (enqueue/join reauth, single-flight).
+fn handlePostReauth(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    seams: Seams,
+) std.mem.Allocator.Error!Response {
+    const target = parseReauthPath(path) orelse
+        return jsonError(allocator, 400, "invalid_path");
+
+    const accounts = try seams.listAccounts(allocator);
+    defer allocator.free(accounts);
+
+    const account = resolveReauthTarget(target, accounts) orelse
+        return jsonError(allocator, 404, "unknown_account");
+
+    const handle = try seams.enqueueReauth(allocator, target.provider, account);
+    defer allocator.free(handle.job_id);
+    defer allocator.free(handle.handoff);
+
+    var json_buf = std.ArrayList(u8).init(allocator);
+    defer json_buf.deinit();
+
+    try json_buf.appendSlice("{\"job_id\":");
+    try std.json.stringify(handle.job_id, .{}, json_buf.writer());
+    try json_buf.appendSlice(",\"state\":\"pending\",\"handoff\":");
+    try std.json.stringify(handle.handoff, .{}, json_buf.writer());
+    try json_buf.appendSlice("}");
+
+    return Response{
+        .status = 200,
+        .content_type = "application/json",
+        .body = try json_buf.toOwnedSlice(),
+        .allocator = allocator,
+    };
+}
+
+/// Handle GET /reauth/{provider}/{selector} (poll job state).
+fn handleGetReauth(
+    allocator: std.mem.Allocator,
+    path: []const u8,
+    seams: Seams,
+) std.mem.Allocator.Error!Response {
+    const target = parseReauthPath(path) orelse
+        return jsonError(allocator, 400, "invalid_path");
+
+    const accounts = try seams.listAccounts(allocator);
+    defer allocator.free(accounts);
+
+    const account = resolveReauthTarget(target, accounts) orelse
+        return jsonError(allocator, 404, "unknown_account");
+
+    const state = try seams.pollReauth(allocator, target.provider, account);
+
+    var json_buf = std.ArrayList(u8).init(allocator);
+    defer json_buf.deinit();
+
+    try json_buf.writer().print(
+        "{{\"state\":\"{s}\"}}",
+        .{state.toString()},
+    );
+
+    return Response{
+        .status = 200,
+        .content_type = "application/json",
+        .body = try json_buf.toOwnedSlice(),
+        .allocator = allocator,
+    };
+}
+
+/// Return the value of `key` in a url-encoded query string, or null if absent.
+/// (No percent-decoding here; presence/shape validation only. The injected
+/// reauth controller is responsible for decoding + verifying the values.)
+fn queryParam(query: []const u8, key: []const u8) ?[]const u8 {
+    var it = std.mem.splitScalar(u8, query, '&');
+    while (it.next()) |pair| {
+        if (pair.len == 0) continue;
+        const eq = std.mem.indexOfScalar(u8, pair, '=') orelse continue;
+        if (std.mem.eql(u8, pair[0..eq], key)) return pair[eq + 1 ..];
+    }
+    return null;
+}
+
+/// Handle GET /callback?code=...&state=... (loopback OAuth redirect target).
+///
+/// Validates PRESENCE of both `code` and `state` (anti-CSRF/state-binding is
+/// the injected reauth controller's job; this surface only gates malformed
+/// callbacks). On success it hands off to the controller — which is a
+/// coordinated follow-up — so for now a validated callback returns 200 and a
+/// missing param returns 400.
+fn handleGetCallback(allocator: std.mem.Allocator, query: []const u8) std.mem.Allocator.Error!Response {
+    const code = queryParam(query, "code");
+    const state = queryParam(query, "state");
+
+    if (code == null or state == null or code.?.len == 0 or state.?.len == 0) {
+        return jsonError(allocator, 400, "missing_code_or_state");
+    }
+
+    // Follow-up: seams.handleCallback(code, state) -> drive reauth controller.
+    const body = try allocator.dupe(u8, "OK");
+    return Response{
+        .status = 200,
+        .content_type = "text/plain",
+        .body = body,
+        .allocator = allocator,
+    };
+}
+
+/// Handle GET /healthz (liveness).
+fn handleGetHealthz(allocator: std.mem.Allocator) std.mem.Allocator.Error!Response {
+    const body = try allocator.dupe(u8, "OK");
+    return Response{
+        .status = 200,
+        .content_type = "text/plain",
+        .body = body,
+        .allocator = allocator,
+    };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// MAIN REQUEST ROUTER
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Route an HTTP request and return a response.
+/// Pure function; no real socket I/O. Host header is checked for loopback-only.
+///
+/// `raw_target` is the request-line target: a path with an optional
+/// "?query" suffix (e.g. "/callback?code=x&state=y"). Routing matches on the
+/// path portion; the query is handed to handlers that need it.
+pub fn routeRequest(
+    allocator: std.mem.Allocator,
+    method: HttpMethod,
+    raw_target: []const u8,
+    host_header: []const u8,
+    seams: Seams,
+) std.mem.Allocator.Error!Response {
+    // SECURITY: Loopback-only check (anti-DNS-rebinding). Checked FIRST so a
+    // non-loopback Host never reaches any account-bearing handler.
+    if (!isLoopbackHost(host_header)) {
+        const body = try allocator.dupe(u8, "");
+        return Response{
+            .status = 403,
+            .content_type = "text/plain",
+            .body = body,
+            .allocator = allocator,
+        };
+    }
+
+    // Split path from query.
+    const path, const query = blk: {
+        if (std.mem.indexOfScalar(u8, raw_target, '?')) |q|
+            break :blk .{ raw_target[0..q], raw_target[q + 1 ..] };
+        break :blk .{ raw_target, "" };
+    };
+
+    // Route matching.
+    if (std.mem.eql(u8, path, "/")) {
+        if (method == .GET) return try handleGetRoot(allocator, seams);
+    }
+
+    if (std.mem.eql(u8, path, "/api/accounts")) {
+        if (method == .GET) return try handleGetApiAccounts(allocator, seams);
+    }
+
+    if (std.mem.startsWith(u8, path, "/reauth/")) {
+        if (method == .POST) return try handlePostReauth(allocator, path, seams);
+        if (method == .GET) return try handleGetReauth(allocator, path, seams);
+    }
+
+    if (std.mem.eql(u8, path, "/callback")) {
+        if (method == .GET) return try handleGetCallback(allocator, query);
+    }
+
+    if (std.mem.eql(u8, path, "/healthz")) {
+        if (method == .GET) return try handleGetHealthz(allocator);
+    }
+
+    // 404.
+    const body = try allocator.dupe(u8, "");
+    return Response{
+        .status = 404,
+        .content_type = "text/plain",
+        .body = body,
+        .allocator = allocator,
+    };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// THIN HTTP LISTENER (injected wrapper around routeRequest)
+//
+// This is the only part that touches a real socket. It is intentionally thin
+// and is NOT exercised by the unit tests (those drive routeRequest directly
+// with synthetic requests + fake seams). Binding the real account/reauth seams
+// and wiring this into the daemon are coordinated follow-ups.
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Minimal parse of an HTTP/1.x request: method, target, and Host header.
+/// Returns null if the request line is malformed or the method is unsupported.
+pub const ParsedRequest = struct {
+    method: HttpMethod,
+    target: []const u8,
+    host: []const u8,
+};
+
+pub fn parseRequest(raw: []const u8) ?ParsedRequest {
+    var lines = std.mem.splitSequence(u8, raw, "\r\n");
+    const request_line = lines.next() orelse return null;
+
+    var parts = std.mem.splitScalar(u8, request_line, ' ');
+    const method_str = parts.next() orelse return null;
+    const target = parts.next() orelse return null;
+    const method = HttpMethod.fromString(method_str) orelse return null;
+
+    var host: []const u8 = "";
+    while (lines.next()) |line| {
+        if (line.len == 0) break; // end of headers
+        const colon = std.mem.indexOfScalar(u8, line, ':') orelse continue;
+        const name = std.mem.trim(u8, line[0..colon], " \t");
+        if (std.ascii.eqlIgnoreCase(name, "host")) {
+            host = std.mem.trim(u8, line[colon + 1 ..], " \t");
+        }
+    }
+
+    return .{ .method = method, .target = target, .host = host };
+}
+
+fn statusText(status: u16) []const u8 {
+    return switch (status) {
+        200 => "OK",
+        400 => "Bad Request",
+        403 => "Forbidden",
+        404 => "Not Found",
+        else => "OK",
+    };
+}
+
+/// Serialize a Response into an HTTP/1.1 wire message. Caller owns the result.
+pub fn serializeResponse(allocator: std.mem.Allocator, resp: Response) std.mem.Allocator.Error![]const u8 {
+    var buf = std.ArrayList(u8).init(allocator);
+    defer buf.deinit();
+    try buf.writer().print(
+        "HTTP/1.1 {d} {s}\r\nContent-Type: {s}\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n",
+        .{ resp.status, statusText(resp.status), resp.content_type, resp.body.len },
+    );
+    try buf.appendSlice(resp.body);
+    return buf.toOwnedSlice();
+}
+
+/// Bind 127.0.0.1:port (loopback ONLY — never a non-loopback address) and serve
+/// requests by delegating each one to routeRequest. Blocking, one connection at
+/// a time; the operator console is single-user and low-traffic by design.
+///
+/// NOTE: not covered by unit tests (real socket I/O). Kept here so the listener
+/// seam is explicit; the daemon wiring + real seams are a coordinated follow-up.
+pub fn serve(allocator: std.mem.Allocator, port: u16, seams: Seams) !void {
+    const loopback = try std.net.Address.parseIp4("127.0.0.1", port);
+    var server = try loopback.listen(.{ .reuse_address = true });
+    defer server.deinit();
+
+    var read_buf: [16 * 1024]u8 = undefined;
+    while (true) {
+        const conn = try server.accept();
+        defer conn.stream.close();
+
+        const n = conn.stream.read(&read_buf) catch continue;
+        const parsed = parseRequest(read_buf[0..n]) orelse continue;
+
+        const resp = routeRequest(allocator, parsed.method, parsed.target, parsed.host, seams) catch continue;
+        defer resp.deinit();
+
+        const wire = serializeResponse(allocator, resp) catch continue;
+        defer allocator.free(wire);
+        _ = conn.stream.writeAll(wire) catch continue;
+    }
+}

--- a/src/enroll/web_ui_tests.zig
+++ b/src/enroll/web_ui_tests.zig
@@ -1,0 +1,487 @@
+const std = @import("std");
+const web_ui = @import("web_ui.zig");
+
+const test_gpa = std.testing.allocator;
+
+// Ensure every declaration in web_ui.zig is analyzed/compiled by the test run.
+test {
+    std.testing.refAllDeclsRecursive(web_ui);
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// FAKE SEAMS FOR TESTING
+//
+// A fake token/secret is seeded into the account data so tests can assert it
+// NEVER appears in any rendered output (HTML or JSON). The masked email hint is
+// the ONLY identity-ish field allowed in output.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// A secret that must never leak into UI/JSON output. Tests assert its absence.
+const SEEDED_SECRET = "sk-live-DEADBEEFsecrettoken0xFEEDFACE";
+/// A raw account id that must never leak into UI/JSON output either.
+const SEEDED_ACCOUNT_ID = "raw-account-id-9f3c2b-DO-NOT-LEAK";
+
+var test_accounts_data: [3]web_ui.AccountHealth = undefined;
+var test_accounts_len: usize = 0;
+
+fn fakeListAccounts(allocator: std.mem.Allocator) ![]web_ui.AccountHealth {
+    const result = try allocator.alloc(web_ui.AccountHealth, test_accounts_len);
+    @memcpy(result, test_accounts_data[0..test_accounts_len]);
+    return result;
+}
+
+var fake_reauth_state: web_ui.ReauthState = .pending;
+// Records the (provider, account) the most recent enqueue/poll was driven with,
+// so index-selector resolution can be asserted.
+var last_enqueue_provider: []const u8 = "";
+var last_enqueue_account: []const u8 = "";
+
+fn fakeEnqueueReauth(allocator: std.mem.Allocator, provider: []const u8, account: []const u8) !web_ui.ReauthJobHandle {
+    last_enqueue_provider = provider;
+    last_enqueue_account = account;
+    const job_id = try allocator.dupe(u8, "job-test-123");
+    // The handoff is operator-facing and intentionally carries NO secret token.
+    const handoff = try allocator.dupe(u8, "device code ABC-123 -> https://verify.example.com");
+    fake_reauth_state = .awaiting_device_code;
+    return .{ .job_id = job_id, .handoff = handoff };
+}
+
+fn fakePollReauth(allocator: std.mem.Allocator, provider: []const u8, account: []const u8) !web_ui.ReauthState {
+    _ = allocator;
+    last_enqueue_provider = provider;
+    last_enqueue_account = account;
+    return fake_reauth_state;
+}
+
+fn fakeNow() i64 {
+    return 1234567890;
+}
+
+fn makeTestSeams() web_ui.Seams {
+    return .{
+        .listAccounts = &fakeListAccounts,
+        .enqueueReauth = &fakeEnqueueReauth,
+        .pollReauth = &fakePollReauth,
+        .now = &fakeNow,
+    };
+}
+
+/// Assert neither the seeded secret nor the raw account id appears in `body`.
+fn assertNoSecretLeak(body: []const u8) !void {
+    try std.testing.expect(std.mem.indexOf(u8, body, SEEDED_SECRET) == null);
+    try std.testing.expect(std.mem.indexOf(u8, body, SEEDED_ACCOUNT_ID) == null);
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// ROUTING + RENDERING TESTS
+// ════════════════════════════════════════════════════════════════════════════
+
+test "GET / renders HTML dashboard" {
+    test_accounts_data[0] = .{
+        .provider = "claude",
+        .account = SEEDED_ACCOUNT_ID,
+        .route_state = "available",
+        .email_hint_masked = "c***@example.com",
+        .reauth_in_progress = false,
+    };
+    test_accounts_len = 1;
+
+    const response = try web_ui.routeRequest(test_gpa, .GET, "/", "127.0.0.1:8080", makeTestSeams());
+    defer response.deinit();
+
+    try std.testing.expectEqual(@as(u16, 200), response.status);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "<html") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "oauth-mux") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "claude") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "c***@example.com") != null);
+    try assertNoSecretLeak(response.body);
+}
+
+test "GET /api/accounts returns JSON with provider and state" {
+    test_accounts_data[0] = .{
+        .provider = "codex",
+        .account = SEEDED_ACCOUNT_ID,
+        .route_state = "credential_unavailable",
+        .email_hint_masked = "s***@internal.com",
+        .reauth_in_progress = true,
+    };
+    test_accounts_len = 1;
+
+    const response = try web_ui.routeRequest(test_gpa, .GET, "/api/accounts", "localhost:8080", makeTestSeams());
+    defer response.deinit();
+
+    try std.testing.expectEqual(@as(u16, 200), response.status);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "\"provider\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "\"credential_unavailable\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "\"reauth_in_progress\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "codex") != null);
+    // REDACTION: no "account" field key, no raw account id, no token.
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "\"account\"") == null);
+    try assertNoSecretLeak(response.body);
+}
+
+test "REDACTION: seeded token never appears in HTML or JSON" {
+    // Stuff the secret into every plausible carrier field to prove the render
+    // path emits only the allow-list. email_hint_masked is intentionally the
+    // only identity field; we still keep it masked.
+    test_accounts_data[0] = .{
+        .provider = "claude",
+        .account = SEEDED_ACCOUNT_ID,
+        .route_state = "auth_permanently_failed",
+        .email_hint_masked = "w***@company.com",
+        .reauth_in_progress = false,
+    };
+    test_accounts_len = 1;
+
+    const html = try web_ui.routeRequest(test_gpa, .GET, "/", "127.0.0.1", makeTestSeams());
+    defer html.deinit();
+    try assertNoSecretLeak(html.body);
+
+    const json = try web_ui.routeRequest(test_gpa, .GET, "/api/accounts", "127.0.0.1", makeTestSeams());
+    defer json.deinit();
+    try assertNoSecretLeak(json.body);
+    // The masked hint is allowed; the raw account id key is not.
+    try std.testing.expect(std.mem.indexOf(u8, json.body, "w***@company.com") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json.body, "\"account\"") == null);
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// SECURITY: ANTI-DNS-REBINDING (HARD INVARIANT)
+// ════════════════════════════════════════════════════════════════════════════
+
+test "403 Forbidden for non-loopback Host header" {
+    test_accounts_len = 0;
+    const response = try web_ui.routeRequest(test_gpa, .GET, "/", "evil.example.com:8080", makeTestSeams());
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 403), response.status);
+}
+
+test "403 for DNS-rebinding suffix-bypass attempts" {
+    test_accounts_len = 0;
+    // These would all pass a naive startsWith() check but must be rejected.
+    const hostile = [_][]const u8{
+        "127.0.0.1.evil.com",
+        "127.0.0.1.evil.com:8080",
+        "localhost.evil.com",
+        "localhost.evil.com:8080",
+        "127.0.0.1x",
+        "localhostx",
+        "10.0.0.5",
+        "0.0.0.0",
+        "",
+        "example.com",
+    };
+    for (hostile) |h| {
+        const response = try web_ui.routeRequest(test_gpa, .GET, "/", h, makeTestSeams());
+        defer response.deinit();
+        try std.testing.expectEqual(@as(u16, 403), response.status);
+    }
+}
+
+test "loopback hosts accepted with and without port" {
+    test_accounts_len = 0;
+    const ok = [_][]const u8{ "127.0.0.1", "127.0.0.1:8080", "localhost", "localhost:3000" };
+    for (ok) |h| {
+        const response = try web_ui.routeRequest(test_gpa, .GET, "/healthz", h, makeTestSeams());
+        defer response.deinit();
+        try std.testing.expectEqual(@as(u16, 200), response.status);
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// REAUTH (single-flight enqueue, poll, index-selector resolution)
+// ════════════════════════════════════════════════════════════════════════════
+
+test "POST /reauth/{provider}/{account} enqueues job" {
+    // Literal-account selector form (documented follow-up route).
+    test_accounts_len = 0;
+    const response = try web_ui.routeRequest(test_gpa, .POST, "/reauth/claude/user-123", "127.0.0.1:8080", makeTestSeams());
+    defer response.deinit();
+
+    try std.testing.expectEqual(@as(u16, 200), response.status);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "\"job_id\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "job-test-123") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "\"handoff\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "\"state\":\"pending\"") != null);
+    try std.testing.expectEqualStrings("claude", last_enqueue_provider);
+    try std.testing.expectEqualStrings("user-123", last_enqueue_account);
+}
+
+test "POST /reauth index selector resolves to real account server-side" {
+    // The board emits a numeric index; the handler resolves it to the raw
+    // account via the seam list. The raw account id is what the seam receives,
+    // but it never appears in any rendered output (asserted elsewhere).
+    test_accounts_data[0] = .{
+        .provider = "claude",
+        .account = SEEDED_ACCOUNT_ID,
+        .route_state = "rate_limited",
+        .email_hint_masked = "c***@example.com",
+        .reauth_in_progress = false,
+    };
+    test_accounts_len = 1;
+
+    const response = try web_ui.routeRequest(test_gpa, .POST, "/reauth/claude/0", "127.0.0.1:8080", makeTestSeams());
+    defer response.deinit();
+
+    try std.testing.expectEqual(@as(u16, 200), response.status);
+    try std.testing.expectEqualStrings("claude", last_enqueue_provider);
+    try std.testing.expectEqualStrings(SEEDED_ACCOUNT_ID, last_enqueue_account);
+    // The response handed to the operator carries no secret/account leak.
+    try assertNoSecretLeak(response.body);
+}
+
+test "POST /reauth index out of range returns 404" {
+    test_accounts_len = 0;
+    const response = try web_ui.routeRequest(test_gpa, .POST, "/reauth/claude/7", "127.0.0.1:8080", makeTestSeams());
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 404), response.status);
+}
+
+test "POST /reauth index provider mismatch returns 404" {
+    test_accounts_data[0] = .{
+        .provider = "claude",
+        .account = SEEDED_ACCOUNT_ID,
+        .route_state = "rate_limited",
+        .email_hint_masked = "c***@example.com",
+        .reauth_in_progress = false,
+    };
+    test_accounts_len = 1;
+    // index 0 exists, but its provider is "claude", not "codex".
+    const response = try web_ui.routeRequest(test_gpa, .POST, "/reauth/codex/0", "127.0.0.1:8080", makeTestSeams());
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 404), response.status);
+}
+
+test "POST /reauth malformed path returns 400" {
+    test_accounts_len = 0;
+    const bad = [_][]const u8{ "/reauth/", "/reauth/claude", "/reauth/claude/", "/reauth//x" };
+    for (bad) |p| {
+        const response = try web_ui.routeRequest(test_gpa, .POST, p, "127.0.0.1:8080", makeTestSeams());
+        defer response.deinit();
+        try std.testing.expectEqual(@as(u16, 400), response.status);
+    }
+}
+
+test "GET /reauth/{provider}/{account} polls job state" {
+    test_accounts_len = 0;
+    fake_reauth_state = .in_progress;
+    const response = try web_ui.routeRequest(test_gpa, .GET, "/reauth/claude/user-123", "127.0.0.1:8080", makeTestSeams());
+    defer response.deinit();
+
+    try std.testing.expectEqual(@as(u16, 200), response.status);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "\"in_progress\"") != null);
+}
+
+test "reauth state transitions rendered in poll responses" {
+    test_accounts_len = 0;
+    const states = [_]web_ui.ReauthState{
+        .pending,
+        .awaiting_device_code,
+        .awaiting_user_confirmation,
+        .in_progress,
+        .success,
+        .failed,
+    };
+    for (states) |state| {
+        fake_reauth_state = state;
+        const response = try web_ui.routeRequest(test_gpa, .GET, "/reauth/test/literal-acct", "127.0.0.1:8080", makeTestSeams());
+        defer response.deinit();
+        try std.testing.expectEqual(@as(u16, 200), response.status);
+        try std.testing.expect(std.mem.indexOf(u8, response.body, state.toString()) != null);
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// CALLBACK
+// ════════════════════════════════════════════════════════════════════════════
+
+test "GET /callback with code+state returns 200" {
+    test_accounts_len = 0;
+    const response = try web_ui.routeRequest(test_gpa, .GET, "/callback?code=abc123&state=xyz789", "127.0.0.1:8080", makeTestSeams());
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 200), response.status);
+}
+
+test "GET /callback missing code or state returns 400" {
+    test_accounts_len = 0;
+    const bad = [_][]const u8{
+        "/callback",
+        "/callback?code=abc123",
+        "/callback?state=xyz789",
+        "/callback?code=&state=xyz789",
+        "/callback?code=abc123&state=",
+    };
+    for (bad) |target| {
+        const response = try web_ui.routeRequest(test_gpa, .GET, target, "127.0.0.1:8080", makeTestSeams());
+        defer response.deinit();
+        try std.testing.expectEqual(@as(u16, 400), response.status);
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// LIVENESS + ROUTING EDGES
+// ════════════════════════════════════════════════════════════════════════════
+
+test "GET /healthz returns 200 OK" {
+    test_accounts_len = 0;
+    const response = try web_ui.routeRequest(test_gpa, .GET, "/healthz", "127.0.0.1:8080", makeTestSeams());
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 200), response.status);
+    try std.testing.expect(std.mem.eql(u8, response.body, "OK"));
+}
+
+test "GET /nonexistent returns 404" {
+    test_accounts_len = 0;
+    const response = try web_ui.routeRequest(test_gpa, .GET, "/nonexistent", "127.0.0.1:8080", makeTestSeams());
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 404), response.status);
+}
+
+test "POST to GET-only route falls through to 404" {
+    test_accounts_len = 0;
+    const response = try web_ui.routeRequest(test_gpa, .POST, "/healthz", "127.0.0.1:8080", makeTestSeams());
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 404), response.status);
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// BOARD CONTENT
+// ════════════════════════════════════════════════════════════════════════════
+
+test "multiple accounts return provider and route_state" {
+    test_accounts_data[0] = .{
+        .provider = "claude",
+        .account = "account-1",
+        .route_state = "available",
+        .email_hint_masked = "c***@example.com",
+        .reauth_in_progress = false,
+    };
+    test_accounts_data[1] = .{
+        .provider = "codex",
+        .account = "account-2",
+        .route_state = "credential_unavailable",
+        .email_hint_masked = "d***@example.com",
+        .reauth_in_progress = true,
+    };
+    test_accounts_len = 2;
+
+    const response = try web_ui.routeRequest(test_gpa, .GET, "/api/accounts", "127.0.0.1:8080", makeTestSeams());
+    defer response.deinit();
+
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "\"claude\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "\"codex\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "\"available\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "\"credential_unavailable\"") != null);
+}
+
+test "HTML shows re-login + identity reminder only for accounts needing reauth" {
+    test_accounts_data[0] = .{
+        .provider = "claude",
+        .account = "good-user",
+        .route_state = "available",
+        .email_hint_masked = "g***@example.com",
+        .reauth_in_progress = false,
+    };
+    test_accounts_data[1] = .{
+        .provider = "codex",
+        .account = "bad-user",
+        .route_state = "auth_permanently_failed",
+        .email_hint_masked = "b***@example.com",
+        .reauth_in_progress = false,
+    };
+    test_accounts_len = 2;
+
+    const response = try web_ui.routeRequest(test_gpa, .GET, "/", "127.0.0.1:8080", makeTestSeams());
+    defer response.deinit();
+    const body = response.body;
+
+    try std.testing.expect(std.mem.indexOf(u8, body, "g***@example.com") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "b***@example.com") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "claude") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "codex") != null);
+    // Exactly one Re-login button: only the failed account gets one.
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, body, ">Re-login</button>"));
+    // The cookieless private-window reminder is server-rendered.
+    try std.testing.expect(std.mem.indexOf(u8, body, "PRIVATE / INCOGNITO") != null);
+}
+
+test "HTML shows in-progress spinner when a job holds the account" {
+    test_accounts_data[0] = .{
+        .provider = "claude",
+        .account = "busy-user",
+        .route_state = "revalidation_needed",
+        .email_hint_masked = "b***@example.com",
+        .reauth_in_progress = true,
+    };
+    test_accounts_len = 1;
+
+    const response = try web_ui.routeRequest(test_gpa, .GET, "/", "127.0.0.1:8080", makeTestSeams());
+    defer response.deinit();
+    const body = response.body;
+
+    try std.testing.expect(std.mem.indexOf(u8, body, "spinner") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "data-reauth=\"in_progress\"") != null);
+    // No re-login button while a job already holds the account.
+    try std.testing.expectEqual(@as(usize, 0), std.mem.count(u8, body, ">Re-login</button>"));
+}
+
+test "empty account list renders empty-state board" {
+    test_accounts_len = 0;
+    const response = try web_ui.routeRequest(test_gpa, .GET, "/", "127.0.0.1:8080", makeTestSeams());
+    defer response.deinit();
+    try std.testing.expectEqual(@as(u16, 200), response.status);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "No accounts configured") != null);
+}
+
+test "empty account list returns empty JSON array" {
+    test_accounts_len = 0;
+    const response = try web_ui.routeRequest(test_gpa, .GET, "/api/accounts", "127.0.0.1:8080", makeTestSeams());
+    defer response.deinit();
+    try std.testing.expectEqualStrings("[]", response.body);
+}
+
+test "HttpMethod.fromString parses GET/POST and rejects others" {
+    try std.testing.expectEqual(web_ui.HttpMethod.GET, web_ui.HttpMethod.fromString("GET").?);
+    try std.testing.expectEqual(web_ui.HttpMethod.POST, web_ui.HttpMethod.fromString("POST").?);
+    try std.testing.expect(web_ui.HttpMethod.fromString("DELETE") == null);
+    try std.testing.expect(web_ui.HttpMethod.fromString("get") == null);
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// LISTENER HELPERS (pure parts of the thin wrapper; serve() itself is untested)
+// ════════════════════════════════════════════════════════════════════════════
+
+test "parseRequest extracts method, target, and Host header" {
+    const raw = "GET /api/accounts HTTP/1.1\r\nHost: 127.0.0.1:8080\r\nAccept: */*\r\n\r\n";
+    const parsed = web_ui.parseRequest(raw).?;
+    try std.testing.expectEqual(web_ui.HttpMethod.GET, parsed.method);
+    try std.testing.expectEqualStrings("/api/accounts", parsed.target);
+    try std.testing.expectEqualStrings("127.0.0.1:8080", parsed.host);
+}
+
+test "parseRequest is case-insensitive for the Host header name" {
+    const raw = "POST /reauth/claude/0 HTTP/1.1\r\nhOsT: localhost\r\n\r\n";
+    const parsed = web_ui.parseRequest(raw).?;
+    try std.testing.expectEqual(web_ui.HttpMethod.POST, parsed.method);
+    try std.testing.expectEqualStrings("localhost", parsed.host);
+}
+
+test "parseRequest rejects unsupported methods and junk" {
+    try std.testing.expect(web_ui.parseRequest("DELETE / HTTP/1.1\r\n\r\n") == null);
+    try std.testing.expect(web_ui.parseRequest("garbage") == null);
+}
+
+test "serializeResponse emits an HTTP/1.1 message with content-length" {
+    const resp = web_ui.Response{
+        .status = 404,
+        .content_type = "text/plain",
+        .body = try test_gpa.dupe(u8, "nope"),
+        .allocator = test_gpa,
+    };
+    defer resp.deinit();
+    const wire = try web_ui.serializeResponse(test_gpa, resp);
+    defer test_gpa.free(wire);
+    try std.testing.expect(std.mem.startsWith(u8, wire, "HTTP/1.1 404 Not Found\r\n"));
+    try std.testing.expect(std.mem.indexOf(u8, wire, "Content-Length: 4\r\n") != null);
+    try std.testing.expect(std.mem.endsWith(u8, wire, "\r\n\r\nnope"));
+}


### PR DESCRIPTION
The `127.0.0.1` operator console for reauth — increment paired with the engine (#344). **New files only**, self-contained over injected seams; zero edits to existing code (deconflicted from the parallel core work).

## What
A server-rendered (no JS build) account-health board + live re-login stepper. `routeRequest(method, path, host, body, seams)` is a **pure function** (no socket in unit tests); the thin `serve()` listener is a documented, untested-by-design wrapper.

6 routes: `GET /` (health board + Re-login), `GET /api/accounts` (no-spend JSON), `POST /reauth/{p}/{a}` (enqueue/join a job → handoff), `GET /reauth/{p}/{a}` (poll state), `GET /callback` (loopback redirect target), `GET /healthz`.

## Security invariants (tested)
- **Anti-DNS-rebinding:** Host must **exactly** equal `127.0.0.1`/`localhost` (optional `:port`); suffix-bypass (`127.0.0.1.evil.com`) → **403**, checked before any account-bearing handler. (Fixed a real `startsWith` bypass from the draft.)
- **Redaction allow-list:** a seeded token **and** a seeded raw `account_id` provably never appear in HTML or JSON; the board uses a **non-identifying row index** (no `account_id` in the DOM), resolved server-side via the seam; only provider + masked email + route_state render.
- **User-mediated re-login:** handlers only enqueue/poll + return the device-code/URL handoff (with the "use a PRIVATE/incognito window" reminder + the intended identity); the UI never completes upstream login. `/callback` returns 400 unless `code`+`state` present.

## Verified
`nix develop --command zig test src/enroll/web_ui_tests.zig` → **All 29 tests passed** (leak-checked). Reproduced on the latest `main` (`c4a7eb3`). Self-contained: `std` + local seam types only — no `@import` of existing `src`, no `build_options`.

## To wire (coordinated follow-ups, shared files)
- `build.zig` `test-webui` step:
```zig
const webui_tests = b.addTest(.{ .root_source_file = b.path("src/enroll/web_ui_tests.zig"), .target = target, .optimize = optimize });
const run_webui_tests = b.addRunArtifact(webui_tests);
b.step("test-webui", "Run operator web UI unit tests").dependOn(&run_webui_tests.step);
test_step.dependOn(&run_webui_tests.step);
```
- Bind the seams (`listAccounts`/`enqueueReauth`/`pollReauth`) to live account-health data + the ReauthJob queue from the engine (#344); wire `serve()` into the daemon; drive `/callback` through the reauth controller.

Part of omux Foundations · reauth-backend-ui (TIN-1808). Pairs with #344 (engine).