### PR TITLE
Fix Codex durable session bridge

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -150,11 +150,14 @@ oauth-mux codex resume <session-id>
 ```
 
 These commands launch the real Codex CLI inside an oauth-mux managed frame.
-Auth and the proxy base URL are mux-owned in a temporary overlay, while Codex
+Auth and the proxy base URL are mux-owned in a managed `CODEX_HOME`, while Codex
 session authority is bridged by reference to the canonical Codex home unless
-`--isolated-session-store` is set. `oauth-mux codex resume` with no id keeps
-native Codex chooser ownership; oauth-mux only checks before spawn that the
-managed overlay exposes the same required session-authority entries so the
+`--isolated-session-store` is set. In canonical bridge mode the managed home is
+durable under the authority home and scrubbed on exit; oauth-mux removes copied
+auth/config material but keeps the bridge so native Codex rollout paths recorded
+through the managed frame remain resumable. `oauth-mux codex resume` with no id
+keeps native Codex chooser ownership; oauth-mux only checks before spawn that
+the managed overlay exposes the same required session-authority entries so the
 chooser does not open empty. When canonical Codex has `state_5.sqlite*` or
 `logs_2.sqlite*`, those files are bridged by reference; in canonical bridge
 mode `CODEX_SQLITE_HOME` points at the canonical authority home so Codex 0.132+

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -230,13 +230,17 @@ oauth-mux codex resume <session-id>
 ```
 
 The managed frame preserves native Codex session authority by reference while
-oauth-mux owns auth and the proxy provider override. Resume chooser mode stays
-native: oauth-mux checks the required session-authority entries before child
-spawn and fails with a redacted diagnostic rather than opening an empty
-chooser. Newer Codex `state_5.sqlite*` and `logs_2.sqlite*` chooser state is
-bridged by reference when present, and canonical bridge mode sets
-`CODEX_SQLITE_HOME` to the canonical authority home. Older homes fall back to
-`sessions/`, `history.jsonl`, `session_index.jsonl`, and `shell_snapshots/`.
+oauth-mux owns auth and the proxy provider override. In canonical bridge mode,
+the managed `CODEX_HOME` is durable under the authority home and scrubbed on
+exit: copied `auth.json`, `installation_id`, and generated `config.toml` are
+removed, but the bridge remains so native Codex rollout paths do not point at a
+deleted temp directory. Resume chooser mode stays native: oauth-mux checks the
+required session-authority entries before child spawn and fails with a redacted
+diagnostic rather than opening an empty chooser. Newer Codex `state_5.sqlite*`
+and `logs_2.sqlite*` chooser state is bridged by reference when present, and
+canonical bridge mode sets `CODEX_SQLITE_HOME` to the canonical authority home.
+Older homes fall back to `sessions/`, `history.jsonl`, `session_index.jsonl`,
+and `shell_snapshots/`.
 See `docs/spec/codex-session-store-portability-policy-2026-05-18.md` for the
 explicit import policy: canonical bridge is supported; silent route-local
 session import/copy is not.

--- a/docs/spec/codex-adapter-contract-2026-05-03.md
+++ b/docs/spec/codex-adapter-contract-2026-05-03.md
@@ -137,15 +137,30 @@ session ids, SQL rows, token material, or provider response bodies, and it
 does not mutate SQLite. Any cleanup of canonical Codex SQLite state remains an
 explicit operator action that must be backed up and reversible.
 
-Implementation update, 2026-05-27: managed resume checks canonical SQLite lock
-contention before spawning Codex. In canonical bridge mode, `oauth-mux codex
-resume...` probes the SQLite lock byte range on `state_5.sqlite` when present.
-If another process holds the lock, oauth-mux emits a redacted
-`sqlite_authority_check` with `db_basename:"state_5.sqlite"`,
-`sqlite_error_class:"database_locked"`, `sqlite_error_code:5`, then aborts
-pre-spawn with `reason:"session_authority_locked"`. The adapter does not kill
-other Codex processes, rewrite session state, or fall back to an overlay-local
-SQLite database.
+Implementation update, 2026-05-27 / 2026-06-02: managed resume checks canonical
+SQLite lock contention before spawning Codex. In canonical bridge mode,
+`oauth-mux codex resume...` probes the SQLite lock byte range on
+`state_5.sqlite` when present and emits a redacted `sqlite_authority_check` with
+`db_basename:"state_5.sqlite"`, `sqlite_error_class:"database_locked"`, and
+`sqlite_error_code:5` when another process holds the byte range. As of
+2026-06-02 this check is diagnostic by default because native Codex 0.135 can run
+multiple concurrent canonical sessions. Setting
+`OMUX_CODEX_STRICT_SQLITE_LOCK_GUARD=1` restores the older pre-spawn abort with
+`reason:"session_authority_locked"` for targeted debugging. The adapter does
+not kill other Codex processes, rewrite session state, or fall back to an
+overlay-local SQLite database.
+
+Implementation update, 2026-06-02: canonical bridge mode no longer uses a
+disposable `$TMPDIR/oauth-mux-codex-*` home. Codex does not expose a supported
+`CODEX_AUTH_FILE` override, so `CODEX_HOME` still has to carry the selected
+account's copied auth material and generated proxy config. To avoid poisoning
+canonical SQLite rows with paths to deleted temp homes, oauth-mux now creates
+canonical bridge homes under the session authority as
+`<authority>/.oauth-mux/managed-codex-homes/omux-managed-codex-*`. On exit it
+scrubs `auth.json`, `installation_id`, and generated `config.toml`, but leaves
+the bridge directory and symlinks in place so any native Codex rollout paths
+recorded through that `CODEX_HOME` remain resolvable. Isolated session-store
+mode still uses a disposable overlay and removes it on exit.
 
 Implementation update, 2026-05-10: managed launch no longer runs broad
 `repairRefreshableCodexAuthFailures()` before child spawn. Network refresh is
@@ -226,8 +241,8 @@ both layers, Level 3 is the default and Level 4 is reachable.
 2. Selects the initial route via broker `account/select` (or local
    selection if the user passed `--account <name>`).
 3. Materializes that account's `auth.json`-equivalent tuple.
-4. Writes a temporary, adapter-owned `CODEX_HOME` directory containing the
-   selected account's `auth.json` and a generated `config.toml` whose
+4. Writes an adapter-owned `CODEX_HOME` directory containing the selected
+   account's `auth.json` and a generated `config.toml` whose
    built-in provider namespace (`model_provider = "openai"`) points at the
    wire-layer proxy via `openai_base_url`. The generated config preserves
    canonical user behavior settings and strips only mux-owned routing
@@ -235,9 +250,11 @@ both layers, Level 3 is the default and Level 4 is reachable.
    fail before child spawn with redacted status. Session-authority paths are
    bridged per
    `docs/spec/harness-session-authority-bridge-2026-05-05.md`, not copied
-   wholesale into this overlay. Operators may pass `--isolated-session-store`
-   for a test/private namespace or `--session-home <path>` for an explicit
-   canonical session authority.
+   wholesale into this overlay. In canonical bridge mode the directory lives
+   under `<authority>/.oauth-mux/managed-codex-homes/` and is scrubbed, not
+   deleted, on exit so native Codex rollout paths remain resolvable. Operators
+   may pass `--isolated-session-store` for a disposable test/private namespace
+   or `--session-home <path>` for an explicit canonical session authority.
 5. Binds the wire-layer proxy on `127.0.0.1:<dynamic-port>`, with the
    proxy holding the account pool reference and the broker session id.
 6. Spawns `codex app-server --listen stdio://` as a child, with
@@ -251,8 +268,9 @@ both layers, Level 3 is the default and Level 4 is reachable.
    traffic.
 10. Renders the user-facing terminal session per §5 (TUI strategy).
 
-On normal exit, removes the temporary `CODEX_HOME` directory and notifies
-broker via `surface/teardown`.
+On normal exit, scrubs mux-owned auth/config material from a durable canonical
+bridge home or removes a disposable isolated `CODEX_HOME`, then notifies broker
+via `surface/teardown`.
 
 ### 2.2 Daemon-attached mode (later)
 
@@ -580,8 +598,11 @@ oauth-mux evidence. Frame shapes are stable under broker `surface_version:
 { "kind": "session_aborted", "adapter": "codex", "reason": "child_wait_error", "exit_code": -1, "final_claim_level": "broker_owned", "synthetic_swap_observed": false, "wait_error": "..." }
 { "kind": "session_aborted", "adapter": "codex", "reason": "child_signal", "exit_code": -1, "term_kind": "signal", "term_code": 9, "signal_name": "SIGKILL", "final_claim_level": "broker_owned", "synthetic_swap_observed": false }
 
-// canonical SQLite authority lock contention before child spawn
-{ "kind": "sqlite_authority_check", "mode": "resume", "sqlite_authority": "canonical_env", "ok": false, "diagnostic": "database_locked", "db_basename": "state_5.sqlite", "next_action": "close_or_wait_for_other_codex_process_then_retry", "sqlite_error_class": "database_locked", "sqlite_error_code": 5, "path_printed": false, "token_material_printed": false, "session_id_printed": false }
+// canonical SQLite authority lock contention is diagnostic by default
+{ "kind": "sqlite_authority_check", "mode": "resume", "sqlite_authority": "canonical_env", "ok": false, "diagnostic": "database_locked", "db_basename": "state_5.sqlite", "next_action": "close_or_wait_for_other_codex_process_then_retry", "sqlite_error_class": "database_locked", "sqlite_error_code": 5, "strict_guard": false, "fatal": false, "path_printed": false, "token_material_printed": false, "session_id_printed": false }
+
+// strict lock guard is opt-in for targeted debugging
+{ "kind": "sqlite_authority_check", "mode": "resume", "sqlite_authority": "canonical_env", "ok": false, "diagnostic": "database_locked", "db_basename": "state_5.sqlite", "next_action": "close_or_wait_for_other_codex_process_then_retry", "sqlite_error_class": "database_locked", "sqlite_error_code": 5, "strict_guard": true, "fatal": true, "path_printed": false, "token_material_printed": false, "session_id_printed": false }
 { "kind": "session_aborted", "adapter": "codex", "reason": "session_authority_locked", "phase": "sqlite_authority_check", "error": "SqliteStateLocked", "exit_code": -1, "term_kind": null, "term_code": null, "signal_name": null, "final_claim_level": "none", "synthetic_swap_observed": false, "pre_spawn": true, "child_spawned": false, "path_printed": false, "token_material_printed": false, "session_id_printed": false }
 ```
 

--- a/docs/spec/harness-session-authority-bridge-2026-05-05.md
+++ b/docs/spec/harness-session-authority-bridge-2026-05-05.md
@@ -29,13 +29,19 @@ spawning Codex. Installed-runtime dogfood has also proven managed resume/load
 through the proxy, including live quota handoff evidence tracked in
 `docs/spec/codex-live-quota-handoff-evidence-2026-05-08.md`.
 
-Implementation update, 2026-05-26: Codex 0.132 reads native SQLite resume
-state from `CODEX_SQLITE_HOME` when set, and the chooser can depend on
-`logs_2.sqlite*` as well as `state_5.sqlite*`. Canonical bridge mode keeps the
-managed `CODEX_HOME` as mux-owned auth/config, sets child `CODEX_SQLITE_HOME`
-to the canonical session authority home, and bridges both SQLite families by
-reference when present. Isolated mode leaves SQLite state in the overlay and
-removes inherited `CODEX_SQLITE_HOME`.
+Implementation update, 2026-05-26 / 2026-06-02: Codex 0.132+ reads native
+SQLite resume state from `CODEX_SQLITE_HOME` when set, and the chooser can
+depend on `logs_2.sqlite*` as well as `state_5.sqlite*`. Canonical bridge mode
+keeps the managed `CODEX_HOME` as mux-owned auth/config, sets child
+`CODEX_SQLITE_HOME` to the canonical session authority home, and bridges both
+SQLite families by reference when present. As of 2026-06-02, that managed
+`CODEX_HOME` is durable under
+`<authority>/.oauth-mux/managed-codex-homes/omux-managed-codex-*`; oauth-mux
+scrubs mux-owned `auth.json`, `installation_id`, and generated `config.toml` on
+exit but leaves the bridge in place so native Codex rollout paths recorded into
+canonical SQLite do not point at deleted temp homes. Isolated mode leaves SQLite
+state in the overlay, removes inherited `CODEX_SQLITE_HOME`, and deletes the
+overlay on exit.
 
 The 2026-05-06 dogfood-6 auth failure exposed the auth-side counterpart:
 Codex can refresh tokens inside the managed overlay, and the adapter must
@@ -165,10 +171,12 @@ requires them for chooser/resume parity.
 
 For canonical Codex SQLite authority, managed resume may probe SQLite's
 standard lock byte range on `state_5.sqlite` before child spawn. A held lock is
-reported as redacted `session_authority_locked` / `database_locked` status with
-the database basename only. oauth-mux must not kill the lock holder, rewrite the
-canonical database, or create an overlay-local SQLite authority to bypass the
-lock.
+reported as redacted `database_locked` status with the database basename only.
+Because native Codex 0.135 can run concurrent canonical sessions, this probe is
+diagnostic by default. `OMUX_CODEX_STRICT_SQLITE_LOCK_GUARD=1` restores the
+older `session_authority_locked` pre-spawn abort for targeted debugging.
+oauth-mux must not kill the lock holder, rewrite the canonical database, or
+create an overlay-local SQLite authority to bypass the lock.
 
 ### 2.4 Cache, Log, and Runtime State
 
@@ -237,14 +245,15 @@ boundary explicit in Codex itself. It requires upstream Codex support.
 
 ### Option B: Local Session Bridge by Reference
 
-Near-term shape: the temporary `CODEX_HOME` contains mux-owned `auth.json` and
+Near-term shape: the managed `CODEX_HOME` contains mux-owned `auth.json` and
 `config.toml`, while session-authority paths are symlinks, directory links, or
-adapter-managed references to the canonical Codex store.
+adapter-managed references to the canonical Codex store. In canonical bridge
+mode this home is durable and scrubbed on exit rather than deleted.
 
 For Codex on Unix-like systems, a candidate overlay is:
 
 ```text
-<tmp>/oauth-mux-codex-XXXX/
+~/.codex/.oauth-mux/managed-codex-homes/omux-managed-codex-XXXX/
   auth.json                 # copied from selected account auth source
   installation_id           # copied if auth-relevant
   config.toml               # generated proxy config
@@ -263,6 +272,10 @@ For Codex on Unix-like systems, a candidate overlay is:
 This keeps `resume <id>` and `resume --last` pointed at the canonical session
 authority without mutating canonical auth/config. For Codex 0.132+,
 `CODEX_SQLITE_HOME` is also set to the canonical authority home in this mode.
+The durable root is required because Codex can persist rollout paths derived
+from `CODEX_HOME` into canonical SQLite. Deleted temp homes make those rows
+unresumable; scrubbed durable bridge homes keep them resolvable without keeping
+selected-account auth material on disk.
 
 Risks to resolve:
 

--- a/scripts/paid-cohort-soak-snapshot.sh
+++ b/scripts/paid-cohort-soak-snapshot.sh
@@ -141,7 +141,7 @@ run_artifact "stay-afloat loop" "stay-afloat-loop.json" "$bin" stay-afloat --loo
 
 {
   printf '\nSpend-gated commands intentionally not run.\n'
-  printf 'The confirmation artifacts prove the spend gates remain closed without --confirm-spend.\n'
+  printf 'The confirmation artifacts prove provider-mutating gates remain closed without --confirm-spend.\n'
   printf 'Use codex revalidate-exhausted, broker-run, or live-provider QA only from an explicit operator-confirmed spend path.\n'
 } | tee -a "$summary"
 

--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -195,6 +195,7 @@ run_case() {
     assert_grep "$label session_started" '"kind":"session_started"' "$ndjson"
     assert_grep "$label canonical session bridge" '"session_authority":"canonical_bridge"' "$ndjson"
     assert_grep "$label canonical sqlite authority" '"sqlite_authority":"canonical_env"' "$ndjson"
+    assert_grep "$label durable bridge cleanup" '"session_home_cleanup":"scrub_durable_bridge"' "$ndjson"
     assert_grep "$label config passthrough status" '"config_passthrough":true,"user_config_present":true' "$ndjson"
     assert_grep "$label config layout" '"config_layout":"root_partitioned"' "$ndjson"
     assert_grep "$label experimental defaults injected" '"experimental_feature_defaults_injected":4' "$ndjson"
@@ -317,6 +318,7 @@ env \
   "$BIN" codex --profile codex-max --isolated-session-store --json-status-file "$ISOLATED_NDJSON" resume --last 2>"$ISOLATED_STDERR"
 assert_grep "isolated session authority" '"kind":"session_started".*"session_authority":"isolated"' "$ISOLATED_NDJSON"
 assert_grep "isolated sqlite authority" '"kind":"session_started".*"sqlite_authority":"isolated_overlay"' "$ISOLATED_NDJSON"
+assert_grep "isolated cleanup deletes overlay" '"kind":"session_started".*"session_home_cleanup":"delete_tree"' "$ISOLATED_NDJSON"
 if [[ "$(jq -r .sqlite_env.codex_sqlite_home_env_set "$ISOLATED_REPORT")" == "false" \
       && "$(jq -r .sqlite_env.path_printed "$ISOLATED_REPORT")" == "false" ]]; then
     echo "  ✓ isolated run scrubbed inherited CODEX_SQLITE_HOME"
@@ -465,14 +467,17 @@ if grep -q -E 'managed-good-session|'"$BAD_AUTHORITY_HOME" "$BAD_AUTHORITY_NDJSO
     exit 1
 fi
 
-echo "smoke-codex-cli-ux: locked canonical sqlite authority fails before spawn"
+echo "smoke-codex-cli-ux: locked canonical sqlite authority is diagnostic by default"
 SQLITE_AUTH_LOCK_NDJSON="$TMP/sqlite-authority-lock/status.ndjson"
 SQLITE_AUTH_LOCK_STDERR="$TMP/sqlite-authority-lock.stderr"
 SQLITE_AUTH_LOCK_REPORT="$TMP/sqlite-authority-lock.report"
 SQLITE_AUTH_LOCK_HEALTH_BEFORE="$TMP/sqlite-authority-lock.health.before"
+SQLITE_AUTH_LOCK_STRICT_NDJSON="$TMP/sqlite-authority-lock-strict/status.ndjson"
+SQLITE_AUTH_LOCK_STRICT_STDERR="$TMP/sqlite-authority-lock-strict.stderr"
+SQLITE_AUTH_LOCK_STRICT_REPORT="$TMP/sqlite-authority-lock-strict.report"
 SQLITE_LOCK_READY="$TMP/sqlite-authority-lock.ready"
 SQLITE_LOCK_RELEASE="$TMP/sqlite-authority-lock.release"
-mkdir -p "$(dirname "$SQLITE_AUTH_LOCK_NDJSON")"
+mkdir -p "$(dirname "$SQLITE_AUTH_LOCK_NDJSON")" "$(dirname "$SQLITE_AUTH_LOCK_STRICT_NDJSON")"
 cp "$STATE_DIR/health.json" "$SQLITE_AUTH_LOCK_HEALTH_BEFORE"
 python3 - "$CANONICAL_SESSION_HOME/state_5.sqlite" "$SQLITE_LOCK_READY" "$SQLITE_LOCK_RELEASE" <<'PY' &
 import fcntl
@@ -509,42 +514,73 @@ if [[ ! -e "$SQLITE_LOCK_READY" ]]; then
     echo "  ✗ sqlite lock helper did not become ready" >&2
     exit 1
 fi
-if OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+
+OMUX_CONFIG="$TMP/oauth-mux.config.json" \
      OMUX_STATE_DIR="$STATE_DIR" \
      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
      CODEX_HOME="$CANONICAL_SESSION_HOME" \
      OMUX_CODEX_SESSION_HOME="$CANONICAL_SESSION_HOME" \
      OMUX_CODEX_CONFIG_HOME="$CANONICAL_SESSION_HOME" \
+     OMUX_STUB_CODEX_TURNS=0 \
      OMUX_STUB_CODEX_REPORT="$SQLITE_AUTH_LOCK_REPORT" \
-     "$BIN" codex --profile codex-max --json-status-file "$SQLITE_AUTH_LOCK_NDJSON" resume 2>"$SQLITE_AUTH_LOCK_STDERR"; then
-    echo "  ✗ locked sqlite authority unexpectedly launched" >&2
+     "$BIN" codex --profile codex-max --json-status-file "$SQLITE_AUTH_LOCK_NDJSON" resume 2>"$SQLITE_AUTH_LOCK_STDERR"
+assert_grep "sqlite authority lock diagnostic" '"kind":"sqlite_authority_check".*"ok":false.*"diagnostic":"database_locked".*"db_basename":"state_5.sqlite".*"sqlite_error_class":"database_locked".*"sqlite_error_code":5' "$SQLITE_AUTH_LOCK_NDJSON"
+assert_grep "sqlite authority lock owner pid" '"kind":"sqlite_authority_check".*"lock_owner_pid":[0-9]+' "$SQLITE_AUTH_LOCK_NDJSON"
+assert_grep "sqlite authority lock non-strict" '"kind":"sqlite_authority_check".*"strict_guard":false.*"fatal":false' "$SQLITE_AUTH_LOCK_NDJSON"
+assert_grep "sqlite authority lock still launches" '"kind":"session_started".*"sqlite_authority":"canonical_env"' "$SQLITE_AUTH_LOCK_NDJSON"
+assert_grep "sqlite authority lock session ends" '"kind":"session_ended".*"exit_code":0' "$SQLITE_AUTH_LOCK_NDJSON"
+if [[ ! -s "$SQLITE_AUTH_LOCK_REPORT" ]]; then
+    echo "  ✗ diagnostic sqlite lock did not launch stub" >&2
+    cat "$SQLITE_AUTH_LOCK_NDJSON" >&2
+    cat "$SQLITE_AUTH_LOCK_STDERR" >&2
+    exit 1
+fi
+if grep -q '"kind":"session_aborted"' "$SQLITE_AUTH_LOCK_NDJSON"; then
+    echo "  ✗ diagnostic sqlite lock aborted before child spawn" >&2
+    cat "$SQLITE_AUTH_LOCK_NDJSON" >&2
+    exit 1
+fi
+if OMUX_CODEX_STRICT_SQLITE_LOCK_GUARD=1 \
+     OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+     OMUX_STATE_DIR="$STATE_DIR" \
+     OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+     CODEX_HOME="$CANONICAL_SESSION_HOME" \
+     OMUX_CODEX_SESSION_HOME="$CANONICAL_SESSION_HOME" \
+     OMUX_CODEX_CONFIG_HOME="$CANONICAL_SESSION_HOME" \
+     OMUX_STUB_CODEX_TURNS=0 \
+     OMUX_STUB_CODEX_REPORT="$SQLITE_AUTH_LOCK_STRICT_REPORT" \
+     "$BIN" codex --profile codex-max --json-status-file "$SQLITE_AUTH_LOCK_STRICT_NDJSON" resume 2>"$SQLITE_AUTH_LOCK_STRICT_STDERR"; then
+    echo "  ✗ strict locked sqlite authority unexpectedly launched" >&2
     exit 1
 fi
 touch "$SQLITE_LOCK_RELEASE"
 wait "$SQLITE_LOCK_PID"
 SQLITE_LOCK_PID=""
-assert_grep "sqlite authority lock diagnostic" '"kind":"sqlite_authority_check".*"ok":false.*"diagnostic":"database_locked".*"db_basename":"state_5.sqlite".*"sqlite_error_class":"database_locked".*"sqlite_error_code":5' "$SQLITE_AUTH_LOCK_NDJSON"
-assert_grep "sqlite authority lock owner pid" '"kind":"sqlite_authority_check".*"lock_owner_pid":[0-9]+' "$SQLITE_AUTH_LOCK_NDJSON"
-assert_grep "sqlite authority lock owner pid printed" '"kind":"sqlite_authority_check".*"lock_owner_pid_printed":true' "$SQLITE_AUTH_LOCK_NDJSON"
-assert_grep "sqlite authority lock terminal status" '"kind":"session_aborted".*"reason":"session_authority_locked".*"phase":"sqlite_authority_check".*"pre_spawn":true.*"child_spawned":false' "$SQLITE_AUTH_LOCK_NDJSON"
-assert_grep "sqlite authority lock stderr" 'canonical Codex sqlite state is locked by another Codex process \(pid [0-9]+\)' "$SQLITE_AUTH_LOCK_STDERR"
-if [[ -e "$SQLITE_AUTH_LOCK_REPORT" ]]; then
-    echo "  ✗ locked sqlite authority launched stub unexpectedly" >&2
-    cat "$SQLITE_AUTH_LOCK_REPORT" >&2
+assert_grep "strict sqlite authority lock diagnostic" '"kind":"sqlite_authority_check".*"ok":false.*"diagnostic":"database_locked".*"db_basename":"state_5.sqlite".*"sqlite_error_class":"database_locked".*"sqlite_error_code":5' "$SQLITE_AUTH_LOCK_STRICT_NDJSON"
+assert_grep "strict sqlite authority lock owner pid" '"kind":"sqlite_authority_check".*"lock_owner_pid":[0-9]+' "$SQLITE_AUTH_LOCK_STRICT_NDJSON"
+assert_grep "strict sqlite authority lock owner pid printed" '"kind":"sqlite_authority_check".*"lock_owner_pid_printed":true' "$SQLITE_AUTH_LOCK_STRICT_NDJSON"
+assert_grep "strict sqlite authority lock fatal" '"kind":"sqlite_authority_check".*"strict_guard":true.*"fatal":true' "$SQLITE_AUTH_LOCK_STRICT_NDJSON"
+assert_grep "strict sqlite authority lock terminal status" '"kind":"session_aborted".*"reason":"session_authority_locked".*"phase":"sqlite_authority_check".*"pre_spawn":true.*"child_spawned":false' "$SQLITE_AUTH_LOCK_STRICT_NDJSON"
+assert_grep "strict sqlite authority lock stderr" 'canonical Codex sqlite state is locked by another Codex process \(pid [0-9]+\)' "$SQLITE_AUTH_LOCK_STRICT_STDERR"
+if [[ -e "$SQLITE_AUTH_LOCK_STRICT_REPORT" ]]; then
+    echo "  ✗ strict locked sqlite authority launched stub unexpectedly" >&2
+    cat "$SQLITE_AUTH_LOCK_STRICT_REPORT" >&2
     exit 1
 fi
 if ! cmp -s "$STATE_DIR/health.json" "$SQLITE_AUTH_LOCK_HEALTH_BEFORE"; then
-    echo "  ✗ locked sqlite authority mutated route health" >&2
+    echo "  ✗ sqlite authority lock check mutated route health" >&2
     diff -u "$SQLITE_AUTH_LOCK_HEALTH_BEFORE" "$STATE_DIR/health.json" >&2 || true
     exit 1
 fi
-if grep -q -E 'managed-good-session|'"$CANONICAL_SESSION_HOME" "$SQLITE_AUTH_LOCK_NDJSON" "$SQLITE_AUTH_LOCK_STDERR"; then
+if grep -q -E 'managed-good-session|'"$CANONICAL_SESSION_HOME" "$SQLITE_AUTH_LOCK_NDJSON" "$SQLITE_AUTH_LOCK_STDERR" "$SQLITE_AUTH_LOCK_STRICT_NDJSON" "$SQLITE_AUTH_LOCK_STRICT_STDERR"; then
     echo "  ✗ locked sqlite authority leaked path or session id" >&2
     cat "$SQLITE_AUTH_LOCK_NDJSON" >&2
     cat "$SQLITE_AUTH_LOCK_STDERR" >&2
+    cat "$SQLITE_AUTH_LOCK_STRICT_NDJSON" >&2
+    cat "$SQLITE_AUTH_LOCK_STRICT_STDERR" >&2
     exit 1
 fi
-echo "  ✓ locked canonical sqlite authority fails before child spawn"
+echo "  ✓ locked canonical sqlite authority is diagnostic unless strict guard is set"
 
 echo "smoke-codex-cli-ux: sqlite lock shaped child startup failure records abort"
 SQLITE_LOCK_NDJSON="$TMP/sqlite-lock/status.ndjson"

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -97,6 +97,18 @@ const CodexSqliteAuthorityMode = enum {
     }
 };
 
+const CodexHomeCleanupMode = enum {
+    delete_tree,
+    scrub_durable_bridge,
+
+    fn toString(self: CodexHomeCleanupMode) []const u8 {
+        return switch (self) {
+            .delete_tree => "delete_tree",
+            .scrub_durable_bridge => "scrub_durable_bridge",
+        };
+    }
+};
+
 const SessionCodexHome = struct {
     path: []u8,
     session_authority: SessionAuthorityMode,
@@ -104,6 +116,7 @@ const SessionCodexHome = struct {
     authority_home: ?[]u8 = null,
     config_authority_home: ?[]u8 = null,
     auth_initial_hash: [32]u8,
+    cleanup_mode: CodexHomeCleanupMode = .delete_tree,
     config_source_present: bool = false,
     config_passthrough: bool = false,
     config_overridden_keys: usize = 0,
@@ -112,7 +125,10 @@ const SessionCodexHome = struct {
     config_layout: []const u8 = "root_partitioned",
 
     fn deinit(self: SessionCodexHome, allocator: std.mem.Allocator) void {
-        std.fs.cwd().deleteTree(self.path) catch {};
+        switch (self.cleanup_mode) {
+            .delete_tree => std.fs.cwd().deleteTree(self.path) catch {},
+            .scrub_durable_bridge => scrubDurableCodexHome(allocator, self.path),
+        }
         allocator.free(self.path);
         if (self.authority_home) |home| allocator.free(home);
         if (self.config_authority_home) |home| allocator.free(home);
@@ -380,6 +396,8 @@ const SqliteAuthorityLockObservation = struct {
     sqlite_error_code: ?u8 = null,
     lock_owner_pid: ?i64 = null,
     next_action: []const u8 = "none",
+    strict_guard: bool = false,
+    fatal: bool = false,
 
     fn locked(self: SqliteAuthorityLockObservation) bool {
         return self.checked and !self.ok;
@@ -639,6 +657,7 @@ fn traceManagedOverlay(
         trace.string("config_layout", codex_home.config_layout),
         trace.string("session_authority", codex_home.session_authority.toString()),
         trace.string("sqlite_authority", codex_home.sqlite_authority.toString()),
+        trace.string("session_home_cleanup", codex_home.cleanup_mode.toString()),
         trace.boolean("config_passthrough", codex_home.config_passthrough),
         trace.boolean("user_config_present", codex_home.config_source_present),
         trace.uint("config_overridden_keys", @intCast(codex_home.config_overridden_keys)),
@@ -668,6 +687,7 @@ fn traceManagedSessionStart(
         trace.string("resume_mode", resume_mode.toString()),
         trace.string("session_authority", codex_home.session_authority.toString()),
         trace.string("sqlite_authority", codex_home.sqlite_authority.toString()),
+        trace.string("session_home_cleanup", codex_home.cleanup_mode.toString()),
         trace.uint("forwarded_arg_count", @intCast(forwarded_arg_count)),
         trace.boolean("child_stdio_inherited", true),
         trace.boolean("codex_home_path_printed", false),
@@ -695,6 +715,7 @@ fn traceManagedSessionEnd(
         trace.string("final_claim_level", proxy.peakClaimLevel().toString()),
         trace.string("session_authority", codex_home.session_authority.toString()),
         trace.string("sqlite_authority", codex_home.sqlite_authority.toString()),
+        trace.string("session_home_cleanup", codex_home.cleanup_mode.toString()),
         trace.boolean("synthetic_swap_observed", proxy.syntheticSwapSeen()),
         trace.boolean("codex_home_path_printed", false),
         trace.boolean("token_material_printed", false),
@@ -1336,12 +1357,14 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         return RunError.ConfigOverrideUnavailable;
     }
 
-    const sqlite_lock_check = try checkResumeSqliteAuthorityLock(allocator, &codex_home, resume_request);
+    var sqlite_lock_check = try checkResumeSqliteAuthorityLock(allocator, &codex_home, resume_request);
+    sqlite_lock_check.strict_guard = envFlag("OMUX_CODEX_STRICT_SQLITE_LOCK_GUARD");
+    sqlite_lock_check.fatal = sqlite_lock_check.locked() and sqlite_lock_check.strict_guard;
     if (emit_status and sqlite_lock_check.checked) {
         try writeSqliteAuthorityCheckStatus(status_writer, sqlite_lock_check);
     }
     try launch_timer.mark(status_writer, emit_status, "sqlite_authority_check");
-    if (sqlite_lock_check.locked()) {
+    if (sqlite_lock_check.fatal) {
         if (sqlite_lock_check.lock_owner_pid) |pid| {
             try stderr.print("oauth-mux codex: canonical Codex sqlite state is locked by another Codex process (pid {d}); close or wait for that process, then retry\n", .{pid});
         } else {
@@ -1369,8 +1392,8 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         const installed_local_mismatch = envFlag("OMUX_INSTALLED_LOCAL_MISMATCH");
 
         try status_writer.print(
-            "{{\"kind\":\"session_started\",\"adapter\":\"codex\",\"adapter_version\":\"{s}\",\"managed_frame_id\":\"{s}\",\"selected_account\":\"{s}\",\"codex_home_path_printed\":false,\"proxy_port\":{d},\"claim_level\":\"broker_owned\",\"auth_authority\":\"mux_owned_overlay\",\"managed_config\":\"mux_owned_overlay\",\"config_layout\":\"{s}\",\"config_passthrough\":{any},\"user_config_present\":{any},\"config_overridden_keys\":{d},\"experimental_feature_defaults_injected\":{d},\"mcp_stdio_unsupported_fields_removed\":{d},\"config_paths_printed\":false,\"session_authority\":\"{s}\",\"sqlite_authority\":\"{s}\",\"session_paths_printed\":false,\"pre_spawn_network_refresh\":false,\"status_file_present\":{any},\"runtime_identity\":{{",
-            .{ cli.version, managed_frame_id, elected.id, proxy_port, codex_home.config_layout, codex_home.config_passthrough, codex_home.config_source_present, codex_home.config_overridden_keys, codex_home.experimental_feature_defaults_injected, codex_home.mcp_stdio_unsupported_fields_removed, codex_home.session_authority.toString(), codex_home.sqlite_authority.toString(), status_file_path != null },
+            "{{\"kind\":\"session_started\",\"adapter\":\"codex\",\"adapter_version\":\"{s}\",\"managed_frame_id\":\"{s}\",\"selected_account\":\"{s}\",\"codex_home_path_printed\":false,\"proxy_port\":{d},\"claim_level\":\"broker_owned\",\"auth_authority\":\"mux_owned_overlay\",\"managed_config\":\"mux_owned_overlay\",\"config_layout\":\"{s}\",\"config_passthrough\":{any},\"user_config_present\":{any},\"config_overridden_keys\":{d},\"experimental_feature_defaults_injected\":{d},\"mcp_stdio_unsupported_fields_removed\":{d},\"config_paths_printed\":false,\"session_authority\":\"{s}\",\"sqlite_authority\":\"{s}\",\"session_home_cleanup\":\"{s}\",\"session_paths_printed\":false,\"pre_spawn_network_refresh\":false,\"status_file_present\":{any},\"runtime_identity\":{{",
+            .{ cli.version, managed_frame_id, elected.id, proxy_port, codex_home.config_layout, codex_home.config_passthrough, codex_home.config_source_present, codex_home.config_overridden_keys, codex_home.experimental_feature_defaults_injected, codex_home.mcp_stdio_unsupported_fields_removed, codex_home.session_authority.toString(), codex_home.sqlite_authority.toString(), codex_home.cleanup_mode.toString(), status_file_path != null },
         );
         try runtime_identity.writeJsonFields(status_writer);
         try status_writer.writeAll(",\"command_spelling\":");
@@ -1683,7 +1706,10 @@ fn writeSqliteAuthorityCheckStatus(writer: anytype, check: SqliteAuthorityLockOb
     }
     try writer.writeAll(",\"lock_owner_pid_printed\":");
     try writer.writeAll(if (check.lock_owner_pid != null) "true" else "false");
-    try writer.writeAll(",\"path_printed\":false,\"token_material_printed\":false,\"session_id_printed\":false}\n");
+    try writer.print(
+        ",\"strict_guard\":{any},\"fatal\":{any},\"path_printed\":false,\"token_material_printed\":false,\"session_id_printed\":false}}\n",
+        .{ check.strict_guard, check.fatal },
+    );
 }
 
 fn writeManagedPreSpawnAbortStatus(
@@ -1870,31 +1896,50 @@ fn makeSessionCodexHome(
     session_home_override: ?[]const u8,
     isolated_session_store: bool,
 ) !SessionCodexHome {
-    const tmp_root = std.process.getEnvVarOwned(allocator, "TMPDIR") catch
-        try allocator.dupe(u8, "/tmp");
-    defer allocator.free(tmp_root);
     const session_authority_home = try resolveCodexSessionAuthorityHome(allocator, session_home_override, isolated_session_store);
     defer if (session_authority_home) |path| allocator.free(path);
     const config_authority_home = try resolveCodexConfigAuthorityHome(allocator);
     defer if (config_authority_home) |path| allocator.free(path);
-    return try createSessionCodexHomeUnder(allocator, tmp_root, source_auth_path, proxy_port, session_authority_home, config_authority_home);
+
+    const root = if (session_authority_home) |home|
+        try durableManagedCodexHomeRoot(allocator, home)
+    else
+        std.process.getEnvVarOwned(allocator, "TMPDIR") catch try allocator.dupe(u8, "/tmp");
+    defer allocator.free(root);
+
+    const cleanup_mode: CodexHomeCleanupMode = if (session_authority_home != null)
+        .scrub_durable_bridge
+    else
+        .delete_tree;
+
+    return try createSessionCodexHomeUnder(
+        allocator,
+        root,
+        source_auth_path,
+        proxy_port,
+        session_authority_home,
+        config_authority_home,
+        cleanup_mode,
+    );
 }
 
 fn createSessionCodexHomeUnder(
     allocator: std.mem.Allocator,
-    tmp_root: []const u8,
+    root: []const u8,
     source_auth_path: []const u8,
     proxy_port: u16,
     session_authority_home: ?[]const u8,
     config_authority_home: ?[]const u8,
+    cleanup_mode: CodexHomeCleanupMode,
 ) !SessionCodexHome {
     var nonce: [8]u8 = undefined;
     std.crypto.random.bytes(&nonce);
     const hex = std.fmt.bytesToHex(nonce, .lower);
-    const name = try std.fmt.allocPrint(allocator, "oauth-mux-codex-{s}", .{hex[0..]});
+    const name = try std.fmt.allocPrint(allocator, "omux-managed-codex-{s}", .{hex[0..]});
     defer allocator.free(name);
 
-    const session_home = try std.fs.path.join(allocator, &.{ tmp_root, name });
+    try std.fs.cwd().makePath(root);
+    const session_home = try std.fs.path.join(allocator, &.{ root, name });
     errdefer allocator.free(session_home);
     try std.fs.cwd().makePath(session_home);
     errdefer std.fs.cwd().deleteTree(session_home) catch {};
@@ -1928,6 +1973,7 @@ fn createSessionCodexHomeUnder(
         .authority_home = if (session_authority_home) |home| try allocator.dupe(u8, home) else null,
         .config_authority_home = if (config_authority_home) |home| try allocator.dupe(u8, home) else null,
         .auth_initial_hash = auth_initial_hash,
+        .cleanup_mode = cleanup_mode,
         .config_source_present = config_observation.source_present,
         .config_passthrough = config_observation.passthrough,
         .config_overridden_keys = config_observation.overridden_keys,
@@ -1935,6 +1981,10 @@ fn createSessionCodexHomeUnder(
         .mcp_stdio_unsupported_fields_removed = config_observation.mcp_stdio_unsupported_fields_removed,
         .config_layout = config_observation.layout,
     };
+}
+
+fn durableManagedCodexHomeRoot(allocator: std.mem.Allocator, authority_home: []const u8) ![]u8 {
+    return try std.fs.path.join(allocator, &.{ authority_home, ".oauth-mux", "managed-codex-homes" });
 }
 
 fn resolveCodexSessionAuthorityHome(
@@ -1983,6 +2033,7 @@ fn defaultCodexHome(allocator: std.mem.Allocator) !?[]u8 {
 fn isManagedCodexOverlayHome(allocator: std.mem.Allocator, path: []const u8) !bool {
     const base = std.fs.path.basename(path);
     if (std.mem.startsWith(u8, base, "oauth-mux-codex-")) return true;
+    if (std.mem.startsWith(u8, base, "omux-managed-codex-")) return true;
 
     const config_path = try std.fs.path.join(allocator, &.{ path, "config.toml" });
     defer allocator.free(config_path);
@@ -2649,6 +2700,27 @@ fn copyFileContents(
     const f = try std.fs.cwd().createFile(dest_path, .{ .mode = 0o600, .truncate = true });
     defer f.close();
     try f.writeAll(bytes);
+}
+
+fn deleteFileIfPresent(path: []const u8) void {
+    if (std.fs.path.isAbsolute(path)) {
+        std.fs.deleteFileAbsolute(path) catch {};
+    } else {
+        std.fs.cwd().deleteFile(path) catch {};
+    }
+}
+
+fn scrubDurableCodexHome(allocator: std.mem.Allocator, session_home: []const u8) void {
+    const scrub_files = [_][]const u8{
+        "auth.json",
+        "installation_id",
+        "config.toml",
+    };
+    for (scrub_files) |name| {
+        const path = std.fs.path.join(allocator, &.{ session_home, name }) catch continue;
+        defer allocator.free(path);
+        deleteFileIfPresent(path);
+    }
 }
 
 fn observeAuthWriteback(
@@ -3460,7 +3532,7 @@ test "createSessionCodexHomeUnder copies auth and does not clobber source config
     const auth_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "account", "auth.json" });
     defer std.testing.allocator.free(auth_path);
 
-    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null, null);
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null, null, .delete_tree);
     defer codex_home.deinit(std.testing.allocator);
     try std.testing.expectEqual(SessionAuthorityMode.isolated, codex_home.session_authority);
     try std.testing.expectEqual(CodexSqliteAuthorityMode.isolated_overlay, codex_home.sqlite_authority);
@@ -3556,7 +3628,7 @@ test "createSessionCodexHomeUnder preserves canonical config behavior settings" 
     const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
     defer std.testing.allocator.free(canonical_path);
 
-    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, canonical_path, canonical_path);
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, canonical_path, canonical_path, .scrub_durable_bridge);
     defer codex_home.deinit(std.testing.allocator);
     try std.testing.expect(codex_home.config_source_present);
     try std.testing.expect(codex_home.config_passthrough);
@@ -3633,7 +3705,7 @@ test "config passthrough preserves explicit experimental feature choices" {
     const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
     defer std.testing.allocator.free(canonical_path);
 
-    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null, canonical_path);
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null, canonical_path, .delete_tree);
     defer codex_home.deinit(std.testing.allocator);
     try std.testing.expectEqual(@as(usize, 3), codex_home.experimental_feature_defaults_injected);
 
@@ -3679,7 +3751,7 @@ test "config passthrough partitions root model provider before trailing table" {
     const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
     defer std.testing.allocator.free(canonical_path);
 
-    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null, canonical_path);
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null, canonical_path, .delete_tree);
     defer codex_home.deinit(std.testing.allocator);
 
     const overlay_config = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "config.toml" });
@@ -3796,7 +3868,7 @@ test "config passthrough is independent from session authority" {
     const session_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "session-home" });
     defer std.testing.allocator.free(session_path);
 
-    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, session_path, config_path);
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, session_path, config_path, .scrub_durable_bridge);
     defer codex_home.deinit(std.testing.allocator);
     try std.testing.expectEqual(SessionAuthorityMode.canonical_bridge, codex_home.session_authority);
     try std.testing.expectEqual(CodexSqliteAuthorityMode.canonical_env, codex_home.sqlite_authority);
@@ -3814,11 +3886,99 @@ test "config passthrough is independent from session authority" {
     try std.testing.expect(std.mem.indexOf(u8, generated_config, "SHOULD_NOT_SURVIVE") == null);
 }
 
+test "canonical bridge uses durable scrubbed managed home root" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("account");
+    try tmp.dir.makePath("canonical");
+    {
+        const auth = try tmp.dir.createFile("account/auth.json", .{ .mode = 0o600 });
+        defer auth.close();
+        try auth.writeAll("{\"tokens\":{\"access_token\":\"fixture\"}}\n");
+    }
+
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const auth_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "account", "auth.json" });
+    defer std.testing.allocator.free(auth_path);
+    const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
+    defer std.testing.allocator.free(canonical_path);
+    const durable_root = try durableManagedCodexHomeRoot(std.testing.allocator, canonical_path);
+    defer std.testing.allocator.free(durable_root);
+
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, durable_root, auth_path, 45678, canonical_path, canonical_path, .scrub_durable_bridge);
+    defer codex_home.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(SessionAuthorityMode.canonical_bridge, codex_home.session_authority);
+    try std.testing.expectEqual(CodexSqliteAuthorityMode.canonical_env, codex_home.sqlite_authority);
+    try std.testing.expectEqual(CodexHomeCleanupMode.scrub_durable_bridge, codex_home.cleanup_mode);
+    try std.testing.expect(std.mem.startsWith(u8, codex_home.path, durable_root));
+    try std.testing.expect(std.mem.startsWith(u8, std.fs.path.basename(codex_home.path), "omux-managed-codex-"));
+}
+
+test "durable managed home cleanup scrubs secrets but preserves bridge" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("account");
+    try tmp.dir.makePath("canonical/sessions");
+    {
+        const auth = try tmp.dir.createFile("account/auth.json", .{ .mode = 0o600 });
+        defer auth.close();
+        try auth.writeAll("{\"tokens\":{\"access_token\":\"fixture\"}}\n");
+    }
+    {
+        const install = try tmp.dir.createFile("account/installation_id", .{ .mode = 0o600 });
+        defer install.close();
+        try install.writeAll("install-fixture\n");
+    }
+
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const auth_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "account", "auth.json" });
+    defer std.testing.allocator.free(auth_path);
+    const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
+    defer std.testing.allocator.free(canonical_path);
+    const durable_root = try durableManagedCodexHomeRoot(std.testing.allocator, canonical_path);
+    defer std.testing.allocator.free(durable_root);
+
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, durable_root, auth_path, 45678, canonical_path, canonical_path, .scrub_durable_bridge);
+    const home_path = try std.testing.allocator.dupe(u8, codex_home.path);
+    defer std.testing.allocator.free(home_path);
+
+    const auth_dst = try std.fs.path.join(std.testing.allocator, &.{ home_path, "auth.json" });
+    defer std.testing.allocator.free(auth_dst);
+    const install_dst = try std.fs.path.join(std.testing.allocator, &.{ home_path, "installation_id" });
+    defer std.testing.allocator.free(install_dst);
+    const config_dst = try std.fs.path.join(std.testing.allocator, &.{ home_path, "config.toml" });
+    defer std.testing.allocator.free(config_dst);
+    const sessions_link = try std.fs.path.join(std.testing.allocator, &.{ home_path, "sessions" });
+    defer std.testing.allocator.free(sessions_link);
+
+    try std.fs.cwd().access(auth_dst, .{});
+    try std.fs.cwd().access(install_dst, .{});
+    try std.fs.cwd().access(config_dst, .{});
+
+    codex_home.deinit(std.testing.allocator);
+
+    try std.testing.expectError(error.FileNotFound, std.fs.cwd().access(auth_dst, .{}));
+    try std.testing.expectError(error.FileNotFound, std.fs.cwd().access(install_dst, .{}));
+    try std.testing.expectError(error.FileNotFound, std.fs.cwd().access(config_dst, .{}));
+
+    var link_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const sessions_target = try std.fs.readLinkAbsolute(sessions_link, &link_buf);
+    const expected_sessions_target = try std.fs.path.join(std.testing.allocator, &.{ canonical_path, "sessions" });
+    defer std.testing.allocator.free(expected_sessions_target);
+    try std.testing.expectEqualStrings(expected_sessions_target, sessions_target);
+}
+
 test "managed Codex overlay homes are not reusable authority homes" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
     try tmp.dir.makePath("oauth-mux-codex-fixture");
+    try tmp.dir.makePath("omux-managed-codex-fixture");
     try tmp.dir.makePath("canonical");
     {
         const cfg = try tmp.dir.createFile("oauth-mux-codex-fixture/config.toml", .{ .mode = 0o600 });
@@ -3846,12 +4006,15 @@ test "managed Codex overlay homes are not reusable authority homes" {
 
     const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
     defer std.testing.allocator.free(root_path);
-    const overlay_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "oauth-mux-codex-fixture" });
-    defer std.testing.allocator.free(overlay_path);
+    const legacy_overlay_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "oauth-mux-codex-fixture" });
+    defer std.testing.allocator.free(legacy_overlay_path);
+    const durable_overlay_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "omux-managed-codex-fixture" });
+    defer std.testing.allocator.free(durable_overlay_path);
     const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
     defer std.testing.allocator.free(canonical_path);
 
-    try std.testing.expect(try isManagedCodexOverlayHome(std.testing.allocator, overlay_path));
+    try std.testing.expect(try isManagedCodexOverlayHome(std.testing.allocator, legacy_overlay_path));
+    try std.testing.expect(try isManagedCodexOverlayHome(std.testing.allocator, durable_overlay_path));
     try std.testing.expect(!try isManagedCodexOverlayHome(std.testing.allocator, canonical_path));
 }
 
@@ -3871,7 +4034,7 @@ test "observeAuthWriteback imports changed overlay auth into mux source" {
     const auth_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "account", "auth.json" });
     defer std.testing.allocator.free(auth_path);
 
-    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null, null);
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null, null, .delete_tree);
     defer codex_home.deinit(std.testing.allocator);
 
     const overlay_auth = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "auth.json" });
@@ -3912,7 +4075,7 @@ test "observeAuthWriteback leaves unchanged overlay auth alone" {
     const auth_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "account", "auth.json" });
     defer std.testing.allocator.free(auth_path);
 
-    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null, null);
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null, null, .delete_tree);
     defer codex_home.deinit(std.testing.allocator);
 
     const observation = try observeAuthWriteback(std.testing.allocator, codex_home.path, auth_path, codex_home.auth_initial_hash);
@@ -3941,7 +4104,7 @@ test "observeAuthWriteback refuses to overwrite independently changed mux source
     const auth_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "account", "auth.json" });
     defer std.testing.allocator.free(auth_path);
 
-    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null, null);
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, null, null, .delete_tree);
     defer codex_home.deinit(std.testing.allocator);
 
     const overlay_auth = try std.fs.path.join(std.testing.allocator, &.{ codex_home.path, "auth.json" });
@@ -4015,7 +4178,7 @@ test "createSessionCodexHomeUnder bridges canonical session authority without co
     const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
     defer std.testing.allocator.free(canonical_path);
 
-    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, canonical_path, canonical_path);
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, canonical_path, canonical_path, .scrub_durable_bridge);
     defer codex_home.deinit(std.testing.allocator);
     try std.testing.expectEqual(SessionAuthorityMode.canonical_bridge, codex_home.session_authority);
     try std.testing.expectEqual(CodexSqliteAuthorityMode.canonical_env, codex_home.sqlite_authority);
@@ -4109,7 +4272,7 @@ test "resume authority accepts bridged state db as chooser authority" {
     const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
     defer std.testing.allocator.free(canonical_path);
 
-    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, canonical_path, canonical_path);
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, canonical_path, canonical_path, .scrub_durable_bridge);
     defer codex_home.deinit(std.testing.allocator);
 
     const check = try checkResumeAuthority(std.testing.allocator, &codex_home, .{ .mode = .chooser });
@@ -4143,7 +4306,7 @@ test "resume authority accepts bridged logs db as chooser authority" {
     const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
     defer std.testing.allocator.free(canonical_path);
 
-    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, canonical_path, canonical_path);
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, canonical_path, canonical_path, .scrub_durable_bridge);
     defer codex_home.deinit(std.testing.allocator);
 
     const check = try checkResumeAuthority(std.testing.allocator, &codex_home, .{ .mode = .chooser });
@@ -4183,7 +4346,7 @@ test "resume authority reports legacy provider namespace residue without failing
     const canonical_path = try std.fs.path.join(std.testing.allocator, &.{ root_path, "canonical" });
     defer std.testing.allocator.free(canonical_path);
 
-    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, canonical_path, canonical_path);
+    const codex_home = try createSessionCodexHomeUnder(std.testing.allocator, root_path, auth_path, 45678, canonical_path, canonical_path, .scrub_durable_bridge);
     defer codex_home.deinit(std.testing.allocator);
 
     const check = try checkResumeAuthority(std.testing.allocator, &codex_home, .{ .mode = .chooser });


### PR DESCRIPTION
## Summary

Fixes the TIN-1851 managed Codex session-authority regression where canonical sqlite rows could record rollout paths under disposable `TMPDIR/oauth-mux-codex-*` homes.

Changes:
- canonical bridge mode now creates durable managed homes under `<authority>/.oauth-mux/managed-codex-homes/omux-managed-codex-*`
- normal cleanup scrubs copied `auth.json`, `installation_id`, and generated `config.toml`, while preserving bridge symlinks so Codex rollout paths stay resolvable
- sqlite authority lock checks are diagnostic by default; `OMUX_CODEX_STRICT_SQLITE_LOCK_GUARD=1` restores the prior pre-spawn abort for targeted debugging
- status frames report `session_home_cleanup`, `strict_guard`, and `fatal`
- docs now describe the durable/scrubbed bridge and diagnostic lock behavior
- removes remaining tracked `no-spend` wording

## Validation

- `git diff --check`
- `nix develop --command zig build test`
- `nix develop --command zig build`
- `scripts/smoke-codex-cli-ux.sh`
- `scripts/smoke-codex-concurrent-sessions.sh`
- `nix develop --command just check-local`

## Notes

This does not claim upstream Codex supports a separate auth-file path. The observed binary does not expose `CODEX_AUTH_FILE`; `CODEX_HOME` remains the auth/config boundary, so durable scrubbed bridge homes are the current vendored-respect compromise.

Untracked `src/reauth/` in the shared local worktree was intentionally left untouched.
