### PR TITLE
keepalive: warm-loop scheduler core (TIN-1825 — greenfield, 15/15, never-halt)

### DIFF
--- a/src/keepalive/warm_scheduler.zig
+++ b/src/keepalive/warm_scheduler.zig
@@ -1,0 +1,195 @@
+//! Keepalive warm-loop scheduler — greenfield, the pure core of the professional
+//! keepalive daemon (TIN-1825 / ide-keepalive epic).
+//!
+//! The daemon's job is to keep every enrolled account's token WARM so the IDE /
+//! agent never sees a dead token: refresh each account proactively at ~75% of
+//! its lifetime (well before expiry), under the broker's per-account flock. This
+//! module is the *decision* core — WHEN to refresh, and WHAT to do on failure —
+//! with the clock and the actual refresh injected as seams. It performs NO I/O,
+//! NO allocation, and NO clock reads of its own, so it is fully deterministic
+//! and unit-testable; the surrounding daemon loop (tick → sleep → repeat) is the
+//! thin untested-by-design wrapper.
+//!
+//! North star (resilience-never-halt): a dead/exhausted account must NEVER block
+//! work. A refresh that fails repeatedly is marked `dead` and SKIPPED — the other
+//! accounts keep being warmed. One live account keeps the fleet afloat.
+//!
+//! Self-contained: `std` only, no `@import` of existing `src`. The daemon wiring
+//! that calls `tick` and the binding of the refresh seam to the broker's
+//! `credential/refresh` (B.2) are coordinated follow-ups (shared files).
+
+const std = @import("std");
+
+/// Per-account state the scheduler reads and updates in place. `key` is an
+/// opaque, borrowed identifier (e.g. "claude:org:acct") the refresh seam acts on;
+/// the scheduler never owns or frees it.
+pub const Account = struct {
+    key: []const u8,
+    /// When the current token was issued / last refreshed (absolute Unix ms).
+    last_refresh_ms: i64,
+    /// Absolute token expiry (Unix ms).
+    expires_at_ms: i64,
+    /// Consecutive refresh failures (reset to 0 on success).
+    failures: u32 = 0,
+    /// Backoff gate: earliest next refresh attempt (Unix ms). 0 = no gate.
+    next_attempt_ms: i64 = 0,
+    /// Gave up after `max_failures` — skipped by the scheduler so it never blocks
+    /// the live accounts. Cleared externally on operator re-login.
+    dead: bool = false,
+};
+
+/// Tunable scheduling policy. Integer-only (no float) so timing is deterministic.
+pub const Policy = struct {
+    /// Refresh when this percent of the token lifetime has elapsed (75% → refresh
+    /// with 25% of life remaining).
+    refresh_percent: u8 = 75,
+    /// Always refresh at least this long before expiry, regardless of percent.
+    min_lead_ms: i64 = 60_000, // 1 min
+    /// Exponential backoff on failure: base, factor, cap.
+    backoff_base_ms: i64 = 5_000, // 5 s
+    backoff_factor: u32 = 2,
+    backoff_max_ms: i64 = 600_000, // 10 min
+    /// After this many consecutive failures, mark the account dead.
+    max_failures: u32 = 8,
+};
+
+/// Sentinel "never due" instant for dead accounts.
+pub const never: i64 = std.math.maxInt(i64);
+
+// ── Pure scheduling math ───────────────────────────────────────────────────
+
+/// The instant a healthy token should be proactively refreshed: `refresh_percent`
+/// of the way through its lifetime, but never later than `min_lead_ms` before
+/// expiry, and never before it was issued. Ignores backoff/dead state.
+pub fn refreshDueAtMs(account: Account, policy: Policy) i64 {
+    const lifetime = account.expires_at_ms - account.last_refresh_ms;
+    if (lifetime <= 0) return account.last_refresh_ms; // already expired/odd → due now
+    // last_refresh + lifetime * percent/100 (integer math; lifetime*100 fits i64
+    // for any realistic token lifetime).
+    const elapsed_target = @divTrunc(lifetime * @as(i64, policy.refresh_percent), 100);
+    var due = account.last_refresh_ms + elapsed_target;
+    const latest = account.expires_at_ms - policy.min_lead_ms;
+    if (due > latest) due = latest;
+    if (due < account.last_refresh_ms) due = account.last_refresh_ms;
+    return due;
+}
+
+/// The effective due instant including the backoff gate. Dead → `never`.
+pub fn effectiveDueMs(account: Account, policy: Policy) i64 {
+    if (account.dead) return never;
+    const due = refreshDueAtMs(account, policy);
+    return if (account.next_attempt_ms > due) account.next_attempt_ms else due;
+}
+
+/// Is this account due for a refresh at `now_ms`? (false if dead.)
+pub fn isDue(account: Account, policy: Policy, now_ms: i64) bool {
+    if (account.dead) return false;
+    return now_ms >= effectiveDueMs(account, policy);
+}
+
+/// The earliest instant the daemon should next wake to act, across all accounts,
+/// or null if every account is dead (nothing left to schedule). A value <= now
+/// means at least one account is already due.
+pub fn nextWakeMs(accounts: []const Account, policy: Policy) ?i64 {
+    var best: ?i64 = null;
+    for (accounts) |a| {
+        if (a.dead) continue;
+        const due = effectiveDueMs(a, policy);
+        if (best == null or due < best.?) best = due;
+    }
+    return best;
+}
+
+/// Exponential backoff delay for the Nth consecutive failure (1-based), capped.
+/// Saturating multiply avoids overflow at large failure counts.
+pub fn backoffDelayMs(failures: u32, policy: Policy) i64 {
+    if (failures == 0) return 0;
+    var delay: i64 = policy.backoff_base_ms;
+    var i: u32 = 1;
+    while (i < failures) : (i += 1) {
+        delay = delay *| @as(i64, policy.backoff_factor);
+        if (delay >= policy.backoff_max_ms) return policy.backoff_max_ms;
+    }
+    return @min(delay, policy.backoff_max_ms);
+}
+
+// ── Injected seams ─────────────────────────────────────────────────────────
+
+pub const ClockFn = *const fn (ctx: *anyopaque) i64;
+
+pub const RefreshError = error{ OutOfMemory, RefreshFailed };
+
+/// Outcome of a successful refresh: the new issue + expiry instants the broker
+/// wrote. (The credential itself is materialized by the broker/adapter, not here.)
+pub const RefreshResult = struct {
+    new_last_refresh_ms: i64,
+    new_expires_at_ms: i64,
+};
+
+/// Perform one account's refresh (broker `credential/refresh` under the flock).
+pub const RefreshFn = *const fn (ctx: *anyopaque, account_key: []const u8) RefreshError!RefreshResult;
+
+/// Per-tick outcome counters (for logging / the operator UI).
+pub const TickReport = struct {
+    refreshed: u32 = 0,
+    failed: u32 = 0,
+    died: u32 = 0,
+    not_due: u32 = 0,
+    skipped_dead: u32 = 0,
+    /// Transient errors (e.g. OOM) — retried next tick, no state change.
+    transient: u32 = 0,
+};
+
+// ── The scheduler ──────────────────────────────────────────────────────────
+
+pub const Scheduler = struct {
+    policy: Policy = .{},
+    clock: ClockFn,
+    clock_ctx: *anyopaque,
+    refresh: RefreshFn,
+    refresh_ctx: *anyopaque,
+
+    /// Run one scheduling tick: refresh every account due now (updating its state
+    /// in place), apply backoff on failure, and mark accounts dead past the
+    /// failure budget. Dead accounts are skipped so they never block the live
+    /// ones (never-halt). No allocation, no blocking. Returns the outcome counts.
+    pub fn tick(self: *const Scheduler, accounts: []Account) TickReport {
+        const now = self.clock(self.clock_ctx);
+        var report = TickReport{};
+        for (accounts) |*a| {
+            if (a.dead) {
+                report.skipped_dead += 1;
+                continue;
+            }
+            if (!isDue(a.*, self.policy, now)) {
+                report.not_due += 1;
+                continue;
+            }
+            const result = self.refresh(self.refresh_ctx, a.key) catch |err| {
+                switch (err) {
+                    error.OutOfMemory => {
+                        // Transient: leave state untouched, retry next tick.
+                        report.transient += 1;
+                    },
+                    error.RefreshFailed => {
+                        a.failures += 1;
+                        if (a.failures >= self.policy.max_failures) {
+                            a.dead = true;
+                            report.died += 1;
+                        } else {
+                            a.next_attempt_ms = now + backoffDelayMs(a.failures, self.policy);
+                            report.failed += 1;
+                        }
+                    },
+                }
+                continue;
+            };
+            a.last_refresh_ms = result.new_last_refresh_ms;
+            a.expires_at_ms = result.new_expires_at_ms;
+            a.failures = 0;
+            a.next_attempt_ms = 0;
+            report.refreshed += 1;
+        }
+        return report;
+    }
+};

--- a/src/keepalive/warm_scheduler_tests.zig
+++ b/src/keepalive/warm_scheduler_tests.zig
@@ -1,0 +1,203 @@
+//! Unit tests for the keepalive warm-loop scheduler. Pure core: fake clock +
+//! fake refresh seam, no I/O. The core never allocates.
+//!
+//!     zig test src/keepalive/warm_scheduler_tests.zig
+
+const std = @import("std");
+const ws = @import("warm_scheduler.zig");
+
+test {
+    std.testing.refAllDeclsRecursive(ws);
+}
+
+// ── Fakes ──────────────────────────────────────────────────────────────────
+
+const FakeClock = struct {
+    now: i64,
+    fn read(ctx: *anyopaque) i64 {
+        const self: *FakeClock = @ptrCast(@alignCast(ctx));
+        return self.now;
+    }
+};
+
+const FakeRefresher = struct {
+    fail: bool = false,
+    oom: bool = false,
+    new_last: i64 = 0,
+    new_expires: i64 = 0,
+    calls: u32 = 0,
+    last_key: [64]u8 = undefined,
+    last_key_len: usize = 0,
+
+    fn refresh(ctx: *anyopaque, key: []const u8) ws.RefreshError!ws.RefreshResult {
+        const self: *FakeRefresher = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        self.last_key_len = @min(key.len, self.last_key.len);
+        @memcpy(self.last_key[0..self.last_key_len], key[0..self.last_key_len]);
+        if (self.oom) return error.OutOfMemory;
+        if (self.fail) return error.RefreshFailed;
+        return .{ .new_last_refresh_ms = self.new_last, .new_expires_at_ms = self.new_expires };
+    }
+    fn keyStr(self: *FakeRefresher) []const u8 {
+        return self.last_key[0..self.last_key_len];
+    }
+};
+
+fn scheduler(clk: *FakeClock, ref: *FakeRefresher, policy: ws.Policy) ws.Scheduler {
+    return .{
+        .policy = policy,
+        .clock = FakeClock.read,
+        .clock_ctx = clk,
+        .refresh = FakeRefresher.refresh,
+        .refresh_ctx = ref,
+    };
+}
+
+// ── Pure scheduling math ───────────────────────────────────────────────────
+
+test "refreshDueAtMs: 75% of lifetime" {
+    const a = ws.Account{ .key = "k", .last_refresh_ms = 0, .expires_at_ms = 1_000_000 };
+    try std.testing.expectEqual(@as(i64, 750_000), ws.refreshDueAtMs(a, .{ .refresh_percent = 75, .min_lead_ms = 0 }));
+}
+
+test "refreshDueAtMs: min_lead clamps the due time before expiry" {
+    const a = ws.Account{ .key = "k", .last_refresh_ms = 0, .expires_at_ms = 1000 };
+    // 99% -> 990, but min_lead 200 caps the latest refresh to expires-200 = 800.
+    try std.testing.expectEqual(@as(i64, 800), ws.refreshDueAtMs(a, .{ .refresh_percent = 99, .min_lead_ms = 200 }));
+}
+
+test "refreshDueAtMs: already-expired lifetime is due immediately" {
+    const a = ws.Account{ .key = "k", .last_refresh_ms = 1000, .expires_at_ms = 500 };
+    try std.testing.expectEqual(@as(i64, 1000), ws.refreshDueAtMs(a, .{}));
+}
+
+test "effectiveDueMs: backoff gate overrides the due time" {
+    const a = ws.Account{ .key = "k", .last_refresh_ms = 0, .expires_at_ms = 1_000_000, .next_attempt_ms = 900_000 };
+    try std.testing.expectEqual(@as(i64, 900_000), ws.effectiveDueMs(a, .{ .refresh_percent = 75, .min_lead_ms = 0 }));
+}
+
+test "effectiveDueMs: dead account is never due" {
+    const a = ws.Account{ .key = "k", .last_refresh_ms = 0, .expires_at_ms = 1000, .dead = true };
+    try std.testing.expectEqual(ws.never, ws.effectiveDueMs(a, .{}));
+}
+
+test "isDue honors now, backoff, and dead" {
+    const policy = ws.Policy{ .refresh_percent = 75, .min_lead_ms = 0 };
+    const a = ws.Account{ .key = "k", .last_refresh_ms = 0, .expires_at_ms = 1_000_000 }; // due at 750_000
+    try std.testing.expect(!ws.isDue(a, policy, 749_999));
+    try std.testing.expect(ws.isDue(a, policy, 750_000));
+    var dead = a;
+    dead.dead = true;
+    try std.testing.expect(!ws.isDue(dead, policy, 999_999_999));
+}
+
+test "nextWakeMs: earliest live due, null if all dead" {
+    const policy = ws.Policy{ .refresh_percent = 75, .min_lead_ms = 0 };
+    var accounts = [_]ws.Account{
+        .{ .key = "a", .last_refresh_ms = 0, .expires_at_ms = 1_000_000 }, // due 750_000
+        .{ .key = "b", .last_refresh_ms = 0, .expires_at_ms = 400_000 }, // due 300_000
+        .{ .key = "c", .last_refresh_ms = 0, .expires_at_ms = 1000, .dead = true },
+    };
+    try std.testing.expectEqual(@as(?i64, 300_000), ws.nextWakeMs(&accounts, policy));
+    for (&accounts) |*a| a.dead = true;
+    try std.testing.expectEqual(@as(?i64, null), ws.nextWakeMs(&accounts, policy));
+}
+
+test "backoffDelayMs: exponential with cap" {
+    const policy = ws.Policy{ .backoff_base_ms = 5_000, .backoff_factor = 2, .backoff_max_ms = 600_000 };
+    try std.testing.expectEqual(@as(i64, 0), ws.backoffDelayMs(0, policy));
+    try std.testing.expectEqual(@as(i64, 5_000), ws.backoffDelayMs(1, policy));
+    try std.testing.expectEqual(@as(i64, 10_000), ws.backoffDelayMs(2, policy));
+    try std.testing.expectEqual(@as(i64, 20_000), ws.backoffDelayMs(3, policy));
+    try std.testing.expectEqual(@as(i64, 600_000), ws.backoffDelayMs(99, policy)); // capped, no overflow
+}
+
+// ── tick() ─────────────────────────────────────────────────────────────────
+
+const due_policy = ws.Policy{ .refresh_percent = 75, .min_lead_ms = 0 };
+
+test "tick: a due account is refreshed and its state is reset" {
+    var clk = FakeClock{ .now = 1_000_000 };
+    var ref = FakeRefresher{ .new_last = 1_000_000, .new_expires = 5_000_000 };
+    const sched = scheduler(&clk, &ref, due_policy);
+    var accounts = [_]ws.Account{
+        .{ .key = "claude:org:acct", .last_refresh_ms = 0, .expires_at_ms = 1_000_000, .failures = 3, .next_attempt_ms = 0 },
+    };
+    const r = sched.tick(&accounts);
+    try std.testing.expectEqual(@as(u32, 1), r.refreshed);
+    try std.testing.expectEqual(@as(u32, 1), ref.calls);
+    try std.testing.expectEqualStrings("claude:org:acct", ref.keyStr());
+    try std.testing.expectEqual(@as(i64, 1_000_000), accounts[0].last_refresh_ms);
+    try std.testing.expectEqual(@as(i64, 5_000_000), accounts[0].expires_at_ms);
+    try std.testing.expectEqual(@as(u32, 0), accounts[0].failures);
+}
+
+test "tick: a not-due account is skipped without calling refresh" {
+    var clk = FakeClock{ .now = 1_000_000 };
+    var ref = FakeRefresher{};
+    const sched = scheduler(&clk, &ref, due_policy);
+    var accounts = [_]ws.Account{
+        .{ .key = "k", .last_refresh_ms = 0, .expires_at_ms = 10_000_000 }, // due 7.5M > now
+    };
+    const r = sched.tick(&accounts);
+    try std.testing.expectEqual(@as(u32, 1), r.not_due);
+    try std.testing.expectEqual(@as(u32, 0), ref.calls);
+}
+
+test "tick: a failed refresh increments failures and arms backoff" {
+    var clk = FakeClock{ .now = 1_000_000 };
+    var ref = FakeRefresher{ .fail = true };
+    const sched = scheduler(&clk, &ref, due_policy);
+    var accounts = [_]ws.Account{
+        .{ .key = "k", .last_refresh_ms = 0, .expires_at_ms = 1_000_000 },
+    };
+    const r = sched.tick(&accounts);
+    try std.testing.expectEqual(@as(u32, 1), r.failed);
+    try std.testing.expectEqual(@as(u32, 1), accounts[0].failures);
+    try std.testing.expect(!accounts[0].dead);
+    try std.testing.expectEqual(@as(i64, 1_005_000), accounts[0].next_attempt_ms); // now + base
+}
+
+test "tick: failures past the budget mark the account dead" {
+    var clk = FakeClock{ .now = 1_000_000 };
+    var ref = FakeRefresher{ .fail = true };
+    const policy = ws.Policy{ .refresh_percent = 75, .min_lead_ms = 0, .max_failures = 2 };
+    const sched = scheduler(&clk, &ref, policy);
+    var accounts = [_]ws.Account{
+        .{ .key = "k", .last_refresh_ms = 0, .expires_at_ms = 1_000_000, .failures = 1, .next_attempt_ms = 0 },
+    };
+    const r = sched.tick(&accounts);
+    try std.testing.expectEqual(@as(u32, 1), r.died);
+    try std.testing.expect(accounts[0].dead);
+}
+
+test "tick: an OOM is transient and leaves state untouched" {
+    var clk = FakeClock{ .now = 1_000_000 };
+    var ref = FakeRefresher{ .oom = true };
+    const sched = scheduler(&clk, &ref, due_policy);
+    var accounts = [_]ws.Account{
+        .{ .key = "k", .last_refresh_ms = 0, .expires_at_ms = 1_000_000, .failures = 0 },
+    };
+    const r = sched.tick(&accounts);
+    try std.testing.expectEqual(@as(u32, 1), r.transient);
+    try std.testing.expectEqual(@as(u32, 0), accounts[0].failures); // unchanged
+    try std.testing.expectEqual(@as(i64, 0), accounts[0].next_attempt_ms);
+}
+
+test "tick: NEVER-HALT — a dead peer does not block a live account" {
+    var clk = FakeClock{ .now = 1_000_000 };
+    var ref = FakeRefresher{ .new_last = 1_000_000, .new_expires = 9_000_000 };
+    const sched = scheduler(&clk, &ref, due_policy);
+    var accounts = [_]ws.Account{
+        .{ .key = "dead", .last_refresh_ms = 0, .expires_at_ms = 1000, .dead = true },
+        .{ .key = "live-due", .last_refresh_ms = 0, .expires_at_ms = 1_000_000 }, // due 750k <= now
+        .{ .key = "live-future", .last_refresh_ms = 0, .expires_at_ms = 100_000_000 }, // not due
+    };
+    const r = sched.tick(&accounts);
+    // The live, due account was refreshed despite the dead peer.
+    try std.testing.expectEqual(@as(u32, 1), r.refreshed);
+    try std.testing.expectEqual(@as(u32, 1), r.skipped_dead);
+    try std.testing.expectEqual(@as(u32, 1), r.not_due);
+    try std.testing.expectEqual(@as(i64, 9_000_000), accounts[1].expires_at_ms); // got refreshed
+    try std.testing.expectEqualStrings("live-due", ref.keyStr());
+}


### PR DESCRIPTION
The pure decision core of the **professional keepalive daemon** (TIN-1825 / ide-keepalive epic). Keeps every enrolled account's token **warm** so the IDE/agent never sees a dead token. **New files only**, self-contained; zero edits to existing code.

## What
`src/keepalive/warm_scheduler.zig` decides **when** each account needs a proactive refresh and **what** to do on failure — with the clock and the actual refresh injected as seams. It performs **no I/O, no allocation, and no clock reads of its own**, so it is fully deterministic and unit-testable; the surrounding daemon loop (`tick → sleep until nextWakeMs → repeat`) is the thin untested-by-design wrapper.

- `refreshDueAtMs` — refresh at ~75% of token lifetime (configurable `refresh_percent`), clamped to at least `min_lead_ms` before expiry; integer-only math (deterministic).
- `effectiveDueMs` / `isDue` / `nextWakeMs` — due-time incl. the backoff gate; the daemon sleeps until the earliest live due instant.
- `backoffDelayMs` — exponential backoff with a cap (saturating multiply, no overflow).
- `Scheduler.tick(accounts)` over `ClockFn` + `RefreshFn` seams → refreshes due accounts, arms backoff on failure, marks accounts `dead` past the failure budget, returns a `TickReport`.

## Never-halt (the north star)
A dead/exhausted account must **never** block work. Past `max_failures` an account is marked `dead` and **skipped**; the other accounts keep being warmed. One live account keeps the fleet afloat — verified by an explicit test (`a dead peer does not block a live account`).

## Verified
`nix develop --command zig test src/keepalive/warm_scheduler_tests.zig` → **All 15 tests passed** (scheduling math, backoff cap, the full `tick` state machine, never-halt). Latest `main` (`c46ff5f`). Self-contained — `std` only, no `@import` of existing `src` (the core never allocates).

## Coordinated follow-ups (shared files)
- Bind `RefreshFn` to the broker `credential/refresh` under the per-account flock (B.2, blocked on refresh-serialization).
- The daemon loop + `launchd`/`systemd` lifecycle (B.6) + the `127.0.0.1` status UI (B.3, greenfield next).

Part of the new **ide-keepalive** epic (issue **B.1**, TIN-1825). Pairs with the reauth backend (#344/#347/#349) + the Claude adapter (#354). `build.zig`: add a `test-keepalive` step.