### PR TITLE
Replace no-spend wording with diagnostic terminology

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ Describe the command, expected behavior, and actual behavior.
 
 ## Redacted diagnostics
 
-Please include relevant output from no-spend commands:
+Please include relevant output from diagnostic commands:
 
 ```bash
 oauth-mux doctor --json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Treat work as core only when it directly improves one of these surfaces:
 - Managed in-session quota/rate/auth/tier handoff.
 - Native-feeling UX for install, preflight, login/pass-through, resume, status,
   and repair.
-- Redacted no-spend AX so agents can inspect state and request safe next actions
+- Redacted diagnostic AX so agents can inspect state and request safe next actions
   without reading tokens or spending provider calls.
 - A reusable harness adapter contract for future Claude, OpenCode, and other
   harness integrations.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ If a shell refresh changes the result, start a fresh shell or use the shell's
 native reload path. For example, fish cannot safely `source ~/.bashrc`; bash
 syntax can fail partway through and leave a misleading mixed environment.
 Its JSON separates `agent_safe_next_actions` from
-`spend_confirmed_next_actions`; text output uses matching no-spend diagnostics
+`spend_confirmed_next_actions`; text output uses matching diagnostics
 and spend-confirmed repair sections. The same JSON includes `repair_summary`,
 a compact blocked-route rollup for agents that need to distinguish expired
 quota-window revalidation, auth handoff, runtime repair, and wait-only states
@@ -279,7 +279,7 @@ AX:
 - Trace events are opt-in and must not print token bytes, raw provider account
   ids, raw Codex session ids, or local auth/config file paths.
 - Agents do not need token files or raw provider stores to choose a next action.
-- Provider-spend behavior is policy-labeled; no-spend inspection surfaces stay
+- Provider-spend behavior is policy-labeled; diagnostic inspection surfaces stay
   separate from managed Codex auto-revalidation and live probes.
 - Diagnostic output should include exact next-action commands.
 
@@ -293,7 +293,7 @@ Keep the claim ladder tied to evidence:
   adapter strategy, daemon beta boundary, release posture, and tracker map.
 - `docs/release-install-lanes.md`: public package lanes versus local dogfood
   lanes.
-- `docs/dogfood-process-fanout.md`: no-spend agent process topology snapshots
+- `docs/dogfood-process-fanout.md`: diagnostic agent process topology snapshots
   and cleanup rules for suspected helper fanout or RSS growth.
 - `docs/lifecycle.md`: application lifecycle, managed Codex flow, agent-safe
   control plane, and claim levels.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Start here when you need the right document without reading every spec.
 
 ## New Users
 
-- `../README.md`: install commands, current supported path, and no-spend
+- `../README.md`: install commands, current supported path, and diagnostic
   diagnostics.
 - `lifecycle.md`: application lifecycle, managed Codex flow, agent-safe control
   plane, route states, and claim ladder diagrams.

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -17,7 +17,7 @@ deep evidence or architecture:
    Same-thread provider semantics, mid-turn streaming recovery, unmanaged
    daemon hot-swap, and non-Codex harness stay-afloat.
 3. How do I try it safely?
-   Install, run no-spend diagnostics, follow labeled auth handoffs, then start
+   Install, run diagnostics, follow labeled auth handoffs, then start
    `oauth-mux codex resume`.
 4. How can an agent inspect state?
    Use JSON commands that do not read token values or spend provider calls.
@@ -193,7 +193,7 @@ mutated.
 
 `doctor runtime`, `route explain`, `route select`, `codex preflight`,
 `stay-afloat next`, `stay-afloat --once`, and bounded `stay-afloat --loop` are
-no-spend surfaces when run without `--execute`. They only use local runtime
+diagnostic surfaces when run without `--execute`. They only use local runtime
 checks plus recorded liveness, so they are safe for agents to run before
 deciding whether a live probe or user-driven reauth is warranted. `codex
 preflight` also classifies the visible `codex` PATH entries so operators can
@@ -239,7 +239,7 @@ quota handoff is proven, but must not turn that into a same-thread continuity,
 mid-turn streaming recovery, unmanaged daemon, or non-Codex provider claim.
 
 `oauth-mux codex broker-plan --profile codex-max --capability codex-max --json`
-is the no-spend broker readiness check. It reads configured Codex auth stores
+is the diagnostic broker readiness check. It reads configured Codex auth stores
 locally and reports whether each route can supply `accessToken`,
 `chatgptAccountId`, and `chatgptPlanType` for a future app-server broker. Its
 output is redacted and planning-only; it does not run Codex, contact OpenAI,
@@ -264,7 +264,7 @@ mediated sessions. It is still not an unmanaged current TUI hot-swap,
 per-request mux, or quota-recovery claim.
 
 `oauth-mux codex broker-401-smoke --profile codex-max --capability codex-max
---confirm-broker --json` proves the controlled no-spend 401 retry loop for a
+--confirm-broker --json` proves the controlled diagnostic 401 retry loop for a
 broker-owned Codex app-server session. oauth-mux points Responses and ChatGPT
 backend traffic at a local mock, returns 401 to the first turn Responses
 request, answers app-server refresh with the next ready route, and verifies the
@@ -272,14 +272,14 @@ retry uses the fallback token. This is the current strongest mediated Codex
 proof; it still does not claim unmanaged TUI hot-swap.
 
 `oauth-mux codex broker-quota-smoke --profile codex-max --capability codex-max
---confirm-broker --json` proves the no-spend quota boundary. It returns a local
+--confirm-broker --json` proves the diagnostic quota boundary. It returns a local
 usage-limit 429 to the first turn, observes that Codex does not issue the 401
 auth-refresh hook, applies a fallback app-server login, and verifies a new
 brokered thread uses fallback Authorization. Same-thread quota recovery remains
 explicitly unproven.
 
 `oauth-mux codex broker-session-plan --profile codex-max --capability codex-max
---json` is the no-spend UX planning surface for broker-owned Codex sessions. It
+--json` is the diagnostic UX planning surface for broker-owned Codex sessions. It
 combines recorded route liveness with app-server auth-broker readiness, then
 reports the selected route, immediate selectable fallbacks, quota-blocked broker
 routes, and the same explicit no-hot-swap/no-same-thread quota boundary. Its
@@ -292,7 +292,7 @@ account, or wait for quota reset. JSON clients read `resilience_actions`; text
 output prints the matching `next:` hint.
 
 `oauth-mux codex broker-session-smoke --profile codex-max --capability codex-max
---confirm-broker --json` is the matching no-spend multi-turn UX smoke. It uses
+--confirm-broker --json` is the matching diagnostic multi-turn UX smoke. It uses
 the session plan's selected and fallback routes, starts a broker-owned
 app-server against local mocked backend endpoints, simulates quota exhaustion on
 turn one, and verifies a new brokered thread uses the fallback route.

--- a/docs/daemon-boundary.md
+++ b/docs/daemon-boundary.md
@@ -41,7 +41,7 @@ into a seamless fallback path.
 
 The current paid Codex Max route matrix is also newer than the original
 2026-04-30 example, and it changes with real auth/quota state. The 2026-05-17
-installed `0.1.7` no-spend refresh has `max-1#codex-max` selected,
+installed `0.1.7` diagnostic snapshot has `max-1#codex-max` selected,
 `max-3#codex-max` and `max-4#codex-max` selectable as spare fallbacks, and
 `max-2#codex-max` blocked as `token_revoked` until the labeled upstream login
 handoff runs. Dashboard credit or mini/Spark availability must not be treated
@@ -126,10 +126,10 @@ session can move this beyond prepared fallback.
 ## Allowed Now
 
 - `oauth-mux daemon run` as the foreground primitive for any future wrapper.
-- `oauth-mux doctor runtime` for no-spend local runtime/session diagnostics,
+- `oauth-mux doctor runtime` for local runtime/session diagnostics,
   including profile-scoped route readiness checks.
-- `oauth-mux route explain` for no-spend route-state explanation.
-- `oauth-mux route select` for no-spend route choice from recorded evidence.
+- `oauth-mux route explain` for diagnostic route-state explanation.
+- `oauth-mux route select` for diagnostic route choice from recorded evidence.
 - `oauth-mux repair-plan` for non-mutating stay-afloat action planning.
 - `oauth-mux repair run` for one explicit, confirmed repair command.
 - `oauth-mux daemon repair-plan` as a compatibility alias for the same

--- a/docs/install-beta-matrix.md
+++ b/docs/install-beta-matrix.md
@@ -22,9 +22,9 @@ The lane contract and current operator rules live in
 | Homebrew formula | 0.1.7 | macOS arm64 | public `jesssullivan/omux` tap | Pass | Public tap PR `Jesssullivan/homebrew-omux#1` updated the formula from the GitHub Release asset; clean QA installed `oauth-mux 0.1.7` and `brew info --json=v2` reports stable `0.1.7`. |
 | deb package | 0.1.7 | hosted Linux amd64 container | public GitHub Release `.deb` asset | Pass | System Package Install QA run `25980333371` installed package and ran `/usr/bin/oauth-mux version`. |
 | rpm package | 0.1.7 | hosted Linux x86_64 container | public GitHub Release `.rpm` asset | Pass | System Package Install QA run `25980333371` installed package and ran `/usr/bin/oauth-mux version`. |
-| Codex route dogfood | 0.1.7 | macOS arm64 | installed binary | Pass with spare fallback | Current 2026-05-17 no-spend truth: `codex-max` selects `max-1`, has `max-3` and `max-4` as selectable fallbacks, and blocks `max-2` as `token_revoked`; `session_start_ready:true`, `fallback_ready:true`, and `single_route_at_risk:false`. |
+| Codex route dogfood | 0.1.7 | macOS arm64 | installed binary | Pass with spare fallback | Current 2026-05-17 diagnostic truth: `codex-max` selects `max-1`, has `max-3` and `max-4` as selectable fallbacks, and blocks `max-2` as `token_revoked`; `session_start_ready:true`, `fallback_ready:true`, and `single_route_at_risk:false`. |
 | lab dogfood | 0.1.7 | macOS arm64 | public npm one-shot | Pass | Public `npx` run reports `oauth-mux 0.1.7` and `doctor --json` reports `ok:true` against local config/state. |
-| first-run source e2e | main | macOS arm64 | source checkout | Pass | `just first-run-e2e` runs with temporary HOME/XDG roots and proves no-config `init --codex-max`, JSON diagnostics, runtime diagnostics, redacted report, no-spend route explanation/select refusal, and non-mutating Codex help. |
+| first-run source e2e | main | macOS arm64 | source checkout | Pass | `just first-run-e2e` runs with temporary HOME/XDG roots and proves no-config `init --codex-max`, JSON diagnostics, runtime diagnostics, redacted report, diagnostic route explanation/select refusal, and non-mutating Codex help. |
 
 ## Evidence Commands
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -22,12 +22,12 @@ flowchart LR
     artifact --> repair["Repair / revalidate loop"]
     repair --> diagnostics
 
-    diagnostics --> noSpend["No-spend JSON surfaces"]
+    diagnostics --> noSpend["Diagnostic JSON surfaces"]
     repair --> userHandoff["User-mediated login / reauth"]
     repair --> liveProbe["Spend-confirmed live probe"]
 ```
 
-The lifecycle separates no-spend inspection from provider-spend operations.
+The lifecycle separates diagnostic inspection from provider-spend operations.
 Agents can inspect route and runtime state without reading token files or
 triggering provider calls. Login, reauth, and live probes remain explicit human
 or operator actions.
@@ -74,7 +74,7 @@ fallback account, and fallback `200` before Codex sees the 429.
 
 ```mermaid
 flowchart TB
-    human["Human or agent"] --> inspect["No-spend JSON command"]
+    human["Human or agent"] --> inspect["Diagnostic JSON command"]
     inspect --> broker["Broker reports route states"]
     broker --> action["Exact safe next action"]
 
@@ -89,7 +89,7 @@ flowchart TB
     confirm --> broker
 ```
 
-No-spend commands:
+Diagnostic commands:
 
 ```bash
 oauth-mux doctor runtime --profile codex-max --capability codex-max --json

--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -122,7 +122,7 @@ Hosted evidence from run `25029923810`:
 
 Current post-handoff Codex Max route truth moves with operator auth and reset
 windows. Use `docs/qa-handoff-matrix.md` as the canonical current-state matrix
-and refresh no-spend truth with:
+and refresh diagnostic truth with:
 
 ```bash
 oauth-mux route explain --profile codex-max --capability codex-max --json
@@ -133,7 +133,7 @@ After the 2026-05-09 engineered handoff burn, the important durable claim is
 not any one account's later availability state; it is that managed Codex quota
 handoff from `codex:max-2` to `codex:max-3` is preserved in
 `docs/evidence/codex-engineered-quota-handoff-20260509/`. Do not describe the
-pool as afloat unless current no-spend route truth shows a selectable primary
+pool as afloat unless current diagnostic route truth shows a selectable primary
 and fallback.
 
 Hosted evidence from PR-branch run `25134175687` on 2026-04-29:

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -69,7 +69,7 @@ oauth-mux repair-plan --profile codex-max --capability codex-max --json
 oauth-mux repair run --profile codex-max --capability codex-max --json
 ```
 
-`oauth-mux doctor` is the no-spend readiness report. It checks whether config is
+`oauth-mux doctor` is the diagnostic readiness report. It checks whether config is
 present and valid, counts configured providers/accounts/profiles, reports
 whether health state exists, and prints the next safe commands for the current
 state.
@@ -87,7 +87,7 @@ The trace format is documented in `docs/tracing.md`. It is designed for
 operator and agent debugging without printing token bytes, raw provider account
 ids, raw Codex session ids, or local auth/config file paths.
 
-`oauth-mux doctor runtime --json` is the no-spend runtime report. It checks
+`oauth-mux doctor runtime --json` is the diagnostic runtime report. It checks
 upstream binary availability, configured account store directories, local write
 access via a temporary marker file, and expected session-file presence. It does
 not read token values, run live probes, open auth flows, or create missing
@@ -103,7 +103,7 @@ prove oauth-mux route liveness. Use `oauth-mux codex preflight --profile
 <profile> --capability <capability> --json` for managed Codex route
 selectability and provider-accepted auth evidence.
 
-`oauth-mux accounts list --json` is the no-spend account inventory. It is the
+`oauth-mux accounts list --json` is the diagnostic account inventory. It is the
 first provider-neutral surface for N-account enrollment and stay-afloat
 planning: it reports each configured provider/account, secret backend name,
 runtime readiness, writeback admission, capability proof status, recorded
@@ -153,7 +153,7 @@ For status-only inspection:
 oauth-mux setup codex --status-only
 ```
 
-For a no-spend canary after onboarding:
+For a diagnostic canary after onboarding:
 
 ```bash
 oauth-mux codex canary
@@ -199,7 +199,7 @@ oauth-mux repair-plan --profile codex-max --capability codex-max --json
 oauth-mux repair-plan --profile codex-mini --capability codex-mini --json
 ```
 
-`route explain` and `route select` are no-spend commands. They read runtime
+`route explain` and `route select` are diagnostic commands. They read runtime
 readiness plus recorded route liveness and do not probe providers or mutate auth
 state. Unrecorded routes are reported as `probe_needed`, and `route select`
 exits nonzero when no route has enough evidence to be selected.
@@ -262,7 +262,7 @@ child config: `terminal_resize_reflow`, `memories`, `external_migration`,
 explicit `false`, win, and oauth-mux does not rewrite the canonical
 `config.toml`.
 
-For a no-spend managed Codex readiness snapshot, use:
+For a diagnostic managed Codex readiness snapshot, use:
 
 ```bash
 oauth-mux codex preflight --profile codex-max --capability codex-max --json
@@ -277,18 +277,18 @@ not call the provider or mutate route health. For Codex blocked routes,
 older than the recorded failure, so a native `login status` success is not enough
 to clear `token_revoked`; a user-mediated login, admitted refresh, or live
 revalidation must write newer evidence. JSON
-clients should prefer `agent_safe_next_actions` for no-spend automation and
+clients should prefer `agent_safe_next_actions` for diagnostic automation and
 treat `spend_confirmed_next_actions` as user-approved route-health repair only.
 Interactive login or reauth commands appear in `user_mediated_next_actions`;
 wrappers may display those commands, but must not run them without the user
-owning the upstream CLI login boundary. Text output uses the same no-spend,
+owning the upstream CLI login boundary. Text output uses the same diagnostic,
 spend-confirmed, and user-mediated repair labels.
 
 When a managed Codex session exhausts every selectable fallback, the wire proxy
 returns typed `oauth_mux_no_account_selectable` JSON instead of a bare provider
 error. That 503 body includes `preflight_command`, `rejection_summary`,
 `agent_safe_next_actions`, and `spend_confirmed_next_actions` so wrappers can
-surface no-spend inspection first and reserve route-health repair for explicit
+surface diagnostic inspection first and reserve route-health repair for explicit
 user approval.
 
 Managed Codex live quota handoff is proven for installed
@@ -329,14 +329,14 @@ for the live 401 repair primitive; it does not yet prove automatic repair of an
 already-running unmanaged Codex process.
 Use
 `oauth-mux codex broker-401-smoke --profile codex-max --capability codex-max
---confirm-broker --json` to prove the no-spend mediated 401 retry loop. It
+--confirm-broker --json` to prove the diagnostic mediated 401 retry loop. It
 starts a disposable app-server with local mocked Responses and ChatGPT backend
 URLs, forces the first turn Responses request to 401, answers app-server
 refresh with the next ready route, and verifies the retried request used that
 fallback token.
 Use
 `oauth-mux codex broker-quota-smoke --profile codex-max --capability codex-max
---confirm-broker --json` to prove the no-spend quota fallback boundary. It
+--confirm-broker --json` to prove the diagnostic quota fallback boundary. It
 simulates usage-limit 429, confirms that this is not the same hook as 401
 auth-refresh, then verifies fallback Authorization on a new brokered thread.
 That is useful stay-afloat evidence, but not same-thread quota recovery.
@@ -388,7 +388,7 @@ Use
 codex-max --from-account max-3 --confirm-drill --json` when you need to observe
 fallback deliberately. It records the named route as quota-exhausted in local
 route health, then verifies broker-owned selection moves to a distinct fallback
-route. This is no-spend and useful for operator drills, but it is controlled
+route. This is diagnostic and useful for operator drills, but it is controlled
 route-state evidence, not provider-originated quota exhaustion.
 
 `stay-afloat launch -- <command>` is the user/wrapper startup boundary. It runs
@@ -612,7 +612,7 @@ just first-run-e2e
 That harness runs with a temporary `HOME`, XDG config/state/data/runtime roots,
 and no inherited `OMUX_*` overrides. It proves `init --codex-max`, JSON
 diagnostics, redacted support output, repair-plan route explanation,
-runtime diagnostics, no-spend route explanation and route-select refusal without
+runtime diagnostics, diagnostic route explanation and route-select refusal without
 health evidence,
 non-clobbering config-candidate generation, config-merge backup behavior, and
 non-mutating Codex help plus the unconfirmed live-QA spend gate without touching
@@ -733,7 +733,7 @@ login, plan token, file key, or consent gate without guessing.
    `oauth-mux enroll figma --account <name> --mode <oauth|pat|plan>
    --confirm-enroll --json`, then set the returned secret env var before any
    proof probe.
-10. Run no-spend checks first: `status`, `health`, and credential parse probes.
+10. Run diagnostic checks first: `status`, `health`, and credential parse probes.
 11. Run live probes only through `scripts/live-provider-qa.sh` or the manual
    Live Provider QA workflow.
 

--- a/docs/provider-repair-contracts.md
+++ b/docs/provider-repair-contracts.md
@@ -37,7 +37,7 @@ The action now has three distinct identity fields:
 - `mediation` is how an agent, wrapper, or user should handle the action.
 - `repair_owner` identifies who owns credential repair when there is one.
 - `command` is the executable oauth-mux repair handoff when oauth-mux has one.
-- `handoff_plan_command` is a no-spend planning command for upstream-owned
+- `handoff_plan_command` is a diagnostic planning command for upstream-owned
   handoffs that do not yet have an oauth-mux executable repair command.
 
 `stay-afloat next --json` wraps the same action contract in a single

--- a/docs/qa-handoff-matrix.md
+++ b/docs/qa-handoff-matrix.md
@@ -57,7 +57,7 @@ capability, such as `codex:max-3#codex-max`.
 | All fallbacks unavailable | every candidate rejected | `quota_handoff_failed_no_account_selectable` with redacted vector | synthetic and managed cassette harness covered; publishable provider cassette/live target |
 | Tier selected-route classification | selected route returns `usage_not_included` | route marked `tier_insufficient`; no quota classification or same-turn quota retry | synthetic covered; live/cassette target |
 | Tier before fallback election | already-tier-blocked B precedes credited C in route pool | B is not elected; C selected | unit matrix covered; live/cassette target |
-| Reset-window repair | quota window expires | no-spend state becomes stale; confirmed revalidation repairs only with provider evidence | live target |
+| Reset-window repair | quota window expires | diagnostic state becomes stale; confirmed revalidation repairs only with provider evidence | live target |
 | API-credit false positive | subscription quota exhausted but API credits exist | Codex subscription route stays quota-blocked | live target |
 | Child signal | Codex child killed/stopped | `session_aborted` with `term_kind`, `term_code`, `signal_name` | status regression added |
 
@@ -68,7 +68,7 @@ capability, such as `codex:max-3#codex-max`.
 | Zig unit tests | none | parser/state invariants and status summarization | quota summary lifetime, child signal terminal fields |
 | Shell smokes | none | CLI UX and local proxy behavior | chooser parity, config passthrough, 401, quota, tier, all-exhausted |
 | Cassette replay | none after capture | real wire-shape regression without provider calls | scrubbed `usage_limit_reached`, 401, tier/rate captures |
-| Live no-spend | no provider spend | installed binary route truth and runtime state | `route explain`, `doctor runtime`, `status-latest` |
+| Live diagnostic | no provider spend | installed binary route truth and runtime state | `route explain`, `doctor runtime`, `status-latest` |
 | Live spend-confirmed | yes | provider-originated quota/auth/tier truth | `probe-all`, `revalidate-exhausted`, managed Codex dogfood |
 
 ## Coverage Reality
@@ -100,15 +100,15 @@ publishable evidence for those same negative shapes.
   `oauth-mux codex resume`.
 - The strongest preserved proof is
   `docs/evidence/codex-engineered-quota-handoff-20260509/`.
-- Current no-spend route truth is volatile and must be refreshed before each
+- Current diagnostic route truth is volatile and must be refreshed before each
   live session. The 2026-05-17 22:24 EDT installed Homebrew `0.1.7` snapshot is
   historical evidence, not current route truth; it was `not_afloat` for
   `codex-max` with all four named routes runtime-ready and broker-ready but
   route liveness `unrecorded`.
-- The 2026-05-20 17:01 UTC no-spend refresh improved that to one selectable
+- The 2026-05-20 17:01 UTC diagnostic snapshot improved that to one selectable
   route (`max-3`) but still had no spare fallback; treat it as historical
   single-route-risk evidence.
-- The 2026-05-21 02:57 UTC post-repair no-spend refresh used user-local
+- The 2026-05-21 02:57 UTC post-repair diagnostic snapshot used user-local
   `oauth-mux 0.1.9`: `codex:max-3#codex-max` is selected, `max-4` is a live
   selectable fallback, and `max-1` / `max-2` remain runtime/broker ready but
   blocked as `unrecorded`.
@@ -132,7 +132,7 @@ the 2026-05-20 release-hygiene refresh, public package lanes resolve to
 `0.1.9`; use `oauth-mux version --json` to distinguish that package binary from
 `~/.local/bin/oauth-mux` or `./zig-out/bin/oauth-mux` worktree dogfood hashes.
 
-No-spend opening sequence:
+Diagnostic opening sequence:
 
 ```bash
 oauth-mux version --json
@@ -154,7 +154,7 @@ Current matrix entry:
 | `codex:max-4#codex-max` | selectable, live | current spare fallback |
 
 Do not start provider-spend cassette or negative-matrix work from memory. Rerun
-the no-spend opener first and verify `session_start_ready:true`,
+the diagnostic opener first and verify `session_start_ready:true`,
 `fallback_ready:true`, and `single_route_at_risk:false`; then proceed only with
 explicit operator approval for the provider-spend capture. If the just-in-time
 refresh falls back to single-route risk, pause and repair/probe before treating
@@ -165,12 +165,12 @@ Spend-confirmed activation sequence:
 1. Refresh private quota UI for the four route labels and confirm the current
    `max-3` / `max-4` primary-fallback pair is still the least risky pair.
 2. With explicit operator consent, run only the smallest targeted provider
-   probe(s) needed to restore spare fallback if the no-spend opener regresses;
+   probe(s) needed to restore spare fallback if the diagnostic opener regresses;
    optionally probe `max-1` / `max-2` only when additional redundancy is worth
    the provider spend.
 3. If a targeted probe reports auth failure, run only the labeled
    `oauth-mux codex login-device max-N` handoff for that route, then rerun the
-   no-spend opener and a spend-confirmed probe only if still needed.
+   diagnostic opener and a spend-confirmed probe only if still needed.
 4. Once `session_start_ready:true` and `fallback_ready:true` are reconfirmed,
    run the chosen negative/live permutation through the intended installed
    `oauth-mux` binary and record provenance.

--- a/docs/spec/broker-mcp-contract-2026-05-03.md
+++ b/docs/spec/broker-mcp-contract-2026-05-03.md
@@ -156,7 +156,7 @@ labelling, not a product limitation we hide.
 Until a non-Codex adapter exists, use the provider-proof and enrollment surfaces
 for those providers. For Claude, that means `oauth-mux enroll claude ...`,
 `CLAUDE_CONFIG_DIR` user-mediated login, `doctor runtime`, `probe
---capability auth-status`, and `stay-afloat --once` as a no-spend route-state
+--capability auth-status`, and `stay-afloat --once` as a diagnostic route-state
 check. It does not mean `oauth-mux claude` seamless handoff exists.
 
 ## 2. Broker MCP Method Surface

--- a/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
+++ b/docs/spec/broker-worktree-quarry-todo-2026-05-05.md
@@ -331,7 +331,7 @@ These need review before public promotion:
   `usage_not_included` or 401, and all-accounts-exhausted reports
   `proxy_same_turn_retry_unavailable` plus a clean no-account-selectable path.
 - Full `just check-local` passed after the proxy and smoke updates.
-- No-spend live route readiness, run with normal local filesystem access:
+- Diagnostic live route readiness, run with normal local filesystem access:
   selected `codex:max-1`; selectable fallbacks `max-2`, `max-3`, and `max-4`;
   `selectable_broker_routes:4`, `selectable_fallback_routes:3`,
   `spare_fallback_ready:true`, `single_route_at_risk:false`.

--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -112,7 +112,7 @@ databases from `CODEX_SQLITE_HOME` when set. In canonical bridge mode,
 oauth-mux keeps `CODEX_HOME` as the mux-owned auth/config overlay but sets
 child `CODEX_SQLITE_HOME` to the canonical session authority home. The overlay
 also symlinks `state_5.sqlite*` and `logs_2.sqlite*` when canonical Codex has
-them, so drift is visible in no-spend smoke tests. Older Codex homes still fall
+them, so drift is visible in diagnostic smoke tests. Older Codex homes still fall
 back to the legacy `sessions/`, `shell_snapshots/`, `history.jsonl`, and
 `session_index.jsonl` authority set. Redacted status reports
 `sqlite_authority`, `resume_authority_state_db_bridged`,

--- a/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
+++ b/docs/spec/codex-inplace-auth-broker-proof-2026-05-02.md
@@ -281,10 +281,10 @@ For quota-driven account changes, use a different action name, such as
    next-turn account selection, but do not claim same-turn quota recovery until
    Codex exposes or proves that hook. `oauth-mux codex broker-quota-smoke
    --profile codex-max --capability codex-max --confirm-broker --json` now
-   proves the first no-spend version: local usage-limit 429 does not produce
+   proves the first diagnostic version: local usage-limit 429 does not produce
    the 401 refresh hook, fallback app-server login is accepted, and a new
    brokered thread uses fallback Authorization.
-10. Add a no-spend session planning surface:
+10. Add a diagnostic session planning surface:
    `oauth-mux codex broker-session-plan --profile codex-max --capability
    codex-max --json` joins recorded route liveness with broker auth readiness
    and reports selected, fallback, quota-blocked, and auth-unready routes for
@@ -295,7 +295,7 @@ For quota-driven account changes, use a different action name, such as
    revalidate exhausted routes, enroll another account, or wait for quota reset.
    JSON clients read `resilience_actions`; text output prints the matching
    `next:` hint.
-11. Add a no-spend broker-owned session smoke:
+11. Add a diagnostic broker-owned session smoke:
    `oauth-mux codex broker-session-smoke --profile codex-max --capability
    codex-max --confirm-broker --json` uses the session plan's selected and
    fallback routes, starts a local app-server session against mocked backend
@@ -319,7 +319,7 @@ For quota-driven account changes, use a different action name, such as
    `oauth-mux codex broker-fallback-drill --profile codex-max --capability
    codex-max --from-account max-3 --confirm-drill --json` records the named
    route as quota-exhausted in local route health and verifies the next
-   broker-owned route selection picks a distinct fallback. This is no-spend
+   broker-owned route selection picks a distinct fallback. This is diagnostic
    route-state evidence, not provider-originated quota evidence.
 15. Only after topology A is green, attempt topology B with a remote TUI and
    sidecar broker.
@@ -338,10 +338,10 @@ For quota-driven account changes, use a different action name, such as
 - The controlled quota smoke proves new-thread fallback after local
   usage-limit classification. It also records the negative evidence:
   same-turn and same-thread quota recovery are not proven.
-- The broker session plan is no-spend and planning-only. It can report a
+- The broker session plan is diagnostic and planning-only. It can report a
   broker-owned session start route plus immediate selectable fallbacks, but it
   does not start Codex, spend provider calls, or claim unmanaged TUI hot-swap.
-- The broker session smoke is no-spend and local. It can prove a multi-turn
+- The broker session smoke is diagnostic and local. It can prove a multi-turn
   broker-owned app-server handoff using session-plan route selection, but it
   still does not prove same-thread quota recovery or unmanaged TUI hot-swap.
 - The broker live run is spend-gated. Its `--prompt` form proves one live turn;
@@ -377,7 +377,7 @@ For quota-driven account changes, use a different action name, such as
   re-probe the provider, and persist the fresh capability evidence. It removes
   the manual health-reset step, but it does not imply dashboard credits make a
   route available for every Codex capability.
-- The broker fallback drill is no-spend but mutates local route health. It can
+- The broker fallback drill is diagnostic but mutates local route health. It can
   observe next-route fallback after a controlled quota-exhausted mark, while
   explicitly not claiming provider-originated quota exhaustion.
 - Cross-account switching is blocked when forced workspace or profile policy

--- a/docs/spec/codex-live-acceptance-checklist-2026-05-08.md
+++ b/docs/spec/codex-live-acceptance-checklist-2026-05-08.md
@@ -83,7 +83,7 @@ Do not close the engineered in-session gate from:
 | Installed exhausted-login handoff | Sign into native Codex as a known exhausted ChatGPT account, then enter through installed `oauth-mux codex resume <id>` with one credited fallback | A returns `usage_limit_reached`; B returns `200`; no visible 429 | Managed load/resume proof. Already observed on 2026-05-08 |
 | Engineered in-session exhaustion | Start A credited; run a long managed session until A reaches provider quota; keep B credited | Same process swaps A -> B and continues | Managed quota handoff proof. Observed on 2026-05-09 |
 | Exhausted ChatGPT quota plus API credits | A has exhausted ChatGPT/Codex subscription quota but separate API credits remain | Codex subscription route still follows ChatGPT quota truth; API credits do not make A selectable for subscription-backed Codex | Prevents credit-dashboard false positives |
-| Reset-window repair | A was quota-exhausted; reset window expires or plan changes | No-spend plan marks revalidation needed; spend-gated revalidation repairs A only after provider evidence | Durable health repair proof |
+| Reset-window repair | A was quota-exhausted; reset window expires or plan changes | Diagnostic plan marks revalidation needed; spend-gated revalidation repairs A only after provider evidence | Durable health repair proof |
 | Tier before fallback | A exhausted; B returns `usage_not_included`; C credited | B is marked `tier_insufficient`, then C handles the request | Typed rejection sequencing |
 | All fallbacks exhausted | Every candidate is quota/rate/tier/auth blocked | Typed `quota_handoff_failed_no_account_selectable` with complete redacted rejection vector | Honest failure UX |
 | Expired but refreshable fallback | B access token expired; B refresh token valid | Preflight/materialization refresh repairs B before selection or retry | Prevents false `NoAccountSelectable` |
@@ -123,7 +123,7 @@ python3 scripts/summarize-codex-status.py <status.ndjson> \
 The installed-binary command is the operator path. The Python command is the
 repo regression oracle.
 
-Check no-spend route state after a quota observation:
+Check diagnostic route state after a quota observation:
 
 ```bash
 oauth-mux codex broker-session-plan \

--- a/docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md
+++ b/docs/spec/codex-managed-resume-ux-refactor-2026-05-06.md
@@ -183,7 +183,7 @@ Recommended command grammar:
 - If needed, split a new implementation ticket for "managed Codex UX
   command grammar and status artifact hardening".
 
-### Phase 1: No-Spend UX Hardening
+### Phase 1: Diagnostic UX Hardening
 
 Implementation targets:
 
@@ -339,7 +339,7 @@ Add or extend shell smokes:
   - shared session authority remains safe.
 
 - Keep `scripts/smoke-codex-acceptance.sh`
-  - no-spend A -> 429 -> B synthetic swap in one stable child PID.
+  - diagnostic A -> 429 -> B synthetic swap in one stable child PID.
 
 ### 5.4 Cassette Coverage
 

--- a/docs/spec/codex-session-store-portability-policy-2026-05-18.md
+++ b/docs/spec/codex-session-store-portability-policy-2026-05-18.md
@@ -80,9 +80,9 @@ oauth-mux does not currently claim:
   store;
 - one account-local Codex home per OAuth route as a complete native Codex home.
 
-## No-Spend Proof
+## Diagnostic Proof
 
-Current no-spend regression coverage:
+Current diagnostic regression coverage:
 
 - `scripts/smoke-codex-cli-ux.sh`
   - proves first-class managed `resume`, `resume --last`, and `resume <id>`
@@ -100,7 +100,7 @@ Current no-spend regression coverage:
   - proves concurrent managed overlays keep distinct proxy/auth/config state
     while sharing canonical session authority safely.
 
-These smokes are local and no-spend. They prove filesystem/session-authority
+These smokes are local and diagnostic. They prove filesystem/session-authority
 behavior, not provider acceptance of cross-account thread continuation.
 
 ## Future Import Gate

--- a/docs/spec/development-timeline-2026-04-27.md
+++ b/docs/spec/development-timeline-2026-04-27.md
@@ -8,7 +8,7 @@ Supersession note, 2026-05-03: this timeline records the original public
 release arc. Current Codex dogfood has moved from the initial starter path to a
 four-route paid `codex-max` cohort with broker-owned session planning, live
 broker-run, exhausted-route revalidation, controlled fallback drills, and a
-no-spend soak snapshot helper. Same-thread quota recovery and unmanaged TUI
+diagnostic soak snapshot helper. Same-thread quota recovery and unmanaged TUI
 hot-swap remain unclaimed.
 
 ## Current Stage
@@ -106,7 +106,7 @@ degradation or auth death.
   SOPS at runtime; token material is never committed or printed.
 
 - Codex canary and secret-scoped live QA
-  `oauth-mux codex canary` captures no-spend config/discovery/status/health and
+  `oauth-mux codex canary` captures diagnostic config/discovery/status/health and
   per-account `codex login status` evidence, then delegates to live probes only
   when `--live` is explicitly supplied.
 

--- a/docs/spec/future-adapter-roadmap-2026-05-10.md
+++ b/docs/spec/future-adapter-roadmap-2026-05-10.md
@@ -18,7 +18,7 @@ Every adapter needs:
 2. named account labels that operators can map privately;
 3. runtime doctor that distinguishes missing CLI, missing login, bad auth,
    quota/rate/tier failure, and local store errors;
-4. no-spend fixture tests for every typed state the adapter emits;
+4. diagnostic fixture tests for every typed state the adapter emits;
 5. one positive live proof and one negative live or cassette proof before
    claiming capability support;
 6. a documented current-process boundary: managed proxy, app-server protocol,

--- a/docs/spec/in-agent-reauth-handoff-contract-2026-05-14.md
+++ b/docs/spec/in-agent-reauth-handoff-contract-2026-05-14.md
@@ -21,7 +21,7 @@ probes, credential rewrites, or session-store repairs.
 
 The supported in-agent behavior is mediation, not credential control:
 
-1. Read no-spend JSON surfaces.
+1. Read diagnostic JSON surfaces.
 2. Show the exact redacted next action to the user.
 3. Wait for user-mediated completion when the action is interactive.
 4. Refresh route evidence with an admitted oauth-mux command.
@@ -46,9 +46,9 @@ Every JSON action exposed to an agent must keep these consent fields explicit:
 - `mediation`
 - `repair_owner`
 
-## 2. No-Spend Surfaces
+## 2. Diagnostic Surfaces
 
-Agents should start with these no-spend commands or their future MCP tool
+Agents should start with these diagnostic commands or their future MCP tool
 equivalents:
 
 ```bash
@@ -111,7 +111,7 @@ permission broker.
 
 Some upstream-owned providers do not have an oauth-mux executable repair
 command yet. In those cases `command` remains `null` and
-`handoff_plan_command` points to a no-spend planning command the agent can show
+`handoff_plan_command` points to a diagnostic planning command the agent can show
 to the user.
 
 After a user completes the upstream login, the agent should ask for an evidence

--- a/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
+++ b/docs/spec/oauth-mux-operational-hardening-plan-2026-05-20.md
@@ -36,7 +36,7 @@ prepared fallback remain diagnostic infrastructure, not the success claim.
 - Current install truth: `/Users/jess/.local/bin/oauth-mux` is PATH-first and
   reports `0.1.12` with build id `v0.1.12`; `/opt/homebrew/bin/oauth-mux` also
   reports `0.1.12`. Native Codex resolves outside oauth-mux.
-- Current no-spend route truth: `oauth-mux codex preflight --profile codex-max
+- Current diagnostic route truth: `oauth-mux codex preflight --profile codex-max
   --capability codex-max --json` reports `ok:true`, `session_start_ready:true`,
   `fallback_ready:true`, `selectable_fallback_routes:2`,
   `single_route_at_risk:false`, `spends_provider_calls:false`, and
@@ -83,7 +83,7 @@ Todo:
 
 - [x] Split streamed proxy outcome into client-disconnect versus upstream
   interruption paths.
-- [x] Add no-spend stub coverage for downstream disconnects and provider
+- [x] Add diagnostic stub coverage for downstream disconnects and provider
   degraded upstream interruption.
 - [x] Add a CI-safe smoke for partial upstream `200` interruption that proves
   no same-turn retry after partial delivery and records provider-degraded route
@@ -97,7 +97,7 @@ Todo:
   Release, user-local, and Homebrew as `0.1.11`; the fix remains included in
   current release `0.1.12`.
 
-## Workstream 2 - No-Spend Route And Process Truth Refresh
+## Workstream 2 - Diagnostic Route And Process Truth Refresh
 
 Priority: P0 before any live Codex spend, cassette capture, or tracker claim.
 
@@ -111,7 +111,7 @@ Completion metric:
 - Any process-fanout concern is backed by fresh redacted snapshot output, not
   by stale memory/process impressions.
 
-No-spend command set:
+Diagnostic command set:
 
 ```bash
 which -a oauth-mux
@@ -129,17 +129,17 @@ python3 scripts/dogfood-process-snapshot.py
 
 Todo:
 
-- [x] Run the no-spend command set immediately after Workstream 1 is landed or
+- [x] Run the diagnostic command set immediately after Workstream 1 is landed or
   intentionally before any live run.
 - [x] Preserve a redacted summary under `docs/evidence/` only if it adds new
   proof value; otherwise keep it as operator scratch.
 - [x] Block cassette/live work while the 2026-05-20 17:01 UTC snapshot showed
   `single_route_at_risk:true`.
-- [x] Re-run no-spend route truth after spend-confirmed route-health repair.
+- [x] Re-run diagnostic route truth after spend-confirmed route-health repair.
 - [ ] Re-run route truth immediately before cassette capture and verify
   `single_route_at_risk:false` still holds.
 
-2026-05-20 17:01 UTC no-spend refresh:
+2026-05-20 17:01 UTC diagnostic snapshot:
 
 - Active installed binary is public Homebrew `oauth-mux 0.1.9`; native Codex
   resolves outside oauth-mux and is not an oauth-mux shim.
@@ -162,7 +162,7 @@ Historical gate from this snapshot: do not start real cassette or
 spend-confirmed live work until spare fallback capacity is restored or the
 operator intentionally accepts a single-route-at-risk run.
 
-2026-05-21 02:57 UTC post-repair no-spend refresh:
+2026-05-21 02:57 UTC post-repair diagnostic snapshot:
 
 - Active binary is user-local `oauth-mux 0.1.9` at
   `/Users/jess/.local/bin/oauth-mux`; Homebrew `0.1.9` remains installed as a
@@ -187,7 +187,7 @@ operator intentionally accepts a single-route-at-risk run.
   `contract:"experimental_socket_stub"`, `hosts_stay_afloat:false`; its fresh
   foreground tick snapshot shows `afloat_with_spare_fallback` but remains
   observational and is not daemon-hosted continuity proof.
-- Current gate: cassette capture may proceed only after a just-in-time no-spend
+- Current gate: cassette capture may proceed only after a just-in-time diagnostic
   route refresh reconfirms the spare fallback and the operator explicitly
   approves any live provider-spend capture.
 
@@ -230,14 +230,14 @@ Todo:
 
 - [ ] Prepare the tracker reconciliation note for `TIN-950` versus `#176`;
   do not post it without explicit operator approval.
-- [x] Add a no-spend capture preflight command that records installed
+- [x] Add a diagnostic capture preflight command that records installed
   `oauth-mux` provenance, native Codex version, mitmproxy availability,
   mitmproxy CA readiness, fallback readiness, latest status verdict, and
   stale-process hints before starting the intercepting proxy.
 - [x] Add explicit capture review promotion gates for preflight success,
   required endpoint path kinds, required HTTP statuses, and required quota
   `error.type` values.
-- [x] Re-run no-spend route truth immediately before capture and keep the
+- [x] Re-run diagnostic route truth immediately before capture and keep the
   generated preflight summary with the capture scratch directory.
 - [x] Capture one successful live turn with the Codex 0.132
   `/backend-api/codex/responses` WebSocket `101` raw upstream path observed
@@ -293,7 +293,7 @@ Todo:
   `brew fetch --force jesssullivan/omux/oauth-mux` passes against the public
   tap.
 - [x] When running the stale-version search, confirm remaining older-version
-  hits are explicitly historical, such as the 2026-05-17 no-spend snapshot or
+  hits are explicitly historical, such as the 2026-05-17 diagnostic snapshot or
   the `0.1.1` npm deprecation cleanup workflow.
 
 ## Workstream 5 - Tracker Hygiene
@@ -327,7 +327,7 @@ Priority: later this week after Workstreams 1-3 are stable.
 
 Completion metric:
 
-- A no-spend sidecar smoke proves loopback transport, remote auth token
+- A diagnostic sidecar smoke proves loopback transport, remote auth token
   handling, connection ordering, and TUI attachment without live provider
   calls.
 - The prototype records whether `thread/start`, `thread/list`,
@@ -338,7 +338,7 @@ Completion metric:
 
 Todo:
 
-- [ ] Keep `TIN-938` / GitHub `#163` scoped to no-spend connection smoke first.
+- [ ] Keep `TIN-938` / GitHub `#163` scoped to diagnostic connection smoke first.
 - [ ] Do not claim managed interactive UX or live sidecar spend proof until a
   separate explicit acceptance run exists.
 
@@ -351,7 +351,7 @@ Completion metric:
 
 - One non-Codex provider has fixture-backed positive and negative proof through
   the provider-authoring checklist.
-- The provider support matrix distinguishes schema-modeled, no-spend proven,
+- The provider support matrix distinguishes schema-modeled, diagnostic proven,
   fixture-backed, and live-proven states.
 - No non-Codex stay-afloat, background daemon, or universal provider claim is
   made before live adapter proof.
@@ -359,7 +359,7 @@ Completion metric:
 Todo:
 
 - [ ] Keep `TIN-736` / GitHub `#68` open and secondary.
-- [ ] Pick the next provider by narrowest no-spend truth surface; likely Claude
+- [ ] Pick the next provider by narrowest diagnostic truth surface; likely Claude
   auth-status first, then MCP/Figma/Linear only when official auth/failure
   boundaries are pinned.
 - [ ] Add fixtures and docs before any public support copy is upgraded.
@@ -379,17 +379,17 @@ Recommended landing slices:
   Completion metric is stale-version search showing only historical older
   versions plus `git diff --check`.
 - Slice C, real cassette PR: starts only after Slice A lands and a just-in-time
-  no-spend route refresh confirms spare fallback. Requires explicit operator
+  diagnostic route refresh confirms spare fallback. Requires explicit operator
   approval for any provider-spend capture.
 - Slice D, later sidecar/provider work: Workstreams 6 and 7 remain secondary
   until the Codex reference adapter has the BrokenPipe and cassette evidence
   stabilized.
 
 1. Land Workstream 1 as a focused BrokenPipe reliability PR.
-2. Refresh Workstream 2 no-spend route/process truth.
+2. Refresh Workstream 2 diagnostic route/process truth.
 3. Run Workstream 3 real cassette capture and replay hardening.
 4. Keep Workstream 4 hygiene moving in small docs/workflow patches.
 5. Reconcile tracker state after the facts are refreshed.
-6. Start Workstream 6 sidecar no-spend prototype later this week.
+6. Start Workstream 6 sidecar diagnostic prototype later this week.
 7. Start Workstream 7 non-Codex provider proof only after Codex evidence is
    stable enough to be the reference path.

--- a/docs/spec/paid-cohort-soak-claim-policy-2026-05-03.md
+++ b/docs/spec/paid-cohort-soak-claim-policy-2026-05-03.md
@@ -25,7 +25,7 @@ Current Codex truth as of this spec:
 Run the soak as an explicit foreground lane for seven calendar days. Do not
 schedule live provider spend by default.
 
-Recommended daily no-spend snapshot for each paid cohort profile:
+Recommended daily diagnostic snapshot for each paid cohort profile:
 
 ```bash
 just paid-cohort-soak-snapshot
@@ -77,7 +77,7 @@ Do not run spend-gated commands from unattended loops. If a route has no spare
 fallback, record the `resilience_actions` and decide manually whether to
 revalidate, enroll another account, or wait for reset.
 
-The daily no-spend snapshot may also include confirmation-gate artifacts such
+The daily diagnostic snapshot may also include confirmation-gate artifacts such
 as `revalidate-exhausted.confirmation.json` or
 `broker-run.confirmation.json`. Those files are expected to report
 `confirmation_required:true`; they prove the operator gate is still closed and

--- a/docs/spec/paid-multi-account-proof-cohort-2026-05-01.md
+++ b/docs/spec/paid-multi-account-proof-cohort-2026-05-01.md
@@ -101,7 +101,7 @@ Current dogfood truth after the 2026-05-09 engineered managed handoff:
   the fallback route returned `status:200`.
 - The strongest preserved proof bundle is
   `docs/evidence/codex-engineered-quota-handoff-20260509/`.
-- Current no-spend route truth for `codex-max` is intentionally not described
+- Current diagnostic route truth for `codex-max` is intentionally not described
   as afloat: `max-1`, `max-2`, and `max-4` are quota-exhausted; `max-3` is
   runtime-ready but recorded `auth_permanently_failed`; there are currently no
   selectable fallback routes until labeled reauth, reset repair, revalidation,
@@ -287,7 +287,7 @@ Not allowed yet:
 
 1. Land the proof-requirements JSON surface so agents can discover the missing
    values without reading this spec.
-2. Enroll the lower-tier Codex account and run no-spend inventory/runtime
+2. Enroll the lower-tier Codex account and run diagnostic inventory/runtime
    checks before live probes.
 3. Decide the Claude third shape: Team seat, Enterprise/self-serve path, or
    API-billed Console auth.

--- a/docs/spec/product-adoption-sprint-2026-04-28.md
+++ b/docs/spec/product-adoption-sprint-2026-04-28.md
@@ -228,7 +228,7 @@ First-run surfaces:
 
 Initial implementation status:
 
-- `oauth-mux doctor [--json]` now provides a no-spend readiness report covering
+- `oauth-mux doctor [--json]` now provides a diagnostic readiness report covering
   config path, state path, config validation, provider/account/profile counts,
   health state presence, and safe next commands.
 - `oauth-mux setup codex` and `oauth-mux codex setup` both route to the Codex

--- a/docs/spec/product-gap-issue-map-2026-05-01.md
+++ b/docs/spec/product-gap-issue-map-2026-05-01.md
@@ -18,7 +18,7 @@ risks are no longer general release mechanics. They are specific product
 boundaries that need separate tracking.
 
 Supersession note, 2026-05-08: the Codex proof ladder now includes
-broker-owned session planning, no-spend local broker smokes, spend-gated
+broker-owned session planning, diagnostic local broker smokes, spend-gated
 broker-run live turns, bounded broker-run session loops, exhausted-route
 revalidation, controlled fallback drills, managed resume, and dogfood-9 live
 auth-continuity plus failed-quota evidence. On 2026-05-08, installed
@@ -229,7 +229,7 @@ Current truth:
 Next split:
 
 - `TIN-861`: prove Claude Code through command-owned auth/session behavior.
-  The first no-spend local proof is captured in
+  The first diagnostic local proof is captured in
   `docs/spec/provider-proof-claude-command-auth-2026-05-01.md`: `auth-status`
   can now run through `claude auth status --json` without first reading or
   mutating Claude's credential store. Its capability proof status is
@@ -318,7 +318,7 @@ these precise provider-proof children.
    app-server stdio external-auth login. `oauth-mux codex broker-401-smoke
    --confirm-broker` proves the local mediated 401 retry path with a fallback
    route. `oauth-mux codex broker-quota-smoke --confirm-broker` proves the
-   local no-spend quota boundary: new brokered thread fallback works after
+   local diagnostic quota boundary: new brokered thread fallback works after
    fallback login, while same-turn and same-thread quota recovery remain
    unclaimed. `oauth-mux codex broker-session-plan` is the next UX slice: it
    combines route liveness with broker readiness to plan a broker-owned Codex

--- a/docs/spec/provider-proof-claude-command-auth-2026-05-01.md
+++ b/docs/spec/provider-proof-claude-command-auth-2026-05-01.md
@@ -51,7 +51,7 @@ require a parsed token before `probe.execute` runs.
 
 ## Local Proof
 
-No-spend Claude proof with isolated oauth-mux state:
+Diagnostic Claude proof with isolated oauth-mux state:
 
 ```bash
 tmp="$(mktemp -d)"

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -150,7 +150,7 @@ in the background just because a route exists.
 Required work:
 
 - per-provider and per-capability budgets;
-- no-spend probes by default;
+- diagnostic probes by default;
 - live probes only with explicit policy;
 - jittered schedules and cooldown windows;
 - account lock files so two daemon/processes do not refresh or reauth the same
@@ -183,7 +183,7 @@ Suggested responsibilities:
 
 1. Load config and health.
 2. Maintain redacted account and route state.
-3. Run no-spend runtime checks on a budget.
+3. Run diagnostic runtime checks on a budget.
 4. Refresh only providers/backends admitted for automatic writeback.
 5. Queue user-visible reauth plans when automation is not admitted.
 6. Expose local status over the existing socket.
@@ -259,7 +259,7 @@ auth:
   token endpoint, refresh ownership, reauth methods, user-interaction mode
 
 probes:
-  no-spend checks, live checks, timeout, budget class, output parser
+  diagnostic checks, live checks, timeout, budget class, output parser
 
 classification:
   status/body/header/exit-code rules into liveness and runtime states
@@ -311,7 +311,7 @@ Every probe or repair action needs a budget class:
 ```text
 free_local          local file/stat/JSON parse
 free_command        upstream CLI status that should not call the provider
-cheap_provider      identity/status endpoint or documented no-spend probe
+cheap_provider      identity/status endpoint or documented diagnostic probe
 spend_provider      model/tool call or any route that may consume quota
 interactive         opens browser, device auth, TTY prompt, or upstream login
 mutating            writes credentials, revokes tokens, creates API keys
@@ -321,7 +321,7 @@ Defaults:
 
 - daemon may run `free_local` and admitted `free_command` checks;
 - daemon may run `cheap_provider` only when the provider descriptor marks the
-  route no-spend and a user policy enables it;
+  route diagnostic and a user policy enables it;
 - daemon never runs `spend_provider`, `interactive`, or `mutating` without an
   explicit operator policy and redacted event log entry.
 
@@ -417,7 +417,7 @@ obvious and copy-pastable for humans and agents.
   - `max-2#codex-max` selected as fallback.
 
 Implementation note, 2026-04-30: `route select` and `route explain` now exist
-as one-shot, no-spend commands over recorded liveness. They do not probe live
+as one-shot, diagnostic commands over recorded liveness. They do not probe live
 providers, open browsers, run repair commands, or mutate secret stores.
 Unrecorded routes surface as `probe_needed`; `route select` exits nonzero when
 there is no `live.available` route with ready runtime state.

--- a/docs/spec/stay-afloat-supervisor-contract-2026-05-01.md
+++ b/docs/spec/stay-afloat-supervisor-contract-2026-05-01.md
@@ -241,7 +241,7 @@ Current schedule reasons:
 | Reason | Meaning |
 | --- | --- |
 | `route_selectable` | A route is already afloat; no wake-up is required. |
-| `probe_due` | A no-spend or admitted probe is useful immediately. |
+| `probe_due` | A diagnostic or admitted probe is useful immediately. |
 | `retry_after` | Provider rate-limit evidence supplied a retry-after window. |
 | `wait_until` | Quota or cooldown evidence supplied an absolute reset time. |
 | `quota_poll` | Quota is exhausted without a known reset; re-check on the conservative quota cadence. |
@@ -285,7 +285,7 @@ Default daemon policy:
 ```
 
 This means a default tick may inspect local files, parse health, check runtime
-readiness, and run admitted no-spend commands. It may not spend subscription
+readiness, and run admitted diagnostic commands. It may not spend subscription
 quota, open auth flows, or mutate credential stores.
 
 Future policy changes must preserve explicitness:

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -47,7 +47,7 @@ The traced decisions are:
 
 - `health.normalize`: persisted transient provider degradation recovered for
   route selection after its retry window expires.
-- `route.evaluate`: no-spend route runtime, liveness, action, and selectability.
+- `route.evaluate`: diagnostic route runtime, liveness, action, and selectability.
 - `codex.native_binary.resolve`: native Codex binary resolution without printing
   absolute paths. Managed Codex launches include `adapter:"managed_codex"` so a
   support trace can distinguish mux-owned launch resolution from explicit

--- a/docs/tracker-updates/2026-05-20/README.md
+++ b/docs/tracker-updates/2026-05-20/README.md
@@ -14,7 +14,7 @@ operator approval.
   `python3 -m py_compile` for Codex stubs, `bash -n` for the provider-degraded
   smoke, `just smoke-codex-provider-degraded-local`, `just test`,
   `just check-local`, and `git diff --check`.
-- Current installed no-spend route truth from the 2026-05-21 02:57 UTC
+- Current installed diagnostic route truth from the 2026-05-21 02:57 UTC
   post-repair refresh: active binary is user-local `oauth-mux 0.1.9`; native
   Codex resolves outside oauth-mux; four `codex-max` route stores are
   runtime/broker ready; `codex:max-3` is selected; `max-4` is a live selectable
@@ -22,7 +22,7 @@ operator approval.
 - Current resilience is `session_start_ready:true`, `fallback_ready:true`,
   `single_route_at_risk:false`.
 - Current cassette/live gate: a real cassette capture can proceed only after a
-  just-in-time no-spend refresh reconfirms spare fallback capacity and the
+  just-in-time diagnostic snapshot reconfirms spare fallback capacity and the
   operator explicitly approves any live provider-spend capture.
 - Daemon remains non-production: `status:"not_running"`,
   `contract:"experimental_socket_stub"`, `hosts_stay_afloat:false`; foreground
@@ -44,12 +44,12 @@ Draft:
 > `just smoke-codex-provider-degraded-local`, `just test`, and
 > `just check-local`.
 >
-> Real cassette capture is still open. The 2026-05-21 post-repair no-spend
+> Real cassette capture is still open. The 2026-05-21 post-repair diagnostic
 > refresh shows user-local `oauth-mux 0.1.9`, `codex:max-3` selected, and
 > `max-4` available as a live selectable fallback. `max-1` and `max-2` remain
 > `unrecorded`. Current resilience is `fallback_ready:true` and
 > `single_route_at_risk:false`, but the next cassette attempt should still do a
-> just-in-time no-spend refresh and get explicit operator approval for any live
+> just-in-time diagnostic snapshot and get explicit operator approval for any live
 > provider-spend capture.
 >
 > Tracker hygiene note: Linear `TIN-950` is marked Done, but this GitHub issue
@@ -69,7 +69,7 @@ Completion metric before closing:
 
 Draft:
 
-> 2026-05-21 post-repair no-spend refresh: `codex:max-3#codex-max` is selected
+> 2026-05-21 post-repair diagnostic snapshot: `codex:max-3#codex-max` is selected
 > and `max-4` is a live selectable fallback. `max-1` and `max-2` are
 > runtime/broker ready but still blocked as `unrecorded`, so the profile is
 > afloat with one spare fallback:
@@ -77,7 +77,7 @@ Draft:
 > `single_route_at_risk:false`.
 >
 > This means the negative permutation matrix can move out of the single-route
-> risk block, but release-grade evidence still requires a just-in-time no-spend
+> risk block, but release-grade evidence still requires a just-in-time diagnostic
 > refresh and explicit approval for provider-spend cases. API-credit
 > false-positive, all-fallbacks-exhausted, tier-insufficient, and reset-window
 > repair remain the priority negative permutations.
@@ -100,7 +100,7 @@ Draft:
 Draft:
 
 > Keep this queued behind the BrokenPipe/cassette path. The first acceptable
-> next step is still a no-spend sidecar smoke proving loopback transport,
+> next step is still a diagnostic sidecar smoke proving loopback transport,
 > remote auth token handling, connection ordering, and TUI attachment. No live
 > sidecar spend proof or managed interactive UX claim should be made until a
 > separate acceptance run exists.

--- a/docs/tracker-updates/2026-05-26/README.md
+++ b/docs/tracker-updates/2026-05-26/README.md
@@ -49,7 +49,7 @@ Core open or active:
 - `TIN-1591` In Progress - process/fd hygiene. Contained, not resolved.
 - `TIN-738` In Progress - broker daemon and adapter contract umbrella.
 - `TIN-937` In Progress - usage-limit diagnostics without restart.
-- `TIN-938` Todo - remote app-server sidecar; keep no-spend loopback only.
+- `TIN-938` Todo - remote app-server sidecar; keep diagnostic loopback only.
 - `TIN-1079` Backlog - engineered quota reset/exhaustion plan; maps to `#212`.
 - `TIN-736` In Progress - provider proof beyond Codex; maps to `#68`.
 - `TIN-893` In Progress - paid Codex cohort.
@@ -118,7 +118,7 @@ Closed but relevant:
    as a WebSocket `101`, but quota/error shapes are still missing.
 3. Move `#212` / `TIN-1079` out of backlog only when fallback capacity and
    operator-approved provider spend are ready for engineered exhaustion.
-4. Keep `#163` / `TIN-938` to a no-spend loopback sidecar smoke until cassette
+4. Keep `#163` / `TIN-938` to a diagnostic loopback sidecar smoke until cassette
    evidence is stronger.
 5. Keep `#68` / `TIN-736` secondary to the Codex reference adapter; admit the
    next provider only through fixture-backed proof.

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -1104,7 +1104,7 @@ printf 'e2e: codex broker-fallback-drill marks selected route exhausted and sele
 broker_fallback_drill="$(PATH="$broker_session_bin:$PATH" OMUX_CONFIG="$broker_session_config" OMUX_STATE_DIR="$broker_session_state" "$bin" codex broker-fallback-drill --profile codex-max --capability codex-max --from-account max-2 --confirm-drill --json)"
 expect_contains "$broker_fallback_drill" '"mode":"codex_broker_fallback_drill"' "broker-fallback-drill reports drill mode after confirmation"
 expect_contains "$broker_fallback_drill" '"ok":true' "broker-fallback-drill succeeds when distinct fallback exists"
-expect_contains "$broker_fallback_drill" '"spends_provider_calls":false' "broker-fallback-drill remains no-spend"
+expect_contains "$broker_fallback_drill" '"spends_provider_calls":false' "broker-fallback-drill remains diagnostic"
 expect_contains "$broker_fallback_drill" '"mutates_route_health":true' "broker-fallback-drill reports route-health mutation"
 expect_contains "$broker_fallback_drill" '"proof_status":"controlled_route_state_fallback_drill"' "broker-fallback-drill scopes proof status"
 expect_contains "$broker_fallback_drill" '"provider_originated_quota":false' "broker-fallback-drill does not claim provider-originated quota"

--- a/scripts/paid-cohort-soak-snapshot.sh
+++ b/scripts/paid-cohort-soak-snapshot.sh
@@ -46,7 +46,7 @@ summary="$out_dir/summary.txt"
 failures=0
 
 {
-  printf 'oauth-mux paid cohort no-spend soak snapshot\n\n'
+  printf 'oauth-mux paid cohort diagnostic soak snapshot\n\n'
   printf 'provider:        %s\n' "$provider"
   printf 'profile:         %s\n' "$profile"
   printf 'capability:      %s\n' "$capability"

--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# No-spend UX smoke for first-class `oauth-mux codex ...` adapter entrypoints.
+# Diagnostic UX smoke for first-class `oauth-mux codex ...` adapter entrypoints.
 #
 # Covers the daily-use resume shapes that should not require raw
 # `codex run -- ...` coercion:

--- a/scripts/smoke-trace.sh
+++ b/scripts/smoke-trace.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# No-spend trace smoke: global tracing emits redacted, OTEL-friendly JSONL for
+# Diagnostic trace smoke: global tracing emits redacted, OTEL-friendly JSONL for
 # route decisions and transient health normalization.
 
 set -euo pipefail

--- a/src/adapters/codex/wire_proxy.zig
+++ b/src/adapters/codex/wire_proxy.zig
@@ -2014,7 +2014,7 @@ fn writeNoAccountSelectableResponse(
     try w.writeAll(",\"agent_safe_next_actions\":[");
     try writeNoAccountNextActionJson(w, .{
         .kind = "codex_preflight",
-        .label = "no-spend Codex preflight",
+        .label = "diagnostic Codex preflight",
         .command = preflight_command,
         .budget = "free_local",
         .agent_safe = true,

--- a/src/main.zig
+++ b/src/main.zig
@@ -18604,7 +18604,7 @@ test "stay-afloat next emits exact exec argv for selected fallback" {
 }
 
 test "stay-afloat next degrades to fallback capability when requested capability exhausted (TIN-1811)" {
-    // No-spend: route selection only reads config + the in-memory health store.
+    // Diagnostic: route selection only reads config + the in-memory health store.
     // codex-max routes are all rate-limited (unselectable); codex-mini routes are
     // live. The codex-max profile declares capability_degradation_chain=["codex-mini"]
     // so the never-halt selector must cross to a live codex-mini route.
@@ -18804,7 +18804,7 @@ test "config rejects capability_degradation_chain with a capability that has no 
 }
 
 test "stay-afloat launch path degrades across capability via selectDegradedRouteNotAttempted (TIN-1811 Phase 2)" {
-    // No-spend: only reads config + the in-memory health store (no exec). The
+    // Diagnostic: only reads config + the in-memory health store (no exec). The
     // launch/observe loops select via selectDegradedRouteNotAttempted; this
     // verifies it crosses to a live codex-mini route when every codex-max route
     // is unselectable, returns ONLY immediately-live routes, and respects the
@@ -18925,7 +18925,7 @@ test "stay-afloat launch path degrades across capability via selectDegradedRoute
 }
 
 test "quota-only codex-max pool is afloat-pending-recovery, not a false not_afloat, and is not launchable (TIN-1812)" {
-    // No-spend: config + in-memory health store only. Every codex-max route is
+    // Diagnostic: config + in-memory health store only. Every codex-max route is
     // quota_exhausted with a future reset window; none are dead; there is NO
     // degradation chain. The pool must report a recoverable fallback (so state is
     // not "not_afloat") and surface the soonest reset window, while remaining


### PR DESCRIPTION
## Summary

- replace human-facing "no-spend" wording with diagnostic / local diagnostic terminology across docs, scripts, issue template, and status labels
- keep machine-readable provider-call policy fields such as spends_provider_calls unchanged
- clean up awkward replacement phrases after the mechanical pass

## Validation

- git grep -n -i "no-spend\|no spend" -- ':!zig-cache' ':!.zig-cache' ':!zig-out'
- git diff --check
- nix develop --command zig build test
- nix develop --command just check-local