### PR TITLE
Serialize Codex auth refresh by account

### DIFF
--- a/docs/spec/broker-mcp-contract-2026-05-03.md
+++ b/docs/spec/broker-mcp-contract-2026-05-03.md
@@ -282,6 +282,12 @@ holds a per-account mutex around refresh so two concurrent adapters can't
 race a refresh-token reuse fault (the failure mode tracked in
 `openai/codex#9634`).
 
+> **Status (2026-06-01): partially implemented for Codex file-backed auth.**
+> `broker_loader.zig` now serializes route-local Codex `auth.json` refresh by
+> provider/account and re-reads the file under the lock before spending a
+> refresh token. The broader JSON-RPC `credential/refresh` result-sharing
+> contract above remains a target contract for future adapter work.
+
 ### 2.4 Quota and observability
 
 #### `quota/observe`

--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -504,6 +504,12 @@ serializes per-account; if a second adapter requests refresh while one is
 in flight, the broker returns the result of the in-flight call (not a
 fresh attempt). Adapters must accept that policy without retry.
 
+> **Status (2026-06-01): partially implemented for route-local Codex
+> `auth.json`.** oauth-mux serializes file-backed Codex refresh by
+> provider/account and re-reads the auth file under the lock before using a
+> refresh token. The adapter-facing JSON-RPC result-sharing behavior is still a
+> target contract, not a general MCP surface.
+
 ## 8. Adapter CLI Surface
 
 ```

--- a/src/broker_loader.zig
+++ b/src/broker_loader.zig
@@ -13,6 +13,7 @@ const broker_types = @import("broker/types.zig");
 const health_mod = @import("health.zig");
 const oauth = @import("oauth.zig");
 const paths = @import("paths.zig");
+const repair_state = @import("repair_state.zig");
 const trace = @import("trace.zig");
 const types = @import("types.zig");
 
@@ -440,8 +441,17 @@ fn refreshCodexAccountAuthFile(
     const path = try accountAuthMaterialPath(allocator, acct_cfg);
     defer allocator.free(path);
 
+    var lock = try repair_state.acquireRepairLockBlocking(allocator, provider, account);
+    defer lock.release();
+
     const bytes = try readFileAlloc(allocator, path);
     defer allocator.free(bytes);
+
+    switch (refreshCodexAuthState(allocator, bytes)) {
+        .not_needed => return,
+        .unavailable => return error.NoRefreshToken,
+        .needed => {},
+    }
 
     var material = try parseCodexAuthRefreshMaterial(allocator, bytes);
     defer material.deinit(allocator);
@@ -456,8 +466,6 @@ fn refreshCodexAccountAuthFile(
     const refreshed = try buildRefreshedCodexAuthJson(allocator, material, result);
     defer allocator.free(refreshed);
     try writeFileReplace(path, refreshed, allocator);
-
-    _ = account;
 }
 
 const CodexAuthRefreshState = enum {
@@ -955,6 +963,94 @@ test "codex auth refresh detection uses access token exp" {
     , .{encoded});
     defer std.testing.allocator.free(fresh_auth);
     try std.testing.expect(!codexAuthShouldRefresh(std.testing.allocator, fresh_auth));
+}
+
+fn testCodexAccessTokenWithExp(allocator: std.mem.Allocator, exp: i64) ![]const u8 {
+    var payload_buf: [96]u8 = undefined;
+    const payload = try std.fmt.bufPrint(&payload_buf, "{{\"exp\":{d}}}", .{exp});
+    var encoded_buf: [160]u8 = undefined;
+    const encoded = std.base64.url_safe_no_pad.Encoder.encode(&encoded_buf, payload);
+    return try std.fmt.allocPrint(allocator, "h.{s}.s", .{encoded});
+}
+
+fn testCodexAuthJsonWithExp(
+    allocator: std.mem.Allocator,
+    exp: i64,
+    refresh_token: []const u8,
+    account_id: []const u8,
+) ![]const u8 {
+    const access_token = try testCodexAccessTokenWithExp(allocator, exp);
+    defer allocator.free(access_token);
+    return try std.fmt.allocPrint(
+        allocator,
+        \\{{"tokens":{{"access_token":"{s}","refresh_token":"{s}","account_id":"{s}"}}}}
+    ,
+        .{ access_token, refresh_token, account_id },
+    );
+}
+
+test "codex refresh rechecks auth file before spending refresh token" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const fresh_auth = try testCodexAuthJsonWithExp(
+        std.testing.allocator,
+        std.time.timestamp() + 3600,
+        "rt-peer-refreshed",
+        "acc",
+    );
+    defer std.testing.allocator.free(fresh_auth);
+
+    const auth_file = try tmp.dir.createFile("auth.json", .{ .mode = 0o600 });
+    try auth_file.writeAll(fresh_auth);
+    auth_file.close();
+
+    const auth_path = try tmp.dir.realpathAlloc(std.testing.allocator, "auth.json");
+    defer std.testing.allocator.free(auth_path);
+    const config_dir = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(config_dir);
+
+    const cfg_json = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "provider_definitions": {{
+        \\    "codex-test": {{
+        \\      "name": "codex-test",
+        \\      "auth": {{
+        \\        "token_endpoint": "://invalid",
+        \\        "client_id": "client"
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "providers": {{
+        \\    "codex": {{
+        \\      "kind": "codex-test",
+        \\      "accounts": {{
+        \\        "refresh-skip": {{
+        \\          "config_dir": "{s}",
+        \\          "secret": {{ "backend": "file", "path": "{s}" }}
+        \\        }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{}},
+        \\  "strategies": {{}}
+        \\}}
+    ,
+        .{ config_dir, auth_path },
+    );
+    defer std.testing.allocator.free(cfg_json);
+
+    var parsed = try config_mod.loadFromBytes(std.testing.allocator, cfg_json);
+    defer parsed.deinit();
+
+    const acct_cfg = parsed.value.providers.map.get("codex").?.accounts.map.get("refresh-skip").?;
+    try refreshCodexAccountAuthFile(std.testing.allocator, parsed.value, "codex", "refresh-skip", acct_cfg);
+
+    const bytes = try readFileAlloc(std.testing.allocator, auth_path);
+    defer std.testing.allocator.free(bytes);
+    try std.testing.expect(!codexAuthShouldRefresh(std.testing.allocator, bytes));
 }
 
 test "materializeChatgpt refuses expired codex token when refresh is unavailable" {

--- a/src/repair_state.zig
+++ b/src/repair_state.zig
@@ -364,6 +364,23 @@ pub fn acquireRepairLock(
     provider: []const u8,
     account: []const u8,
 ) !RepairLock {
+    return acquireRepairLockWithMode(allocator, provider, account, true);
+}
+
+pub fn acquireRepairLockBlocking(
+    allocator: std.mem.Allocator,
+    provider: []const u8,
+    account: []const u8,
+) !RepairLock {
+    return acquireRepairLockWithMode(allocator, provider, account, false);
+}
+
+fn acquireRepairLockWithMode(
+    allocator: std.mem.Allocator,
+    provider: []const u8,
+    account: []const u8,
+    nonblocking: bool,
+) !RepairLock {
     const path = try lockPath(allocator, provider, account);
     errdefer allocator.free(path);
     try ensureParentDir(path);
@@ -372,9 +389,9 @@ pub fn acquireRepairLock(
         .truncate = false,
         .mode = 0o600,
         .lock = .exclusive,
-        .lock_nonblocking = true,
+        .lock_nonblocking = nonblocking,
     }) catch |e| switch (e) {
-        error.WouldBlock => return error.RepairInProgress,
+        error.WouldBlock => if (nonblocking) return error.RepairInProgress else return e,
         else => return e,
     };
     errdefer file.close();
@@ -496,7 +513,7 @@ fn parseStartedAt(bytes: []const u8) ?i64 {
 
 fn ensureParentDir(path: []const u8) !void {
     if (std.fs.path.dirname(path)) |dir| {
-        std.fs.makeDirAbsolute(dir) catch |e| switch (e) {
+        std.fs.cwd().makePath(dir) catch |e| switch (e) {
             error.PathAlreadyExists => {},
             else => return e,
         };


### PR DESCRIPTION
## Summary

- serialize route-local Codex auth refresh with a provider/account repair lock
- re-read auth.json under the lock before spending a refresh token, so waiters skip if a peer already refreshed it
- make repair lock directory creation recursive for fresh runtime dirs
- document the current status boundary: file-backed Codex refresh is serialized; generic JSON-RPC credential/refresh result-sharing is still future adapter work

Fixes #336.

## Validation

- git diff --check
- nix develop --command zig build test
- nix develop --command just check-local