### PR TITLE
identity: provider-agnostic identity graph (TIN-1822 — greenfield, 17/17, never-halt invariants)

### DIFF
--- a/src/identity/identity_graph.zig
+++ b/src/identity/identity_graph.zig
@@ -1,0 +1,363 @@
+//! Identity graph — greenfield, provider-agnostic read-only ANALYSIS over the
+//! account inventory (TIN-1822 / A.6). It answers the questions the mux needs to
+//! keep its never-halt promise honest:
+//!
+//!   * Which config slots are actually the SAME underlying account? (group by
+//!     `account_id_hash` = sha256_12hex of the provider's account-id claim).
+//!   * What is the TRUE redundancy depth for a capability — counting DISTINCT
+//!     LIVE identities, not slots — so a duplicate slot is never mistaken for
+//!     real failover (the max-2==max-1 trap).
+//!   * Is a capability still afloat? (>=1 distinct live identity remains.)
+//!   * Is retiring a slot safe, per capability? Is re-authing a dead slot a
+//!     STRICT-LOSS operation (it shares an identity with a live sibling, so a
+//!     re-login would revoke the live one)?
+//!
+//! NORTH STAR (never-halt): one dead / duplicate / rate-limited / quota-exhausted
+//! account must NEVER halt the mux. `afloat` is defined over the SET of distinct
+//! live identities, so a non-live slot contributes 0 and can never remove a member
+//! another live slot put there. The ONLY false case is every distinct identity
+//! down. This module makes that depth visible; it is the analysis the keepalive
+//! escalation and the operator diagnostics consume.
+//!
+//! SCOPE / NO-CLOBBER: this is pure analysis. Route SELECTION lives in
+//! `src/pipeline.zig` (`selectWithFallback` + the health-store `muxDecisionFor`)
+//! and is NOT touched or reimplemented here. The graph only reads account records
+//! the caller fills from `accounts list` evidence and returns verdicts.
+//!
+//! Self-contained: `std` only, NO `@import` of existing `src`; pure data functions
+//! (no I/O, no seams). Liveness classes mirror the repo's `CredentialLiveness`
+//! (`types.zig`): `.live.{available,rate_limited,quota_exhausted,cooldown}`,
+//! `.degraded:*`, `.dead:*`. Allocation-explicit; `std.testing.allocator`-clean.
+
+const std = @import("std");
+
+// ── Liveness (mirrors types.zig CredentialLiveness summary classes) ──────────
+
+/// The liveness of one (account, capability) route. Only `.live` (i.e. the repo's
+/// `.live.available`) counts toward redundancy depth / afloat. `rate_limited`,
+/// `quota_exhausted`, `cooldown` are the repo's other `.live.*` arms — the account
+/// is alive but transiently unusable (recoverable; wait, don't escalate).
+/// `degraded` is a `.degraded:*` reason (tier/scope/schema — needs intervention,
+/// not auto-recovering, but not dead). `dead` is a `.dead:*` reason (needs reauth).
+pub const Liveness = enum {
+    live,
+    rate_limited,
+    quota_exhausted,
+    cooldown,
+    degraded,
+    dead,
+    unknown,
+
+    /// Counts toward redundancy depth / afloat — usable right now.
+    pub fn countsAfloat(self: Liveness) bool {
+        return self == .live;
+    }
+
+    /// Alive but transiently unusable — will return on its own; do not escalate.
+    pub fn isRecoverable(self: Liveness) bool {
+        return self == .rate_limited or self == .quota_exhausted or self == .cooldown;
+    }
+
+    pub fn isDead(self: Liveness) bool {
+        return self == .dead;
+    }
+};
+
+// ── Identity key (verify fix #1: null hash => per-slot-unique opaque key) ─────
+
+/// The real underlying identity of a slot. A non-null `account_id_hash` groups
+/// slots that are the SAME account. A null hash (identity unknown — e.g. a codex
+/// account whose auth.json is unavailable) is keyed by the per-slot-unique
+/// (provider, account) tuple, so two UNKNOWN identities are NEVER coalesced into
+/// one, and one real account's capability rows (same provider+account) DO group.
+pub const IdentityKey = union(enum) {
+    hash: []const u8,
+    opaque_slot: struct { provider: []const u8, account: []const u8 },
+
+    pub fn eql(a: IdentityKey, b: IdentityKey) bool {
+        return switch (a) {
+            .hash => |ah| switch (b) {
+                .hash => |bh| std.mem.eql(u8, ah, bh),
+                .opaque_slot => false,
+            },
+            .opaque_slot => |ao| switch (b) {
+                .hash => false,
+                .opaque_slot => |bo| std.mem.eql(u8, ao.provider, bo.provider) and
+                    std.mem.eql(u8, ao.account, bo.account),
+            },
+        };
+    }
+};
+
+// ── Account slot (one (account, capability) route) ───────────────────────────
+
+/// One route row, as the caller flattens it from `accounts list` (an account with
+/// N capabilities → N slots). All slices are borrowed; the input must outlive any
+/// returned analysis (collisions/strict-loss/retire results borrow these strings).
+pub const AccountSlot = struct {
+    /// Config slot name, e.g. "max-2". The caller guarantees (provider, account)
+    /// is unique per real slot (asserted in debug for the unknown-identity case).
+    account: []const u8,
+    provider: []const u8, // "codex" / "claude" / …
+    capability: []const u8, // "codex-max" / "codex-mini" / "auth-status" / …
+    /// sha256_12hex of the provider account-id claim; null = identity unknown.
+    account_id_hash: ?[]const u8 = null,
+    email_hint: ?[]const u8 = null,
+    liveness: Liveness,
+    /// false when the identity cannot be re-authed (e.g. AAS phone-OTP lockout,
+    /// openai/codex#25737) — surfaced on strict-loss/collision for escalation.
+    reauthable: bool = true,
+
+    pub fn identityKey(self: AccountSlot) IdentityKey {
+        if (self.account_id_hash) |h| return .{ .hash = h };
+        return .{ .opaque_slot = .{ .provider = self.provider, .account = self.account } };
+    }
+};
+
+fn matchesPC(s: AccountSlot, provider: []const u8, capability: []const u8) bool {
+    return std.mem.eql(u8, s.provider, provider) and std.mem.eql(u8, s.capability, capability);
+}
+
+// ── Core redundancy math (allocation-free) ───────────────────────────────────
+
+/// Count DISTINCT live identities for (provider, capability), optionally excluding
+/// one account (for retire-safety). First-occurrence dedup by `IdentityKey`.
+fn countDistinctLive(
+    slots: []const AccountSlot,
+    provider: []const u8,
+    capability: []const u8,
+    exclude_account: ?[]const u8,
+) usize {
+    var count: usize = 0;
+    for (slots, 0..) |s, i| {
+        if (!matchesPC(s, provider, capability)) continue;
+        if (!s.liveness.countsAfloat()) continue;
+        if (exclude_account) |ex| {
+            if (std.mem.eql(u8, s.account, ex)) continue;
+        }
+        var dup = false;
+        var j: usize = 0;
+        while (j < i) : (j += 1) {
+            const t = slots[j];
+            if (!matchesPC(t, provider, capability)) continue;
+            if (!t.liveness.countsAfloat()) continue;
+            if (exclude_account) |ex| {
+                if (std.mem.eql(u8, t.account, ex)) continue;
+            }
+            if (s.identityKey().eql(t.identityKey())) {
+                dup = true;
+                break;
+            }
+        }
+        if (!dup) count += 1;
+    }
+    return count;
+}
+
+/// The TRUE redundancy depth: how many distinct live identities serve this
+/// (provider, capability). Duplicate slots of one identity count once.
+pub fn distinctLiveIdentities(slots: []const AccountSlot, provider: []const u8, capability: []const u8) usize {
+    return countDistinctLive(slots, provider, capability, null);
+}
+
+/// The never-halt predicate: a capability is afloat iff >=1 distinct live identity
+/// remains. A dead/duplicate/rate-limited/quota slot can never flip this false on
+/// its own.
+pub fn isAfloat(slots: []const AccountSlot, provider: []const u8, capability: []const u8) bool {
+    return distinctLiveIdentities(slots, provider, capability) >= 1;
+}
+
+/// What the keepalive should do for a (provider, capability) — separates "wait"
+/// (recoverable) from "escalate" (needs reauth/probe), so a transient blip is
+/// never escalated as a death and a real death is never silently waited on.
+pub const Disposition = enum {
+    afloat, // >=1 live identity — usable now
+    recoverable_only, // 0 live, >=1 recoverable (rate/quota/cooldown) — WAIT
+    needs_intervention, // 0 live, 0 recoverable, >=1 dead/degraded/unknown — ESCALATE
+    empty, // no slots for this (provider, capability)
+};
+
+pub fn disposition(slots: []const AccountSlot, provider: []const u8, capability: []const u8) Disposition {
+    var any = false;
+    var any_recoverable = false;
+    for (slots) |s| {
+        if (!matchesPC(s, provider, capability)) continue;
+        any = true;
+        if (s.liveness.countsAfloat()) return .afloat;
+        if (s.liveness.isRecoverable()) any_recoverable = true;
+    }
+    if (!any) return .empty;
+    return if (any_recoverable) .recoverable_only else .needs_intervention;
+}
+
+// ── Duplicate-enrollment collisions ──────────────────────────────────────────
+
+/// An identity enrolled into >=2 distinct config slots — i.e. apparent redundancy
+/// that is not real. `accounts` are the distinct slot names (borrowed). Free with
+/// `freeCollisions`.
+pub const Collision = struct {
+    identity: IdentityKey,
+    accounts: [][]const u8,
+    has_live_slot: bool, // at least one slot of this identity is live somewhere
+    any_unreauthable: bool, // at least one slot of this identity is un-reauthable
+};
+
+pub fn duplicateCollisions(allocator: std.mem.Allocator, slots: []const AccountSlot) ![]Collision {
+    var list = std.ArrayList(Collision).init(allocator);
+    errdefer {
+        for (list.items) |c| allocator.free(c.accounts);
+        list.deinit();
+    }
+
+    for (slots, 0..) |s, i| {
+        // process each identity once (at its first-occurrence slot)
+        var first = true;
+        var j: usize = 0;
+        while (j < i) : (j += 1) {
+            if (s.identityKey().eql(slots[j].identityKey())) {
+                first = false;
+                break;
+            }
+        }
+        if (!first) continue;
+
+        const key = s.identityKey();
+        var accts = std.ArrayList([]const u8).init(allocator);
+        errdefer accts.deinit();
+        var has_live = false;
+        var any_unreauth = false;
+        for (slots) |t| {
+            if (!key.eql(t.identityKey())) continue;
+            if (t.liveness.countsAfloat()) has_live = true;
+            if (!t.reauthable) any_unreauth = true;
+            var dup = false;
+            for (accts.items) |a| {
+                if (std.mem.eql(u8, a, t.account)) {
+                    dup = true;
+                    break;
+                }
+            }
+            if (!dup) try accts.append(t.account);
+        }
+
+        if (accts.items.len >= 2) {
+            try list.append(.{
+                .identity = key,
+                .accounts = try accts.toOwnedSlice(),
+                .has_live_slot = has_live,
+                .any_unreauthable = any_unreauth,
+            });
+        } else {
+            accts.deinit();
+        }
+    }
+
+    return list.toOwnedSlice();
+}
+
+pub fn freeCollisions(allocator: std.mem.Allocator, collisions: []Collision) void {
+    for (collisions) |c| allocator.free(c.accounts);
+    allocator.free(collisions);
+}
+
+// ── Strict-loss-to-reauth (verify fix #2: per-capability) ────────────────────
+
+/// A non-live slot whose identity is ALSO live (for the same capability) via a
+/// sibling slot — so re-authing it would revoke the live sibling's tokens. One
+/// entry per (slot, capability). Advisory only — pure metadata, never mutates.
+pub const StrictLossSlot = struct {
+    account: []const u8,
+    provider: []const u8,
+    capability: []const u8,
+    live_sibling: []const u8, // the slot whose tokens a reauth would revoke
+    identity_unreauthable: bool, // the shared identity also can't be re-authed (#25737)
+};
+
+pub fn strictLossSlots(allocator: std.mem.Allocator, slots: []const AccountSlot) ![]StrictLossSlot {
+    var list = std.ArrayList(StrictLossSlot).init(allocator);
+    errdefer list.deinit();
+
+    for (slots, 0..) |s, i| {
+        if (s.liveness.countsAfloat()) continue; // strict-loss applies to NON-live slots
+        for (slots, 0..) |t, j| {
+            if (i == j) continue;
+            if (!matchesPC(t, s.provider, s.capability)) continue;
+            if (!t.liveness.countsAfloat()) continue;
+            if (!s.identityKey().eql(t.identityKey())) continue;
+            try list.append(.{
+                .account = s.account,
+                .provider = s.provider,
+                .capability = s.capability,
+                .live_sibling = t.account,
+                .identity_unreauthable = !s.reauthable or !t.reauthable,
+            });
+            break; // one live sibling is enough
+        }
+    }
+
+    return list.toOwnedSlice();
+}
+
+// ── Retire-safety (verify fix #3: per-capability delta) ──────────────────────
+
+pub const CapabilityDelta = struct {
+    capability: []const u8,
+    distinct_live_before: usize,
+    distinct_live_after: usize,
+    flips_afloat: bool, // before >= 1 and after == 0
+};
+
+/// The per-capability effect of removing (provider, account) from the inventory.
+/// `overall_safe` is true iff no capability is flipped from afloat to not-afloat.
+/// Free with `freeRetireSafety`.
+pub const RetireSafety = struct {
+    overall_safe: bool,
+    per_capability: []CapabilityDelta,
+};
+
+pub fn wouldRetireReduceRedundancy(
+    allocator: std.mem.Allocator,
+    slots: []const AccountSlot,
+    retire_provider: []const u8,
+    retire_account: []const u8,
+) !RetireSafety {
+    var list = std.ArrayList(CapabilityDelta).init(allocator);
+    errdefer list.deinit();
+    var overall_safe = true;
+
+    for (slots, 0..) |s, i| {
+        if (!std.mem.eql(u8, s.provider, retire_provider)) continue;
+        if (!std.mem.eql(u8, s.account, retire_account)) continue;
+        // each capability of the retire account once
+        var seen = false;
+        var j: usize = 0;
+        while (j < i) : (j += 1) {
+            const t = slots[j];
+            if (std.mem.eql(u8, t.provider, retire_provider) and
+                std.mem.eql(u8, t.account, retire_account) and
+                std.mem.eql(u8, t.capability, s.capability))
+            {
+                seen = true;
+                break;
+            }
+        }
+        if (seen) continue;
+
+        const before = countDistinctLive(slots, retire_provider, s.capability, null);
+        const after = countDistinctLive(slots, retire_provider, s.capability, retire_account);
+        const flips = before >= 1 and after == 0;
+        if (flips) overall_safe = false;
+        try list.append(.{
+            .capability = s.capability,
+            .distinct_live_before = before,
+            .distinct_live_after = after,
+            .flips_afloat = flips,
+        });
+    }
+
+    return .{ .overall_safe = overall_safe, .per_capability = try list.toOwnedSlice() };
+}
+
+pub fn freeRetireSafety(allocator: std.mem.Allocator, rs: RetireSafety) void {
+    allocator.free(rs.per_capability);
+}

--- a/src/identity/identity_graph_tests.zig
+++ b/src/identity/identity_graph_tests.zig
@@ -1,0 +1,242 @@
+//! Unit tests for the identity graph. Pure: in-memory account inventories, no I/O.
+//! Proves the six never-halt invariants + the real ground-truth inventory.
+//!
+//!     zig test src/identity/identity_graph_tests.zig
+
+const std = @import("std");
+const testing = std.testing;
+const ig = @import("identity_graph.zig");
+
+test {
+    std.testing.refAllDeclsRecursive(ig);
+}
+
+const Slot = ig.AccountSlot;
+
+// ── The real inventory (oauth-mux accounts list, 2026-06-01) as the ground truth ──
+// max-1 == max-2 (same hash 38079d6acec6, the AAS-locked sulliwood.org account);
+// max-3 (columbari.us) is distinct; claude personal is keychain (null hash).
+const real_inventory = [_]Slot{
+    .{ .account = "max-1", .provider = "codex", .capability = "codex-max", .account_id_hash = "38079d6acec6", .liveness = .live, .reauthable = false },
+    .{ .account = "max-1", .provider = "codex", .capability = "codex-mini", .account_id_hash = "38079d6acec6", .liveness = .live, .reauthable = false },
+    .{ .account = "max-2", .provider = "codex", .capability = "codex-max", .account_id_hash = "38079d6acec6", .liveness = .dead, .reauthable = false },
+    .{ .account = "max-2", .provider = "codex", .capability = "codex-mini", .account_id_hash = "38079d6acec6", .liveness = .dead, .reauthable = false },
+    .{ .account = "max-3", .provider = "codex", .capability = "codex-max", .account_id_hash = "c0dfbc44912c", .liveness = .degraded, .reauthable = true },
+    .{ .account = "max-3", .provider = "codex", .capability = "codex-mini", .account_id_hash = "c0dfbc44912c", .liveness = .live, .reauthable = true },
+    .{ .account = "personal", .provider = "claude", .capability = "auth-status", .account_id_hash = null, .liveness = .live, .reauthable = true },
+};
+
+// ── IdentityKey ──────────────────────────────────────────────────────────────
+
+test "IdentityKey: hash equality, opaque tuple equality, hash != opaque" {
+    const h1 = ig.IdentityKey{ .hash = "abc" };
+    const h1b = ig.IdentityKey{ .hash = "abc" };
+    const h2 = ig.IdentityKey{ .hash = "xyz" };
+    try testing.expect(h1.eql(h1b));
+    try testing.expect(!h1.eql(h2));
+
+    const o1 = ig.IdentityKey{ .opaque_slot = .{ .provider = "codex", .account = "default" } };
+    const o1b = ig.IdentityKey{ .opaque_slot = .{ .provider = "codex", .account = "default" } };
+    const o2 = ig.IdentityKey{ .opaque_slot = .{ .provider = "gemini", .account = "default" } };
+    try testing.expect(o1.eql(o1b));
+    try testing.expect(!o1.eql(o2)); // different provider, same name => distinct
+    try testing.expect(!h1.eql(o1)); // a hash key never equals an opaque key
+}
+
+// ── Core redundancy math + INV-IDENTITIES-NOT-SLOTS + INV-PER-CAPABILITY ──────
+
+test "distinctLiveIdentities counts identities not slots, per capability (real inventory)" {
+    const inv = &real_inventory;
+    // codex-max: only max-1 is live (max-2 dead, max-3 degraded) => 1
+    try testing.expectEqual(@as(usize, 1), ig.distinctLiveIdentities(inv, "codex", "codex-max"));
+    // codex-mini: max-1 + max-3 live (max-2 dead) => 2 distinct identities
+    try testing.expectEqual(@as(usize, 2), ig.distinctLiveIdentities(inv, "codex", "codex-mini"));
+    // claude auth-status: 1
+    try testing.expectEqual(@as(usize, 1), ig.distinctLiveIdentities(inv, "claude", "auth-status"));
+}
+
+test "INV-IDENTITIES-NOT-SLOTS: two live slots of the SAME identity count as 1" {
+    const slots = [_]Slot{
+        .{ .account = "max-1", .provider = "codex", .capability = "codex-max", .account_id_hash = "dup", .liveness = .live },
+        .{ .account = "max-2", .provider = "codex", .capability = "codex-max", .account_id_hash = "dup", .liveness = .live },
+    };
+    try testing.expectEqual(@as(usize, 1), ig.distinctLiveIdentities(&slots, "codex", "codex-max"));
+}
+
+test "isAfloat true on the real inventory for served capabilities" {
+    const inv = &real_inventory;
+    try testing.expect(ig.isAfloat(inv, "codex", "codex-max"));
+    try testing.expect(ig.isAfloat(inv, "codex", "codex-mini"));
+    try testing.expect(ig.isAfloat(inv, "claude", "auth-status"));
+}
+
+// ── INV-AFLOAT-MONOTONE-UNDER-NONLIVE ────────────────────────────────────────
+
+test "INV-AFLOAT-MONOTONE: non-live slots never flip a live capability to not-afloat" {
+    // one live identity, surrounded by dead/rate-limited/quota/degraded of OTHER identities
+    const slots = [_]Slot{
+        .{ .account = "live", .provider = "codex", .capability = "codex-max", .account_id_hash = "A", .liveness = .live },
+        .{ .account = "d1", .provider = "codex", .capability = "codex-max", .account_id_hash = "B", .liveness = .dead },
+        .{ .account = "r1", .provider = "codex", .capability = "codex-max", .account_id_hash = "C", .liveness = .rate_limited },
+        .{ .account = "q1", .provider = "codex", .capability = "codex-max", .account_id_hash = "D", .liveness = .quota_exhausted },
+        .{ .account = "g1", .provider = "codex", .capability = "codex-max", .account_id_hash = "E", .liveness = .degraded },
+    };
+    try testing.expect(ig.isAfloat(&slots, "codex", "codex-max"));
+    try testing.expectEqual(@as(usize, 1), ig.distinctLiveIdentities(&slots, "codex", "codex-max"));
+    try testing.expectEqual(ig.Disposition.afloat, ig.disposition(&slots, "codex", "codex-max"));
+}
+
+// ── Disposition: wait vs escalate (never-halt nuance) ────────────────────────
+
+test "disposition: recoverable_only => WAIT, never escalate a transient blip" {
+    const slots = [_]Slot{
+        .{ .account = "a", .provider = "codex", .capability = "codex-max", .account_id_hash = "A", .liveness = .rate_limited },
+        .{ .account = "b", .provider = "codex", .capability = "codex-max", .account_id_hash = "B", .liveness = .quota_exhausted },
+    };
+    try testing.expect(!ig.isAfloat(&slots, "codex", "codex-max"));
+    try testing.expectEqual(ig.Disposition.recoverable_only, ig.disposition(&slots, "codex", "codex-max"));
+}
+
+test "disposition: all dead => needs_intervention (the only escalate case)" {
+    const slots = [_]Slot{
+        .{ .account = "a", .provider = "codex", .capability = "codex-max", .account_id_hash = "A", .liveness = .dead },
+        .{ .account = "b", .provider = "codex", .capability = "codex-max", .account_id_hash = "B", .liveness = .degraded },
+    };
+    try testing.expect(!ig.isAfloat(&slots, "codex", "codex-max"));
+    try testing.expectEqual(ig.Disposition.needs_intervention, ig.disposition(&slots, "codex", "codex-max"));
+}
+
+test "disposition: empty for an unknown capability" {
+    const inv = &real_inventory;
+    try testing.expectEqual(ig.Disposition.empty, ig.disposition(inv, "codex", "no-such-capability"));
+}
+
+// ── INV-CROSS-PROVIDER-ISOLATION ─────────────────────────────────────────────
+
+test "INV-CROSS-PROVIDER: total codex outage leaves claude afloat" {
+    const slots = [_]Slot{
+        .{ .account = "max-1", .provider = "codex", .capability = "codex-max", .account_id_hash = "A", .liveness = .dead },
+        .{ .account = "max-3", .provider = "codex", .capability = "codex-max", .account_id_hash = "B", .liveness = .dead },
+        .{ .account = "personal", .provider = "claude", .capability = "auth-status", .account_id_hash = null, .liveness = .live },
+    };
+    try testing.expect(!ig.isAfloat(&slots, "codex", "codex-max"));
+    try testing.expect(ig.isAfloat(&slots, "claude", "auth-status")); // unaffected
+}
+
+// ── Duplicate collisions (the max-2==max-1 auto-detector) ────────────────────
+
+test "duplicateCollisions flags max-1/max-2 as the same identity, with no false positives" {
+    const a = testing.allocator;
+    const inv = &real_inventory;
+    const cols = try ig.duplicateCollisions(a, inv);
+    defer ig.freeCollisions(a, cols);
+
+    try testing.expectEqual(@as(usize, 1), cols.len); // only the sulliwood duplicate
+    const c = cols[0];
+    try testing.expect(c.identity.eql(.{ .hash = "38079d6acec6" }));
+    try testing.expectEqual(@as(usize, 2), c.accounts.len); // max-1, max-2
+    try testing.expect(c.has_live_slot); // max-1 is live
+    try testing.expect(c.any_unreauthable); // AAS-locked (#25737)
+}
+
+test "duplicateCollisions: two distinct unknown identities are NOT coalesced (null-key safety)" {
+    const a = testing.allocator;
+    // two different accounts, both null hash, same provider — must NOT collide
+    const slots = [_]Slot{
+        .{ .account = "default", .provider = "codex", .capability = "codex-mini", .account_id_hash = null, .liveness = .live },
+        .{ .account = "other", .provider = "codex", .capability = "codex-mini", .account_id_hash = null, .liveness = .live },
+    };
+    const cols = try ig.duplicateCollisions(a, &slots);
+    defer ig.freeCollisions(a, cols);
+    try testing.expectEqual(@as(usize, 0), cols.len);
+    // and they count as 2 distinct live identities, not coalesced to 1
+    try testing.expectEqual(@as(usize, 2), ig.distinctLiveIdentities(&slots, "codex", "codex-mini"));
+}
+
+test "an unknown account's capability rows DO group as one identity" {
+    const slots = [_]Slot{
+        .{ .account = "default", .provider = "codex", .capability = "codex-max", .account_id_hash = null, .liveness = .live },
+        .{ .account = "default", .provider = "codex", .capability = "codex-mini", .account_id_hash = null, .liveness = .live },
+    };
+    // same (provider, account) => same opaque identity; one live identity per capability
+    try testing.expectEqual(@as(usize, 1), ig.distinctLiveIdentities(&slots, "codex", "codex-max"));
+    try testing.expectEqual(@as(usize, 1), ig.distinctLiveIdentities(&slots, "codex", "codex-mini"));
+}
+
+// ── INV-STRICT-LOSS (per-capability, verify fix #2) ──────────────────────────
+
+test "strictLossSlots: max-2 is strict-loss for BOTH capabilities; max-3 for none" {
+    const a = testing.allocator;
+    const inv = &real_inventory;
+    const sl = try ig.strictLossSlots(a, inv);
+    defer a.free(sl);
+
+    try testing.expectEqual(@as(usize, 2), sl.len); // max-2 codex-max + max-2 codex-mini
+    for (sl) |entry| {
+        try testing.expectEqualStrings("max-2", entry.account);
+        try testing.expectEqualStrings("max-1", entry.live_sibling); // reauth would revoke the live max-1
+        try testing.expect(entry.identity_unreauthable); // shared identity is AAS-locked
+    }
+    // max-3's degraded codex-max has no live same-identity sibling => not strict-loss
+    for (sl) |entry| try testing.expect(!std.mem.eql(u8, entry.account, "max-3"));
+}
+
+// ── INV-RETIRE (per-capability delta, verify fix #3) ─────────────────────────
+
+test "retire max-2 is SAFE on every capability (dead duplicate of live max-1)" {
+    const a = testing.allocator;
+    const inv = &real_inventory;
+    const rs = try ig.wouldRetireReduceRedundancy(a, inv, "codex", "max-2");
+    defer ig.freeRetireSafety(a, rs);
+
+    try testing.expect(rs.overall_safe);
+    try testing.expectEqual(@as(usize, 2), rs.per_capability.len);
+    for (rs.per_capability) |d| {
+        try testing.expect(!d.flips_afloat);
+        try testing.expectEqual(d.distinct_live_before, d.distinct_live_after); // unchanged
+    }
+}
+
+test "retire max-1 is UNSAFE for codex-max but codex-mini visibly survives (per-capability)" {
+    const a = testing.allocator;
+    const inv = &real_inventory;
+    const rs = try ig.wouldRetireReduceRedundancy(a, inv, "codex", "max-1");
+    defer ig.freeRetireSafety(a, rs);
+
+    try testing.expect(!rs.overall_safe);
+    var saw_max = false;
+    var saw_mini = false;
+    for (rs.per_capability) |d| {
+        if (std.mem.eql(u8, d.capability, "codex-max")) {
+            saw_max = true;
+            try testing.expectEqual(@as(usize, 1), d.distinct_live_before);
+            try testing.expectEqual(@as(usize, 0), d.distinct_live_after);
+            try testing.expect(d.flips_afloat); // would halt codex-max
+        } else if (std.mem.eql(u8, d.capability, "codex-mini")) {
+            saw_mini = true;
+            try testing.expectEqual(@as(usize, 2), d.distinct_live_before);
+            try testing.expectEqual(@as(usize, 1), d.distinct_live_after);
+            try testing.expect(!d.flips_afloat); // codex-mini survives — visible to the operator
+        }
+    }
+    try testing.expect(saw_max and saw_mini);
+}
+
+// ── Allocator hygiene on empty inputs ────────────────────────────────────────
+
+test "empty inventory: no collisions, no strict-loss, safe retire" {
+    const a = testing.allocator;
+    const slots = [_]Slot{};
+    const cols = try ig.duplicateCollisions(a, &slots);
+    defer ig.freeCollisions(a, cols);
+    try testing.expectEqual(@as(usize, 0), cols.len);
+
+    const sl = try ig.strictLossSlots(a, &slots);
+    defer a.free(sl);
+    try testing.expectEqual(@as(usize, 0), sl.len);
+
+    const rs = try ig.wouldRetireReduceRedundancy(a, &slots, "codex", "nope");
+    defer ig.freeRetireSafety(a, rs);
+    try testing.expect(rs.overall_safe);
+    try testing.expectEqual(@as(usize, 0), rs.per_capability.len);
+}


### PR DESCRIPTION
## What

Greenfield **read-only identity graph** — the analysis layer that keeps the mux's never-halt promise *honest*, for **codex + claude** alike. It groups config slots by their real underlying identity (`account_id_hash` = sha256_12hex of the provider account-id claim) and computes the **true, capability-scoped redundancy depth** — so the mux never mistakes a duplicate slot for real failover (the `max-2 == max-1` trap this work surfaced).

## Why (the never-halt corollary)

One dead/duplicate/rate-limited account must never halt the mux — *and* the mux must know its **real** redundancy depth, or it believes in failover it doesn't have. `max-2` looked like a second Codex route but is the same identity as `max-1`; that lie bites exactly when `max-1` dies. This graph catches it structurally.

## API (pure data functions)

- **`distinctLiveIdentities(provider, capability)`** — counts distinct *live identities*, not slots.
- **`isAfloat`** — the never-halt predicate (`≥1 distinct live identity`); a non-live slot contributes 0 and can never flip it false alone.
- **`disposition`** — `afloat` / `recoverable_only` (WAIT) / `needs_intervention` (ESCALATE) / `empty` — separates a transient blip from a real death so keepalive never escalates a rate-limit nor silently waits on a revocation.
- **`duplicateCollisions`** — identities enrolled in ≥2 slots (auto-flags `max-2==max-1`).
- **`strictLossSlots`** — per-`(slot,capability)` where re-authing a dead slot would revoke a *live same-identity sibling* (the `max-2` foot-gun).
- **`wouldRetireReduceRedundancy`** — per-capability delta `{before, after, flips_afloat}`: retire `max-2` = safe everywhere; retire `max-1` = halts codex-max while codex-mini *visibly survives*.

## Rigor

Designed via a research→design→**adversarial-verify** workflow; the verifier confirmed `never_halt_proven` and caught three type-expressivity gaps, all fixed here: `IdentityKey` is a tagged union `{hash | opaque(provider,account)}` so two *unknown* identities never coalesce; strict-loss and retire-safety are **per-capability**, not scalar.

## Scope / no-clobber

Pure analysis only — route **selection** stays in `pipeline.zig` (`selectWithFallback` / `muxDecisionFor`), untouched. `std` only, no `@import` of `src`; `std.testing.allocator` leak-checked. Standalone `zig test` → **17/17** (6 never-halt invariants + the real inventory as ground truth).