### PR TITLE
reauth: loopback PKCE callback server (TIN-1807 — greenfield, 34/34, anti-rebinding + CSRF-first + RFC 7636 vector)

### DIFF
--- a/src/enroll/callback_server.zig
+++ b/src/enroll/callback_server.zig
@@ -1,0 +1,551 @@
+//! Loopback PKCE callback server for cookieless reauth (greenfield increment 3).
+//!
+//! This is the `redirect_loopback` half of the reauth backend: a one-shot,
+//! ephemeral `127.0.0.1` listener that captures the OAuth authorization-code
+//! redirect (`?code=…&state=…`), validates CSRF + the loopback Host, drives the
+//! PKCE S256 code exchange through an injected seam, confirms the returned
+//! identity matches the account being re-authed (clone / wrong-identity guard),
+//! and hands back a `CallbackData`. It is the real backing for the operator web
+//! UI's `GET /callback` route stub.
+//!
+//! Same proven shape as the engine (`reauth.zig`) and web UI (`web_ui.zig`):
+//!   * a PURE CORE (`handleCallbackRequest`) that takes the parsed request as
+//!     plain strings + injected seams and touches NO socket, clock, or disk —
+//!     fully unit-testable with `std.testing.allocator` leak-checking;
+//!   * a thin, untested-by-design listener wrapper (`CallbackServerListener`)
+//!     that owns the real `std.net` socket and delegates every decision to the
+//!     pure core.
+//!
+//! Self-contained: `std` only. No `@import` of existing `src/`, no
+//! `build_options`, so `zig test src/enroll/callback_server_tests.zig` runs with
+//! zero build wiring. The inline `deriveChallenge` mirrors
+//! `src/oauth.zig:generatePkce` (S256) byte-for-byte; production wiring should
+//! call the real `oauth.generatePkce` instead of the local convenience helper.
+//!
+//! Security model (RFC 8252 loopback, RFC 7636 PKCE, OAuth 2.1 state):
+//!   * bind 127.0.0.1 ONLY, ephemeral port (never 0.0.0.0 / a hostname);
+//!   * reject any inbound Host that is not EXACTLY 127.0.0.1/localhost
+//!     (optional :port) — suffix bypass (127.0.0.1.evil.com) is anti-DNS-rebinding;
+//!   * state is 16 random bytes (128-bit), single-use, constant-time compared,
+//!     and validated BEFORE the error-redirect branch (a forged ?error= callback
+//!     is still CSRF-checked);
+//!   * the PKCE code_verifier is ephemeral in-process, passed only to the
+//!     exchange seam, and NEVER returned in CallbackData, logged, or rendered;
+//!   * the static success page echoes NO request data (no code/state/token);
+//!   * after exchange the returned account_id MUST match the expected account.
+
+const std = @import("std");
+
+// ── Public data types ──────────────────────────────────────────────────────
+
+/// The validated, exchanged result of a single loopback callback. The caller
+/// owns every slice and frees them with `freeCallbackData`. Note: there is no
+/// `verifier` field — the PKCE verifier is ephemeral and never escapes here.
+pub const CallbackData = struct {
+    /// Authorization code that was exchanged (kept for audit only).
+    code: []const u8,
+    /// The CSRF nonce this callback was validated against (fixed array, not a
+    /// slice: it is the raw 16 bytes, never the encoded query value).
+    state: [16]u8,
+    access_token: []const u8,
+    refresh_token: ?[]const u8 = null,
+    expires_in: ?i64 = null,
+    /// Identity the tokens belong to (for operator display + confirmation).
+    email: []const u8,
+    account_id: []const u8,
+};
+
+/// Token endpoint (`POST /token`) response, produced by the exchange seam.
+pub const TokenEndpointResponse = struct {
+    access_token: []const u8,
+    token_type: []const u8 = "Bearer",
+    expires_in: ?i64 = null,
+    refresh_token: ?[]const u8 = null,
+    /// JWT used by the identity seam to derive email + account_id.
+    id_token: ?[]const u8 = null,
+};
+
+/// Identity extracted from the exchanged tokens.
+pub const IdentityInfo = struct {
+    email: []const u8,
+    account_id: []const u8,
+};
+
+/// Errors the pure core can surface. `OutOfMemory` is propagated distinctly so
+/// the caller can retry; everything else is a terminal validation failure.
+pub const CallbackServerError = error{
+    /// Required `state` (or, post-validation, `code`) absent or empty.
+    MissingCodeOrState,
+    /// Received state did not match the expected nonce (CSRF / replay).
+    StateMismatch,
+    /// Host header is missing or not exactly loopback (anti-DNS-rebinding).
+    HostHeaderRejected,
+    /// Provider sent `?error=…` (e.g. access_denied) after a valid-state callback.
+    ErrorRedirect,
+    /// The token exchange seam failed.
+    CodeExchangeFailed,
+    /// The identity-extraction seam failed.
+    IdentityExtractFailed,
+    /// Exchanged identity's account_id != the account being re-authed.
+    IdentityMismatch,
+    /// Deadline passed before a usable callback arrived.
+    Timeout,
+    OutOfMemory,
+};
+
+// ── Injected seams ─────────────────────────────────────────────────────────
+//
+// Each seam is a bare fn pointer plus an opaque ctx, exactly like the engine's
+// device_code seams, so the pure core needs no network, clock, or disk and the
+// tests inject deterministic fakes.
+
+/// Wall-clock seconds (Unix epoch). Injected so the deadline is virtual in tests.
+pub const ClockFn = *const fn (ctx: *anyopaque) i64;
+
+/// Errors the exchange seam may surface (small, exhaustive — no `else` prong).
+pub const ExchangeError = error{ OutOfMemory, ExchangeFailed };
+
+/// `POST` the authorization code + PKCE verifier to the token endpoint.
+/// Returns freshly-allocated slices the core frees after use.
+pub const ExchangeCodeFn = *const fn (
+    allocator: std.mem.Allocator,
+    ctx: *anyopaque,
+    token_uri: []const u8,
+    code: []const u8,
+    code_verifier: [43]u8,
+    client_id: []const u8,
+    client_secret: []const u8,
+    redirect_uri: []const u8,
+) ExchangeError!TokenEndpointResponse;
+
+/// Errors the identity seam may surface.
+pub const IdentityError = error{ OutOfMemory, ExtractFailed };
+
+/// Derive (email, account_id) from the exchanged tokens (JWT or userinfo).
+/// Returns freshly-allocated slices; ownership transfers to the core, which
+/// either moves them into `CallbackData` or frees them on mismatch/failure.
+pub const ExtractIdentityFn = *const fn (
+    allocator: std.mem.Allocator,
+    ctx: *anyopaque,
+    id_token: ?[]const u8,
+    access_token: []const u8,
+) IdentityError!IdentityInfo;
+
+/// Bundle of every external coupling the core needs. Three seams cover all I/O.
+pub const CallbackServerSeams = struct {
+    clock: ClockFn,
+    exchange_code: ExchangeCodeFn,
+    extract_identity: ExtractIdentityFn,
+    clock_ctx: *anyopaque,
+    exchange_code_ctx: *anyopaque,
+    extract_identity_ctx: *anyopaque,
+};
+
+// ── Pure core ──────────────────────────────────────────────────────────────
+
+/// Parse + validate a single loopback callback request and, if it is a valid
+/// success redirect, exchange the code and confirm identity. NO socket/clock/FS
+/// access of its own — every side effect is an injected seam.
+///
+/// Validation order is security-significant:
+///   1. Host must be exactly loopback (before anything else is trusted).
+///   2. `state` must be present and CSRF-valid — checked BEFORE the error
+///      branch so a forged `?error=…&state=WRONG` is rejected as StateMismatch,
+///      not silently accepted as a provider error.
+///   3. only then: distinguish a provider error redirect from a real code,
+///      check the deadline, exchange, and confirm identity.
+pub fn handleCallbackRequest(
+    allocator: std.mem.Allocator,
+    seams: CallbackServerSeams,
+    method: []const u8,
+    target: []const u8,
+    host_header: []const u8,
+    expected_state: [16]u8,
+    pkce_verifier: [43]u8,
+    expected_account_id: ?[]const u8,
+    token_uri: []const u8,
+    client_id: []const u8,
+    client_secret: []const u8,
+    redirect_uri: []const u8,
+    deadline_s: i64,
+) CallbackServerError!CallbackData {
+    _ = method; // GET-only is enforced by the listener; the core is method-agnostic.
+
+    // 1. Anti-DNS-rebinding: loopback Host only (RFC 8252 §7.3).
+    try validateLoopbackHost(host_header);
+
+    // 2. Extract query params.
+    const query = splitQuery(target);
+    const state_str = queryParam(query, "state") orelse return error.MissingCodeOrState;
+    if (state_str.len == 0) return error.MissingCodeOrState;
+
+    // 3. CSRF FIRST: reject any callback whose state does not match, regardless
+    //    of whether it carries a code or an error (defense-in-depth).
+    try validateState(state_str, expected_state);
+
+    // 4. Provider error redirect (?error=access_denied&state=…) — state already
+    //    proven valid, so this is a genuine provider-side denial, not a forgery.
+    if (queryParam(query, "error") != null) return error.ErrorRedirect;
+
+    // 5. Success path requires a non-empty code.
+    const code = queryParam(query, "code") orelse return error.MissingCodeOrState;
+    if (code.len == 0) return error.MissingCodeOrState;
+
+    // 6. Deadline guard before the (network) exchange.
+    if (seams.clock(seams.clock_ctx) >= deadline_s) return error.Timeout;
+
+    // 7. Exchange the code + PKCE verifier for tokens.
+    const token_resp = seams.exchange_code(
+        allocator,
+        seams.exchange_code_ctx,
+        token_uri,
+        code,
+        pkce_verifier,
+        client_id,
+        client_secret,
+        redirect_uri,
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.ExchangeFailed => return error.CodeExchangeFailed,
+    };
+    defer {
+        allocator.free(token_resp.access_token);
+        if (token_resp.refresh_token) |rt| allocator.free(rt);
+        if (token_resp.id_token) |it| allocator.free(it);
+    }
+
+    // 8. Derive identity (email + account_id) from the tokens.
+    const identity = seams.extract_identity(
+        allocator,
+        seams.extract_identity_ctx,
+        token_resp.id_token,
+        token_resp.access_token,
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.ExtractFailed => return error.IdentityExtractFailed,
+    };
+
+    // 9. Clone / wrong-identity guard: the exchanged account must match the one
+    //    being re-authed. Free the identity (it would otherwise leak) and abort.
+    if (expected_account_id) |expected| {
+        if (!std.mem.eql(u8, identity.account_id, expected)) {
+            allocator.free(identity.account_id);
+            allocator.free(identity.email);
+            return error.IdentityMismatch;
+        }
+    }
+
+    // 10. Assemble the result. The identity slices are MOVED into CallbackData;
+    //     errdefer frees them only if a subsequent dupe fails (leak-safety).
+    errdefer allocator.free(identity.email);
+    errdefer allocator.free(identity.account_id);
+
+    const code_owned = try allocator.dupe(u8, code);
+    errdefer allocator.free(code_owned);
+    const access_owned = try allocator.dupe(u8, token_resp.access_token);
+    errdefer allocator.free(access_owned);
+    const refresh_owned = if (token_resp.refresh_token) |rt|
+        try allocator.dupe(u8, rt)
+    else
+        null;
+
+    return .{
+        .code = code_owned,
+        .state = expected_state,
+        .access_token = access_owned,
+        .refresh_token = refresh_owned,
+        .expires_in = token_resp.expires_in,
+        .email = identity.email,
+        .account_id = identity.account_id,
+    };
+}
+
+/// Free a `CallbackData` produced by `handleCallbackRequest`.
+pub fn freeCallbackData(allocator: std.mem.Allocator, data: CallbackData) void {
+    allocator.free(data.code);
+    allocator.free(data.access_token);
+    if (data.refresh_token) |rt| allocator.free(rt);
+    allocator.free(data.email);
+    allocator.free(data.account_id);
+}
+
+// ── Validation + parsing helpers (pure) ────────────────────────────────────
+
+/// Accept only an exact loopback Host (optional :port). Splitting on the first
+/// ':' and requiring an exact string match defeats the suffix bypass
+/// (`127.0.0.1.evil.com`, `localhost.attacker`) that `startsWith` would allow.
+pub fn validateLoopbackHost(host_header: []const u8) CallbackServerError!void {
+    if (host_header.len == 0) return error.HostHeaderRejected;
+    const host = if (std.mem.indexOfScalar(u8, host_header, ':')) |colon|
+        host_header[0..colon]
+    else
+        host_header;
+    if (std.mem.eql(u8, host, "127.0.0.1")) return;
+    if (std.mem.eql(u8, host, "localhost")) return;
+    return error.HostHeaderRejected;
+}
+
+/// Return the query portion of a request target (`/callback?a=b` -> `a=b`).
+fn splitQuery(target: []const u8) []const u8 {
+    return if (std.mem.indexOfScalar(u8, target, '?')) |q| target[q + 1 ..] else "";
+}
+
+/// First value for `key` in an `&`-separated query string, or null. Values are
+/// returned raw (no percent-decoding); base64url state and OAuth codes are
+/// URL-safe so this is sufficient for validation + exchange.
+pub fn queryParam(query: []const u8, key: []const u8) ?[]const u8 {
+    var it = std.mem.splitScalar(u8, query, '&');
+    while (it.next()) |pair| {
+        if (pair.len == 0) continue;
+        const eq = std.mem.indexOfScalar(u8, pair, '=') orelse continue;
+        if (std.mem.eql(u8, pair[0..eq], key)) return pair[eq + 1 ..];
+    }
+    return null;
+}
+
+/// Constant-time validation of the received (base64url) state against the
+/// expected 16-byte nonce. Any decode failure or length mismatch is a plain
+/// StateMismatch (no oracle); the byte compare never early-exits.
+pub fn validateState(received_str: []const u8, expected: [16]u8) CallbackServerError!void {
+    const decoder = std.base64.url_safe_no_pad.Decoder;
+    const decoded_len = decoder.calcSizeForSlice(received_str) catch return error.StateMismatch;
+    if (decoded_len != expected.len) return error.StateMismatch;
+    var decoded: [16]u8 = undefined;
+    decoder.decode(decoded[0..], received_str) catch return error.StateMismatch;
+    var diff: u8 = 0;
+    for (expected, decoded) |a, b| diff |= a ^ b;
+    if (diff != 0) return error.StateMismatch;
+}
+
+/// Encode a 16-byte state nonce to its base64url (no-pad) query form. The
+/// listener puts this in the `state` parameter of the authorize URL.
+pub fn encodeState(nonce: [16]u8) [22]u8 {
+    var out: [22]u8 = undefined;
+    _ = std.base64.url_safe_no_pad.Encoder.encode(out[0..], nonce[0..]);
+    return out;
+}
+
+/// Derive the PKCE S256 challenge for a verifier — base64url(SHA256(verifier)).
+/// Mirrors `src/oauth.zig:generatePkce` so the local convenience helper matches
+/// production exactly.
+pub fn deriveChallenge(verifier: [43]u8) [43]u8 {
+    var hash: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(verifier[0..], &hash, .{});
+    var challenge: [43]u8 = undefined;
+    _ = std.base64.url_safe_no_pad.Encoder.encode(challenge[0..], hash[0..]);
+    return challenge;
+}
+
+/// A fresh PKCE verifier + challenge + state nonce for one loopback attempt.
+pub const PkceState = struct {
+    verifier: [43]u8,
+    challenge: [43]u8,
+    state_nonce: [16]u8,
+};
+
+/// Convenience: generate a verifier + challenge + state nonce. Uses
+/// `std.crypto.random` directly (like `oauth.generatePkce`); not unit-tested
+/// for randomness — the deterministic math is covered via `deriveChallenge`.
+/// Production wiring should prefer the real `oauth.generatePkce` for the PKCE
+/// pair and only borrow the state-nonce generation here.
+pub fn generatePkceAndState() PkceState {
+    var verifier_bytes: [32]u8 = undefined;
+    std.crypto.random.bytes(&verifier_bytes);
+    var verifier: [43]u8 = undefined;
+    _ = std.base64.url_safe_no_pad.Encoder.encode(verifier[0..], verifier_bytes[0..]);
+
+    var state_nonce: [16]u8 = undefined;
+    std.crypto.random.bytes(&state_nonce);
+
+    return .{
+        .verifier = verifier,
+        .challenge = deriveChallenge(verifier),
+        .state_nonce = state_nonce,
+    };
+}
+
+// ── Authorize URL (emitted, never auto-opened — consent boundary) ──────────
+
+fn isUnreserved(c: u8) bool {
+    return (c >= 'A' and c <= 'Z') or
+        (c >= 'a' and c <= 'z') or
+        (c >= '0' and c <= '9') or
+        c == '-' or c == '_' or c == '.' or c == '~';
+}
+
+/// Percent-encode per RFC 3986 (unreserved set passes through). Used for the
+/// `redirect_uri` / `scope` / `client_id` values placed in the authorize URL.
+pub fn percentEncode(allocator: std.mem.Allocator, s: []const u8) ![]u8 {
+    const hex = "0123456789ABCDEF";
+    var out = std.ArrayList(u8).init(allocator);
+    errdefer out.deinit();
+    for (s) |c| {
+        if (isUnreserved(c)) {
+            try out.append(c);
+        } else {
+            try out.append('%');
+            try out.append(hex[c >> 4]);
+            try out.append(hex[c & 0x0F]);
+        }
+    }
+    return out.toOwnedSlice();
+}
+
+/// Inputs for the authorization-code + PKCE authorize URL.
+pub const AuthorizeParams = struct {
+    authorize_endpoint: []const u8,
+    client_id: []const u8,
+    redirect_uri: []const u8,
+    scope: []const u8,
+    challenge: [43]u8, // PKCE S256 challenge (base64url, URL-safe as-is)
+    state: [22]u8, // base64url(nonce) (URL-safe as-is)
+};
+
+/// Build the `redirect_loopback` authorize URL. This is EMITTED to the operator
+/// (printed / shown as a UI link) and deliberately NOT auto-opened: the operator
+/// chooses the isolated/private browser context, which is what guarantees the
+/// right identity for multi-account users. Caller owns the returned slice.
+pub fn buildAuthorizeUrl(allocator: std.mem.Allocator, p: AuthorizeParams) ![]u8 {
+    const enc_client = try percentEncode(allocator, p.client_id);
+    defer allocator.free(enc_client);
+    const enc_redirect = try percentEncode(allocator, p.redirect_uri);
+    defer allocator.free(enc_redirect);
+    const enc_scope = try percentEncode(allocator, p.scope);
+    defer allocator.free(enc_scope);
+    return std.fmt.allocPrint(
+        allocator,
+        "{s}?response_type=code&client_id={s}&redirect_uri={s}" ++
+            "&scope={s}&state={s}&code_challenge={s}&code_challenge_method=S256",
+        .{ p.authorize_endpoint, enc_client, enc_redirect, enc_scope, p.state[0..], p.challenge[0..] },
+    );
+}
+
+// ── Success page (static, secret-free) ─────────────────────────────────────
+
+/// The HTML shown to the browser after a successful capture. It is a constant
+/// with NO interpolation of any request data, so no code/state/token can leak
+/// into rendered output. Closes the tab automatically after a short delay.
+pub const success_page_html: []const u8 =
+    "<!doctype html><html><head><meta charset=\"utf-8\">" ++
+    "<title>Re-authentication complete</title></head><body>" ++
+    "<h1>Re-authentication complete</h1>" ++
+    "<p>You may close this window and return to your terminal.</p>" ++
+    "<script>setTimeout(function(){window.close();},1500);</script>" ++
+    "</body></html>";
+
+/// Minimal HTTP/1.1 response bytes for the success page.
+pub fn renderSuccessResponse(allocator: std.mem.Allocator) ![]u8 {
+    return std.fmt.allocPrint(
+        allocator,
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n" ++
+            "Content-Length: {d}\r\nConnection: close\r\n\r\n{s}",
+        .{ success_page_html.len, success_page_html },
+    );
+}
+
+// ── Listener wrapper (thin, untested by design) ────────────────────────────
+//
+// This is the ONLY code that touches a real socket. It mirrors the repo's
+// existing loopback idiom (src/adapters/codex/wire_proxy.zig: parseIp →
+// listen(.reuse_address) → listen_address → accept → conn.stream). All
+// decisions are delegated to the pure core above, which is exhaustively tested.
+
+/// One-shot loopback callback listener. `listenOnce` binds an ephemeral
+/// 127.0.0.1 port, reports it (for building redirect_uri), accepts exactly one
+/// connection, and runs the pure core over the parsed request.
+pub const CallbackServerListener = struct {
+    allocator: std.mem.Allocator,
+    seams: CallbackServerSeams,
+    token_uri: []const u8,
+    client_id: []const u8,
+    client_secret: []const u8,
+    expected_account_id: ?[]const u8 = null,
+    timeout_s: i64 = 300,
+
+    pub const Captured = struct {
+        port: u16,
+        callback: CallbackData,
+    };
+
+    /// Bind 127.0.0.1:0, accept one callback, validate + exchange, respond.
+    /// Untested by design (real socket I/O); the logic lives in the pure core.
+    pub fn listenOnce(
+        self: *const CallbackServerListener,
+        pkce_verifier: [43]u8,
+        state_nonce: [16]u8,
+    ) !Captured {
+        const loopback = try std.net.Address.parseIp("127.0.0.1", 0);
+        var server = try loopback.listen(.{ .reuse_address = true });
+        defer server.deinit();
+
+        const port = server.listen_address.getPort();
+        const redirect_uri = try std.fmt.allocPrint(
+            self.allocator,
+            "http://127.0.0.1:{d}/callback",
+            .{port},
+        );
+        defer self.allocator.free(redirect_uri);
+
+        const start = self.seams.clock(self.seams.clock_ctx);
+        const deadline = start + self.timeout_s;
+
+        var conn = try server.accept();
+        defer conn.stream.close();
+
+        var buf: [16 * 1024]u8 = undefined;
+        const n = try conn.stream.read(&buf);
+        const raw = buf[0..n];
+
+        const line = parseRequestLine(raw) orelse return error.MissingCodeOrState;
+        const host_header = parseHostHeader(raw) orelse "";
+
+        const callback = try handleCallbackRequest(
+            self.allocator,
+            self.seams,
+            line.method,
+            line.target,
+            host_header,
+            state_nonce,
+            pkce_verifier,
+            self.expected_account_id,
+            self.token_uri,
+            self.client_id,
+            self.client_secret,
+            redirect_uri,
+            deadline,
+        );
+
+        const resp = try renderSuccessResponse(self.allocator);
+        defer self.allocator.free(resp);
+        conn.stream.writeAll(resp) catch {};
+
+        return .{ .port = port, .callback = callback };
+    }
+};
+
+const RequestLine = struct { method: []const u8, target: []const u8 };
+
+/// Parse "GET /callback?… HTTP/1.1" from the first line. Pure helper.
+pub fn parseRequestLine(raw: []const u8) ?RequestLine {
+    const eol = std.mem.indexOfScalar(u8, raw, '\r') orelse raw.len;
+    var parts = std.mem.splitScalar(u8, raw[0..eol], ' ');
+    const method = parts.next() orelse return null;
+    const target = parts.next() orelse return null;
+    if (method.len == 0 or target.len == 0) return null;
+    return .{ .method = method, .target = target };
+}
+
+/// Extract the (case-insensitive) `Host` header value. Pure helper.
+pub fn parseHostHeader(raw: []const u8) ?[]const u8 {
+    var lines = std.mem.splitSequence(u8, raw, "\r\n");
+    _ = lines.next(); // request line
+    while (lines.next()) |line| {
+        if (line.len == 0) break; // end of headers
+        const colon = std.mem.indexOfScalar(u8, line, ':') orelse continue;
+        const name = line[0..colon];
+        if (std.ascii.eqlIgnoreCase(name, "Host")) {
+            return std.mem.trim(u8, line[colon + 1 ..], " \t");
+        }
+    }
+    return null;
+}

--- a/src/enroll/callback_server_tests.zig
+++ b/src/enroll/callback_server_tests.zig
@@ -1,0 +1,425 @@
+//! Unit tests for the loopback PKCE callback server (pure core + pure helpers).
+//!
+//! Run standalone, zero build wiring:
+//!     zig test src/enroll/callback_server_tests.zig
+//!
+//! Everything here exercises the PURE CORE (`handleCallbackRequest`) and the
+//! pure parse/validate helpers via injected fake seams — no real socket is
+//! opened. `refAllDeclsRecursive` forces the whole module (including the
+//! untested-by-design listener wrapper) to compile. All allocations go through
+//! `std.testing.allocator`, so any leak fails the test.
+
+const std = @import("std");
+const cb = @import("callback_server.zig");
+
+test {
+    std.testing.refAllDeclsRecursive(cb);
+}
+
+// ── Fake seams ─────────────────────────────────────────────────────────────
+
+const Recorder = struct {
+    now: i64 = 1_000_000,
+
+    exchange_fail: bool = false,
+    exchange_oom: bool = false,
+    access_token: []const u8 = "at-xyz",
+    refresh_token: ?[]const u8 = "rt-xyz",
+    id_token: ?[]const u8 = "jwt-xyz",
+    expires_in: ?i64 = 3600,
+
+    identity_fail: bool = false,
+    identity_oom: bool = false,
+    email: []const u8 = "user@work.example",
+    account_id: []const u8 = "acc-work",
+
+    fn clockFn(ctx: *anyopaque) i64 {
+        const self: *Recorder = @ptrCast(@alignCast(ctx));
+        return self.now;
+    }
+
+    fn exchangeFn(
+        allocator: std.mem.Allocator,
+        ctx: *anyopaque,
+        token_uri: []const u8,
+        code: []const u8,
+        code_verifier: [43]u8,
+        client_id: []const u8,
+        client_secret: []const u8,
+        redirect_uri: []const u8,
+    ) cb.ExchangeError!cb.TokenEndpointResponse {
+        _ = token_uri;
+        _ = code;
+        _ = code_verifier;
+        _ = client_id;
+        _ = client_secret;
+        _ = redirect_uri;
+        const self: *Recorder = @ptrCast(@alignCast(ctx));
+        if (self.exchange_oom) return error.OutOfMemory;
+        if (self.exchange_fail) return error.ExchangeFailed;
+        return .{
+            .access_token = try allocator.dupe(u8, self.access_token),
+            .refresh_token = if (self.refresh_token) |rt| try allocator.dupe(u8, rt) else null,
+            .id_token = if (self.id_token) |it| try allocator.dupe(u8, it) else null,
+            .expires_in = self.expires_in,
+        };
+    }
+
+    fn identityFn(
+        allocator: std.mem.Allocator,
+        ctx: *anyopaque,
+        id_token: ?[]const u8,
+        access_token: []const u8,
+    ) cb.IdentityError!cb.IdentityInfo {
+        _ = id_token;
+        _ = access_token;
+        const self: *Recorder = @ptrCast(@alignCast(ctx));
+        if (self.identity_oom) return error.OutOfMemory;
+        if (self.identity_fail) return error.ExtractFailed;
+        return .{
+            .email = try allocator.dupe(u8, self.email),
+            .account_id = try allocator.dupe(u8, self.account_id),
+        };
+    }
+
+    fn seams(self: *Recorder) cb.CallbackServerSeams {
+        return .{
+            .clock = clockFn,
+            .exchange_code = exchangeFn,
+            .extract_identity = identityFn,
+            .clock_ctx = self,
+            .exchange_code_ctx = self,
+            .extract_identity_ctx = self,
+        };
+    }
+};
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const nonce: [16]u8 = .{ 0xAB, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0xFF };
+const other_nonce: [16]u8 = .{ 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x00, 0x10 };
+const verifier: [43]u8 = .{0xCD} ** 43;
+
+const loopback_host = "127.0.0.1:54321";
+const redirect = "http://127.0.0.1:54321/callback";
+const far_future: i64 = 9_999_999_999;
+
+/// Build "/callback?code=<code>&state=<base64url(nonce)>" into `buf`.
+fn successTarget(buf: []u8, code: []const u8, n: [16]u8) []const u8 {
+    const enc = cb.encodeState(n);
+    return std.fmt.bufPrint(buf, "/callback?code={s}&state={s}", .{ code, enc[0..] }) catch unreachable;
+}
+
+/// Drive the pure core with the standard fixtures, overriding only `target`,
+/// `host`, `expected_state`, `expected_account`, and `deadline`.
+fn call(
+    rec: *Recorder,
+    target: []const u8,
+    host: []const u8,
+    expected_state: [16]u8,
+    expected_account: ?[]const u8,
+    deadline: i64,
+) cb.CallbackServerError!cb.CallbackData {
+    return cb.handleCallbackRequest(
+        std.testing.allocator,
+        rec.seams(),
+        "GET",
+        target,
+        host,
+        expected_state,
+        verifier,
+        expected_account,
+        "https://token.example/oauth/token",
+        "client-id",
+        "client-secret",
+        redirect,
+        deadline,
+    );
+}
+
+// ── Happy path ─────────────────────────────────────────────────────────────
+
+test "happy path: valid code + state -> CallbackData with moved identity" {
+    var rec = Recorder{};
+    var buf: [256]u8 = undefined;
+    const target = successTarget(&buf, "auth-code-1", nonce);
+
+    const data = try call(&rec, target, loopback_host, nonce, "acc-work", far_future);
+    defer cb.freeCallbackData(std.testing.allocator, data);
+
+    try std.testing.expectEqualStrings("auth-code-1", data.code);
+    try std.testing.expectEqualStrings("at-xyz", data.access_token);
+    try std.testing.expectEqualStrings("user@work.example", data.email);
+    try std.testing.expectEqualStrings("acc-work", data.account_id);
+    try std.testing.expect(data.refresh_token != null);
+    try std.testing.expectEqualStrings("rt-xyz", data.refresh_token.?);
+    try std.testing.expectEqual(@as(?i64, 3600), data.expires_in);
+    try std.testing.expectEqualSlices(u8, nonce[0..], data.state[0..]);
+}
+
+test "happy path: expected_account null skips identity match" {
+    var rec = Recorder{ .account_id = "whatever-account" };
+    var buf: [256]u8 = undefined;
+    const target = successTarget(&buf, "auth-code-2", nonce);
+
+    const data = try call(&rec, target, "localhost", nonce, null, far_future);
+    defer cb.freeCallbackData(std.testing.allocator, data);
+    try std.testing.expectEqualStrings("whatever-account", data.account_id);
+}
+
+test "happy path: refresh token absent" {
+    var rec = Recorder{ .refresh_token = null };
+    var buf: [256]u8 = undefined;
+    const target = successTarget(&buf, "auth-code-3", nonce);
+
+    const data = try call(&rec, target, loopback_host, nonce, "acc-work", far_future);
+    defer cb.freeCallbackData(std.testing.allocator, data);
+    try std.testing.expect(data.refresh_token == null);
+}
+
+// ── Missing / malformed params ─────────────────────────────────────────────
+
+test "missing state -> MissingCodeOrState" {
+    var rec = Recorder{};
+    try std.testing.expectError(error.MissingCodeOrState, call(&rec, "/callback?code=xyz", loopback_host, nonce, "acc-work", far_future));
+}
+
+test "empty state -> MissingCodeOrState" {
+    var rec = Recorder{};
+    try std.testing.expectError(error.MissingCodeOrState, call(&rec, "/callback?code=xyz&state=", loopback_host, nonce, "acc-work", far_future));
+}
+
+test "missing code (valid state, no error) -> MissingCodeOrState" {
+    var rec = Recorder{};
+    const enc = cb.encodeState(nonce);
+    var buf: [128]u8 = undefined;
+    const target = std.fmt.bufPrint(&buf, "/callback?state={s}", .{enc[0..]}) catch unreachable;
+    try std.testing.expectError(error.MissingCodeOrState, call(&rec, target, loopback_host, nonce, "acc-work", far_future));
+}
+
+test "empty code (valid state) -> MissingCodeOrState" {
+    var rec = Recorder{};
+    const enc = cb.encodeState(nonce);
+    var buf: [128]u8 = undefined;
+    const target = std.fmt.bufPrint(&buf, "/callback?code=&state={s}", .{enc[0..]}) catch unreachable;
+    try std.testing.expectError(error.MissingCodeOrState, call(&rec, target, loopback_host, nonce, "acc-work", far_future));
+}
+
+// ── Host header (anti-DNS-rebinding) ───────────────────────────────────────
+
+test "DNS-rebind suffix host -> HostHeaderRejected" {
+    var rec = Recorder{};
+    var buf: [256]u8 = undefined;
+    const target = successTarget(&buf, "c", nonce);
+    try std.testing.expectError(error.HostHeaderRejected, call(&rec, target, "127.0.0.1.evil.com", nonce, "acc-work", far_future));
+}
+
+test "non-loopback host -> HostHeaderRejected" {
+    var rec = Recorder{};
+    var buf: [256]u8 = undefined;
+    const target = successTarget(&buf, "c", nonce);
+    try std.testing.expectError(error.HostHeaderRejected, call(&rec, target, "example.com", nonce, "acc-work", far_future));
+}
+
+test "missing host -> HostHeaderRejected" {
+    var rec = Recorder{};
+    var buf: [256]u8 = undefined;
+    const target = successTarget(&buf, "c", nonce);
+    try std.testing.expectError(error.HostHeaderRejected, call(&rec, target, "", nonce, "acc-work", far_future));
+}
+
+// ── State / CSRF ───────────────────────────────────────────────────────────
+
+test "state mismatch (different nonce, same length) -> StateMismatch" {
+    var rec = Recorder{};
+    var buf: [256]u8 = undefined;
+    const target = successTarget(&buf, "c", other_nonce); // received encodes other_nonce
+    try std.testing.expectError(error.StateMismatch, call(&rec, target, loopback_host, nonce, "acc-work", far_future));
+}
+
+test "state garbage (wrong length) -> StateMismatch" {
+    var rec = Recorder{};
+    try std.testing.expectError(error.StateMismatch, call(&rec, "/callback?code=c&state=abc", loopback_host, nonce, "acc-work", far_future));
+}
+
+test "CSRF is checked BEFORE the error branch: bad state + error= -> StateMismatch" {
+    var rec = Recorder{};
+    var buf: [256]u8 = undefined;
+    const enc = cb.encodeState(other_nonce); // wrong state
+    const target = std.fmt.bufPrint(&buf, "/callback?error=access_denied&state={s}", .{enc[0..]}) catch unreachable;
+    // Must be StateMismatch (not ErrorRedirect) — forged error callbacks are rejected.
+    try std.testing.expectError(error.StateMismatch, call(&rec, target, loopback_host, nonce, "acc-work", far_future));
+}
+
+// ── Provider error redirect ────────────────────────────────────────────────
+
+test "valid-state provider error redirect -> ErrorRedirect" {
+    var rec = Recorder{};
+    var buf: [256]u8 = undefined;
+    const enc = cb.encodeState(nonce);
+    const target = std.fmt.bufPrint(&buf, "/callback?error=access_denied&state={s}", .{enc[0..]}) catch unreachable;
+    try std.testing.expectError(error.ErrorRedirect, call(&rec, target, loopback_host, nonce, "acc-work", far_future));
+}
+
+// ── Deadline / timeout ─────────────────────────────────────────────────────
+
+test "deadline passed -> Timeout" {
+    var rec = Recorder{ .now = 2_000_000 };
+    var buf: [256]u8 = undefined;
+    const target = successTarget(&buf, "c", nonce);
+    // clock (2_000_000) >= deadline (2_000_000) -> Timeout, before any exchange.
+    try std.testing.expectError(error.Timeout, call(&rec, target, loopback_host, nonce, "acc-work", 2_000_000));
+}
+
+// ── Seam failures ──────────────────────────────────────────────────────────
+
+test "exchange seam failure -> CodeExchangeFailed" {
+    var rec = Recorder{ .exchange_fail = true };
+    var buf: [256]u8 = undefined;
+    const target = successTarget(&buf, "c", nonce);
+    try std.testing.expectError(error.CodeExchangeFailed, call(&rec, target, loopback_host, nonce, "acc-work", far_future));
+}
+
+test "exchange seam OOM -> OutOfMemory" {
+    var rec = Recorder{ .exchange_oom = true };
+    var buf: [256]u8 = undefined;
+    const target = successTarget(&buf, "c", nonce);
+    try std.testing.expectError(error.OutOfMemory, call(&rec, target, loopback_host, nonce, "acc-work", far_future));
+}
+
+test "identity seam failure -> IdentityExtractFailed (no leak of token_resp)" {
+    var rec = Recorder{ .identity_fail = true };
+    var buf: [256]u8 = undefined;
+    const target = successTarget(&buf, "c", nonce);
+    try std.testing.expectError(error.IdentityExtractFailed, call(&rec, target, loopback_host, nonce, "acc-work", far_future));
+}
+
+test "identity seam OOM -> OutOfMemory" {
+    var rec = Recorder{ .identity_oom = true };
+    var buf: [256]u8 = undefined;
+    const target = successTarget(&buf, "c", nonce);
+    try std.testing.expectError(error.OutOfMemory, call(&rec, target, loopback_host, nonce, "acc-work", far_future));
+}
+
+// ── Identity / clone guard ─────────────────────────────────────────────────
+
+test "identity mismatch (clone guard) -> IdentityMismatch (identity freed)" {
+    var rec = Recorder{ .account_id = "acc-personal" }; // exchanged a DIFFERENT account
+    var buf: [256]u8 = undefined;
+    const target = successTarget(&buf, "c", nonce);
+    // Expected acc-work, got acc-personal -> reject, and the identity must be
+    // freed (testing.allocator would flag a leak otherwise).
+    try std.testing.expectError(error.IdentityMismatch, call(&rec, target, loopback_host, nonce, "acc-work", far_future));
+}
+
+// ── Pure helpers ───────────────────────────────────────────────────────────
+
+test "validateLoopbackHost accepts loopback forms" {
+    try cb.validateLoopbackHost("127.0.0.1");
+    try cb.validateLoopbackHost("127.0.0.1:65535");
+    try cb.validateLoopbackHost("localhost");
+    try cb.validateLoopbackHost("localhost:8080");
+}
+
+test "validateLoopbackHost rejects suffix + foreign hosts" {
+    try std.testing.expectError(error.HostHeaderRejected, cb.validateLoopbackHost("127.0.0.1.evil.com"));
+    try std.testing.expectError(error.HostHeaderRejected, cb.validateLoopbackHost("localhost.evil.com"));
+    try std.testing.expectError(error.HostHeaderRejected, cb.validateLoopbackHost("github.com"));
+    try std.testing.expectError(error.HostHeaderRejected, cb.validateLoopbackHost(""));
+}
+
+test "queryParam extracts and reports missing keys" {
+    const q = "code=abc&state=xyz&error=";
+    try std.testing.expectEqualStrings("abc", cb.queryParam(q, "code").?);
+    try std.testing.expectEqualStrings("xyz", cb.queryParam(q, "state").?);
+    try std.testing.expectEqualStrings("", cb.queryParam(q, "error").?);
+    try std.testing.expect(cb.queryParam(q, "missing") == null);
+}
+
+test "encodeState/validateState round-trip" {
+    const enc = cb.encodeState(nonce);
+    try cb.validateState(enc[0..], nonce);
+    try std.testing.expectError(error.StateMismatch, cb.validateState(enc[0..], other_nonce));
+}
+
+test "deriveChallenge matches RFC 7636 Appendix B vector" {
+    // RFC 7636 B.1: verifier -> S256 challenge.
+    const rfc_verifier: [43]u8 = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk".*;
+    const expected_challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+    const got = cb.deriveChallenge(rfc_verifier);
+    try std.testing.expectEqualStrings(expected_challenge, got[0..]);
+}
+
+test "generatePkceAndState is internally consistent" {
+    const ps = cb.generatePkceAndState();
+    try std.testing.expectEqual(@as(usize, 43), ps.verifier.len);
+    const ch = cb.deriveChallenge(ps.verifier);
+    try std.testing.expectEqualSlices(u8, ch[0..], ps.challenge[0..]);
+}
+
+// ── Authorize URL (emitted, consent boundary) ──────────────────────────────
+
+test "percentEncode encodes reserved chars, passes unreserved" {
+    const e = try cb.percentEncode(std.testing.allocator, "http://127.0.0.1:8080/callback");
+    defer std.testing.allocator.free(e);
+    try std.testing.expectEqualStrings("http%3A%2F%2F127.0.0.1%3A8080%2Fcallback", e);
+    const f = try cb.percentEncode(std.testing.allocator, "openid email");
+    defer std.testing.allocator.free(f);
+    try std.testing.expectEqualStrings("openid%20email", f);
+}
+
+test "buildAuthorizeUrl assembles an S256 PKCE request with encoded values" {
+    const ps = cb.generatePkceAndState();
+    const enc_state = cb.encodeState(ps.state_nonce);
+    const url = try cb.buildAuthorizeUrl(std.testing.allocator, .{
+        .authorize_endpoint = "https://auth.example/authorize",
+        .client_id = "cid-1",
+        .redirect_uri = "http://127.0.0.1:8080/callback",
+        .scope = "openid email",
+        .challenge = ps.challenge,
+        .state = enc_state,
+    });
+    defer std.testing.allocator.free(url);
+    try std.testing.expect(std.mem.startsWith(u8, url, "https://auth.example/authorize?response_type=code"));
+    try std.testing.expect(std.mem.indexOf(u8, url, "code_challenge_method=S256") != null);
+    try std.testing.expect(std.mem.indexOf(u8, url, "redirect_uri=http%3A%2F%2F127.0.0.1%3A8080%2Fcallback") != null);
+    try std.testing.expect(std.mem.indexOf(u8, url, "scope=openid%20email") != null);
+    // The challenge appears verbatim (already URL-safe base64url).
+    try std.testing.expect(std.mem.indexOf(u8, url, ps.challenge[0..]) != null);
+}
+
+// ── Redaction (success page leaks nothing) ─────────────────────────────────
+
+test "success response echoes no request data" {
+    const resp = try cb.renderSuccessResponse(std.testing.allocator);
+    defer std.testing.allocator.free(resp);
+    try std.testing.expect(std.mem.indexOf(u8, resp, "200 OK") != null);
+    // No code / token / verifier / state value can appear in a static page.
+    try std.testing.expect(std.mem.indexOf(u8, resp, "auth-code") == null);
+    try std.testing.expect(std.mem.indexOf(u8, resp, "at-xyz") == null);
+    try std.testing.expect(std.mem.indexOf(u8, resp, "rt-xyz") == null);
+    try std.testing.expect(std.mem.indexOf(u8, resp, "jwt-xyz") == null);
+}
+
+// ── Listener HTTP parse helpers (pure parts of the untested wrapper) ────────
+
+test "parseRequestLine extracts method + target" {
+    const raw = "GET /callback?code=x&state=y HTTP/1.1\r\nHost: 127.0.0.1:8080\r\n\r\n";
+    const line = cb.parseRequestLine(raw).?;
+    try std.testing.expectEqualStrings("GET", line.method);
+    try std.testing.expectEqualStrings("/callback?code=x&state=y", line.target);
+}
+
+test "parseRequestLine rejects empty input" {
+    try std.testing.expect(cb.parseRequestLine("") == null);
+}
+
+test "parseHostHeader is case-insensitive and trims" {
+    const raw = "GET /callback HTTP/1.1\r\nhost:  127.0.0.1:8080  \r\nAccept: */*\r\n\r\n";
+    try std.testing.expectEqualStrings("127.0.0.1:8080", cb.parseHostHeader(raw).?);
+}
+
+test "parseHostHeader returns null when absent" {
+    const raw = "GET /callback HTTP/1.1\r\nAccept: */*\r\n\r\n";
+    try std.testing.expect(cb.parseHostHeader(raw) == null);
+}


### PR DESCRIPTION
The one-shot `127.0.0.1` callback server for `redirect_loopback` reauth — the real backing for the operator web UI's `GET /callback` stub (#347) and the `redirect_loopback` half of the engine (#344). **New files only**, self-contained over injected seams; zero edits to existing code (deconflicted from the parallel core work).

Implements **TIN-1807** (`src/enroll/callback_server.zig`).

## What
Same proven shape as the engine/web UI: `handleCallbackRequest(...)` is a **pure function** (no socket/clock/disk — all I/O is injected via 3 seams: `clock` / `exchange_code` / `extract_identity`); the thin `CallbackServerListener` is a documented, untested-by-design `std.net` wrapper mirroring the repo's own loopback idiom (`wire_proxy.zig`: `parseIp("127.0.0.1",0)` → `listen(.reuse_address)` → `listen_address` → `accept` → `conn.stream`).

Full pure `redirect_loopback` surface:
- `buildAuthorizeUrl` — **emitted** to the operator (printed / UI link), **never auto-opened**. That's the consent boundary: the operator picks the **isolated/private browser context**, which is exactly what guarantees the right identity for users with many Google/GSuite accounts (work/personal/startup/family). RFC 3986 percent-encoding.
- `handleCallbackRequest` — capture `?code=&state=` → validate → exchange → confirm identity → `CallbackData`.

## Security invariants (tested)
- **Anti-DNS-rebinding:** Host must **exactly** equal `127.0.0.1`/`localhost` (optional `:port`); suffix bypass (`127.0.0.1.evil.com`) → `HostHeaderRejected`, checked before anything is trusted (RFC 8252 §7.3).
- **CSRF before the error branch:** state is validated **first** — a forged `?error=access_denied&state=WRONG` is rejected as `StateMismatch`, *not* accepted as a provider error. 16-byte (128-bit) nonce, single-use, **constant-time** compare. (This corrects an ordering bug in the design sketch where the `?error=` branch ran before state validation.)
- **PKCE S256 verifier is ephemeral:** a parameter to the core, passed only to the exchange seam, **never** returned in `CallbackData`, logged, or rendered. `deriveChallenge` is verified against the **RFC 7636 Appendix B** test vector.
- **Identity (clone) guard:** the exchanged `account_id` MUST match the account being re-authed, else `IdentityMismatch` (identity freed — no leak). Prevents rebinding to the wrong account.
- **Loopback bind only** (`127.0.0.1:0` ephemeral), one-shot accept, TTL deadline before the exchange.
- **Redaction:** the static success page echoes no request data (no code/state/token).

## Verified
`nix develop --command zig test src/enroll/callback_server_tests.zig` → **All 34 tests passed** (`std.testing.allocator` leak-checked; `refAllDeclsRecursive` forces the whole module — including the listener — to compile on zig 0.14.1). Reproduced on latest `main` (`c4a7eb3`). Self-contained: `std` only — no `@import` of existing `src`, no `build_options`. (The inline `deriveChallenge` mirrors `src/oauth.zig:generatePkce` byte-for-byte; wiring should swap to the real `oauth.generatePkce`.)

## To wire (coordinated follow-ups, shared files)
- `build.zig` `test-callback` step:
```zig
const callback_tests = b.addTest(.{ .root_source_file = b.path("src/enroll/callback_server_tests.zig"), .target = target, .optimize = optimize });
const run_callback_tests = b.addRunArtifact(callback_tests);
b.step("test-callback", "Run loopback callback server unit tests").dependOn(&run_callback_tests.step);
test_step.dependOn(&run_callback_tests.step);
```
- Bind the seams: real `exchange_code` (POST token endpoint) + `extract_identity` (id_token JWT / userinfo); wire `listenOnce` into the engine's `redirect_loopback` flow (#344) under the per-account lock; replace the web UI `/callback` stub (#347) with a call into this core; atomic `writeStore` of the result.

Part of omux Foundations · reauth-backend-ui (TIN-1807). Pairs with #344 (engine) + #347 (web UI).