### PR TITLE
Fix Codex probe recovery after transient reconnect

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -8315,6 +8315,7 @@ fn runProbe(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Pro
     ctx.provider_name = args.provider;
     ctx.account_name = args.account;
     ctx.capability_name = args.capability;
+    ctx.probe_recheck_blocked = args.account != null;
 
     const result = pipeline.runProbe(&ctx);
     store.persist();

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -30,6 +30,7 @@ pub const Context = struct {
     target_argv: []const []const u8 = &.{},
     shell: types.ShellKind = .posix,
     probe_only: bool = false,
+    probe_recheck_blocked: bool = false,
     last_probe_executed: bool = false,
     last_probe_status: ?u16 = null,
     last_probe_decision: ?types.MuxDecision = null,
@@ -106,30 +107,33 @@ fn selectWithFallback(ctx: *Context) PipelineError!void {
 
         const key = health_mod.accountKey(candidate.provider, candidate.account);
         const decision = ctx.health.muxDecisionFor(candidate.provider, candidate.account, candidate.capability);
+        const bypass_health_gate = ctx.probe_only and ctx.probe_recheck_blocked;
 
-        switch (decision) {
-            .try_next_account => {
-                log.debug("pipeline: skip {s}:{s} (health: try_next)", .{ candidate.provider, candidate.account });
-                continue;
-            },
-            .try_next_provider => {
-                if (skipped_provider_count < skipped_providers.len) {
-                    skipped_providers[skipped_provider_count] = candidate.provider;
-                    skipped_provider_count += 1;
-                }
-                log.debug("pipeline: skip {s}:{s} (health: try_next_provider)", .{ candidate.provider, candidate.account });
-                continue;
-            },
-            .give_up => {
-                log.debug("pipeline: skip {s}:{s} (health: give_up)", .{ candidate.provider, candidate.account });
-                continue;
-            },
-            .wait_and_retry => {
-                // Could wait, but for now try next account
-                log.debug("pipeline: skip {s}:{s} (health: rate limited)", .{ candidate.provider, candidate.account });
-                continue;
-            },
-            .use_this => {},
+        if (!bypass_health_gate) {
+            switch (decision) {
+                .try_next_account => {
+                    log.debug("pipeline: skip {s}:{s} (health: try_next)", .{ candidate.provider, candidate.account });
+                    continue;
+                },
+                .try_next_provider => {
+                    if (skipped_provider_count < skipped_providers.len) {
+                        skipped_providers[skipped_provider_count] = candidate.provider;
+                        skipped_provider_count += 1;
+                    }
+                    log.debug("pipeline: skip {s}:{s} (health: try_next_provider)", .{ candidate.provider, candidate.account });
+                    continue;
+                },
+                .give_up => {
+                    log.debug("pipeline: skip {s}:{s} (health: give_up)", .{ candidate.provider, candidate.account });
+                    continue;
+                },
+                .wait_and_retry => {
+                    // Could wait, but for now try next account
+                    log.debug("pipeline: skip {s}:{s} (health: rate limited)", .{ candidate.provider, candidate.account });
+                    continue;
+                },
+                .use_this => {},
+            }
         }
 
         // Set context for this attempt
@@ -1309,6 +1313,68 @@ test "runProbe executes auth none command probe without reading missing secret" 
     try std.testing.expectEqual(@as(?u16, 200), ctx.last_probe_status);
     try std.testing.expectEqual(types.MuxDecision.use_this, ctx.last_probe_decision.?);
     try std.testing.expect(store.accounts.get("toy:default#status") != null);
+}
+
+test "runProbe with explicit account rechecks previously degraded command route" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "defaults": { "provider": "toy" },
+        \\  "provider_definitions": {
+        \\    "toy": {
+        \\      "name": "toy",
+        \\      "credential": { "access_token_path": "access" },
+        \\      "capabilities": [
+        \\        {
+        \\          "name": "status",
+        \\          "probe": {
+        \\            "transport": "command",
+        \\            "auth": "none",
+        \\            "command": ["sh", "-c", "printf '{\"type\":\"turn.completed\"}'"],
+        \\            "budget": "free_command"
+        \\          }
+        \\        }
+        \\      ]
+        \\    }
+        \\  },
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": {
+        \\          "secret": { "backend": "env", "variable": "OMUX_TEST_SECRET_THAT_IS_NOT_SET" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try config_mod.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    store.recordHttpClassification("toy:default#status", 400, .{ .degraded = .unknown_4xx });
+
+    var ctx = Context.init(std.testing.allocator, parsed.value, &store);
+    defer ctx.deinit();
+    ctx.provider_name = "toy";
+    ctx.account_name = "default";
+    ctx.capability_name = "status";
+    ctx.probe_recheck_blocked = true;
+
+    try runProbe(&ctx);
+
+    try std.testing.expect(ctx.last_probe_executed);
+    try std.testing.expectEqual(@as(?u16, 200), ctx.last_probe_status);
+    try std.testing.expectEqual(types.MuxDecision.use_this, ctx.last_probe_decision.?);
+    const health = store.accounts.get("toy:default#status").?;
+    switch (health.liveness) {
+        .live => |live| try std.testing.expect(live.availability == .available),
+        else => return error.TestUnexpectedResult,
+    }
 }
 
 test "runProbe does not poison liveness when command probe binary is missing" {

--- a/src/provider_schema.zig
+++ b/src/provider_schema.zig
@@ -986,6 +986,7 @@ pub fn defaultProbeBudget(transport: ProbeTransport) types.ActionBudget {
 }
 
 pub fn classifyCodexExecJsonl(allocator: std.mem.Allocator, jsonl: []const u8) ?types.HttpClassification {
+    var first_error: ?types.HttpClassification = null;
     var lines = std.mem.splitScalar(u8, jsonl, '\n');
     while (lines.next()) |line| {
         const trimmed = std.mem.trim(u8, line, " \t\r");
@@ -999,15 +1000,18 @@ pub fn classifyCodexExecJsonl(allocator: std.mem.Allocator, jsonl: []const u8) ?
 
             if (std.mem.eql(u8, event_type, "error")) {
                 if (resolveJsonString(parsed.value, "message")) |message| {
-                    return classifyCodexErrorMessage(allocator, message);
+                    if (first_error == null) first_error = classifyCodexErrorMessage(allocator, message);
+                    continue;
                 }
             }
         }
 
-        if (classifyCodexErrorValue(parsed.value)) |classification| return classification;
+        if (classifyCodexErrorValue(parsed.value)) |classification| {
+            if (first_error == null) first_error = classification;
+        }
     }
 
-    return null;
+    return first_error;
 }
 
 pub fn classifyCodexAppServerJsonRpc(allocator: std.mem.Allocator, jsonl: []const u8) ?types.HttpClassification {
@@ -1945,6 +1949,25 @@ test "classifyCodexExecJsonl success cassette" {
         \\{"type":"thread.started","thread_id":"redacted"}
         \\{"type":"turn.started"}
         \\{"type":"item.completed","item":{"type":"agent_message","text":"OMUX_CODEX_SPARK_PROBE"}}
+        \\{"type":"turn.completed","usage":{"input_tokens":26656,"cached_input_tokens":3712,"output_tokens":57,"reasoning_output_tokens":43}}
+        \\
+    ;
+    try std.testing.expectEqual(
+        types.HttpClassification.success,
+        classifyCodexExecJsonl(std.testing.allocator, jsonl).?,
+    );
+}
+
+test "classifyCodexExecJsonl treats transient reconnect errors before completion as success" {
+    const jsonl =
+        \\Reading additional input from stdin...
+        \\{"type":"thread.started","thread_id":"redacted"}
+        \\{"type":"turn.started"}
+        \\2026-06-01T19:45:49Z ERROR codex_api::endpoint::responses_websocket: failed to connect to websocket: HTTP error: 405 Method Not Allowed
+        \\{"type":"error","message":"Reconnecting... 2/5 (unexpected status 405 Method Not Allowed: {\"detail\":\"Method Not Allowed\"}, url: ws://127.0.0.1:51243/backend-api/responses)"}
+        \\2026-06-01T19:45:50Z ERROR codex_api::endpoint::responses_websocket: failed to connect to websocket: HTTP error: 405 Method Not Allowed
+        \\{"type":"error","message":"Reconnecting... 5/5 (unexpected status 405 Method Not Allowed: {\"detail\":\"Method Not Allowed\"}, url: ws://127.0.0.1:51243/backend-api/responses)"}
+        \\{"type":"item.completed","item":{"type":"agent_message","text":"OMUX_CODEX_MINI_PROBE"}}
         \\{"type":"turn.completed","usage":{"input_tokens":26656,"cached_input_tokens":3712,"output_tokens":57,"reasoning_output_tokens":43}}
         \\
     ;


### PR DESCRIPTION
## Summary

- Treat Codex CLI transient reconnect error events as provisional during `codex exec --json` probe classification; a later `turn.completed` now wins.
- Let explicit `oauth-mux probe --provider ... --account ... --capability ...` recheck a previously blocked route instead of skipping on stale route health.
- Add regression coverage for both the transient reconnect transcript and explicit blocked-route re-probe.

## Dogfood evidence

A live `max-3#codex-mini` probe produced transient WebSocket 405 reconnect events followed by a successful `turn.completed`. Before this change, oauth-mux persisted that as `degraded:unknown_4xx`; with this branch, the same route re-probes successfully and is restored to live.

Post-fix local route truth:

- `session_start_ready: true`
- `fallback_ready: true`
- `selectable_routes: 2`
- `selectable_fallback_routes: 1`
- `single_route_at_risk: false`

## Validation

- `git diff --check`
- `nix develop --command zig build test`
- `nix develop --command just build`
- Live provider probe: `./zig-out/bin/oauth-mux probe --provider codex --account max-3 --capability codex-mini --json`
- `nix develop --command just check-local`