### PR TITLE
reauth: Claude (Claude Code) reauth adapter — first non-Codex adapter (greenfield, 20/20, verified OAuth)

### DIFF
--- a/src/enroll/claude_reauth.zig
+++ b/src/enroll/claude_reauth.zig
@@ -1,0 +1,377 @@
+//! Claude (Claude Code) reauth adapter — greenfield, provider-specific OAuth.
+//!
+//! The first NON-Codex adapter: the Claude-specific pieces of a re-login flow,
+//! plugging into the flow-agnostic reauth engine (#344) and the loopback PKCE
+//! callback server (#349). Claude Code authenticates with **OAuth 2.1 loopback
+//! PKCE (S256)** — the SAME shape #349 already captures — so this module owns
+//! only what is Claude-specific: the verified endpoints + public client id, the
+//! authorize-URL / token-exchange / refresh request builders, parsing the token
+//! endpoint response, and materializing the `~/.claude/.credentials.json`
+//! (`claudeAiOauth`) credential shape.
+//!
+//! Verified 2026-06-01 (code.claude.com/docs/en/authentication, cedws
+//! ANTHROPIC_AUTH gist, querymt/anthropic-auth, anthropics/claude-code #39445):
+//!   * authorize  https://console.anthropic.com/oauth/authorize
+//!   * token      https://console.anthropic.com/v1/oauth/token   (exchange + refresh)
+//!   * client_id  9d1c250a-e61b-44d9-88ed-5944d1962f5e           (Claude Code public client)
+//!   * loopback PKCE S256, ephemeral 127.0.0.1/localhost callback (NOT device_code)
+//!   * credential ~/.claude/.credentials.json (0600):
+//!       {"claudeAiOauth":{"accessToken":"sk-ant-oat01-…","refreshToken":"sk-ant-ort01-…",
+//!        "expiresAt":<unix MILLISECONDS>,"scopes":[…],"subscriptionType":"max"}}
+//! NOTE: the repo's declarative `claude_def` (src/provider_schema.zig:683) +
+//! `oauth.zig:115` currently carry the WRONG token endpoint (`claude.ai/…`);
+//! fixing those is coordinated work (shared files), not part of this module.
+//!
+//! Shape mirrors the engine/web-UI/callback siblings: a PURE provider core (the
+//! builders/parsers) plus a thin `ClaudeReauthAdapter` over an INJECTED HTTP
+//! seam, so the whole module is unit-testable with `std.testing.allocator`
+//! (leak-checked) and no real network. Self-contained: `std` only, no `@import`
+//! of existing `src`. The `percentEncode`/`deriveChallenge` helpers intentionally
+//! mirror callback_server.zig (#349); they de-dup into a shared oauth/http util
+//! on integration.
+
+const std = @import("std");
+
+// ── Verified Claude OAuth constants ────────────────────────────────────────
+
+pub const authorize_endpoint = "https://console.anthropic.com/oauth/authorize";
+pub const token_endpoint = "https://console.anthropic.com/v1/oauth/token";
+pub const default_client_id = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+/// Scopes confirmed in the credential `scopes` array; `org:create_api_key` may
+/// also be requested by Claude Code — verify against a live account if needed.
+pub const default_scopes = "user:inference user:profile";
+pub const form_content_type = "application/x-www-form-urlencoded";
+
+pub const access_token_prefix = "sk-ant-oat01-";
+pub const refresh_token_prefix = "sk-ant-ort01-";
+
+// ── Token model ────────────────────────────────────────────────────────────
+
+/// Claude tokens in the broker's normalized form. `expires_at_ms` is an ABSOLUTE
+/// Unix-millisecond instant (the token endpoint returns relative `expires_in`
+/// seconds; the credential file stores absolute `expiresAt` ms — both normalize
+/// here). Caller owns every slice; free with `freeTokens`.
+pub const ClaudeTokens = struct {
+    access_token: []const u8,
+    refresh_token: []const u8,
+    expires_at_ms: i64,
+    /// Space-joined scope string (as the OAuth `scope` field), or null.
+    scopes: ?[]const u8 = null,
+    subscription_type: ?[]const u8 = null,
+};
+
+pub fn freeTokens(allocator: std.mem.Allocator, t: ClaudeTokens) void {
+    allocator.free(t.access_token);
+    allocator.free(t.refresh_token);
+    if (t.scopes) |s| allocator.free(s);
+    if (t.subscription_type) |s| allocator.free(s);
+}
+
+pub const ParseError = error{ OutOfMemory, ParseFailed };
+
+/// True if the access token is at/after expiry (with `skew_ms` early margin) —
+/// the predicate a keepalive scheduler uses to decide a proactive refresh.
+pub fn isAccessTokenExpired(t: ClaudeTokens, now_ms: i64, skew_ms: i64) bool {
+    return now_ms + skew_ms >= t.expires_at_ms;
+}
+
+pub fn looksLikeAccessToken(s: []const u8) bool {
+    return std.mem.startsWith(u8, s, access_token_prefix);
+}
+pub fn looksLikeRefreshToken(s: []const u8) bool {
+    return std.mem.startsWith(u8, s, refresh_token_prefix);
+}
+
+// ── Pure request builders ──────────────────────────────────────────────────
+
+/// Claude authorize URL (EMITTED to the operator, never auto-opened — the
+/// operator picks the isolated/private browser, guaranteeing the right identity
+/// for multi-account users). `challenge` is the PKCE S256 challenge; `state` is
+/// the caller's CSRF value (e.g. base64url(nonce)).
+pub fn buildAuthorizeUrl(
+    allocator: std.mem.Allocator,
+    client_id: []const u8,
+    scopes: []const u8,
+    redirect_uri: []const u8,
+    challenge: [43]u8,
+    state: []const u8,
+) ![]u8 {
+    const enc_cid = try percentEncode(allocator, client_id);
+    defer allocator.free(enc_cid);
+    const enc_redirect = try percentEncode(allocator, redirect_uri);
+    defer allocator.free(enc_redirect);
+    const enc_scope = try percentEncode(allocator, scopes);
+    defer allocator.free(enc_scope);
+    const enc_state = try percentEncode(allocator, state);
+    defer allocator.free(enc_state);
+    return std.fmt.allocPrint(
+        allocator,
+        "{s}?response_type=code&client_id={s}&redirect_uri={s}" ++
+            "&scope={s}&state={s}&code_challenge={s}&code_challenge_method=S256",
+        .{ authorize_endpoint, enc_cid, enc_redirect, enc_scope, enc_state, challenge[0..] },
+    );
+}
+
+/// Form body for the authorization-code → token exchange POST. The PKCE verifier
+/// is base64url (URL-safe) so it is emitted verbatim; it is never logged here.
+pub fn buildTokenExchangeBody(
+    allocator: std.mem.Allocator,
+    client_id: []const u8,
+    code: []const u8,
+    code_verifier: [43]u8,
+    redirect_uri: []const u8,
+) ![]u8 {
+    const enc_code = try percentEncode(allocator, code);
+    defer allocator.free(enc_code);
+    const enc_redirect = try percentEncode(allocator, redirect_uri);
+    defer allocator.free(enc_redirect);
+    const enc_cid = try percentEncode(allocator, client_id);
+    defer allocator.free(enc_cid);
+    return std.fmt.allocPrint(
+        allocator,
+        "grant_type=authorization_code&code={s}&redirect_uri={s}&client_id={s}&code_verifier={s}",
+        .{ enc_code, enc_redirect, enc_cid, code_verifier[0..] },
+    );
+}
+
+/// Form body for the refresh-token grant POST.
+pub fn buildRefreshBody(
+    allocator: std.mem.Allocator,
+    client_id: []const u8,
+    refresh_token: []const u8,
+) ![]u8 {
+    const enc_rt = try percentEncode(allocator, refresh_token);
+    defer allocator.free(enc_rt);
+    const enc_cid = try percentEncode(allocator, client_id);
+    defer allocator.free(enc_cid);
+    return std.fmt.allocPrint(
+        allocator,
+        "grant_type=refresh_token&refresh_token={s}&client_id={s}",
+        .{ enc_rt, enc_cid },
+    );
+}
+
+// ── Pure parsers ───────────────────────────────────────────────────────────
+
+const TokenWire = struct {
+    access_token: []const u8,
+    refresh_token: []const u8 = "",
+    expires_in: i64 = 0,
+    scope: []const u8 = "",
+    token_type: []const u8 = "",
+};
+
+/// Parse the OAuth token-endpoint JSON response. `expires_in` (relative seconds)
+/// is normalized to an absolute `expires_at_ms` using the injected `now_ms`.
+pub fn parseTokenEndpointResponse(
+    allocator: std.mem.Allocator,
+    json: []const u8,
+    now_ms: i64,
+) ParseError!ClaudeTokens {
+    var parsed = std.json.parseFromSlice(TokenWire, allocator, json, .{ .ignore_unknown_fields = true }) catch |e| {
+        return if (e == error.OutOfMemory) error.OutOfMemory else error.ParseFailed;
+    };
+    defer parsed.deinit();
+    const w = parsed.value;
+    if (w.access_token.len == 0) return error.ParseFailed;
+
+    const access = try allocator.dupe(u8, w.access_token);
+    errdefer allocator.free(access);
+    const refresh = try allocator.dupe(u8, w.refresh_token);
+    errdefer allocator.free(refresh);
+    const scopes = if (w.scope.len > 0) try allocator.dupe(u8, w.scope) else null;
+
+    return .{
+        .access_token = access,
+        .refresh_token = refresh,
+        .expires_at_ms = now_ms + w.expires_in * std.time.ms_per_s,
+        .scopes = scopes,
+        .subscription_type = null,
+    };
+}
+
+const CredInner = struct {
+    accessToken: []const u8,
+    refreshToken: []const u8 = "",
+    expiresAt: i64 = 0,
+    subscriptionType: []const u8 = "",
+};
+const CredOuter = struct { claudeAiOauth: CredInner };
+
+/// Parse an existing `~/.claude/.credentials.json` (`claudeAiOauth`) file.
+/// `expiresAt` is already absolute Unix ms. (scopes array is ignored on read.)
+pub fn parseCredentialJson(allocator: std.mem.Allocator, json: []const u8) ParseError!ClaudeTokens {
+    var parsed = std.json.parseFromSlice(CredOuter, allocator, json, .{ .ignore_unknown_fields = true }) catch |e| {
+        return if (e == error.OutOfMemory) error.OutOfMemory else error.ParseFailed;
+    };
+    defer parsed.deinit();
+    const c = parsed.value.claudeAiOauth;
+    if (c.accessToken.len == 0) return error.ParseFailed;
+
+    const access = try allocator.dupe(u8, c.accessToken);
+    errdefer allocator.free(access);
+    const refresh = try allocator.dupe(u8, c.refreshToken);
+    errdefer allocator.free(refresh);
+    const sub = if (c.subscriptionType.len > 0) try allocator.dupe(u8, c.subscriptionType) else null;
+
+    return .{
+        .access_token = access,
+        .refresh_token = refresh,
+        .expires_at_ms = c.expiresAt,
+        .scopes = null,
+        .subscription_type = sub,
+    };
+}
+
+/// Serialize tokens to the Claude credential file shape. Token/scope/subscription
+/// values are constrained OAuth charsets (`[A-Za-z0-9._:-]`) with no JSON
+/// metacharacters, so they are emitted without escaping; the adapter validates
+/// the token prefixes before writing.
+pub fn buildCredentialJson(allocator: std.mem.Allocator, t: ClaudeTokens) ![]u8 {
+    var scopes_arr = std.ArrayList(u8).init(allocator);
+    defer scopes_arr.deinit();
+    try scopes_arr.append('[');
+    if (t.scopes) |sc| {
+        var it = std.mem.splitScalar(u8, sc, ' ');
+        var first = true;
+        while (it.next()) |s| {
+            if (s.len == 0) continue;
+            if (!first) try scopes_arr.append(',');
+            first = false;
+            try scopes_arr.append('"');
+            try scopes_arr.appendSlice(s);
+            try scopes_arr.append('"');
+        }
+    }
+    try scopes_arr.append(']');
+
+    const sub = t.subscription_type orelse "";
+    return std.fmt.allocPrint(
+        allocator,
+        "{{\"claudeAiOauth\":{{\"accessToken\":\"{s}\",\"refreshToken\":\"{s}\"," ++
+            "\"expiresAt\":{d},\"scopes\":{s},\"subscriptionType\":\"{s}\"}}}}",
+        .{ t.access_token, t.refresh_token, t.expires_at_ms, scopes_arr.items, sub },
+    );
+}
+
+// ── Adapter over an injected HTTP seam ─────────────────────────────────────
+
+pub const HttpError = error{ OutOfMemory, HttpFailed };
+
+/// POST `body` to `url` and return the freshly-allocated response body.
+pub const HttpPostFn = *const fn (
+    allocator: std.mem.Allocator,
+    ctx: *anyopaque,
+    url: []const u8,
+    body: []const u8,
+    content_type: []const u8,
+) HttpError![]u8;
+
+pub const ClaudeReauthError = error{ OutOfMemory, ExchangeFailed, RefreshFailed };
+
+/// The Claude reauth adapter: provider config + an injected HTTP seam. Composes
+/// with the engine (#344) + callback server (#349): the engine emits
+/// `authorizeUrl`, #349 captures the loopback callback, then `exchangeCode`
+/// turns the code into tokens and `materialize` writes the credential file.
+pub const ClaudeReauthAdapter = struct {
+    http_post: HttpPostFn,
+    http_ctx: *anyopaque,
+    client_id: []const u8 = default_client_id,
+    scopes: []const u8 = default_scopes,
+
+    pub fn authorizeUrl(
+        self: *const ClaudeReauthAdapter,
+        allocator: std.mem.Allocator,
+        redirect_uri: []const u8,
+        challenge: [43]u8,
+        state: []const u8,
+    ) ![]u8 {
+        return buildAuthorizeUrl(allocator, self.client_id, self.scopes, redirect_uri, challenge, state);
+    }
+
+    pub fn exchangeCode(
+        self: *const ClaudeReauthAdapter,
+        allocator: std.mem.Allocator,
+        code: []const u8,
+        code_verifier: [43]u8,
+        redirect_uri: []const u8,
+        now_ms: i64,
+    ) ClaudeReauthError!ClaudeTokens {
+        const body = buildTokenExchangeBody(allocator, self.client_id, code, code_verifier, redirect_uri) catch
+            return error.OutOfMemory;
+        defer allocator.free(body);
+        return self.post(allocator, body, now_ms, error.ExchangeFailed);
+    }
+
+    pub fn refresh(
+        self: *const ClaudeReauthAdapter,
+        allocator: std.mem.Allocator,
+        refresh_token: []const u8,
+        now_ms: i64,
+    ) ClaudeReauthError!ClaudeTokens {
+        const body = buildRefreshBody(allocator, self.client_id, refresh_token) catch
+            return error.OutOfMemory;
+        defer allocator.free(body);
+        return self.post(allocator, body, now_ms, error.RefreshFailed);
+    }
+
+    fn post(
+        self: *const ClaudeReauthAdapter,
+        allocator: std.mem.Allocator,
+        body: []const u8,
+        now_ms: i64,
+        fail: ClaudeReauthError,
+    ) ClaudeReauthError!ClaudeTokens {
+        const resp = self.http_post(allocator, self.http_ctx, token_endpoint, body, form_content_type) catch |e| switch (e) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.HttpFailed => return fail,
+        };
+        defer allocator.free(resp);
+        return parseTokenEndpointResponse(allocator, resp, now_ms) catch |e| switch (e) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.ParseFailed => return fail,
+        };
+    }
+
+    /// Serialize the exchanged/refreshed tokens to the credential file content.
+    pub fn materialize(self: *const ClaudeReauthAdapter, allocator: std.mem.Allocator, t: ClaudeTokens) ![]u8 {
+        _ = self;
+        return buildCredentialJson(allocator, t);
+    }
+};
+
+// ── Small shared helpers (mirror callback_server.zig #349) ─────────────────
+
+fn isUnreserved(c: u8) bool {
+    return (c >= 'A' and c <= 'Z') or
+        (c >= 'a' and c <= 'z') or
+        (c >= '0' and c <= '9') or
+        c == '-' or c == '_' or c == '.' or c == '~';
+}
+
+/// RFC 3986 percent-encoding (unreserved set passes through).
+pub fn percentEncode(allocator: std.mem.Allocator, s: []const u8) ![]u8 {
+    const hex = "0123456789ABCDEF";
+    var out = std.ArrayList(u8).init(allocator);
+    errdefer out.deinit();
+    for (s) |c| {
+        if (isUnreserved(c)) {
+            try out.append(c);
+        } else {
+            try out.append('%');
+            try out.append(hex[c >> 4]);
+            try out.append(hex[c & 0x0F]);
+        }
+    }
+    return out.toOwnedSlice();
+}
+
+/// PKCE S256 challenge for a verifier — base64url(SHA256(verifier)). Mirrors
+/// `oauth.generatePkce` / callback_server.zig.
+pub fn deriveChallenge(verifier: [43]u8) [43]u8 {
+    var hash: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(verifier[0..], &hash, .{});
+    var challenge: [43]u8 = undefined;
+    _ = std.base64.url_safe_no_pad.Encoder.encode(challenge[0..], hash[0..]);
+    return challenge;
+}

--- a/src/enroll/claude_reauth_tests.zig
+++ b/src/enroll/claude_reauth_tests.zig
@@ -1,0 +1,275 @@
+//! Unit tests for the Claude reauth adapter (pure builders/parsers + the
+//! adapter over a fake HTTP seam). No real network.
+//!
+//!     zig test src/enroll/claude_reauth_tests.zig
+//!
+//! All allocations go through `std.testing.allocator`, so any leak fails.
+
+const std = @import("std");
+const cr = @import("claude_reauth.zig");
+
+test {
+    std.testing.refAllDeclsRecursive(cr);
+}
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const token_response_json =
+    \\{"access_token":"sk-ant-oat01-AAA","refresh_token":"sk-ant-ort01-BBB","expires_in":3600,"scope":"user:inference user:profile","token_type":"Bearer"}
+;
+const credential_json =
+    \\{"claudeAiOauth":{"accessToken":"sk-ant-oat01-CCC","refreshToken":"sk-ant-ort01-DDD","expiresAt":1748276587173,"scopes":["user:inference","user:profile"],"subscriptionType":"max"}}
+;
+
+const verifier: [43]u8 = .{0xCD} ** 43;
+
+// ── Fake HTTP seam ─────────────────────────────────────────────────────────
+
+const Recorder = struct {
+    response: []const u8 = "{}",
+    fail: bool = false,
+    url_buf: [256]u8 = undefined,
+    url_len: usize = 0,
+    body_buf: [512]u8 = undefined,
+    body_len: usize = 0,
+    ct_buf: [64]u8 = undefined,
+    ct_len: usize = 0,
+
+    fn postFn(
+        allocator: std.mem.Allocator,
+        ctx: *anyopaque,
+        url: []const u8,
+        body: []const u8,
+        content_type: []const u8,
+    ) cr.HttpError![]u8 {
+        const self: *Recorder = @ptrCast(@alignCast(ctx));
+        self.url_len = @min(url.len, self.url_buf.len);
+        @memcpy(self.url_buf[0..self.url_len], url[0..self.url_len]);
+        self.body_len = @min(body.len, self.body_buf.len);
+        @memcpy(self.body_buf[0..self.body_len], body[0..self.body_len]);
+        self.ct_len = @min(content_type.len, self.ct_buf.len);
+        @memcpy(self.ct_buf[0..self.ct_len], content_type[0..self.ct_len]);
+        if (self.fail) return error.HttpFailed;
+        return allocator.dupe(u8, self.response);
+    }
+
+    fn seenUrl(self: *Recorder) []const u8 {
+        return self.url_buf[0..self.url_len];
+    }
+    fn seenBody(self: *Recorder) []const u8 {
+        return self.body_buf[0..self.body_len];
+    }
+    fn seenContentType(self: *Recorder) []const u8 {
+        return self.ct_buf[0..self.ct_len];
+    }
+    fn adapter(self: *Recorder) cr.ClaudeReauthAdapter {
+        return .{ .http_post = postFn, .http_ctx = self };
+    }
+};
+
+fn contains(haystack: []const u8, needle: []const u8) bool {
+    return std.mem.indexOf(u8, haystack, needle) != null;
+}
+
+// ── Request builders ───────────────────────────────────────────────────────
+
+test "buildAuthorizeUrl uses the verified Claude endpoint + client_id + S256" {
+    const challenge = cr.deriveChallenge(verifier);
+    const url = try cr.buildAuthorizeUrl(
+        std.testing.allocator,
+        cr.default_client_id,
+        cr.default_scopes,
+        "http://127.0.0.1:8123/callback",
+        challenge,
+        "state-xyz",
+    );
+    defer std.testing.allocator.free(url);
+    try std.testing.expect(std.mem.startsWith(u8, url, "https://console.anthropic.com/oauth/authorize?response_type=code"));
+    try std.testing.expect(contains(url, "client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e"));
+    try std.testing.expect(contains(url, "code_challenge_method=S256"));
+    try std.testing.expect(contains(url, "redirect_uri=http%3A%2F%2F127.0.0.1%3A8123%2Fcallback"));
+    try std.testing.expect(contains(url, "scope=user%3Ainference%20user%3Aprofile"));
+    try std.testing.expect(contains(url, "state=state-xyz"));
+    try std.testing.expect(contains(url, challenge[0..]));
+}
+
+test "buildTokenExchangeBody is a valid authorization_code grant" {
+    const body = try cr.buildTokenExchangeBody(
+        std.testing.allocator,
+        cr.default_client_id,
+        "the-code",
+        verifier,
+        "http://127.0.0.1:8123/callback",
+    );
+    defer std.testing.allocator.free(body);
+    try std.testing.expect(contains(body, "grant_type=authorization_code"));
+    try std.testing.expect(contains(body, "code=the-code"));
+    try std.testing.expect(contains(body, "client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e"));
+    try std.testing.expect(contains(body, "redirect_uri=http%3A%2F%2F127.0.0.1%3A8123%2Fcallback"));
+    try std.testing.expect(contains(body, "code_verifier="));
+}
+
+test "buildRefreshBody is a valid refresh_token grant" {
+    const body = try cr.buildRefreshBody(std.testing.allocator, cr.default_client_id, "sk-ant-ort01-RRR");
+    defer std.testing.allocator.free(body);
+    try std.testing.expect(contains(body, "grant_type=refresh_token"));
+    try std.testing.expect(contains(body, "refresh_token=sk-ant-ort01-RRR"));
+    try std.testing.expect(contains(body, "client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e"));
+}
+
+// ── Token endpoint response parsing ────────────────────────────────────────
+
+test "parseTokenEndpointResponse normalizes expires_in -> absolute ms" {
+    const t = try cr.parseTokenEndpointResponse(std.testing.allocator, token_response_json, 1000);
+    defer cr.freeTokens(std.testing.allocator, t);
+    try std.testing.expectEqualStrings("sk-ant-oat01-AAA", t.access_token);
+    try std.testing.expectEqualStrings("sk-ant-ort01-BBB", t.refresh_token);
+    // 1000 ms + 3600 s * 1000 = 3_601_000 ms
+    try std.testing.expectEqual(@as(i64, 3_601_000), t.expires_at_ms);
+    try std.testing.expectEqualStrings("user:inference user:profile", t.scopes.?);
+}
+
+test "parseTokenEndpointResponse rejects missing access_token" {
+    try std.testing.expectError(error.ParseFailed, cr.parseTokenEndpointResponse(std.testing.allocator, "{\"refresh_token\":\"x\"}", 0));
+}
+
+test "parseTokenEndpointResponse rejects invalid JSON" {
+    try std.testing.expectError(error.ParseFailed, cr.parseTokenEndpointResponse(std.testing.allocator, "not json", 0));
+}
+
+// ── Credential file (claudeAiOauth) build + parse ──────────────────────────
+
+test "buildCredentialJson emits the verified claudeAiOauth shape" {
+    const t = cr.ClaudeTokens{
+        .access_token = "sk-ant-oat01-CCC",
+        .refresh_token = "sk-ant-ort01-DDD",
+        .expires_at_ms = 1748276587173,
+        .scopes = "user:inference user:profile",
+        .subscription_type = "max",
+    };
+    const json = try cr.buildCredentialJson(std.testing.allocator, t);
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(contains(json, "\"claudeAiOauth\":{"));
+    try std.testing.expect(contains(json, "\"accessToken\":\"sk-ant-oat01-CCC\""));
+    try std.testing.expect(contains(json, "\"refreshToken\":\"sk-ant-ort01-DDD\""));
+    try std.testing.expect(contains(json, "\"expiresAt\":1748276587173"));
+    try std.testing.expect(contains(json, "\"scopes\":[\"user:inference\",\"user:profile\"]"));
+    try std.testing.expect(contains(json, "\"subscriptionType\":\"max\""));
+}
+
+test "parseCredentialJson reads absolute ms expiresAt + subscriptionType" {
+    const t = try cr.parseCredentialJson(std.testing.allocator, credential_json);
+    defer cr.freeTokens(std.testing.allocator, t);
+    try std.testing.expectEqualStrings("sk-ant-oat01-CCC", t.access_token);
+    try std.testing.expectEqualStrings("sk-ant-ort01-DDD", t.refresh_token);
+    try std.testing.expectEqual(@as(i64, 1748276587173), t.expires_at_ms);
+    try std.testing.expectEqualStrings("max", t.subscription_type.?);
+}
+
+test "credential build -> parse round-trip" {
+    const orig = cr.ClaudeTokens{
+        .access_token = "sk-ant-oat01-RT",
+        .refresh_token = "sk-ant-ort01-RT",
+        .expires_at_ms = 1700000000000,
+        .scopes = "user:inference",
+        .subscription_type = "pro",
+    };
+    const json = try cr.buildCredentialJson(std.testing.allocator, orig);
+    defer std.testing.allocator.free(json);
+    const back = try cr.parseCredentialJson(std.testing.allocator, json);
+    defer cr.freeTokens(std.testing.allocator, back);
+    try std.testing.expectEqualStrings(orig.access_token, back.access_token);
+    try std.testing.expectEqualStrings(orig.refresh_token, back.refresh_token);
+    try std.testing.expectEqual(orig.expires_at_ms, back.expires_at_ms);
+    try std.testing.expectEqualStrings("pro", back.subscription_type.?);
+}
+
+// ── Predicates ─────────────────────────────────────────────────────────────
+
+test "isAccessTokenExpired honors skew" {
+    const t = cr.ClaudeTokens{ .access_token = "a", .refresh_token = "r", .expires_at_ms = 10_000 };
+    try std.testing.expect(!cr.isAccessTokenExpired(t, 5_000, 0));
+    try std.testing.expect(cr.isAccessTokenExpired(t, 10_000, 0)); // at expiry
+    try std.testing.expect(cr.isAccessTokenExpired(t, 9_500, 1_000)); // within skew
+    try std.testing.expect(!cr.isAccessTokenExpired(t, 8_000, 1_000));
+}
+
+test "token prefix recognizers" {
+    try std.testing.expect(cr.looksLikeAccessToken("sk-ant-oat01-xyz"));
+    try std.testing.expect(!cr.looksLikeAccessToken("sk-ant-ort01-xyz"));
+    try std.testing.expect(cr.looksLikeRefreshToken("sk-ant-ort01-xyz"));
+    try std.testing.expect(!cr.looksLikeRefreshToken("nope"));
+}
+
+test "deriveChallenge matches RFC 7636 Appendix B vector" {
+    const rfc_verifier: [43]u8 = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk".*;
+    const got = cr.deriveChallenge(rfc_verifier);
+    try std.testing.expectEqualStrings("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM", got[0..]);
+}
+
+test "percentEncode encodes reserved, passes unreserved" {
+    const e = try cr.percentEncode(std.testing.allocator, "a:b/c d");
+    defer std.testing.allocator.free(e);
+    try std.testing.expectEqualStrings("a%3Ab%2Fc%20d", e);
+}
+
+// ── Adapter over the fake HTTP seam ────────────────────────────────────────
+
+test "adapter.exchangeCode posts an auth-code grant to the token endpoint and parses tokens" {
+    var rec = Recorder{ .response = token_response_json };
+    const adapter = rec.adapter();
+    const t = try adapter.exchangeCode(std.testing.allocator, "the-code", verifier, "http://127.0.0.1:9/callback", 1000);
+    defer cr.freeTokens(std.testing.allocator, t);
+
+    try std.testing.expectEqualStrings("https://console.anthropic.com/v1/oauth/token", rec.seenUrl());
+    try std.testing.expectEqualStrings("application/x-www-form-urlencoded", rec.seenContentType());
+    try std.testing.expect(contains(rec.seenBody(), "grant_type=authorization_code"));
+    try std.testing.expectEqualStrings("sk-ant-oat01-AAA", t.access_token);
+    try std.testing.expectEqual(@as(i64, 3_601_000), t.expires_at_ms);
+}
+
+test "adapter.refresh posts a refresh grant and parses tokens" {
+    var rec = Recorder{ .response = token_response_json };
+    const adapter = rec.adapter();
+    const t = try adapter.refresh(std.testing.allocator, "sk-ant-ort01-OLD", 2000);
+    defer cr.freeTokens(std.testing.allocator, t);
+    try std.testing.expect(contains(rec.seenBody(), "grant_type=refresh_token"));
+    try std.testing.expect(contains(rec.seenBody(), "refresh_token=sk-ant-ort01-OLD"));
+    try std.testing.expectEqual(@as(i64, 3_602_000), t.expires_at_ms);
+}
+
+test "adapter.exchangeCode maps HTTP failure -> ExchangeFailed" {
+    var rec = Recorder{ .fail = true };
+    const adapter = rec.adapter();
+    try std.testing.expectError(error.ExchangeFailed, adapter.exchangeCode(std.testing.allocator, "c", verifier, "http://127.0.0.1:9/callback", 0));
+}
+
+test "adapter.refresh maps HTTP failure -> RefreshFailed" {
+    var rec = Recorder{ .fail = true };
+    const adapter = rec.adapter();
+    try std.testing.expectError(error.RefreshFailed, adapter.refresh(std.testing.allocator, "rt", 0));
+}
+
+test "adapter.exchangeCode maps unparseable response -> ExchangeFailed" {
+    var rec = Recorder{ .response = "garbage" };
+    const adapter = rec.adapter();
+    try std.testing.expectError(error.ExchangeFailed, adapter.exchangeCode(std.testing.allocator, "c", verifier, "http://127.0.0.1:9/callback", 0));
+}
+
+test "adapter.materialize writes a parseable credential file" {
+    var rec = Recorder{};
+    const adapter = rec.adapter();
+    const t = cr.ClaudeTokens{
+        .access_token = "sk-ant-oat01-M",
+        .refresh_token = "sk-ant-ort01-M",
+        .expires_at_ms = 1700000000000,
+        .scopes = "user:inference user:profile",
+        .subscription_type = "max",
+    };
+    const json = try adapter.materialize(std.testing.allocator, t);
+    defer std.testing.allocator.free(json);
+    const back = try cr.parseCredentialJson(std.testing.allocator, json);
+    defer cr.freeTokens(std.testing.allocator, back);
+    try std.testing.expectEqualStrings("sk-ant-oat01-M", back.access_token);
+    try std.testing.expectEqual(@as(i64, 1700000000000), back.expires_at_ms);
+}


### PR DESCRIPTION
The **first non-Codex adapter**: the Claude-specific OAuth pieces of a re-login flow, composing with the flow-agnostic engine (#344) and the loopback PKCE callback server (#349). **New files only**, self-contained over an injected HTTP seam; zero edits to existing code.

Claude Code authenticates with **OAuth 2.1 loopback PKCE (S256)** — the *same* shape #349 already captures — so this module owns only what is Claude-specific.

## Verified facts (not the stub's guesses)
Confirmed independently from multiple sources ([Claude Code auth docs](https://code.claude.com/docs/en/authentication), [cedws ANTHROPIC_AUTH gist](https://gist.github.com/cedws/3a24b2c7569bb610e24aa90dd217d9f2), [querymt/anthropic-auth](https://github.com/querymt/anthropic-auth), [claude-code #39445](https://github.com/anthropics/claude-code/issues/39445)):
- **authorize** `https://console.anthropic.com/oauth/authorize`
- **token** `https://console.anthropic.com/v1/oauth/token` (exchange + refresh)
- **client_id** `9d1c250a-e61b-44d9-88ed-5944d1962f5e` (Claude Code public client)
- **credential** `~/.claude/.credentials.json` → `{"claudeAiOauth":{"accessToken":"sk-ant-oat01-…","refreshToken":"sk-ant-ort01-…","expiresAt":<unix MS>,"scopes":[…],"subscriptionType":"max"}}`

> ⚠️ The repo's declarative `claude_def` (`provider_schema.zig:683`) + `oauth.zig:115` currently carry the **wrong** token endpoint (`claude.ai/…`). Fixing those is coordinated shared-file work (roadmap **A.1**), deliberately **not** in this greenfield module.

## What's here
A pure provider core + a thin `ClaudeReauthAdapter` over an injected `HttpPostFn` seam:
- `buildAuthorizeUrl` / `buildTokenExchangeBody` / `buildRefreshBody` — request builders (RFC 3986 encoded)
- `parseTokenEndpointResponse` — normalizes the relative `expires_in` (seconds) to an **absolute `expires_at_ms`**
- `buildCredentialJson` / `parseCredentialJson` — the verified `claudeAiOauth` file shape (ms `expiresAt`), round-trip tested
- `ClaudeReauthAdapter.{authorizeUrl,exchangeCode,refresh,materialize}` over the HTTP seam
- `isAccessTokenExpired` (the predicate a keepalive scheduler will use), `sk-ant-oat01-/ort01-` recognizers

## Verified
`nix develop --command zig test src/enroll/claude_reauth_tests.zig` → **All 20 tests passed** (`std.testing.allocator` leak-checked; `refAllDeclsRecursive`; RFC 7636 Appendix B PKCE vector; adapter posts real grants to the token endpoint through a fake seam). Latest `main` (`c46ff5f`). Self-contained — `std` only, no `@import` of existing `src`. (`percentEncode`/`deriveChallenge` mirror #349 and de-dup into a shared util on integration.)

## Coordinated follow-ups (shared files)
- Fix the `claude_def` / `oauth.zig` token endpoint (**A.1**)
- Extend the `CredentialMaterializer` vtable with the Claude token shape (**A.4**, blocked on zig-core de-codexing)
- Bind the HTTP seam to the real client + wire `authorizeUrl→#349 callback→exchangeCode→materialize` into the engine reauth job under the per-account flock

Part of the new **Adapter Maturation** epic (issue **A.5**). Pairs with #344 (engine) + #349 (callback). `build.zig`: add a `test-claude` step (`addTest` on `src/enroll/claude_reauth_tests.zig`).