### PR TITLE
Fix Codex Max route reporting

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -188,6 +188,11 @@ To probe one route class across every expected Codex account:
 oauth-mux codex probe-all --capability codex-mini --json
 ```
 
+For Codex, `codex-max` and `codex-mini` are oauth-mux route-health labels.
+They are not redacted account-tier assertions and are not necessarily the model
+the child process will print. Live managed evidence should report both the
+selected route health key and the observed child model when available.
+
 To inspect the stay-afloat decision loop without running a canary:
 
 ```bash

--- a/docs/spec/codex-max-operator-plan-2026-04-25.md
+++ b/docs/spec/codex-max-operator-plan-2026-04-25.md
@@ -62,6 +62,12 @@ Supersession note, 2026-05-03: current `codex-max` dogfood is tracked in
 has four broker-ready routes, with `max-1` selected, `max-4` spare fallback,
 and `max-2`/`max-3` quota-exhausted for `codex-max`.
 
+Supersession note, 2026-06-02: installed Codex CLI 0.135.0 live managed
+dogfood observed the child model as `gpt-5.5`. The oauth-mux `codex-mini`
+profile/route label is route-health evidence, not an account subscription tier
+or child model assertion. A Max-tagged account can legitimately have a live
+fallback route-health lane while the child still runs `gpt-5.5`.
+
 Only login status, auth store paths, and mux probe classifications were
 inspected. Token contents were not read or printed.
 
@@ -232,7 +238,7 @@ The built-in Codex provider now has command-transport probes for the semantic
 route labels:
 
 ```text
-codex-max  -> codex exec --json --ephemeral --ignore-rules -m gpt-5.3-codex
+codex-max  -> codex exec --json --ephemeral --ignore-rules -m gpt-5.5
 codex-mini -> codex exec --json --ephemeral --ignore-rules -m gpt-5.3-codex-spark
 ```
 

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -164,9 +164,9 @@ jq -e '
   and .ok == false
   and .scope.profile == "codex-max"
   and .scope.capability == "codex-max"
-  and .accounts == 6
-  and .action_needed_accounts == 6
-  and (.route_reports | length) == 6
+  and .accounts == 3
+  and .action_needed_accounts == 3
+  and (.route_reports | length) == 3
   and all(.route_reports[]; .provider == "codex" and .capability == "codex-max" and .ready == false)
 ' "$runtime_doctor_scoped" >/dev/null
 expect_not_contains "$(cat "$runtime_doctor_scoped")" "$store_root/max-1" "scoped runtime doctor does not print concrete Codex store paths"
@@ -248,7 +248,7 @@ repair_plan_json="$tmp/repair-plan-codex-max.json"
 run_json "$repair_plan_json" repair-plan --profile codex-max --capability codex-max --json
 jq -e '
   .profile == "codex-max"
-  and (.routes | length) == 6
+  and (.routes | length) == 3
   and all(.routes[]; .provider == "codex" and .capability == "codex-max" and .action.mutating == false)
   and all(.routes[]; .action.kind == "fix_runtime" or .action.kind == "probe_needed" or .action.kind == "revalidation_needed" or .action.kind == "none" or .action.kind == "wait_and_retry" or .action.kind == "wait_for_quota" or .action.kind == "wait_for_cooldown")
   and all(.routes[]; if .action.kind == "fix_runtime" then
@@ -267,7 +267,7 @@ jq -e '
   and .capability == "codex-max"
   and .ok == false
   and .selected == null
-  and (.routes | length) == 6
+  and (.routes | length) == 3
   and all(.routes[]; .provider == "codex" and .capability == "codex-max" and .action.mutating == false)
   and all(.routes[]; .action.kind == "fix_runtime" or .action.kind == "probe_needed")
   and all(.routes[]; if .action.kind == "fix_runtime" then
@@ -302,19 +302,19 @@ jq -e '
   and (.environment.omux_codex_config_home_present | type) == "boolean"
   and .environment.path_printed == false
   and .ok == false
-  and .route_summary.routes_total == 6
+  and .route_summary.routes_total == 3
   and .route_summary.selectable_routes == 0
   and (.blocked_route_reasons | length) == 1
-  and (.blocked_route_reasons[] | select(.reason == "auth_broker_unready" and .count == 6))
+  and (.blocked_route_reasons[] | select(.reason == "auth_broker_unready" and .count == 3))
   and .repair_summary.route_repair_required == true
   and .repair_summary.agent_safe_inspection_available == true
-  and .repair_summary.blocked_routes == 6
+  and .repair_summary.blocked_routes == 3
   and .repair_summary.dominant_blocker == "auth_broker_unready"
-  and .repair_summary.dominant_blocker_count == 6
-  and .repair_summary.auth_broker_unready_routes == 6
+  and .repair_summary.dominant_blocker_count == 3
+  and .repair_summary.auth_broker_unready_routes == 3
   and .repair_summary.revalidation_needed_routes == 0
   and .repair_summary.user_handoff_required == false
-  and (.blocked_routes | length) == 6
+  and (.blocked_routes | length) == 3
   and all(.blocked_routes[]; .provider == "codex" and .capability == "codex-max" and .selectable == false and .broker_ready == false and .blocked_reason == "auth_broker_unready" and .action.mutating == false)
   and (.next_actions | length) == 1
   and (.next_actions | index("oauth-mux codex broker-session-plan --profile codex-max --capability codex-max --json") != null)
@@ -355,7 +355,7 @@ jq -e '
   and .executed == false
   and .afloat == false
   and .selected == null
-  and (.routes | length) == 6
+  and (.routes | length) == 3
   and all(.routes[]; .route.provider == "codex" and .route.capability == "codex-max")
   and all(.routes[]; if .route.action.kind == "fix_runtime" then
     .route.action.command == null
@@ -380,7 +380,7 @@ jq -e '
   .action == "select"
   and .ok == false
   and .selected == null
-  and (.routes | length) == 6
+  and (.routes | length) == 3
 ' "$route_select_json" >/dev/null
 
 printf 'first-run e2e: repair run refuses to mutate without admitted repair\n'

--- a/scripts/live-codex-mux-e2e.sh
+++ b/scripts/live-codex-mux-e2e.sh
@@ -149,6 +149,37 @@ if [[ -s "$NDJSON" ]]; then
     "$ROOT/scripts/summarize-codex-status.py" "$NDJSON" >"$SUMMARY_FILE" || true
 fi
 
+if [[ -s "$SUMMARY_FILE" && -s "$STDERR_FILE" ]]; then
+    python3 - "$SUMMARY_FILE" "$STDERR_FILE" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+summary_path = Path(sys.argv[1])
+stderr_path = Path(sys.argv[2])
+
+try:
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+except Exception:
+    raise SystemExit(0)
+
+observed_model = None
+for line in stderr_path.read_text(encoding="utf-8", errors="replace").splitlines():
+    match = re.match(r"\s*model:\s*([^\s]+)\s*$", line)
+    if match:
+        observed_model = match.group(1)
+        break
+
+if observed_model:
+    summary["observed_child_model"] = observed_model
+    summary["observed_child_model_source"] = "codex_stderr"
+    summary["route_capability_is_child_model"] = False
+
+summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+fi
+
 echo "live-codex-mux-e2e: evidence_dir=$EVIDENCE_DIR"
 echo "live-codex-mux-e2e: exit_code=$EXIT_CODE"
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -3192,10 +3192,15 @@ fn collectRepairPlanRoutes(
         for (profile.providers) |provider_ref| {
             const parsed = parseRepairRouteSpec(provider_ref) orelse return error.ConfigValidationError;
             if (!repairRouteMatchesAccountFilter(parsed, args.account)) continue;
+            if (args.capability) |requested_capability| {
+                if (parsed.capability) |declared_capability| {
+                    if (!std.mem.eql(u8, declared_capability, requested_capability)) continue;
+                }
+            }
             try routes.append(.{
                 .provider = parsed.provider,
                 .account = parsed.account,
-                .capability = args.capability orelse parsed.capability,
+                .capability = parsed.capability orelse args.capability,
             });
         }
         return routes;
@@ -5583,10 +5588,9 @@ const DegradedSelection = struct {
 };
 
 // TIN-1811: collect a profile's routes for a single target capability, preserving
-// each route's *declared* capability. collectRepairPlanRoutes relabels every
-// route to `args.capability`, which would mislabel (e.g.) codex-max routes as
-// codex-mini during fallback evaluation; this keeps only the routes that actually
-// declare the target capability so the fallback set is correct.
+// each route's *declared* capability. This is used by degradation so the
+// fallback set is explicit and does not inherit the originally requested
+// capability label.
 fn collectProfileRoutesForCapability(
     allocator: std.mem.Allocator,
     cfg: config.Config,
@@ -17606,7 +17610,10 @@ test "collectRepairPlanRoutes expands profile capability routes" {
     const parsed = try config.loadFromBytes(std.testing.allocator, json);
     defer parsed.deinit();
 
-    var routes = try collectRepairPlanRoutes(std.testing.allocator, parsed.value, .{ .profile = "codex-max" });
+    var routes = try collectRepairPlanRoutes(std.testing.allocator, parsed.value, .{
+        .profile = "codex-max",
+        .capability = "codex-max",
+    });
     defer routes.deinit();
 
     try std.testing.expectEqual(@as(usize, 2), routes.items.len);
@@ -17614,6 +17621,53 @@ test "collectRepairPlanRoutes expands profile capability routes" {
     try std.testing.expectEqualStrings("max-1", routes.items[0].account);
     try std.testing.expectEqualStrings("codex-max", routes.items[0].capability.?);
     try std.testing.expectEqualStrings("max-2", routes.items[1].account);
+}
+
+test "collectRepairPlanRoutes preserves declared profile route capabilities when scoped" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "max-1": {
+        \\          "secret": { "backend": "file", "path": "/tmp/omux/max-1/auth.json" }
+        \\        },
+        \\        "max-2": {
+        \\          "secret": { "backend": "file", "path": "/tmp/omux/max-2/auth.json" }
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {
+        \\    "codex-max": {
+        \\      "providers": [
+        \\        "codex:max-1#codex-max",
+        \\        "codex:max-1#codex-mini",
+        \\        "codex:max-2#codex-max",
+        \\        "codex:max-2#codex-mini"
+        \\      ],
+        \\      "capability_degradation_chain": ["codex-mini"]
+        \\    }
+        \\  },
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try config.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var routes = try collectRepairPlanRoutes(std.testing.allocator, parsed.value, .{
+        .profile = "codex-max",
+        .capability = "codex-max",
+    });
+    defer routes.deinit();
+
+    try std.testing.expectEqual(@as(usize, 2), routes.items.len);
+    try std.testing.expectEqualStrings("max-1", routes.items[0].account);
+    try std.testing.expectEqualStrings("codex-max", routes.items[0].capability.?);
+    try std.testing.expectEqualStrings("max-2", routes.items[1].account);
+    try std.testing.expectEqualStrings("codex-max", routes.items[1].capability.?);
 }
 
 test "runtime doctor route scope reports only requested profile routes" {
@@ -19119,10 +19173,7 @@ test "Codex broker summary does not claim same-account duplicate as spare fallba
     const parsed = try config.loadFromBytes(std.testing.allocator, cfg_json);
     defer parsed.deinit();
 
-    var routes = try collectRepairPlanRoutes(std.testing.allocator, parsed.value, .{
-        .profile = "codex-max",
-        .capability = "codex-max",
-    });
+    var routes = try collectRepairPlanRoutes(std.testing.allocator, parsed.value, .{ .profile = "codex-max" });
     defer routes.deinit();
     try std.testing.expectEqual(@as(usize, 2), routes.items.len);
     try std.testing.expect(sameFallbackAccount(routes.items[0], routes.items[1]));

--- a/src/provider_schema.zig
+++ b/src/provider_schema.zig
@@ -621,7 +621,7 @@ const flakehub_capabilities = [_]CapabilityDefinition{
 const codex_capabilities = [_]CapabilityDefinition{
     .{
         .name = "codex-max",
-        .aliases = &.{ "max", "gpt-5.3-codex", "gpt-5.1-codex-max" },
+        .aliases = &.{ "max", "gpt-5.5", "gpt-5.3-codex", "gpt-5.1-codex-max" },
         .proof_status = proof_live,
         .proof_requirements = &.{
             "codex CLI installed",
@@ -640,7 +640,7 @@ const codex_capabilities = [_]CapabilityDefinition{
                 "--ephemeral",
                 "--ignore-rules",
                 "-m",
-                "gpt-5.3-codex",
+                "gpt-5.5",
                 "Reply exactly: OMUX_CODEX_MAX_PROBE",
             },
             .budget = .spend_provider,
@@ -1711,11 +1711,11 @@ test "codex capabilities include semantic max and mini command probes" {
     try std.testing.expectEqualStrings("codex", codex_def.runtime.required_binaries[0]);
 
     try std.testing.expectEqualStrings("codex-max", codex_def.capabilities[0].name);
-    const max_plan = probePlanForCapability(codex_def, "gpt-5.3-codex").?;
+    const max_plan = probePlanForCapability(codex_def, "gpt-5.5").?;
     try std.testing.expectEqual(ProbeTransport.command, max_plan.transport);
     try std.testing.expectEqualStrings("codex-max", max_plan.capability);
     try std.testing.expectEqualStrings("codex", max_plan.command.?[0]);
-    try std.testing.expectEqualStrings("gpt-5.3-codex", max_plan.command.?[6]);
+    try std.testing.expectEqualStrings("gpt-5.5", max_plan.command.?[6]);
     try std.testing.expectEqual(@as(u32, 120_000), max_plan.timeout_ms);
     try std.testing.expectEqual(types.ActionBudget.spend_provider, max_plan.budget);
     try std.testing.expectEqualStrings("codex-max", probePlanForCapability(codex_def, "max").?.capability);


### PR DESCRIPTION
## Summary

- Preserve declared Codex profile route capabilities when diagnostics are scoped to `--capability`, so `codex-max` reports no longer relabel `#codex-mini` rows as Max rows.
- Update the built-in Codex Max probe from stale `gpt-5.3-codex` to observed current `gpt-5.5`.
- Add live e2e summary fields for the observed child model from Codex stderr, keeping route-health labels separate from the child model.
- Update operator docs to state that `codex-max` / `codex-mini` are route-health labels, not redacted account-tier assertions.

## Validation

- `git diff --check`
- `bash -n scripts/live-codex-mux-e2e.sh scripts/summarize-codex-status.py`
- `nix develop --command zig build test`
- `nix develop --command zig build`
- `nix develop --command ./scripts/first-run-e2e.sh`
- `nix develop --command just check-local`

## Live evidence

- Source-built `oauth-mux probe --provider codex --account max-3 --capability codex-max --json` returned `probe_status: 200`, `decision: use_this`, and `liveness: live.available` on `codex:max-3#codex-max`.
- Source-built `codex preflight --profile codex-max --capability codex-max --json` selected `codex:max-3#codex-max` and reported only the three real Max scoped routes.
- Live managed e2e selected `codex:max-3`, observed child model `gpt-5.5`, received 200 proxy turns, and returned the expected token. The child then hung during shutdown before the script could report PASS; that is tracked as a separate live harness shutdown regression and is not claimed as a full e2e pass here.
