### PR TITLE
Fix Codex durable bridge cleanup on child exit

### DIFF
--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -153,6 +153,33 @@ assert_grep() {
     fi
 }
 
+assert_durable_bridge_homes_scrubbed() {
+    local label=$1
+    local root="$CANONICAL_SESSION_HOME/.oauth-mux/managed-codex-homes"
+    if [[ ! -d "$root" ]]; then
+        echo "  ✗ $label durable managed home root missing" >&2
+        exit 1
+    fi
+
+    local leaked
+    leaked="$(find "$root" -mindepth 2 -maxdepth 2 \( -name auth.json -o -name installation_id -o -name config.toml \) -print -quit)"
+    if [[ -n "$leaked" ]]; then
+        echo "  ✗ $label left token/config material in durable managed home" >&2
+        find "$root" -mindepth 2 -maxdepth 2 \( -name auth.json -o -name installation_id -o -name config.toml \) -print >&2
+        exit 1
+    fi
+
+    local bridge_count
+    bridge_count="$(find "$root" -mindepth 2 -maxdepth 2 -type l -name sessions -print | wc -l | tr -d ' ')"
+    if [[ "$bridge_count" -eq 0 ]]; then
+        echo "  ✗ $label preserved no durable session bridge" >&2
+        find "$root" -maxdepth 2 -print >&2
+        exit 1
+    fi
+
+    echo "  ✓ $label scrubbed durable auth/config material while preserving bridge homes"
+}
+
 run_case() {
     local mode=$1 label=$2 expected_argv=$3
     shift 3
@@ -624,6 +651,7 @@ if grep -q -E 'managed-good-session|'"$CANONICAL_SESSION_HOME" "$SQLITE_LOCK_NDJ
     cat "$SQLITE_LOCK_NDJSON" >&2
     exit 1
 fi
+assert_durable_bridge_homes_scrubbed "sqlite lock nonzero child cleanup"
 echo "  ✓ sqlite lock shaped startup failure records abort without route-health mutation"
 
 echo "smoke-codex-cli-ux: forwarded config provider override fails before spawn"

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -1330,7 +1330,8 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
         opts.session_home,
         opts.isolated_session_store,
     );
-    defer codex_home.deinit(allocator);
+    var codex_home_deinit_needed = true;
+    defer if (codex_home_deinit_needed) codex_home.deinit(allocator);
     traceManagedOverlay(allocator, elected.id, launch_defaults.profile, proxy_port, &codex_home);
     try launch_timer.mark(status_writer, emit_status, "overlay_creation");
 
@@ -1549,8 +1550,16 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
 
     // Propagate exit code.
     switch (term) {
-        .Exited => |c| if (c != 0) std.process.exit(c),
-        else => std.process.exit(1),
+        .Exited => |c| if (c != 0) {
+            codex_home.deinit(allocator);
+            codex_home_deinit_needed = false;
+            std.process.exit(c);
+        },
+        else => {
+            codex_home.deinit(allocator);
+            codex_home_deinit_needed = false;
+            std.process.exit(1);
+        },
     }
 }
 


### PR DESCRIPTION
## Summary

- scrub durable managed Codex bridge homes before propagating a nonzero child exit
- add a CLI UX smoke assertion that nonzero child startup failures leave no copied auth/config material behind while preserving the durable session bridge
- cleaned up the stale copied overlay material left by the failed live TIN-1852 run on neo

## Validation

- bash -n scripts/smoke-codex-cli-ux.sh
- nix develop --command zig build test
- nix develop --command zig build && scripts/smoke-codex-cli-ux.sh
- scripts/smoke-codex-concurrent-sessions.sh
- git diff --check
- nix develop --command just check-local