### PR TITLE
cassettes: Claude OAuth reauth recorder/replayer (TIN-1823 — greenfield, 15/15, neutralize-on-disk)

### DIFF
--- a/src/cassettes/claude_oauth_cassette.zig
+++ b/src/cassettes/claude_oauth_cassette.zig
@@ -1,0 +1,396 @@
+//! Claude (Claude Code) OAuth reauth CASSETTE — greenfield, the deterministic
+//! offline-proof core for the Claude reauth adapter (PR#354) and the keepalive
+//! warm scheduler (PR#355). TIN-1823 / A.7 (cassettes/recorder+replayer).
+//!
+//! Why this exists: re-authing accounts and warming tokens means hitting a real
+//! OAuth token endpoint. To unit-test the adapter/scheduler WITHOUT a live
+//! account or network — and without ever materializing a real secret — we replay
+//! a recorded token-endpoint exchange. The hazard a token cassette must avoid is
+//! obvious: a refresh token is account-takeover-grade, and the repo's own
+//! `src/fixture_redaction.zig` scanner (run in the main test suite) walks
+//! `test/fixtures/` and REJECTS any file containing `sk-`, `access_token`,
+//! `refresh_token`, `id_token`, etc.
+//!
+//! Design: NEUTRALIZE-ON-DISK, RECONSTRUCT-IN-MEMORY.
+//!   * On disk (`test/fixtures/cassettes/claude/*.jsonl`) a cassette line carries
+//!     only NON-secret shape: the op, the HTTP status, the token LENGTH-CLASSES,
+//!     and the (non-secret) expiry/scope/token_type. It contains none of the
+//!     forbidden markers, so it passes the fixture scanner.
+//!   * At replay time the `Replayer` RECONSTRUCTS the real-shaped token-endpoint
+//!     JSON body in memory (`{"access_token":"sk-ant-oat01-…", …}`) so the real
+//!     adapter parser + prefix checks are exercised. That body is never written
+//!     to disk. The `sk-ant-…` prefix constants live in THIS source file, which
+//!     the fixture scanner does not walk.
+//!
+//! The `Recorder` (for an optional, opt-in live capture) redacts AT CAPTURE TIME,
+//! FAIL-CLOSED: it extracts only the length-class + non-secret fields and drops
+//! the line unless the response matches the known token shape, so a renamed
+//! upstream field can never leak a raw value. The recommended default is to
+//! HAND-AUTHOR the neutral fixtures (no real secret ever exists) — see the repo
+//! runbook; the recorder is the regression escape hatch.
+//!
+//! Self-contained: `std` only, NO `@import` of existing `src`. The HTTP and
+//! refresh seams below are STRUCTURAL copies of `claude_reauth.HttpPostFn`
+//! (PR#354) and `warm_scheduler.RefreshFn` (PR#355); the replayer/shim are
+//! assignable wherever those seams are expected (checked at compile time on the
+//! integration branch). Pure, allocation-explicit, `std.testing.allocator`-clean.
+
+const std = @import("std");
+
+// ── Local structural mirrors of the PR#354 / PR#355 seams (no @import of src) ──
+
+/// Mirror of `claude_reauth.HttpError`.
+pub const HttpError = error{ OutOfMemory, HttpFailed };
+
+/// Mirror of `claude_reauth.HttpPostFn`: POST `body` to `url`, return the
+/// freshly-allocated response body bytes (the caller frees). Non-2xx is signalled
+/// as `error.HttpFailed` (the body-only seam carries no status to the adapter).
+pub const HttpPostFn = *const fn (
+    allocator: std.mem.Allocator,
+    ctx: *anyopaque,
+    url: []const u8,
+    body: []const u8,
+    content_type: []const u8,
+) HttpError![]u8;
+
+/// Mirror of `warm_scheduler.RefreshError`.
+pub const RefreshError = error{ OutOfMemory, RefreshFailed };
+
+/// Mirror of `warm_scheduler.RefreshResult`.
+pub const RefreshResult = struct {
+    new_last_refresh_ms: i64,
+    new_expires_at_ms: i64,
+};
+
+/// Mirror of `warm_scheduler.RefreshFn`.
+pub const RefreshFn = *const fn (ctx: *anyopaque, account_key: []const u8) RefreshError!RefreshResult;
+
+// ── Real-shape constants (source-only; NEVER written to a fixture file) ─────────
+
+pub const token_endpoint = "https://console.anthropic.com/v1/oauth/token";
+pub const form_content_type = "application/x-www-form-urlencoded";
+pub const access_token_prefix = "sk-ant-oat01-";
+pub const refresh_token_prefix = "sk-ant-ort01-";
+
+/// The single, constant redaction filler. A fixed char keeps cassettes
+/// byte-deterministic across re-records and is class-preserving / value-
+/// destroying (it carries length, never the secret).
+pub const filler_char: u8 = 'A';
+
+// ── Cassette model ─────────────────────────────────────────────────────────
+
+pub const Op = enum {
+    exchange, // grant_type=authorization_code
+    refresh, // grant_type=refresh_token
+
+    fn fromStr(s: []const u8) ?Op {
+        if (std.mem.eql(u8, s, "exchange")) return .exchange;
+        if (std.mem.eql(u8, s, "refresh")) return .refresh;
+        return null;
+    }
+
+    /// Discriminator carried in the request FORM body (the token endpoint URL is
+    /// constant for both ops, so we key off the grant_type — the analogue of the
+    /// codex cassettes' (method,path) key).
+    fn fromRequestBody(body: []const u8) ?Op {
+        if (std.mem.indexOf(u8, body, "grant_type=authorization_code") != null) return .exchange;
+        if (std.mem.indexOf(u8, body, "grant_type=refresh_token") != null) return .refresh;
+        return null;
+    }
+};
+
+/// One recorded exchange — NON-secret shape only.
+pub const Entry = struct {
+    op: Op,
+    status: u16,
+    /// Length-class of the access/refresh token values (so length assertions stay
+    /// exercised); the values themselves are never stored.
+    at_len: usize,
+    rt_len: usize,
+    /// Relative expiry (seconds). Non-secret. Replay computes the absolute instant
+    /// from an injected clock, keeping determinism.
+    ttl_s: i64,
+    scope: []const u8, // non-secret; arena-owned
+    ttype: []const u8, // token_type, non-secret; arena-owned
+};
+
+pub const ParseError = error{ OutOfMemory, MalformedCassette };
+
+/// A parsed cassette: a slice of entries backed by an internal arena. Call
+/// `deinit` to free everything.
+pub const Cassette = struct {
+    entries: []Entry,
+    arena: std.heap.ArenaAllocator,
+
+    pub fn deinit(self: *Cassette) void {
+        self.arena.deinit();
+    }
+
+    /// Parse newline-delimited JSON (one `Entry` per non-empty line). Pure: no
+    /// I/O, no globals. Unknown fields are ignored (tolerant to additive drift).
+    pub fn parse(gpa: std.mem.Allocator, jsonl: []const u8) ParseError!Cassette {
+        var arena = std.heap.ArenaAllocator.init(gpa);
+        errdefer arena.deinit();
+        const a = arena.allocator();
+
+        var list = std.ArrayList(Entry).init(a);
+
+        // On-disk neutral schema (no forbidden markers).
+        const RawEntry = struct {
+            v: u32 = 1,
+            op: []const u8 = "",
+            status: u16 = 0,
+            at_len: usize = 0,
+            rt_len: usize = 0,
+            ttl_s: i64 = 0,
+            scope: []const u8 = "",
+            ttype: []const u8 = "Bearer",
+        };
+
+        var it = std.mem.splitScalar(u8, jsonl, '\n');
+        while (it.next()) |raw_line| {
+            const line = std.mem.trim(u8, raw_line, " \t\r");
+            if (line.len == 0) continue;
+
+            const parsed = std.json.parseFromSlice(RawEntry, gpa, line, .{
+                .ignore_unknown_fields = true,
+            }) catch return error.MalformedCassette;
+            defer parsed.deinit();
+            const r = parsed.value;
+
+            const op = Op.fromStr(r.op) orelse return error.MalformedCassette;
+            if (r.status == 0) return error.MalformedCassette;
+
+            try list.append(.{
+                .op = op,
+                .status = r.status,
+                .at_len = r.at_len,
+                .rt_len = r.rt_len,
+                .ttl_s = r.ttl_s,
+                .scope = try a.dupe(u8, r.scope),
+                .ttype = try a.dupe(u8, r.ttype),
+            });
+        }
+
+        return .{ .entries = try list.toOwnedSlice(), .arena = arena };
+    }
+};
+
+// ── Reconstruction (neutral Entry -> real-shaped token-endpoint body, in memory) ─
+
+/// Build a token value: real prefix + filler padded to `total_len` (clamped so it
+/// is never shorter than the prefix). Source-only; never persisted.
+fn buildTokenValue(a: std.mem.Allocator, prefix: []const u8, total_len: usize) ![]u8 {
+    const pad: usize = if (total_len > prefix.len) total_len - prefix.len else 0;
+    var buf = try a.alloc(u8, prefix.len + pad);
+    @memcpy(buf[0..prefix.len], prefix);
+    @memset(buf[prefix.len..], filler_char);
+    return buf;
+}
+
+/// Reconstruct the REAL-shaped token-endpoint success body for a 2xx entry. The
+/// returned bytes carry `sk-ant-…` prefixes + `access_token`/`refresh_token`
+/// keys so the real adapter parser is exercised — but they exist only in memory.
+pub fn reconstructSuccessBody(a: std.mem.Allocator, entry: Entry) ![]u8 {
+    const access = try buildTokenValue(a, access_token_prefix, entry.at_len);
+    defer a.free(access);
+    const refresh = try buildTokenValue(a, refresh_token_prefix, entry.rt_len);
+    defer a.free(refresh);
+
+    return std.fmt.allocPrint(
+        a,
+        "{{\"access_token\":\"{s}\",\"refresh_token\":\"{s}\"," ++
+            "\"expires_in\":{d},\"scope\":\"{s}\",\"token_type\":\"{s}\"}}",
+        .{ access, refresh, entry.ttl_s, entry.scope, entry.ttype },
+    );
+}
+
+// ── Replayer: serves as an HttpPostFn ──────────────────────────────────────
+
+pub const Miss = struct {
+    op: Op,
+    reason: enum { no_line_for_op, failure_status },
+};
+
+/// Replays a cassette as the adapter's injected HTTP seam. One saturating cursor
+/// per op (a single line replays every tick; a multi-line sequence plays in order
+/// then sticks on the last). Matching keys off the request body's grant_type, so
+/// it is robust to the constant endpoint URL.
+pub const Replayer = struct {
+    cassette: *const Cassette,
+    exchange_cursor: usize = 0,
+    refresh_cursor: usize = 0,
+    last_miss: ?Miss = null,
+
+    fn nextEntry(self: *Replayer, op: Op) ?*const Entry {
+        var seen: usize = 0;
+        var idx: usize = 0;
+        // Walk entries for this op; pick the one at the op-local cursor, saturating.
+        const cursor = switch (op) {
+            .exchange => self.exchange_cursor,
+            .refresh => self.refresh_cursor,
+        };
+        var last_for_op: ?*const Entry = null;
+        while (idx < self.cassette.entries.len) : (idx += 1) {
+            const e = &self.cassette.entries[idx];
+            if (e.op != op) continue;
+            last_for_op = e;
+            if (seen == cursor) {
+                // advance (saturate at the last matching entry)
+                switch (op) {
+                    .exchange => self.exchange_cursor += 1,
+                    .refresh => self.refresh_cursor += 1,
+                }
+                return e;
+            }
+            seen += 1;
+        }
+        // Cursor past the end: saturate on the last matching entry, if any.
+        return last_for_op;
+    }
+
+    /// Matches `HttpPostFn`. Returns a freshly-allocated reconstructed body for a
+    /// 2xx entry, or `error.HttpFailed` for a failure-status entry or an op miss
+    /// (a value-free diagnostic is recorded in `last_miss`).
+    pub fn post(
+        allocator: std.mem.Allocator,
+        ctx: *anyopaque,
+        url: []const u8,
+        body: []const u8,
+        content_type: []const u8,
+    ) HttpError![]u8 {
+        const self: *Replayer = @ptrCast(@alignCast(ctx));
+        _ = url;
+        _ = content_type;
+
+        const op = Op.fromRequestBody(body) orelse {
+            // Unknown grant: treat as a refresh miss for diagnostics (fail-closed).
+            self.last_miss = .{ .op = .refresh, .reason = .no_line_for_op };
+            return error.HttpFailed;
+        };
+
+        const entry = self.nextEntry(op) orelse {
+            self.last_miss = .{ .op = op, .reason = .no_line_for_op };
+            return error.HttpFailed;
+        };
+
+        if (entry.status >= 400) {
+            self.last_miss = .{ .op = op, .reason = .failure_status };
+            return error.HttpFailed;
+        }
+
+        return reconstructSuccessBody(allocator, entry.*) catch return error.OutOfMemory;
+    }
+};
+
+// ── Recorder: wraps a real HttpPostFn, neutralizes at capture, fail-closed ─────
+
+/// Pure, fail-closed neutralizer: given a REAL token-endpoint success body, emit
+/// one neutral JSONL line carrying only length-class + non-secret fields. Returns
+/// `error.MalformedCassette` (drop the line) unless the body matches the known
+/// token shape with the expected `sk-ant-…` prefixes — so a renamed/unknown field
+/// can never carry a raw value through. The real token VALUES are never copied.
+pub fn neutralizeSuccessBody(a: std.mem.Allocator, op: Op, real_body: []const u8) ParseError![]u8 {
+    const Shape = struct {
+        access_token: []const u8 = "",
+        refresh_token: []const u8 = "",
+        expires_in: i64 = 0,
+        scope: []const u8 = "",
+        token_type: []const u8 = "Bearer",
+    };
+    const parsed = std.json.parseFromSlice(Shape, a, real_body, .{
+        .ignore_unknown_fields = true,
+    }) catch return error.MalformedCassette;
+    defer parsed.deinit();
+    const s = parsed.value;
+
+    // Fail-closed: only record if the secret fields match the known prefixes.
+    if (!std.mem.startsWith(u8, s.access_token, access_token_prefix)) return error.MalformedCassette;
+    if (!std.mem.startsWith(u8, s.refresh_token, refresh_token_prefix)) return error.MalformedCassette;
+
+    const op_str = switch (op) {
+        .exchange => "exchange",
+        .refresh => "refresh",
+    };
+    return std.fmt.allocPrint(
+        a,
+        "{{\"v\":1,\"op\":\"{s}\",\"status\":200,\"at_len\":{d},\"rt_len\":{d}," ++
+            "\"ttl_s\":{d},\"scope\":\"{s}\",\"ttype\":\"{s}\"}}",
+        .{ op_str, s.access_token.len, s.refresh_token.len, s.expires_in, s.scope, s.token_type },
+    );
+}
+
+/// Wraps a real HTTP seam: forwards the request unchanged, appends a neutral
+/// recorded line to `sink` (JSONL), and returns the inner body untouched so
+/// recording is transparent to the adapter. On a fail-closed redaction drop the
+/// request still succeeds — only the cassette line is skipped (never raw-written).
+pub const Recorder = struct {
+    inner: HttpPostFn,
+    inner_ctx: *anyopaque,
+    sink: *std.ArrayList(u8),
+
+    pub fn post(
+        allocator: std.mem.Allocator,
+        ctx: *anyopaque,
+        url: []const u8,
+        body: []const u8,
+        content_type: []const u8,
+    ) HttpError![]u8 {
+        const self: *Recorder = @ptrCast(@alignCast(ctx));
+        const resp = try self.inner(allocator, self.inner_ctx, url, body, content_type);
+        // Record best-effort; a redaction failure drops the line, never the call.
+        if (Op.fromRequestBody(body)) |op| {
+            if (neutralizeSuccessBody(allocator, op, resp)) |line| {
+                defer allocator.free(line);
+                self.sink.appendSlice(line) catch {};
+                self.sink.append('\n') catch {};
+            } else |_| {}
+        }
+        return resp;
+    }
+};
+
+// ── Scheduler binding: replayer -> warm_scheduler.RefreshFn shim ───────────────
+
+/// Binds a `Replayer` as the keepalive scheduler's refresh seam. A `tick` that
+/// finds an account due calls this; it replays the `refresh` cassette, parses the
+/// (non-secret) relative expiry, and returns the absolute instants the scheduler
+/// records. A failure cassette maps to `error.RefreshFailed` — driving the
+/// scheduler's backoff/dead path (never-halt) while siblings stay warm.
+pub const SchedulerBinding = struct {
+    replayer: *Replayer,
+    allocator: std.mem.Allocator,
+    now_ms: i64,
+
+    /// Matches `warm_scheduler.RefreshFn`.
+    pub fn refresh(ctx: *anyopaque, account_key: []const u8) RefreshError!RefreshResult {
+        const self: *SchedulerBinding = @ptrCast(@alignCast(ctx));
+        _ = account_key;
+
+        // A minimal refresh-grant body so the replayer matches op=refresh.
+        const req = "grant_type=refresh_token";
+        const resp = Replayer.post(
+            self.allocator,
+            @ptrCast(self.replayer),
+            token_endpoint,
+            req,
+            form_content_type,
+        ) catch |e| switch (e) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.HttpFailed => return error.RefreshFailed,
+        };
+        defer self.allocator.free(resp);
+
+        const Shape = struct { expires_in: i64 = 0 };
+        const parsed = std.json.parseFromSlice(Shape, self.allocator, resp, .{
+            .ignore_unknown_fields = true,
+        }) catch return error.RefreshFailed;
+        defer parsed.deinit();
+
+        const ttl_ms = parsed.value.expires_in *| std.time.ms_per_s;
+        return .{
+            .new_last_refresh_ms = self.now_ms,
+            .new_expires_at_ms = self.now_ms +| ttl_ms,
+        };
+    }
+};

--- a/src/cassettes/claude_oauth_cassette_tests.zig
+++ b/src/cassettes/claude_oauth_cassette_tests.zig
@@ -1,0 +1,259 @@
+//! Unit tests for the Claude OAuth reauth cassette. Pure: in-memory cassettes +
+//! the on-disk neutral fixtures, no network. Proves: neutralize-on-disk /
+//! reconstruct-in-memory, that no forbidden marker is ever produced, that the
+//! reconstructed body is real-shaped (sk-ant- prefixes parse), that the replayer
+//! serves as the adapter HttpPostFn, and that the scheduler RefreshFn shim drives
+//! a success refresh + a never-halt failure.
+//!
+//!     zig test src/cassettes/claude_oauth_cassette_tests.zig
+
+const std = @import("std");
+const testing = std.testing;
+const cas = @import("claude_oauth_cassette.zig");
+
+test {
+    std.testing.refAllDeclsRecursive(cas);
+}
+
+// The exact forbidden markers from src/fixture_redaction.zig — anything the
+// repo's fixture scanner rejects. Neutral cassette output must contain NONE.
+const forbidden_markers = [_][]const u8{
+    "access_token", "refresh_token", "id_token",     "client_secret",
+    "authorization:", "authorization=", "bearer ",   "bearer%20",
+    "set-cookie:",  "cookie:",       "sk-",          "sess-",
+};
+
+fn containsForbidden(bytes: []const u8) bool {
+    for (forbidden_markers) |m| {
+        if (std.ascii.indexOfIgnoreCase(bytes, m) != null) return true;
+    }
+    return false;
+}
+
+// A synthetic REAL-shaped token-endpoint body, built in memory in the test (the
+// sk-ant- prefix comes from the module's public constant, never a literal here;
+// this file lives under src/, which the fixture scanner does not walk).
+fn fakeRealBody(a: std.mem.Allocator, ttl: i64) ![]u8 {
+    const pad = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"; // length-class filler
+    return std.fmt.allocPrint(
+        a,
+        "{{\"access_token\":\"{s}{s}\",\"refresh_token\":\"{s}{s}\"," ++
+            "\"expires_in\":{d},\"scope\":\"user:inference user:profile\",\"token_type\":\"Bearer\"}}",
+        .{ cas.access_token_prefix, pad, cas.refresh_token_prefix, pad, ttl },
+    );
+}
+
+fn cassetteFromLine(a: std.mem.Allocator, line: []const u8) !cas.Cassette {
+    return cas.Cassette.parse(a, line);
+}
+
+// ── Reconstruction / parser-still-runs ─────────────────────────────────────
+
+test "reconstructSuccessBody emits a real-shaped body with sk-ant- prefixes that parses" {
+    const a = testing.allocator;
+    const entry = cas.Entry{ .op = .refresh, .status = 200, .at_len = 108, .rt_len = 108, .ttl_s = 3600, .scope = "user:inference", .ttype = "Bearer" };
+    const body = try cas.reconstructSuccessBody(a, entry);
+    defer a.free(body);
+
+    // Real shape: the adapter parser would accept this (prefixes + expires_in).
+    try testing.expect(std.mem.indexOf(u8, body, cas.access_token_prefix) != null);
+    try testing.expect(std.mem.indexOf(u8, body, cas.refresh_token_prefix) != null);
+
+    const Shape = struct { access_token: []const u8 = "", refresh_token: []const u8 = "", expires_in: i64 = 0 };
+    const parsed = try std.json.parseFromSlice(Shape, a, body, .{ .ignore_unknown_fields = true });
+    defer parsed.deinit();
+    try testing.expect(std.mem.startsWith(u8, parsed.value.access_token, cas.access_token_prefix));
+    try testing.expectEqual(@as(usize, 108), parsed.value.access_token.len); // length-class preserved
+    try testing.expectEqual(@as(i64, 3600), parsed.value.expires_in);
+}
+
+test "reconstruct is byte-deterministic" {
+    const a = testing.allocator;
+    const entry = cas.Entry{ .op = .refresh, .status = 200, .at_len = 64, .rt_len = 64, .ttl_s = 100, .scope = "x", .ttype = "Bearer" };
+    const b1 = try cas.reconstructSuccessBody(a, entry);
+    defer a.free(b1);
+    const b2 = try cas.reconstructSuccessBody(a, entry);
+    defer a.free(b2);
+    try testing.expectEqualStrings(b1, b2);
+}
+
+// ── Neutralize (capture-time redaction), fail-closed ───────────────────────
+
+test "neutralizeSuccessBody strips secrets, keeps length-class, emits no forbidden marker" {
+    const a = testing.allocator;
+    const real = try fakeRealBody(a, 3600);
+    defer a.free(real);
+    // sanity: the REAL body of course contains a forbidden marker
+    try testing.expect(containsForbidden(real));
+
+    const line = try cas.neutralizeSuccessBody(a, .refresh, real);
+    defer a.free(line);
+    // the NEUTRAL on-disk line must be marker-free (passes fixture_redaction)
+    try testing.expect(!containsForbidden(line));
+    // and must carry the length-class, not the value
+    const expect_len = cas.access_token_prefix.len + 48;
+    var buf: [16]u8 = undefined;
+    const needle = try std.fmt.bufPrint(&buf, "\"at_len\":{d}", .{expect_len});
+    try testing.expect(std.mem.indexOf(u8, line, needle) != null);
+}
+
+test "neutralize is fail-closed on a wrong-prefix access token" {
+    const a = testing.allocator;
+    const body = "{\"access_token\":\"nope-not-a-claude-token\",\"refresh_token\":\"x\",\"expires_in\":1}";
+    try testing.expectError(error.MalformedCassette, cas.neutralizeSuccessBody(a, .refresh, body));
+}
+
+test "neutralize is fail-closed on a shape-mismatched body" {
+    const a = testing.allocator;
+    const body = "{\"unexpected\":true}";
+    try testing.expectError(error.MalformedCassette, cas.neutralizeSuccessBody(a, .refresh, body));
+}
+
+test "neutralize round-trip: real -> neutral -> cassette -> reconstruct keeps prefixes" {
+    const a = testing.allocator;
+    const real = try fakeRealBody(a, 1200);
+    defer a.free(real);
+    const line = try cas.neutralizeSuccessBody(a, .refresh, real);
+    defer a.free(line);
+
+    var cassette = try cassetteFromLine(a, line);
+    defer cassette.deinit();
+    try testing.expectEqual(@as(usize, 1), cassette.entries.len);
+    try testing.expectEqual(cas.Op.refresh, cassette.entries[0].op);
+
+    const reconstructed = try cas.reconstructSuccessBody(a, cassette.entries[0]);
+    defer a.free(reconstructed);
+    try testing.expect(std.mem.indexOf(u8, reconstructed, cas.access_token_prefix) != null);
+}
+
+// ── Recorder ────────────────────────────────────────────────────────────────
+
+const FakeInner = struct {
+    ttl: i64,
+    calls: u32 = 0,
+    fn post(allocator: std.mem.Allocator, ctx: *anyopaque, url: []const u8, body: []const u8, content_type: []const u8) cas.HttpError![]u8 {
+        const self: *FakeInner = @ptrCast(@alignCast(ctx));
+        self.calls += 1;
+        _ = url;
+        _ = body;
+        _ = content_type;
+        return fakeRealBody(allocator, self.ttl) catch return error.OutOfMemory;
+    }
+};
+
+test "Recorder forwards the call unchanged and appends a marker-free neutral line" {
+    const a = testing.allocator;
+    var sink = std.ArrayList(u8).init(a);
+    defer sink.deinit();
+    var inner = FakeInner{ .ttl = 3600 };
+    var rec = cas.Recorder{ .inner = FakeInner.post, .inner_ctx = &inner, .sink = &sink };
+
+    const resp = try cas.Recorder.post(a, &rec, cas.token_endpoint, "grant_type=refresh_token", cas.form_content_type);
+    defer a.free(resp);
+
+    try testing.expectEqual(@as(u32, 1), inner.calls);
+    // returned body is the inner real body, untouched
+    try testing.expect(std.mem.indexOf(u8, resp, cas.access_token_prefix) != null);
+    // the recorded sink line is neutral / marker-free
+    try testing.expect(sink.items.len > 0);
+    try testing.expect(!containsForbidden(sink.items));
+}
+
+// ── Replayer as the adapter HttpPostFn ─────────────────────────────────────
+
+test "Replayer.post replays a refresh 200 as a reconstructed body" {
+    const a = testing.allocator;
+    var cassette = try cassetteFromLine(a,
+        "{\"v\":1,\"op\":\"refresh\",\"status\":200,\"at_len\":80,\"rt_len\":80,\"ttl_s\":3600,\"scope\":\"s\",\"ttype\":\"Bearer\"}");
+    defer cassette.deinit();
+    var rp = cas.Replayer{ .cassette = &cassette };
+
+    const body = try cas.Replayer.post(a, &rp, cas.token_endpoint, "grant_type=refresh_token", cas.form_content_type);
+    defer a.free(body);
+    try testing.expect(std.mem.indexOf(u8, body, cas.refresh_token_prefix) != null);
+    try testing.expect(rp.last_miss == null);
+}
+
+test "Replayer.post on an op with no recorded line returns HttpFailed + value-free miss" {
+    const a = testing.allocator;
+    // exchange-only cassette, but we replay a refresh
+    var cassette = try cassetteFromLine(a,
+        "{\"v\":1,\"op\":\"exchange\",\"status\":200,\"at_len\":80,\"rt_len\":80,\"ttl_s\":1,\"scope\":\"s\",\"ttype\":\"Bearer\"}");
+    defer cassette.deinit();
+    var rp = cas.Replayer{ .cassette = &cassette };
+
+    try testing.expectError(error.HttpFailed, cas.Replayer.post(a, &rp, cas.token_endpoint, "grant_type=refresh_token", cas.form_content_type));
+    try testing.expect(rp.last_miss != null);
+    try testing.expectEqual(cas.Op.refresh, rp.last_miss.?.op);
+}
+
+test "Replayer.post on a failure-status entry returns HttpFailed" {
+    const a = testing.allocator;
+    var cassette = try cassetteFromLine(a, "{\"v\":1,\"op\":\"refresh\",\"status\":400}");
+    defer cassette.deinit();
+    var rp = cas.Replayer{ .cassette = &cassette };
+
+    try testing.expectError(error.HttpFailed, cas.Replayer.post(a, &rp, cas.token_endpoint, "grant_type=refresh_token", cas.form_content_type));
+    try testing.expectEqual(@as(?cas.Op, cas.Op.refresh), if (rp.last_miss) |m| m.op else null);
+}
+
+test "Replayer cursor plays in order then saturates on the last entry" {
+    const a = testing.allocator;
+    var cassette = try cassetteFromLine(a,
+        "{\"v\":1,\"op\":\"refresh\",\"status\":200,\"at_len\":80,\"rt_len\":80,\"ttl_s\":1,\"scope\":\"s\",\"ttype\":\"Bearer\"}\n" ++
+        "{\"v\":1,\"op\":\"refresh\",\"status\":400}");
+    defer cassette.deinit();
+    var rp = cas.Replayer{ .cassette = &cassette };
+
+    const first = try cas.Replayer.post(a, &rp, cas.token_endpoint, "grant_type=refresh_token", cas.form_content_type);
+    a.free(first); // first replay = 200
+    // second replay = 400 (HttpFailed), and it then saturates on the 400
+    try testing.expectError(error.HttpFailed, cas.Replayer.post(a, &rp, cas.token_endpoint, "grant_type=refresh_token", cas.form_content_type));
+    try testing.expectError(error.HttpFailed, cas.Replayer.post(a, &rp, cas.token_endpoint, "grant_type=refresh_token", cas.form_content_type));
+}
+
+// ── Scheduler RefreshFn shim ────────────────────────────────────────────────
+
+test "SchedulerBinding.refresh maps a 200 cassette to an advanced RefreshResult" {
+    const a = testing.allocator;
+    var cassette = try cassetteFromLine(a,
+        "{\"v\":1,\"op\":\"refresh\",\"status\":200,\"at_len\":80,\"rt_len\":80,\"ttl_s\":3600,\"scope\":\"s\",\"ttype\":\"Bearer\"}");
+    defer cassette.deinit();
+    var rp = cas.Replayer{ .cassette = &cassette };
+    var bind = cas.SchedulerBinding{ .replayer = &rp, .allocator = a, .now_ms = 1_000_000 };
+
+    const result = try cas.SchedulerBinding.refresh(&bind, "claude:work");
+    try testing.expectEqual(@as(i64, 1_000_000), result.new_last_refresh_ms);
+    try testing.expectEqual(@as(i64, 1_000_000 + 3600 * std.time.ms_per_s), result.new_expires_at_ms);
+}
+
+test "SchedulerBinding.refresh maps a 4xx cassette to RefreshFailed (never-halt)" {
+    const a = testing.allocator;
+    var cassette = try cassetteFromLine(a, "{\"v\":1,\"op\":\"refresh\",\"status\":400}");
+    defer cassette.deinit();
+    var rp = cas.Replayer{ .cassette = &cassette };
+    var bind = cas.SchedulerBinding{ .replayer = &rp, .allocator = a, .now_ms = 5 };
+
+    try testing.expectError(error.RefreshFailed, cas.SchedulerBinding.refresh(&bind, "claude:work"));
+}
+
+// ── On-disk fixture loads + replays (the committed neutral cassette) ────────
+
+test "the committed refresh_200 fixture loads, is marker-free, and replays" {
+    const a = testing.allocator;
+    const path = "test/fixtures/cassettes/claude/refresh_200.jsonl";
+    const bytes = std.fs.cwd().readFileAlloc(a, path, 1 << 16) catch |err| switch (err) {
+        error.FileNotFound => return error.SkipZigTest, // run from repo root
+        else => return err,
+    };
+    defer a.free(bytes);
+
+    try testing.expect(!containsForbidden(bytes)); // the on-disk fixture carries no secret marker
+
+    var cassette = try cas.Cassette.parse(a, bytes);
+    defer cassette.deinit();
+    var rp = cas.Replayer{ .cassette = &cassette };
+    const body = try cas.Replayer.post(a, &rp, cas.token_endpoint, "grant_type=refresh_token", cas.form_content_type);
+    defer a.free(body);
+    try testing.expect(std.mem.indexOf(u8, body, cas.access_token_prefix) != null);
+}

--- a/test/fixtures/cassettes/claude/exchange_200.jsonl
+++ b/test/fixtures/cassettes/claude/exchange_200.jsonl
@@ -1,0 +1,1 @@
+{"v":1,"op":"exchange","status":200,"at_len":108,"rt_len":108,"ttl_s":3600,"scope":"user:inference user:profile","ttype":"Bearer"}

--- a/test/fixtures/cassettes/claude/refresh_200.jsonl
+++ b/test/fixtures/cassettes/claude/refresh_200.jsonl
@@ -1,0 +1,1 @@
+{"v":1,"op":"refresh","status":200,"at_len":108,"rt_len":108,"ttl_s":3600,"scope":"user:inference user:profile","ttype":"Bearer"}

--- a/test/fixtures/cassettes/claude/refresh_4xx.jsonl
+++ b/test/fixtures/cassettes/claude/refresh_4xx.jsonl
@@ -1,0 +1,1 @@
+{"v":1,"op":"refresh","status":400}


### PR DESCRIPTION
## What

Greenfield **Claude OAuth reauth cassette** — the deterministic, offline-proof core for the Claude reauth adapter (#354) and the keepalive warm scheduler (#355). Replay a recorded Claude OAuth token-endpoint exchange with **no live account, no network, and no secret ever on disk** (TIN-1823 / A.7).

## Why neutralize-on-disk

The repo's own `src/fixture_redaction.zig` (run in the main test suite) walks `test/fixtures/` and rejects any file containing `sk-`, `access_token`, `refresh_token`, `id_token`, … A naive token cassette would break the suite the moment it lands. So:

- **On disk** (`test/fixtures/cassettes/claude/*.jsonl`): each line carries only non-secret shape — `op`, HTTP `status`, token **length-class** (`at_len`/`rt_len`), and the non-secret `ttl_s`/`scope`/`token_type`. Zero forbidden markers.
- **At replay**: the `Replayer` **reconstructs the real-shaped body in memory** (`{"access_token":"sk-ant-oat01-…", …}`) so the real adapter parser + prefix checks are exercised. The `sk-ant-` prefix consts live in source (the scanner doesn't walk `src/`).

Verified: the **real** `fixture_redaction` scanner passes over the new fixtures (not just the module's own assertion).

## Pieces

- **`Replayer`** — serves as the adapter `HttpPostFn`; op keyed off `grant_type`; per-op saturating cursor; value-free miss diagnostics.
- **`Recorder`** — wraps a real seam, redacts **at capture time, fail-closed** (drops the line unless the body matches the known `sk-ant-` shape). Opt-in live-capture escape hatch; the default is hand-authored neutral fixtures (no real secret ever exists).
- **`SchedulerBinding`** — shims the replayer as `warm_scheduler.RefreshFn`: a success cassette advances the `RefreshResult`; a 4xx maps to `RefreshFailed` (never-halt path).

## Discipline

Self-contained: `std` only, **no `@import` of existing `src`**; the HTTP/refresh seams are structural mirrors of #354/#355 (compile-checked on an integration branch). `std.testing.allocator` leak-checked. Standalone `zig test src/cassettes/claude_oauth_cassette_tests.zig` → **15/15**. New files only; Codex's tree untouched.

This was designed via a research+design+verify workflow; the adversarial verifier caught the `fixture_redaction` collision pre-build, which this design resolves.