### PR TITLE
identity: Claude stable-identity labeler (TIN-1822 producer — greenfield, 14/14)

### DIFF
--- a/src/identity/claude_identity.zig
+++ b/src/identity/claude_identity.zig
@@ -1,0 +1,167 @@
+//! Claude (Claude Code) stable-identity labeler — greenfield, the producer half of
+//! TIN-1822. It turns a Claude account profile (the `oauthAccount` block of
+//! `<CLAUDE_CONFIG_DIR>/.claude.json`, or `~/.claude.json`) into a stable,
+//! non-secret `ClaudeIdentity` whose `account_id_hash` feeds the identity graph
+//! (`identity_graph.zig`, its `IdentityKey.hash`).
+//!
+//! Canonical key: `oauthAccount.accountUuid` (server-issued, durable per-account
+//! UUID; stable across re-logins, distinct across accounts). NOT `userID` (a
+//! 64-char per-INSTALL anonymous hash that collides across accounts in one config
+//! dir and fragments one account across installs) and NOT `organizationUuid` (a
+//! many-accounts-to-one billing/rate-limit pool — context-dependent, never the
+//! per-account key, never composited into it). This mirrors Codex exactly:
+//! Codex hashes `chatgpt_account_id`, Claude hashes `accountUuid`, both via the
+//! same `sha256_12hex` (first 6 bytes of SHA-256 → 12 lowercase hex).
+//!
+//! Fail-safe: any empty/malformed input, absent `oauthAccount`, or absent
+//! `accountUuid` yields `present=false` with `account_id_hash=null` — so the graph
+//! keys the slot as an OPAQUE per-(provider,account) identity (the honest
+//! representation of "authenticated-but-unprofiled"), instead of coalescing all
+//! profile-less Claude accounts under one hashed-empty-string key.
+//!
+//! Redaction (enforced structurally): the struct holds NO raw UUID, email, or
+//! token — only `sha256_12hex` hashes, a masked email hint (`j***@domain`), and an
+//! `org_display` that is flagged identifying and must be gated to operator-only,
+//! non-agent surfaces.
+//!
+//! OWNERSHIP / LIFETIME: a `ClaudeIdentity` OWNS its slices and frees them in
+//! `deinit`. The identity graph's `AccountSlot` BORROWS `account_id_hash`, so a
+//! `ClaudeIdentity` MUST outlive any `AccountSlot` that borrows it — do not
+//! `deinit` it until graph analysis is done (or `dupe` the hash into the slot's
+//! arena). `stable_label`/`org_id_hash`/`org_display` are producer-local
+//! diagnostics — only `account_id_hash` (and a masked `email_hint`) ever crosses
+//! into the graph.
+//!
+//! Self-contained: `std` only, NO `@import` of existing `src` (the `sha256_12hex`,
+//! `maskEmail`, `nonEmpty` helpers are re-derived locally to match the Codex ones
+//! byte-for-byte). Pure (no I/O — the caller reads the file and passes the bytes).
+//! `std.testing.allocator`-clean. Zig 0.14.1.
+
+const std = @import("std");
+
+pub const account_id_source_label: []const u8 = "oauthAccount.accountUuid";
+
+/// Parse result. `present` is true only when a usable `accountUuid` was found.
+/// `reason` is a static string literal (never owned). All `?[]const u8` payloads
+/// are allocator-OWNED when non-null and freed by `deinit`.
+pub const ClaudeIdentity = struct {
+    present: bool = false,
+    /// One of: "input_empty", "json_invalid", "oauth_account_missing",
+    /// "account_uuid_missing", "identity_present". Static literal.
+    reason: []const u8 = "input_empty",
+    /// Static provenance for the canonical id when present, else null.
+    account_id_source: ?[]const u8 = null,
+    /// sha256_12hex(accountUuid). THIS is what the identity graph consumes as
+    /// `IdentityKey.hash`. OWNED. null when no stable identity (graph keys opaque).
+    account_id_hash: ?[]const u8 = null,
+    /// sha256_12hex(organizationUuid): a SEPARATE hashed grouping dimension, NOT a
+    /// graph input. OWNED. null when org absent/empty (never a hash of "").
+    org_id_hash: ?[]const u8 = null,
+    /// Hashed, non-secret composite label for logs/UX: `claude:<org12|noorg>:<acct12>`.
+    /// Producer-local diagnostic, not a graph input. OWNED. null iff no identity.
+    stable_label: ?[]const u8 = null,
+    /// Masked email "j***@domain" — never the raw local part. OWNED. null when absent.
+    email_hint: ?[]const u8 = null,
+    /// organizationName — IDENTIFYING human display for OPERATOR-ONLY surfaces;
+    /// must NOT be emitted on agent/MCP surfaces. OWNED. null when absent.
+    org_display: ?[]const u8 = null,
+
+    /// Frees every owned slice. Safe on the zero/unknown value (all nulls).
+    pub fn deinit(self: ClaudeIdentity, allocator: std.mem.Allocator) void {
+        if (self.account_id_hash) |v| allocator.free(v);
+        if (self.org_id_hash) |v| allocator.free(v);
+        if (self.stable_label) |v| allocator.free(v);
+        if (self.email_hint) |v| allocator.free(v);
+        if (self.org_display) |v| allocator.free(v);
+    }
+};
+
+// ── Local helpers (re-derived to match the Codex ones; no @import of src) ─────
+
+/// Lowercase hex of the first 6 bytes of SHA-256 → 12 chars. Matches the repo's
+/// `shortSha256HexAlloc` (golden: sha256_12hex("acct-test") == "660d25a9d7ee").
+fn sha256_12hex(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
+    var digest: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(value, &digest, .{});
+    const hex = "0123456789abcdef";
+    const out = try allocator.alloc(u8, 12);
+    for (digest[0..6], 0..) |b, i| {
+        out[i * 2] = hex[b >> 4];
+        out[i * 2 + 1] = hex[b & 0x0f];
+    }
+    return out;
+}
+
+fn nonEmpty(s: ?[]const u8) ?[]const u8 {
+    if (s) |v| {
+        if (v.len > 0) return v;
+    }
+    return null;
+}
+
+/// "jess@sulliwood.org" → "j***@sulliwood.org". Returns null for a non-email
+/// (no '@', or empty local part) so a malformed value never produces a hint.
+fn maskEmail(allocator: std.mem.Allocator, email: []const u8) !?[]u8 {
+    const at = std.mem.indexOfScalar(u8, email, '@') orelse return null;
+    if (at == 0) return null; // empty local part
+    const domain = email[at..]; // includes '@'
+    return try std.fmt.allocPrint(allocator, "{c}***{s}", .{ email[0], domain });
+}
+
+fn buildStableLabel(allocator: std.mem.Allocator, acct12: []const u8, org12: ?[]const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator, "claude:{s}:{s}", .{ org12 orelse "noorg", acct12 });
+}
+
+// ── Parser ───────────────────────────────────────────────────────────────────
+
+const OAuthAccount = struct {
+    accountUuid: ?[]const u8 = null,
+    organizationUuid: ?[]const u8 = null,
+    organizationName: ?[]const u8 = null,
+    emailAddress: ?[]const u8 = null,
+};
+
+const RootJson = struct {
+    oauthAccount: ?OAuthAccount = null,
+};
+
+/// Parse a Claude account profile JSON (the contents of `.claude.json`) into a
+/// stable identity. Pure + fail-safe: never crashes; an unusable input returns a
+/// `present=false` value with `account_id_hash=null`.
+pub fn parseClaudeIdentity(allocator: std.mem.Allocator, raw: []const u8) !ClaudeIdentity {
+    const trimmed = std.mem.trim(u8, raw, " \t\r\n");
+    if (trimmed.len == 0) return .{ .present = false, .reason = "input_empty" };
+
+    const parsed = std.json.parseFromSlice(RootJson, allocator, raw, .{
+        .ignore_unknown_fields = true,
+    }) catch {
+        return .{ .present = false, .reason = "json_invalid" };
+    };
+    defer parsed.deinit();
+
+    const oauth = parsed.value.oauthAccount orelse
+        return .{ .present = false, .reason = "oauth_account_missing" };
+    const acct_uuid = nonEmpty(oauth.accountUuid) orelse
+        return .{ .present = false, .reason = "account_uuid_missing" };
+
+    var result = ClaudeIdentity{
+        .present = true,
+        .reason = "identity_present",
+        .account_id_source = account_id_source_label,
+    };
+    errdefer result.deinit(allocator);
+
+    result.account_id_hash = try sha256_12hex(allocator, acct_uuid);
+    if (nonEmpty(oauth.organizationUuid)) |org_uuid| {
+        result.org_id_hash = try sha256_12hex(allocator, org_uuid);
+    }
+    if (nonEmpty(oauth.organizationName)) |org_name| {
+        result.org_display = try allocator.dupe(u8, org_name);
+    }
+    if (nonEmpty(oauth.emailAddress)) |email| {
+        result.email_hint = try maskEmail(allocator, email);
+    }
+    result.stable_label = try buildStableLabel(allocator, result.account_id_hash.?, result.org_id_hash);
+
+    return result;
+}

--- a/src/identity/claude_identity_tests.zig
+++ b/src/identity/claude_identity_tests.zig
@@ -1,0 +1,199 @@
+//! Unit tests for the Claude stable-identity labeler. Pure: synthetic profiles
+//! inline (no real PII, no fixtures), no I/O.
+//!
+//!     zig test src/identity/claude_identity_tests.zig
+
+const std = @import("std");
+const testing = std.testing;
+const ci = @import("claude_identity.zig");
+
+test {
+    std.testing.refAllDeclsRecursive(ci);
+}
+
+// sha256_12hex of the empty string — must NEVER be emitted as any identity hash
+// (emitting it would coalesce all profile-less / no-org accounts into one).
+const empty_hash = "e3b0c44298fc";
+
+// A synthetic full profile. All UUIDs/email are fake — this file lives under
+// src/ (not scanned) and carries no real PII or tokens.
+const full_profile =
+    \\{
+    \\  "userID": "0000000000000000000000000000000000000000000000000000000000000000",
+    \\  "oauthAccount": {
+    \\    "accountUuid": "11111111-2222-3333-4444-555555555555",
+    \\    "organizationUuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    \\    "organizationName": "Acme Robotics",
+    \\    "emailAddress": "jess@example.com",
+    \\    "billingType": "subscription"
+    \\  }
+    \\}
+;
+
+// ── Happy path ──────────────────────────────────────────────────────────────
+
+test "parse a full profile: present, hashed identity, masked email, org display" {
+    const a = testing.allocator;
+    const id = try ci.parseClaudeIdentity(a, full_profile);
+    defer id.deinit(a);
+
+    try testing.expect(id.present);
+    try testing.expectEqualStrings("identity_present", id.reason);
+    try testing.expectEqualStrings("oauthAccount.accountUuid", id.account_id_source.?);
+
+    try testing.expectEqual(@as(usize, 12), id.account_id_hash.?.len);
+    try testing.expectEqual(@as(usize, 12), id.org_id_hash.?.len);
+    // stable label = claude:<org12>:<acct12>
+    var buf: [64]u8 = undefined;
+    const want = try std.fmt.bufPrint(&buf, "claude:{s}:{s}", .{ id.org_id_hash.?, id.account_id_hash.? });
+    try testing.expectEqualStrings(want, id.stable_label.?);
+    // masked email, raw local part gone
+    try testing.expectEqualStrings("j***@example.com", id.email_hint.?);
+    try testing.expectEqualStrings("Acme Robotics", id.org_display.?);
+}
+
+test "golden vector: sha256_12hex matches the Codex shortSha256HexAlloc" {
+    // Codex golden (main.zig:791): sha256_12hex("acct-test") == "660d25a9d7ee".
+    // Feed accountUuid="acct-test" and assert the produced hash matches.
+    const a = testing.allocator;
+    const id = try ci.parseClaudeIdentity(a,
+        \\{"oauthAccount":{"accountUuid":"acct-test"}}
+    );
+    defer id.deinit(a);
+    try testing.expectEqualStrings("660d25a9d7ee", id.account_id_hash.?);
+}
+
+// ── Redaction ───────────────────────────────────────────────────────────────
+
+test "redaction: no raw uuid or email local-part in label/hint" {
+    const a = testing.allocator;
+    const id = try ci.parseClaudeIdentity(a, full_profile);
+    defer id.deinit(a);
+
+    // raw account/org UUID segments never appear in the label
+    try testing.expect(std.mem.indexOf(u8, id.stable_label.?, "11111111") == null);
+    try testing.expect(std.mem.indexOf(u8, id.stable_label.?, "aaaaaaaa") == null);
+    // raw email local part never appears in the hint
+    try testing.expect(std.mem.indexOf(u8, id.email_hint.?, "jess") == null);
+}
+
+// ── Stability + uniqueness ──────────────────────────────────────────────────
+
+test "stability: same profile yields an identical hash + label" {
+    const a = testing.allocator;
+    const id1 = try ci.parseClaudeIdentity(a, full_profile);
+    defer id1.deinit(a);
+    const id2 = try ci.parseClaudeIdentity(a, full_profile);
+    defer id2.deinit(a);
+    try testing.expectEqualStrings(id1.account_id_hash.?, id2.account_id_hash.?);
+    try testing.expectEqualStrings(id1.stable_label.?, id2.stable_label.?);
+}
+
+test "uniqueness: distinct accountUuids yield distinct hashes" {
+    const a = testing.allocator;
+    const id1 = try ci.parseClaudeIdentity(a,
+        \\{"oauthAccount":{"accountUuid":"account-one"}}
+    );
+    defer id1.deinit(a);
+    const id2 = try ci.parseClaudeIdentity(a,
+        \\{"oauthAccount":{"accountUuid":"account-two"}}
+    );
+    defer id2.deinit(a);
+    try testing.expect(!std.mem.eql(u8, id1.account_id_hash.?, id2.account_id_hash.?));
+}
+
+// ── No-org (personal) ───────────────────────────────────────────────────────
+
+test "no-org account: org_id_hash is null (NOT a hash of empty), label uses noorg" {
+    const a = testing.allocator;
+    const id = try ci.parseClaudeIdentity(a,
+        \\{"oauthAccount":{"accountUuid":"solo-account","emailAddress":"a@b.com"}}
+    );
+    defer id.deinit(a);
+    try testing.expect(id.present);
+    try testing.expect(id.org_id_hash == null); // never sha256_12hex("")
+    try testing.expect(id.org_display == null);
+    var buf: [48]u8 = undefined;
+    const want = try std.fmt.bufPrint(&buf, "claude:noorg:{s}", .{id.account_id_hash.?});
+    try testing.expectEqualStrings(want, id.stable_label.?);
+}
+
+// ── The empty-string-hash coalescing guard (verify correction #5) ───────────
+
+test "no identity hash is ever the hash of the empty string" {
+    const a = testing.allocator;
+    // a profile with an empty-string org and a real account
+    const id = try ci.parseClaudeIdentity(a,
+        \\{"oauthAccount":{"accountUuid":"x","organizationUuid":"","organizationName":""}}
+    );
+    defer id.deinit(a);
+    try testing.expect(id.account_id_hash == null or !std.mem.eql(u8, id.account_id_hash.?, empty_hash));
+    try testing.expect(id.org_id_hash == null); // empty org => null, never empty_hash
+    try testing.expect(id.org_display == null); // empty name => null
+}
+
+// ── Fail-safe branches (never crash; present=false; hash=null) ──────────────
+
+test "fail-safe: empty input => input_empty, unknown identity" {
+    const a = testing.allocator;
+    for ([_][]const u8{ "", "   \n\t " }) |raw| {
+        const id = try ci.parseClaudeIdentity(a, raw);
+        defer id.deinit(a);
+        try testing.expect(!id.present);
+        try testing.expectEqualStrings("input_empty", id.reason);
+        try testing.expect(id.account_id_hash == null);
+    }
+}
+
+test "fail-safe: malformed JSON => json_invalid" {
+    const a = testing.allocator;
+    const id = try ci.parseClaudeIdentity(a, "{ not json");
+    defer id.deinit(a);
+    try testing.expect(!id.present);
+    try testing.expectEqualStrings("json_invalid", id.reason);
+    try testing.expect(id.account_id_hash == null);
+}
+
+test "fail-safe: JSON null literal never crashes, returns unknown (reason pinned)" {
+    const a = testing.allocator;
+    const id = try ci.parseClaudeIdentity(a, "null");
+    defer id.deinit(a);
+    try testing.expect(!id.present);
+    try testing.expect(id.account_id_hash == null);
+    // Pin the classification so a std.json version bump can't silently change it.
+    // (json `null` into a struct-typed parse is a parse error in 0.14.1 => json_invalid.)
+    try testing.expectEqualStrings("json_invalid", id.reason);
+}
+
+test "fail-safe: no oauthAccount => oauth_account_missing" {
+    const a = testing.allocator;
+    const id = try ci.parseClaudeIdentity(a,
+        \\{"userID":"abc","projects":{}}
+    );
+    defer id.deinit(a);
+    try testing.expect(!id.present);
+    try testing.expectEqualStrings("oauth_account_missing", id.reason);
+    try testing.expect(id.account_id_hash == null);
+}
+
+test "fail-safe: oauthAccount without accountUuid => account_uuid_missing" {
+    const a = testing.allocator;
+    const id = try ci.parseClaudeIdentity(a,
+        \\{"oauthAccount":{"organizationUuid":"o","emailAddress":"a@b.com"}}
+    );
+    defer id.deinit(a);
+    try testing.expect(!id.present);
+    try testing.expectEqualStrings("account_uuid_missing", id.reason);
+    try testing.expect(id.account_id_hash == null);
+}
+
+test "fail-safe: empty accountUuid string => account_uuid_missing (not empty hash)" {
+    const a = testing.allocator;
+    const id = try ci.parseClaudeIdentity(a,
+        \\{"oauthAccount":{"accountUuid":""}}
+    );
+    defer id.deinit(a);
+    try testing.expect(!id.present);
+    try testing.expectEqualStrings("account_uuid_missing", id.reason);
+    try testing.expect(id.account_id_hash == null);
+}


### PR DESCRIPTION
## What

The **producer half** of TIN-1822 (the graph/consumer half is #359). A pure parser that turns a Claude account profile (the `oauthAccount` block of `<CLAUDE_CONFIG_DIR>/.claude.json`) into a stable, non-secret `ClaudeIdentity` whose `account_id_hash` feeds the identity graph's `IdentityKey.hash`.

## Canonical key (researched + adversarially verified)

`oauthAccount.accountUuid` → `sha256_12hex` — the Claude equivalent of Codex's `chatgpt_account_id`. The **golden vector** `sha256_12hex("acct-test") == "660d25a9d7ee"` confirms the hash matches the repo's `shortSha256HexAlloc` **byte-for-byte**, so a Claude hash and a Codex hash compute identically and drop straight into the graph.

Explicitly **not**:
- `userID` — a 64-char *per-install* anonymous hash (collides across accounts in one config dir, fragments one account across installs).
- `organizationUuid` — a *many-accounts-to-one* billing/rate-limit pool; carried only as a separate `org_id_hash` dimension, never the per-account key, never composited into it.

## Fail-safe (the never-coalesce guard)

Empty / malformed / JSON-`null` / absent-`oauthAccount` / absent-`accountUuid` → `present=false`, `account_id_hash=null`, so the graph keys the slot **opaquely** (`per-(provider,account)`) instead of merging all profile-less accounts under a hash of the empty string. Regression test asserts no emitted hash is ever `sha256_12hex("") == "e3b0c44298fc"`.

## Redaction (structural)

No raw UUID/email/token — only `sha256_12hex` hashes, a masked email hint (`j***@domain`), and an `org_display` flagged operator-only. Ownership documented: the identity **owns** its slices; the graph **borrows** `account_id_hash`, so the identity must outlive any `AccountSlot` built from it.

## Provenance

Designed via a research→design→adversarial-verify workflow (verdict: **sound**). The research corrected the key choice (`accountUuid`, not `userID`/`org`) against real Claude Code identity behavior (per-install `userID`, many-accounts-per-org, stale-`oauthAccount` hazard).

Self-contained: `std` only, no `@import` of `src` (`sha256_12hex`/`maskEmail`/`nonEmpty` re-derived locally); pure; `std.testing.allocator` leak-checked. Standalone `zig test` → **14/14**. Together with #359 this completes TIN-1822 (producer + consumer).