### PR TITLE
Add Codex proxy capability degradation

### DIFF
--- a/examples/codex-max.config.json
+++ b/examples/codex-max.config.json
@@ -46,9 +46,13 @@
     "codex-max": {
       "providers": [
         "codex:max-1#codex-max",
+        "codex:max-1#codex-mini",
         "codex:max-2#codex-max",
-        "codex:max-3#codex-max"
+        "codex:max-2#codex-mini",
+        "codex:max-3#codex-max",
+        "codex:max-3#codex-mini"
       ],
+      "capability_degradation_chain": ["codex-mini"],
       "strategy": "health-weighted",
       "affinity_ttl_minutes": 20
     },

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -1150,7 +1150,7 @@ expect_contains "$broker_route_explain_text_after_drill" 'next: revalidate exhau
 broker_stay_afloat_text_after_drill="$(PATH="$broker_session_bin:$PATH" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" stay-afloat --once --profile codex-max --capability codex-max)"
 expect_contains "$broker_stay_afloat_text_after_drill" 'next: revalidate exhausted routes, enroll another Codex account, or wait for quota reset' "stay-afloat text after drill includes Codex risk actions"
 
-printf 'e2e: expired Codex quota windows surface revalidation-needed\n'
+printf 'e2e: expired Codex quota windows recover during route planning\n'
 expired_quota_state="$tmp/broker-expired-quota-state"
 mkdir -p "$expired_quota_state"
 cat >"$expired_quota_state/health.json" <<'EOF'
@@ -1195,13 +1195,12 @@ cat >"$expired_quota_state/health.json" <<'EOF'
 }
 EOF
 expired_quota_plan="$(PATH="$broker_session_bin:$PATH" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$expired_quota_state" "$bin" codex broker-session-plan --profile codex-max --capability codex-max --json)"
-expect_contains "$expired_quota_plan" '"selected":{"provider":"codex","account":"max-3"' "expired quota plan keeps stale routes blocked until revalidated"
-expect_contains "$expired_quota_plan" '"skip_reason":"revalidation_needed"' "expired quota plan distinguishes stale quota block"
-expect_contains "$expired_quota_plan" '"kind":"revalidation_needed"' "expired quota plan emits revalidation-needed route action"
-expect_contains "$expired_quota_plan" '"revalidation_needed":true' "expired quota liveness marks revalidation needed"
-expect_contains "$expired_quota_plan" '"reset_window_state":"expired"' "expired quota liveness marks reset window expired"
-expect_contains "$expired_quota_plan" '"route_role":"revalidation_needed"' "expired quota plan uses explicit route role"
-expect_contains "$expired_quota_plan" '"resilience_actions":[{"kind":"revalidate_exhausted_routes"' "expired quota plan still recommends spend-gated revalidation"
+expect_contains "$expired_quota_plan" '"selected":{"provider":"codex","account":"max-1"' "expired quota plan revives first expired quota route"
+expect_contains "$expired_quota_plan" '"selectable_routes":3' "expired quota plan treats expired quota routes as selectable"
+expect_contains "$expired_quota_plan" '"blocked_broker_routes":0' "expired quota plan has no stale quota blockers"
+expect_contains "$expired_quota_plan" '"resilience_actions":[]' "expired quota plan does not require manual revalidation"
+expect_not_contains "$expired_quota_plan" '"skip_reason":"revalidation_needed"' "expired quota plan does not report stale quota block"
+expect_not_contains "$expired_quota_plan" '"reset_window_state":"expired"' "expired quota liveness no longer exposes expired reset as blocked"
 
 printf 'e2e: codex broker-session-smoke requires explicit confirmation before starting app-server\n'
 broker_session_smoke_prompt="$(OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex broker-session-smoke --profile codex-max --capability codex-max --json)"

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -164,9 +164,9 @@ jq -e '
   and .ok == false
   and .scope.profile == "codex-max"
   and .scope.capability == "codex-max"
-  and .accounts == 3
-  and .action_needed_accounts == 3
-  and (.route_reports | length) == 3
+  and .accounts == 6
+  and .action_needed_accounts == 6
+  and (.route_reports | length) == 6
   and all(.route_reports[]; .provider == "codex" and .capability == "codex-max" and .ready == false)
 ' "$runtime_doctor_scoped" >/dev/null
 expect_not_contains "$(cat "$runtime_doctor_scoped")" "$store_root/max-1" "scoped runtime doctor does not print concrete Codex store paths"
@@ -248,7 +248,7 @@ repair_plan_json="$tmp/repair-plan-codex-max.json"
 run_json "$repair_plan_json" repair-plan --profile codex-max --capability codex-max --json
 jq -e '
   .profile == "codex-max"
-  and (.routes | length) == 3
+  and (.routes | length) == 6
   and all(.routes[]; .provider == "codex" and .capability == "codex-max" and .action.mutating == false)
   and all(.routes[]; .action.kind == "fix_runtime" or .action.kind == "probe_needed" or .action.kind == "revalidation_needed" or .action.kind == "none" or .action.kind == "wait_and_retry" or .action.kind == "wait_for_quota" or .action.kind == "wait_for_cooldown")
   and all(.routes[]; if .action.kind == "fix_runtime" then
@@ -267,7 +267,7 @@ jq -e '
   and .capability == "codex-max"
   and .ok == false
   and .selected == null
-  and (.routes | length) == 3
+  and (.routes | length) == 6
   and all(.routes[]; .provider == "codex" and .capability == "codex-max" and .action.mutating == false)
   and all(.routes[]; .action.kind == "fix_runtime" or .action.kind == "probe_needed")
   and all(.routes[]; if .action.kind == "fix_runtime" then
@@ -302,19 +302,19 @@ jq -e '
   and (.environment.omux_codex_config_home_present | type) == "boolean"
   and .environment.path_printed == false
   and .ok == false
-  and .route_summary.routes_total == 3
+  and .route_summary.routes_total == 6
   and .route_summary.selectable_routes == 0
   and (.blocked_route_reasons | length) == 1
-  and (.blocked_route_reasons[] | select(.reason == "auth_broker_unready" and .count == 3))
+  and (.blocked_route_reasons[] | select(.reason == "auth_broker_unready" and .count == 6))
   and .repair_summary.route_repair_required == true
   and .repair_summary.agent_safe_inspection_available == true
-  and .repair_summary.blocked_routes == 3
+  and .repair_summary.blocked_routes == 6
   and .repair_summary.dominant_blocker == "auth_broker_unready"
-  and .repair_summary.dominant_blocker_count == 3
-  and .repair_summary.auth_broker_unready_routes == 3
+  and .repair_summary.dominant_blocker_count == 6
+  and .repair_summary.auth_broker_unready_routes == 6
   and .repair_summary.revalidation_needed_routes == 0
   and .repair_summary.user_handoff_required == false
-  and (.blocked_routes | length) == 3
+  and (.blocked_routes | length) == 6
   and all(.blocked_routes[]; .provider == "codex" and .capability == "codex-max" and .selectable == false and .broker_ready == false and .blocked_reason == "auth_broker_unready" and .action.mutating == false)
   and (.next_actions | length) == 1
   and (.next_actions | index("oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json") != null)
@@ -355,7 +355,7 @@ jq -e '
   and .executed == false
   and .afloat == false
   and .selected == null
-  and (.routes | length) == 3
+  and (.routes | length) == 6
   and all(.routes[]; .route.provider == "codex" and .route.capability == "codex-max")
   and all(.routes[]; if .route.action.kind == "fix_runtime" then
     .route.action.command == null
@@ -380,7 +380,7 @@ jq -e '
   .action == "select"
   and .ok == false
   and .selected == null
-  and (.routes | length) == 3
+  and (.routes | length) == 6
 ' "$route_select_json" >/dev/null
 
 printf 'first-run e2e: repair run refuses to mutate without admitted repair\n'
@@ -495,7 +495,7 @@ jq -e '
   and (.providers.codex.accounts["max-1"].secret.backend == "file")
   and (.providers.codex.accounts["max-2"].secret.backend == "file")
   and (.providers.codex.accounts["max-3"].secret.backend == "file")
-  and (.profiles["codex-max"].providers | length) == 3
+  and (.profiles["codex-max"].providers | length) == 6
   and (.profiles.default.providers | index("claude:personal") != null)
 ' "$drift_config" >/dev/null
 jq -e '

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -583,7 +583,7 @@ pub const Proxy = struct {
                 appendRejection(a, &rejections, elected.id, .credential_unavailable, @errorName(err)) catch {};
                 self.logEvent("proxy_materialize_failed", .{ .account = elected.id, .err = @errorName(err) });
                 self.pool.markUnauthorized(elected.id) catch {};
-                self.recordDurableRouteState(elected.id, .credential_unavailable, 0, null);
+                self.recordDurableRouteState(elected.id, elected.capability, .credential_unavailable, 0, null);
                 pending_failure_kind = null;
                 pending_failure_account = elected.id;
                 pending_transport_error = null;
@@ -639,7 +639,7 @@ pub const Proxy = struct {
                 appendRejection(a, &rejections, elected.id, .provider_degraded, @errorName(err)) catch {};
                 self.logEvent("proxy_upstream_failed", .{ .account = elected.id, .err = @errorName(err) });
                 self.traceUpstreamFailure(req, elected.id, @errorName(err));
-                self.recordDurableRouteState(elected.id, .provider_degraded, 503, 60);
+                self.recordDurableRouteState(elected.id, elected.capability, .provider_degraded, 503, 60);
                 self.pool.markProviderDegraded(elected.id, std.time.timestamp() + 60) catch {};
                 pending_failure_kind = .provider_5xx;
                 pending_failure_account = elected.id;
@@ -676,14 +676,14 @@ pub const Proxy = struct {
                     .retry_attempted = false,
                 });
                 self.traceUpstreamFailure(req, elected.id, err_name);
-                self.recordDurableRouteState(elected.id, .provider_degraded, 503, 60);
+                self.recordDurableRouteState(elected.id, elected.capability, .provider_degraded, 503, 60);
                 self.pool.markProviderDegraded(elected.id, std.time.timestamp() + 60) catch {};
                 final_account = elected.id;
                 break;
             }
 
             // ── 5. Apply classification + log ──────────────────────
-            self.applyClassification(elected.id, status_and_class.classification) catch |err| {
+            self.applyClassification(elected.id, elected.capability, status_and_class.classification) catch |err| {
                 self.logEvent("proxy_apply_classification_failed", .{ .account = elected.id, .err = @errorName(err) });
             };
 
@@ -939,25 +939,27 @@ pub const Proxy = struct {
     fn applyClassification(
         self: *Proxy,
         account_id: []const u8,
+        capability: ?[]const u8,
         c: Classification,
     ) !void {
         const now_unix = std.time.timestamp();
         var store = health_mod.HealthStore.load(std.heap.page_allocator, .{});
         defer store.deinit();
-        try applyClassificationWithStore(self.pool, &store, account_id, c, now_unix, self.capability);
+        try applyClassificationWithStore(self.pool, &store, account_id, c, now_unix, capability orelse self.capability);
         store.persist();
     }
 
     fn recordDurableRouteState(
         self: *Proxy,
         account_id: []const u8,
+        capability: ?[]const u8,
         state: RouteState,
         status: u16,
         retry_after_s: ?u32,
     ) void {
         var store = health_mod.HealthStore.load(std.heap.page_allocator, .{});
         defer store.deinit();
-        recordDurableRouteStateInStore(&store, account_id, self.capability, state, status, retry_after_s);
+        recordDurableRouteStateInStore(&store, account_id, capability orelse self.capability, state, status, retry_after_s);
         store.persist();
     }
 
@@ -2794,6 +2796,35 @@ test "successful managed proxy turn records capability route health" {
         .live => |live| try std.testing.expectEqual(core_types.Availability.available, live.availability),
         else => return error.ExpectedLiveHealth,
     }
+}
+
+test "managed proxy records fallback capability health under elected capability" {
+    var pool = account_pool_mod.AccountPool.init(std.testing.allocator);
+    defer pool.deinit();
+    try pool.add(.{
+        .id = "codex:max-1",
+        .capability = "codex-mini",
+        .selectable = true,
+        .liveness = .live,
+        .availability = .available,
+    });
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+
+    const elected = try pool.elect("codex-max", "codex-max", &.{});
+    try std.testing.expectEqualStrings("codex-mini", elected.capability.?);
+    try applyClassificationWithStore(&pool, &store, elected.id, .{
+        .kind = .provider_5xx,
+    }, 1_788_000_000, elected.capability);
+
+    try std.testing.expect(store.accounts.get("codex:max-1#codex-max") == null);
+    const recorded = store.accounts.get("codex:max-1#codex-mini") orelse {
+        return error.ExpectedFallbackCapabilityEvidence;
+    };
+    try std.testing.expectEqual(@as(?u16, 500), recorded.last_http_status);
+    try std.testing.expectEqual(health_mod.ProbeHintClass.provider_degraded, recorded.last_probe_hint_class.?);
+    try std.testing.expectEqual(core_types.MuxDecision.try_next_provider, recorded.last_probe_decision.?);
 }
 
 test "parseRequest reads start line + headers + content-length body" {

--- a/src/broker/account_pool.zig
+++ b/src/broker/account_pool.zig
@@ -15,6 +15,7 @@ pub const Availability = enum { available, rate_limited, quota_exhausted, cooldo
 
 pub const AccountSummary = struct {
     id: []const u8, // owned by pool
+    capability: ?[]const u8 = null, // owned by pool when present
     selectable: bool,
     liveness: Liveness,
     availability: Availability,
@@ -33,15 +34,24 @@ pub const AccountPool = struct {
     }
 
     pub fn deinit(self: *AccountPool) void {
-        for (self.accounts.items) |a| self.allocator.free(a.id);
+        for (self.accounts.items) |a| {
+            self.allocator.free(a.id);
+            if (a.capability) |capability| self.allocator.free(capability);
+        }
         self.accounts.deinit(self.allocator);
     }
 
     pub fn add(self: *AccountPool, summary: AccountSummary) !void {
         const owned_id = try self.allocator.dupe(u8, summary.id);
         errdefer self.allocator.free(owned_id);
+        const owned_capability = if (summary.capability) |capability|
+            try self.allocator.dupe(u8, capability)
+        else
+            null;
+        errdefer if (owned_capability) |capability| self.allocator.free(capability);
         var owned = summary;
         owned.id = owned_id;
+        owned.capability = owned_capability;
         try self.accounts.append(self.allocator, owned);
     }
 

--- a/src/broker/methods.zig
+++ b/src/broker/methods.zig
@@ -186,6 +186,10 @@ fn accountList(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
     for (list_buf.items) |a| {
         var entry = std.json.ObjectMap.init(ctx.allocator);
         entry.put("id", .{ .string = a.id }) catch return oom();
+        entry.put(
+            "capability",
+            if (a.capability) |cap| std.json.Value{ .string = cap } else std.json.Value{ .null = {} },
+        ) catch return oom();
         entry.put("selectable", .{ .bool = a.selectable }) catch return oom();
         entry.put("liveness", .{ .string = @tagName(a.liveness) }) catch return oom();
         entry.put("availability", .{ .string = @tagName(a.availability) }) catch return oom();
@@ -233,6 +237,10 @@ fn accountSelect(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
 
     var out = std.json.ObjectMap.init(ctx.allocator);
     out.put("account", .{ .string = elected.id }) catch return oom();
+    out.put(
+        "capability",
+        if (elected.capability) |cap| std.json.Value{ .string = cap } else std.json.Value{ .null = {} },
+    ) catch return oom();
 
     // Phase 1 returns a placeholder credential_handle. Real materialization
     // happens in task #18 (credential/materialize).
@@ -339,6 +347,10 @@ fn accountSwap(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
     // Build response.
     var out = std.json.ObjectMap.init(ctx.allocator);
     out.put("account", .{ .string = elected.id }) catch return oom();
+    out.put(
+        "capability",
+        if (elected.capability) |cap| std.json.Value{ .string = cap } else std.json.Value{ .null = {} },
+    ) catch return oom();
     const handle = std.fmt.allocPrint(
         ctx.allocator,
         "ch:{s}:{x}",
@@ -460,6 +472,10 @@ fn quotaStatus(ctx: *Context, params: ?std.json.Value) DispatchOutcome {
     for (ctx.pool.accounts.items) |a| {
         var entry = std.json.ObjectMap.init(ctx.allocator);
         entry.put("id", .{ .string = a.id }) catch return oom();
+        entry.put(
+            "capability",
+            if (a.capability) |cap| std.json.Value{ .string = cap } else std.json.Value{ .null = {} },
+        ) catch return oom();
         entry.put("availability", .{ .string = @tagName(a.availability) }) catch return oom();
         if (a.next_eligible_at) |t| {
             entry.put("next_eligible_at", .{ .integer = t }) catch return oom();

--- a/src/broker_loader.zig
+++ b/src/broker_loader.zig
@@ -93,6 +93,11 @@ pub fn populatePoolFromRouteHealthScoped(
     applyRouteHealth(pool, cfg, profile_name, capability_name, store);
 }
 
+const RouteHealthMatch = struct {
+    health: health_mod.AccountHealth,
+    capability: ?[]const u8 = null,
+};
+
 pub const CodexAuthRepairSummary = struct {
     attempted: usize = 0,
     refreshed: usize = 0,
@@ -161,9 +166,16 @@ fn applyRouteHealth(
             entry.selectable = false;
             entry.liveness = .unknown;
             entry.availability = .unknown;
+            setPoolEntryCapability(pool, entry, null) catch {};
             continue;
         };
-        applyHealthToPoolEntry(entry, route_health);
+        setPoolEntryCapability(pool, entry, route_health.capability) catch {
+            entry.selectable = false;
+            entry.liveness = .unknown;
+            entry.availability = .unknown;
+            continue;
+        };
+        applyHealthToPoolEntry(entry, route_health.health);
     }
 }
 
@@ -174,7 +186,7 @@ fn routeHealthForPoolAccount(
     requested_capability: ?[]const u8,
     account_id: []const u8,
     store: *health_mod.HealthStore,
-) ?health_mod.AccountHealth {
+) ?RouteHealthMatch {
     const now = std.time.timestamp();
     const colon = std.mem.indexOfScalar(u8, account_id, ':') orelse return null;
     const provider = account_id[0..colon];
@@ -184,55 +196,114 @@ fn routeHealthForPoolAccount(
         const effective = health_mod.effectiveHealthForRouteSelection(account_health, now);
         tracePoolHealthNormalization(allocator, provider, account, null, "account", account_health.liveness, effective.liveness);
         if (accountLivenessBlocksRoute(effective.liveness)) {
-            if (authMaterialRepairHealth(allocator, cfg, provider, account, account_health)) |repaired| return repaired;
-            return effective;
+            if (authMaterialRepairHealth(allocator, cfg, provider, account, account_health)) |repaired| return .{ .health = repaired };
+            return .{ .health = effective };
         }
     }
 
     if (profile_name) |name| {
         if (cfg.profiles.map.get(name)) |profile| {
+            if (requested_capability) |want| {
+                if (profileHasAccountCapability(profile, account_id, want)) {
+                    if (capabilityHealthForPoolAccount(allocator, cfg, provider, account, want, store, now)) |requested| {
+                        if (!accountLivenessBlocksRoute(requested.health.liveness)) return requested;
+                        if (fallbackCapabilityHealthForPoolAccount(allocator, cfg, profile, account_id, provider, account, want, store, now)) |fallback| return fallback;
+                        return requested;
+                    }
+                    if (fallbackCapabilityHealthForPoolAccount(allocator, cfg, profile, account_id, provider, account, want, store, now)) |fallback| return fallback;
+                    return null;
+                }
+                if (fallbackCapabilityHealthForPoolAccount(allocator, cfg, profile, account_id, provider, account, want, store, now)) |fallback| return fallback;
+            }
+
             for (profile.providers) |profile_entry| {
                 const hash = std.mem.indexOfScalar(u8, profile_entry, '#') orelse continue;
                 const head = profile_entry[0..hash];
                 if (!std.mem.eql(u8, head, account_id)) continue;
                 const capability = profile_entry[hash + 1 ..];
-                if (requested_capability) |want| {
-                    if (!std.mem.eql(u8, capability, want)) continue;
-                }
-                const capability_key = health_mod.capabilityKey(provider, account, capability);
-                if (store.accounts.get(capability_key.slice())) |capability_health| {
-                    const effective = health_mod.effectiveHealthForRouteSelection(capability_health, now);
-                    tracePoolHealthNormalization(allocator, provider, account, capability, "capability", capability_health.liveness, effective.liveness);
-                    if (accountLivenessBlocksRoute(effective.liveness)) {
-                        if (authMaterialRepairHealth(allocator, cfg, provider, account, capability_health)) |repaired| return repaired;
-                    }
-                    return effective;
-                }
+                if (capabilityHealthForPoolAccount(allocator, cfg, provider, account, capability, store, now)) |match| return match;
             }
         }
     }
 
     if (requested_capability) |capability| {
-        const capability_key = health_mod.capabilityKey(provider, account, capability);
-        if (store.accounts.get(capability_key.slice())) |capability_health| {
-            const effective = health_mod.effectiveHealthForRouteSelection(capability_health, now);
-            tracePoolHealthNormalization(allocator, provider, account, capability, "capability", capability_health.liveness, effective.liveness);
-            if (accountLivenessBlocksRoute(effective.liveness)) {
-                if (authMaterialRepairHealth(allocator, cfg, provider, account, capability_health)) |repaired| return repaired;
-            }
-            return effective;
-        }
+        if (capabilityHealthForPoolAccount(allocator, cfg, provider, account, capability, store, now)) |match| return match;
     }
 
     if (store.accounts.get(account_key.slice())) |account_health| {
         const effective = health_mod.effectiveHealthForRouteSelection(account_health, now);
         tracePoolHealthNormalization(allocator, provider, account, null, "account", account_health.liveness, effective.liveness);
         if (accountLivenessBlocksRoute(effective.liveness)) {
-            if (authMaterialRepairHealth(allocator, cfg, provider, account, account_health)) |repaired| return repaired;
+            if (authMaterialRepairHealth(allocator, cfg, provider, account, account_health)) |repaired| return .{ .health = repaired };
         }
-        return effective;
+        return .{ .health = effective };
     }
     return null;
+}
+
+fn profileHasAccountCapability(profile: config_mod.ProfileConfig, account_id: []const u8, capability: []const u8) bool {
+    for (profile.providers) |profile_entry| {
+        const hash = std.mem.indexOfScalar(u8, profile_entry, '#') orelse continue;
+        if (!std.mem.eql(u8, profile_entry[0..hash], account_id)) continue;
+        if (std.mem.eql(u8, profile_entry[hash + 1 ..], capability)) return true;
+    }
+    return false;
+}
+
+fn capabilityHealthForPoolAccount(
+    allocator: std.mem.Allocator,
+    cfg: config_mod.Config,
+    provider: []const u8,
+    account: []const u8,
+    capability: []const u8,
+    store: *health_mod.HealthStore,
+    now: i64,
+) ?RouteHealthMatch {
+    const capability_key = health_mod.capabilityKey(provider, account, capability);
+    const capability_health = store.accounts.get(capability_key.slice()) orelse return null;
+    const effective = health_mod.effectiveHealthForRouteSelection(capability_health, now);
+    tracePoolHealthNormalization(allocator, provider, account, capability, "capability", capability_health.liveness, effective.liveness);
+    if (accountLivenessBlocksRoute(effective.liveness)) {
+        if (authMaterialRepairHealth(allocator, cfg, provider, account, capability_health)) |repaired| {
+            return .{ .health = repaired, .capability = capability };
+        }
+    }
+    return .{ .health = effective, .capability = capability };
+}
+
+fn fallbackCapabilityHealthForPoolAccount(
+    allocator: std.mem.Allocator,
+    cfg: config_mod.Config,
+    profile: config_mod.ProfileConfig,
+    account_id: []const u8,
+    provider: []const u8,
+    account: []const u8,
+    requested_capability: []const u8,
+    store: *health_mod.HealthStore,
+    now: i64,
+) ?RouteHealthMatch {
+    const chain = profile.capability_degradation_chain orelse return null;
+    for (chain) |fallback_capability| {
+        if (std.mem.eql(u8, requested_capability, fallback_capability)) continue;
+        if (!profileHasAccountCapability(profile, account_id, fallback_capability)) continue;
+        const fallback = capabilityHealthForPoolAccount(allocator, cfg, provider, account, fallback_capability, store, now) orelse continue;
+        if (!accountLivenessBlocksRoute(fallback.health.liveness)) return fallback;
+    }
+    return null;
+}
+
+fn setPoolEntryCapability(
+    pool: *broker.AccountPool,
+    entry: *broker.account_pool_mod.AccountSummary,
+    capability: ?[]const u8,
+) !void {
+    if (entry.capability) |old| {
+        pool.allocator.free(old);
+        entry.capability = null;
+    }
+    if (capability) |cap| {
+        entry.capability = try pool.allocator.dupe(u8, cap);
+    }
 }
 
 fn tracePoolHealthNormalization(
@@ -1189,6 +1260,94 @@ test "populatePoolFromRouteHealthScoped keeps mixed-profile capabilities isolate
             try std.testing.expectEqual(broker.account_pool_mod.Availability.quota_exhausted, entry.availability);
         }
     }
+}
+
+test "populatePoolFromRouteHealthScoped degrades to fallback capability when requested route is blocked" {
+    const cfg_json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "/tmp/a" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "codex-max": {
+        \\      "providers": ["codex:max-1#codex-max", "codex:max-1#codex-mini"],
+        \\      "capability_degradation_chain": ["codex-mini"]
+        \\    }
+        \\  }
+        \\}
+    ;
+    var parsed = try config_mod.loadFromBytes(std.testing.allocator, cfg_json);
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    store.recordCapabilityHttpStatus("codex", "max-1", "codex-max", 429, 7200);
+    const mini = try store.getOrCreate("codex:max-1#codex-mini");
+    mini.liveness = .{ .live = .{ .availability = .available } };
+    mini.last_probe_hint_class = .none;
+    mini.last_probe_decision = .use_this;
+
+    var pool = broker.AccountPool.init(std.testing.allocator);
+    defer pool.deinit();
+    try populatePoolFromRouteHealthScoped(&pool, parsed.value, "codex-max", "codex-max", &store);
+
+    const elected = try pool.elect("codex-max", "codex-max", &.{});
+    try std.testing.expectEqualStrings("codex:max-1", elected.id);
+    try std.testing.expectEqualStrings("codex-mini", elected.capability.?);
+    try std.testing.expect(elected.selectable);
+    try std.testing.expectEqual(broker.account_pool_mod.Availability.available, elected.availability);
+}
+
+test "populatePoolFromRouteHealthScoped does not degrade around account-dead auth health" {
+    const cfg_json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "/tmp/a" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "codex-max": {
+        \\      "providers": ["codex:max-1#codex-max", "codex:max-1#codex-mini"],
+        \\      "capability_degradation_chain": ["codex-mini"]
+        \\    }
+        \\  }
+        \\}
+    ;
+    var parsed = try config_mod.loadFromBytes(std.testing.allocator, cfg_json);
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    const account_health = try store.getOrCreate("codex:max-1");
+    account_health.liveness = .{ .dead = .{
+        .reason = .token_revoked,
+        .since = std.time.timestamp() - 120,
+    } };
+    account_health.last_probe_hint_class = .auth_dead;
+    account_health.last_probe_decision = .try_next_account;
+    const mini = try store.getOrCreate("codex:max-1#codex-mini");
+    mini.liveness = .{ .live = .{ .availability = .available } };
+    mini.last_probe_hint_class = .none;
+    mini.last_probe_decision = .use_this;
+
+    var pool = broker.AccountPool.init(std.testing.allocator);
+    defer pool.deinit();
+    try populatePoolFromRouteHealthScoped(&pool, parsed.value, "codex-max", "codex-max", &store);
+
+    try std.testing.expectError(broker_types.BrokerError.NoAccountSelectable, pool.elect("codex-max", "codex-max", &.{}));
+    try std.testing.expectEqual(broker.account_pool_mod.Liveness.dead, pool.accounts.items[0].liveness);
+    try std.testing.expect(pool.accounts.items[0].capability == null);
 }
 
 test "populatePoolFromRouteHealth lets expired provider degradation yield to capability health" {

--- a/src/health.zig
+++ b/src/health.zig
@@ -200,7 +200,17 @@ pub fn recoverExpiredTransientHealth(health: *AccountHealth, now: i64) void {
                 health.last_probe_decision = .use_this;
                 health.consecutive_failures = 0;
             },
-            .available, .quota_exhausted => {},
+            .quota_exhausted => |quota| {
+                const retry_at = health.quota_exhausted_until orelse quota.window_resets_at orelse return;
+                if (now < retry_at) return;
+                health.liveness = .{ .live = .{ .availability = .available } };
+                health.quota_exhausted_until = null;
+                health.last_probe_retry_after_s = null;
+                health.last_probe_hint_class = .none;
+                health.last_probe_decision = .use_this;
+                health.consecutive_failures = 0;
+            },
+            .available => {},
         },
         .degraded => |d| {
             const retry_at = d.retry_at orelse return;
@@ -1198,6 +1208,29 @@ test "effectiveHealthForRouteSelection recovers expired live retry windows" {
     try std.testing.expectEqual(ProbeHintClass.none, recovered_rate_limit.last_probe_hint_class.?);
     try std.testing.expectEqual(types.MuxDecision.use_this, recovered_rate_limit.last_probe_decision.?);
     try std.testing.expectEqual(@as(u32, 0), recovered_rate_limit.consecutive_failures);
+
+    const recovered_quota = effectiveHealthForRouteSelection(.{
+        .liveness = .{ .live = .{ .availability = .{ .quota_exhausted = .{
+            .exhausted_at = now - 3600,
+            .window_resets_at = now - 1,
+        } } } },
+        .quota_exhausted_until = now - 1,
+        .last_probe_retry_after_s = 3600,
+        .last_probe_hint_class = .quota_exhausted,
+        .last_probe_decision = .try_next_account,
+        .consecutive_failures = 2,
+    }, now);
+    switch (recovered_quota.liveness) {
+        .live => |live| switch (live.availability) {
+            .available => {},
+            else => return error.TestUnexpectedResult,
+        },
+        else => return error.TestUnexpectedResult,
+    }
+    try std.testing.expect(recovered_quota.quota_exhausted_until == null);
+    try std.testing.expectEqual(ProbeHintClass.none, recovered_quota.last_probe_hint_class.?);
+    try std.testing.expectEqual(types.MuxDecision.use_this, recovered_quota.last_probe_decision.?);
+    try std.testing.expectEqual(@as(u32, 0), recovered_quota.consecutive_failures);
 
     const blocked_rate_limit = effectiveHealthForRouteSelection(.{
         .liveness = .{ .live = .{ .availability = .{ .rate_limited = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -8949,9 +8949,13 @@ fn writeCodexMaxStarterConfig(allocator: std.mem.Allocator, writer: anytype, sto
         \\    "codex-max": {
         \\      "providers": [
         \\        "codex:max-1#codex-max",
+        \\        "codex:max-1#codex-mini",
         \\        "codex:max-2#codex-max",
-        \\        "codex:max-3#codex-max"
+        \\        "codex:max-2#codex-mini",
+        \\        "codex:max-3#codex-max",
+        \\        "codex:max-3#codex-mini"
         \\      ],
+        \\      "capability_degradation_chain": ["codex-mini"],
         \\      "strategy": "health-weighted",
         \\      "affinity_ttl_minutes": 20
         \\    },
@@ -19216,10 +19220,10 @@ test "recoverable fallback readiness deduplicates quota rows by account" {
     try std.testing.expectEqual(@as(usize, 1), recoverableFallbackRouteCount(&evaluations, 0, "codex-mini"));
 }
 
-test "expired quota window is not counted as recoverable (TIN-1812 boundary)" {
-    // No-spend: a quota route whose window has already passed needs revalidation,
-    // not a guaranteed wait, so it must NOT count as a recoverable fallback and
-    // the pool stays "not_afloat" (no false afloat signal).
+test "expired quota window recovers during route evaluation" {
+    // A quota route whose window has already passed should become selectable
+    // during route-health normalization. Future quota windows remain pending
+    // recovery; expired windows must not keep the pool falsely halted.
     const json =
         \\{
         \\  "version": 1,
@@ -19266,13 +19270,15 @@ test "expired quota window is not counted as recoverable (TIN-1812 boundary)" {
     defer evaluations.deinit();
     try collectRouteEvaluations(std.testing.allocator, parsed.value, &store, routes.items, &evaluations);
 
-    try std.testing.expectEqual(@as(usize, 0), recoverableFallbackRouteCount(evaluations.items, null, null));
+    const selected = firstSelectableRoute(evaluations.items);
+    try std.testing.expect(selected != null);
+    try std.testing.expectEqual(@as(usize, 0), recoverableFallbackRouteCount(evaluations.items, selected, null));
     try std.testing.expect(soonestQuotaWindowReset(evaluations.items) == null);
 
     var buf = std.ArrayList(u8).init(std.testing.allocator);
     defer buf.deinit();
-    try writeRouteResilienceJson(buf.writer(), evaluations.items, null);
-    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"state\":\"not_afloat\"") != null);
+    try writeRouteResilienceJson(buf.writer(), evaluations.items, selected);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"state\":\"afloat_without_spare_fallback\"") != null);
 }
 
 test "stay-afloat next emits mediated repair action when no route is selectable" {


### PR DESCRIPTION
## Summary

- let Codex proxy/broker pool loading degrade account capability from codex-max to configured fallback capability when the requested route is blocked but fallback route health is live
- recover expired quota windows during persisted health normalization so stale quota state does not keep sessions falsely halted
- record proxy health under the elected fallback capability and expose elected capability in broker MCP account surfaces
- update generated Codex Max starter config and first-run/e2e expectations for the built-in codex-mini degradation lane

## Validation

- git diff --check
- nix develop --command zig build test
- nix develop --command zig build && nix develop --command just smoke-codex-cli-ux-local
- ./scripts/first-run-e2e.sh
- nix develop --command just check-local