### PR TITLE
TIN-1851: home-is-store Codex muxxing (structural fix for ~3-week canonical poisoning)

### DIFF
--- a/docs/writeups/2026-06-02-tin1851-home-is-store-muxxing.md
+++ b/docs/writeups/2026-06-02-tin1851-home-is-store-muxxing.md
@@ -1,0 +1,72 @@
+# TIN-1851: home-is-store Codex muxxing (the real fix)
+
+**Status:** implemented on `tin-1851-codex-muxxing-fix`. Default behavior change.
+
+## Problem
+
+The previous default muxxed a Codex session through a *canonical bridge* overlay:
+a throwaway `CODEX_HOME` whose `sessions/` and `state_5.sqlite` were symlinked to the
+canonical `~/.codex`, with child `CODEX_SQLITE_HOME` pointed at the canonical store.
+Codex recorded the ephemeral overlay's `rollout_path`s into the **shared canonical**
+`state_5.sqlite`; when the overlay (or `$TMPDIR`) was reaped those rows dangled. This
+corrupted the user's real `~/.codex` for ~3 weeks and broke even bare, non-muxxed
+Codex sessions. (See the codex-muxxing temp-home poisoning notes and `bde09d72`, which
+decoupled muxxing to opt-in as a stopgap.)
+
+## Model B: home-is-store (default `isolated_persistent`)
+
+Each muxxed account already enrolls with a dedicated per-account home, e.g.
+
+```json
+"max-1": {
+  "config_dir": "~/.local/share/oauth-mux/codex/max-1",
+  "secret": { "backend": "file", "path": "~/.local/share/oauth-mux/codex/max-1/auth.json" }
+}
+```
+
+The fix uses that home **directly** as `CODEX_HOME`:
+
+- `CODEX_HOME = dirname(source_auth_path)` — guaranteed equal to the exact `auth.json`
+  the refresh/identity locks key on, and the file codex reads at `$CODEX_HOME/auth.json`.
+- **No auth copy**: codex refreshes `auth.json` in place; there is no overlay buffer to
+  diverge or lose a rotated refresh token from.
+- **No canonical bridge**: `sqlite_authority = isolated_overlay`, `CODEX_SQLITE_HOME` is
+  removed, so codex writes its **own** `state_5.sqlite` and `sessions/` inside the home.
+  The canonical `~/.codex` is never a write target → the poisoning vector is *structurally*
+  gone, and distinct accounts get fully disjoint stores (the product goal: concurrent use
+  of distinct $200 accounts).
+- **Persistent**: the home is durable, so native `codex resume` works without symlink
+  bridging or `CODEX_SQLITE_HOME` juggling.
+
+The legacy bridge stays available, strictly opt-in, via `TINYLAND_CODEX_MUX_MODE=shared_canonical`
+(or `--mux-mode shared_canonical`). `--session-home` and `--isolated-session-store` keep their
+existing meanings.
+
+## Guard set (load-bearing — naive home-is-store is unsafe without these)
+
+1. **Canonical-overlap refuse** (`ensureNotCanonicalCodexHome`): fatal if the resolved
+   `CODEX_HOME` (lexically or symlink-resolved) is, contains, or is contained by `~/.codex`.
+   Prevents a misconfigured `secret.path`/`config_dir` from writing managed config + state
+   into the real store.
+2. **Home derived from the auth file** + basename must be `auth.json`; refuse a home with no
+   usable `auth.json` rather than silently bootstrapping an empty/unauthenticated home.
+3. **Fresh config, scrubbed on exit**: the managed `config.toml` is written fresh each launch
+   (no passthrough self-read) carrying only the proxy override; on clean exit it is deleted
+   (`persist_scrub_config`) so a dead ephemeral proxy port can never brick a later bare-codex
+   run, and the home is not misclassified as a managed overlay next launch.
+4. **Per-account + identity session flock** (landed in the 2c increment): the session holds
+   `acquireRepairLockBlocking("codex", account)` — the *same* lock domain as background
+   refresh — plus a `sha256_12hex(account_id)` identity flock, for the whole session. Same
+   account or shared upstream identity cannot run concurrently and self-revoke the rotating
+   refresh chain.
+5. **Auth integrity preflight + shadow backup** (`auth.json.omux-bak`): recover a torn in-place
+   write / crash-mid-refresh; refuse if neither the live file nor the shadow is usable.
+
+## Verification
+
+Unit tests cover the dispatch, the overlap guard, the config/shadow scrub, and crash recovery.
+Per the unit-green≠working lesson, the gate is the **live** `scripts/live-codex-mux-e2e.sh`
+(driven against `jess@xoxd.ai`): a real managed `codex exec` returns the token, **0** new
+`oauth-mux-codex`/`omux-managed` rows appear in canonical `~/.codex/state_5.sqlite`, integrity
+stays `ok`, no token/config material leaks under `~/.codex/.oauth-mux`, and `session_authority`
+is `isolated`. Follow-up: bounded `sessions/` retention sweep; config-validation home-uniqueness.

--- a/scripts/live-codex-mux-e2e.sh
+++ b/scripts/live-codex-mux-e2e.sh
@@ -15,6 +15,10 @@ CAPABILITY="${OMUX_LIVE_E2E_CAPABILITY:-codex-max}"
 CONFIRM="${OMUX_LIVE_CODEX_E2E_CONFIRM:-}"
 TOKEN="${OMUX_LIVE_E2E_TOKEN:-OMUX_TIN1852_EXEC_OK}"
 PROMPT="${OMUX_LIVE_E2E_PROMPT:-Reply with exactly this token and nothing else: $TOKEN}"
+# TIN-1851: the default mux mode is home-is-store, whose session authority is
+# "isolated". A shared_canonical opt-in run emits "canonical_bridge"; override
+# this to match when exercising that legacy mode.
+EXPECT_AUTHORITY="${OMUX_LIVE_E2E_EXPECT_AUTHORITY:-isolated}"
 STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 EVIDENCE_DIR="${OMUX_LIVE_E2E_DIR:-$ROOT/dist/live-qa/tin1852-$STAMP}"
 NDJSON="$EVIDENCE_DIR/status.ndjson"
@@ -215,7 +219,7 @@ fi
 
 if [[ -s "$NDJSON" ]]; then
     jq -e 'select(.kind == "session_started") | .runtime_identity.binary_sha256' "$NDJSON" >/dev/null
-    jq -e 'select(.kind == "session_started") | select(.session_authority == "canonical_bridge")' "$NDJSON" >/dev/null
+    jq -e --arg a "$EXPECT_AUTHORITY" 'select(.kind == "session_started") | select(.session_authority == $a)' "$NDJSON" >/dev/null
     jq -e 'select(.kind == "session_ended") | select(.exit_code == 0)' "$NDJSON" >/dev/null
 fi
 

--- a/scripts/smoke-codex-acceptance.sh
+++ b/scripts/smoke-codex-acceptance.sh
@@ -135,7 +135,10 @@ echo "smoke-codex-acceptance: stub upstream pid=$UPSTREAM_PID port=$UPSTREAM_POR
 
 # 3. Run oauth-mux codex run
 echo "smoke-codex-acceptance: running adapter..."
-OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+# This smoke exercises legacy canonical-bridge proxy/quota wiring. TIN-1851's
+# default home-is-store mode is covered by smoke-codex-cli-ux.
+TINYLAND_CODEX_MUX_MODE=shared_canonical \
+  OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_STATE_DIR="$STATE_DIR" \
   OMUX_UPSTREAM_HOST="127.0.0.1:$UPSTREAM_PORT" \
   OMUX_UPSTREAM_SCHEME="http" \

--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -180,6 +180,47 @@ assert_durable_bridge_homes_scrubbed() {
     echo "  ✓ $label scrubbed durable auth/config material while preserving bridge homes"
 }
 
+echo "smoke-codex-cli-ux: default mux mode is home-is-store"
+DEFAULT_HOME_NDJSON="$TMP/default-home/status.ndjson"
+DEFAULT_HOME_STDERR="$TMP/default-home.stderr"
+DEFAULT_HOME_REPORT="$TMP/default-home.report"
+mkdir -p "$(dirname "$DEFAULT_HOME_NDJSON")"
+env -u TINYLAND_CODEX_MUX_MODE \
+  OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+  OMUX_STATE_DIR="$STATE_DIR" \
+  OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+  CODEX_HOME="$CANONICAL_SESSION_HOME" \
+  CODEX_SQLITE_HOME="$CANONICAL_SESSION_HOME" \
+  OMUX_CODEX_SESSION_HOME="$CANONICAL_SESSION_HOME" \
+  OMUX_CODEX_CONFIG_HOME="$CANONICAL_SESSION_HOME" \
+  OMUX_STUB_CODEX_TURNS=0 \
+  OMUX_STUB_CODEX_REPORT="$DEFAULT_HOME_REPORT" \
+  "$BIN" codex --profile codex-max --json-status-file "$DEFAULT_HOME_NDJSON" -- exec --skip-git-repo-check "default-home-is-store" 2>"$DEFAULT_HOME_STDERR"
+assert_grep "default home-is-store session authority" '"kind":"session_started".*"session_authority":"isolated"' "$DEFAULT_HOME_NDJSON"
+assert_grep "default home-is-store sqlite authority" '"kind":"session_started".*"sqlite_authority":"isolated_overlay"' "$DEFAULT_HOME_NDJSON"
+assert_grep "default home-is-store cleanup" '"kind":"session_started".*"session_home_cleanup":"persist_scrub_config"' "$DEFAULT_HOME_NDJSON"
+assert_grep "default home-is-store session ends" '"kind":"session_ended".*"exit_code":0' "$DEFAULT_HOME_NDJSON"
+if [[ "$(jq -r .sqlite_env.codex_sqlite_home_env_set "$DEFAULT_HOME_REPORT")" == "false" \
+      && "$(jq -r .sqlite_env.path_printed "$DEFAULT_HOME_REPORT")" == "false" ]]; then
+    echo "  ✓ default home-is-store scrubbed inherited CODEX_SQLITE_HOME"
+else
+    echo "  ✗ default home-is-store leaked CODEX_SQLITE_HOME" >&2
+    cat "$DEFAULT_HOME_REPORT" >&2
+    exit 1
+fi
+if [[ -d "$CANONICAL_SESSION_HOME/.oauth-mux/managed-codex-homes" ]]; then
+    echo "  ✗ default home-is-store wrote a canonical managed bridge" >&2
+    find "$CANONICAL_SESSION_HOME/.oauth-mux" -maxdepth 3 -print >&2
+    exit 1
+else
+    echo "  ✓ default home-is-store did not create a canonical managed bridge"
+fi
+
+# The resume/chooser assertions below intentionally exercise the legacy
+# canonical bridge. TIN-1851 makes home-is-store the default, so this block must
+# opt into the bridge instead of relying on ambient defaults.
+export TINYLAND_CODEX_MUX_MODE=shared_canonical
+
 run_case() {
     local mode=$1 label=$2 expected_argv=$3
     shift 3

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -37,6 +37,7 @@ const health_mod = @import("../../health.zig");
 const identity_hash = @import("../../identity_hash.zig");
 const paths = @import("../../paths.zig");
 const pipeline = @import("../../pipeline.zig");
+const repair_state = @import("../../repair_state.zig");
 const runtime_mod = @import("../../runtime.zig");
 const shell = @import("../../shell.zig");
 const trace = @import("../../trace.zig");
@@ -1352,6 +1353,47 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     };
     defer allocator.free(source_auth_path);
     try launch_timer.mark(status_writer, emit_status, "auth_refresh_preflight");
+
+    // TIN-1851: serialize this muxxed session against (a) a concurrent refresh of
+    // the SAME account — the warm-scheduler/proxy-materializer take the same
+    // per-account repair lock, and (b) another live session of the SAME UPSTREAM
+    // IDENTITY — two oauth-mux slots backed by one account share one rotating
+    // refresh chain, so running both would self-revoke it. Lock order: per-account
+    // repair lock first (it also guards the first-launch home/auth migration),
+    // then the identity lock keyed on sha256_12hex(tokens.account_id). The
+    // per-account lock is re-entrant within this process (the in-process proxy
+    // refresh re-acquires it) via the repair-lock re-entrancy guard. Both held
+    // across spawn → wait → finalize and released by defer.
+    const session_account_only = elected.id[std.mem.indexOfScalar(u8, elected.id, ':').? + 1 ..];
+    var session_repair_lock = repair_state.acquireRepairLockBlocking(allocator, "codex", session_account_only) catch |e| {
+        try stderr.print("oauth-mux codex: could not acquire account lock for {s}: {s}\n", .{ session_account_only, @errorName(e) });
+        try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "session_authority_locked", "account_lock", @errorName(e), session_started_emitted);
+        return RunError.SessionAuthorityLocked;
+    };
+    defer session_repair_lock.release();
+
+    const session_identity_hash = try codexIdentityHashForAuthFile(allocator, source_auth_path);
+    defer if (session_identity_hash) |h| allocator.free(h);
+    var session_identity_lock: ?repair_state.RepairLock = null;
+    defer if (session_identity_lock) |*l| l.release();
+    if (session_identity_hash) |h| {
+        session_identity_lock = repair_state.acquireRepairLock(allocator, "codex-identity", h) catch |e| switch (e) {
+            error.RepairInProgress => {
+                try stderr.print(
+                    "oauth-mux codex: account {s} shares its upstream identity with another live muxxed session; refusing to run concurrently (would self-revoke the shared refresh chain)\n",
+                    .{session_account_only},
+                );
+                try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "duplicate_upstream_identity", "identity_lock", "DuplicateUpstreamIdentity", session_started_emitted);
+                return RunError.SessionAuthorityLocked;
+            },
+            else => {
+                try stderr.print("oauth-mux codex: identity lock error: {s}\n", .{@errorName(e)});
+                try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "session_authority_locked", "identity_lock", @errorName(e), session_started_emitted);
+                return RunError.SessionAuthorityLocked;
+            },
+        };
+    }
+    try launch_timer.mark(status_writer, emit_status, "session_locks");
 
     // 4. Bind the wire-layer reverse proxy. The adapter stays alive
     // as the broker/proxy owner while the codex child runs with

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -34,6 +34,7 @@ const broker_loader = @import("../../broker_loader.zig");
 const cli = @import("../../cli.zig");
 const config_mod = @import("../../config.zig");
 const health_mod = @import("../../health.zig");
+const identity_hash = @import("../../identity_hash.zig");
 const paths = @import("../../paths.zig");
 const pipeline = @import("../../pipeline.zig");
 const runtime_mod = @import("../../runtime.zig");
@@ -551,6 +552,64 @@ fn expandTilde(allocator: std.mem.Allocator, p: []const u8) ![]u8 {
     const home = try std.process.getEnvVarOwned(allocator, "HOME");
     defer allocator.free(home);
     return try std.fmt.allocPrint(allocator, "{s}{s}", .{ home, p[1..] });
+}
+
+/// Extract the upstream Codex account id (`tokens.account_id`) from an auth.json's
+/// bytes — the same source the account inventory hashes — so the muxxing identity
+/// guard (TIN-1851) keys on the SAME identity. Returns null when absent/malformed
+/// (e.g. an api-key auth.json with no account_id). Caller owns the result.
+fn codexAccountIdFromAuthBytes(allocator: std.mem.Allocator, bytes: []const u8) !?[]u8 {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, bytes, .{}) catch return null;
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+    const tokens = parsed.value.object.get("tokens") orelse return null;
+    if (tokens != .object) return null;
+    const acct = tokens.object.get("account_id") orelse return null;
+    if (acct != .string or acct.string.len == 0) return null;
+    return try allocator.dupe(u8, acct.string);
+}
+
+/// Resolve the upstream-identity hash (sha256_12hex of `tokens.account_id`) for an
+/// account's auth.json file. Returns null when the file is absent/unparseable or
+/// carries no account_id — the caller must then refuse the muxxed launch with a
+/// diagnostic rather than key the duplicate-identity guard on a missing id.
+fn codexIdentityHashForAuthFile(allocator: std.mem.Allocator, auth_path: []const u8) !?[]u8 {
+    const bytes = readFileAbsoluteOrCwd(allocator, auth_path, 1 << 20) catch |e| switch (e) {
+        error.FileNotFound => return null,
+        else => return e,
+    };
+    defer allocator.free(bytes);
+    const account_id = (try codexAccountIdFromAuthBytes(allocator, bytes)) orelse return null;
+    defer allocator.free(account_id);
+    return try identity_hash.sha256_12hex(allocator, account_id);
+}
+
+fn readFileAbsoluteOrCwd(allocator: std.mem.Allocator, path: []const u8, max: usize) ![]u8 {
+    if (std.fs.path.isAbsolute(path)) {
+        const file = try std.fs.openFileAbsolute(path, .{});
+        defer file.close();
+        return try file.readToEndAlloc(allocator, max);
+    }
+    return std.fs.cwd().readFileAlloc(allocator, path, max);
+}
+
+test "codexAccountIdFromAuthBytes extracts tokens.account_id and hashes to the inventory key" {
+    const a = std.testing.allocator;
+    const id = (try codexAccountIdFromAuthBytes(a,
+        "{\"tokens\":{\"account_id\":\"acct-test\",\"access_token\":\"x\"}}")).?;
+    defer a.free(id);
+    try std.testing.expectEqualStrings("acct-test", id);
+    const h = try identity_hash.sha256_12hex(a, id);
+    defer a.free(h);
+    try std.testing.expectEqualStrings("660d25a9d7ee", h); // same key the inventory shows
+}
+
+test "codexAccountIdFromAuthBytes returns null on absent/empty/malformed account_id" {
+    const a = std.testing.allocator;
+    try std.testing.expect((try codexAccountIdFromAuthBytes(a, "{\"tokens\":{\"access_token\":\"x\"}}")) == null);
+    try std.testing.expect((try codexAccountIdFromAuthBytes(a, "{}")) == null);
+    try std.testing.expect((try codexAccountIdFromAuthBytes(a, "not json")) == null);
+    try std.testing.expect((try codexAccountIdFromAuthBytes(a, "{\"tokens\":{\"account_id\":\"\"}}")) == null);
 }
 
 fn getEnvOwnedOrDefault(

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -54,6 +54,11 @@ pub const RunOptions = struct {
     /// If true, do not bridge canonical sessions/history into the
     /// managed CODEX_HOME overlay.
     isolated_session_store: bool = false,
+    /// TIN-1851 session storage model, explicit override only. null means
+    /// "resolve from TINYLAND_CODEX_MUX_MODE, else default isolated_persistent"
+    /// (home-is-store, per-account durable home). shared_canonical opts back
+    /// into the legacy canonical-bridge overlay. Resolved by resolveMuxMode().
+    mux_mode: ?MuxMode = null,
     /// If true, emit NDJSON status frames to stderr.
     json_status: bool = false,
     /// Optional file path for NDJSON status frames. When set, status
@@ -99,14 +104,61 @@ const CodexSqliteAuthorityMode = enum {
     }
 };
 
+/// TIN-1851: how a muxxed session resolves its CODEX_HOME.
+///   - isolated_persistent (default): home-is-store. CODEX_HOME is the account's
+///     own dedicated persistent home (config_dir); codex reads/writes auth.json,
+///     state_5.sqlite and sessions/ there directly. No canonical bridge, no temp
+///     overlay, no auth copy — structurally cannot poison the canonical ~/.codex.
+///   - shared_canonical (opt-in, TINYLAND_CODEX_MUX_MODE=shared_canonical): the
+///     legacy canonical-bridge overlay (CODEX_SQLITE_HOME=canonical). Kept only as
+///     an explicit escape hatch; do NOT make it the default (it caused the 3-week
+///     ~/.codex poisoning — see docs and the codex-muxxing temp-home poisoning notes).
+pub const MuxMode = enum {
+    isolated_persistent,
+    shared_canonical,
+
+    fn toString(self: MuxMode) []const u8 {
+        return switch (self) {
+            .isolated_persistent => "isolated_persistent",
+            .shared_canonical => "shared_canonical",
+        };
+    }
+};
+
+/// Resolve the effective mux mode: an explicit CLI override wins, otherwise
+/// TINYLAND_CODEX_MUX_MODE=shared_canonical opts into the legacy bridge, else
+/// the safe default (isolated_persistent / home-is-store).
+fn resolveMuxMode(allocator: std.mem.Allocator, override: ?MuxMode) MuxMode {
+    if (override) |m| return m;
+    const env = std.process.getEnvVarOwned(allocator, "TINYLAND_CODEX_MUX_MODE") catch return .isolated_persistent;
+    defer allocator.free(env);
+    if (std.mem.eql(u8, env, "shared_canonical")) return .shared_canonical;
+    return .isolated_persistent;
+}
+
+test "resolveMuxMode honors explicit override over env/default" {
+    try std.testing.expectEqual(MuxMode.shared_canonical, resolveMuxMode(std.testing.allocator, .shared_canonical));
+    try std.testing.expectEqual(MuxMode.isolated_persistent, resolveMuxMode(std.testing.allocator, .isolated_persistent));
+}
+
+test "resolveMuxMode defaults to isolated_persistent when unset" {
+    // The test environment does not set TINYLAND_CODEX_MUX_MODE.
+    try std.testing.expectEqual(MuxMode.isolated_persistent, resolveMuxMode(std.testing.allocator, null));
+}
+
 const CodexHomeCleanupMode = enum {
     delete_tree,
     scrub_durable_bridge,
+    /// home-is-store: the home is a durable per-account store — keep auth.json,
+    /// sessions/ and state_5.sqlite, but delete the per-session managed config.toml
+    /// (its proxy port is dead after exit) and the auth shadow backup on clean exit.
+    persist_scrub_config,
 
     fn toString(self: CodexHomeCleanupMode) []const u8 {
         return switch (self) {
             .delete_tree => "delete_tree",
             .scrub_durable_bridge => "scrub_durable_bridge",
+            .persist_scrub_config => "persist_scrub_config",
         };
     }
 };
@@ -130,6 +182,7 @@ const SessionCodexHome = struct {
         switch (self.cleanup_mode) {
             .delete_tree => std.fs.cwd().deleteTree(self.path) catch {},
             .scrub_durable_bridge => scrubDurableCodexHome(allocator, self.path),
+            .persist_scrub_config => scrubPersistentCodexHomeConfig(allocator, self.path),
         }
         allocator.free(self.path);
         if (self.authority_home) |home| allocator.free(home);
@@ -1418,19 +1471,34 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     const managed_frame_id = try std.fmt.allocPrint(allocator, "omux-codex-{d}-{d}", .{ std.time.milliTimestamp(), proxy_port });
     defer allocator.free(managed_frame_id);
 
-    // 5. Create a per-session CODEX_HOME overlay containing copied
-    // auth material, generated proxy config, and canonical session
-    // authority references unless isolation was explicitly requested.
-    // This prevents concurrent adapter sessions from clobbering
-    // auth/config while keeping resume/history behavior aligned with
-    // bare Codex.
-    const codex_home = try makeSessionCodexHome(
+    // 5. Resolve the session CODEX_HOME. The default (isolated_persistent) is
+    // home-is-store: the account's own durable home is used directly with an
+    // isolated sqlite, so no canonical ~/.codex state is ever written. The
+    // shared_canonical mode (or --session-home) opts back into the legacy
+    // canonical-bridge overlay; --isolated-session-store forces an ephemeral
+    // isolated overlay. The session locks above already serialize this against a
+    // concurrent refresh / duplicate-identity session.
+    const effective_mux_mode = resolveMuxMode(allocator, opts.mux_mode);
+    const codex_home = makeSessionCodexHome(
         allocator,
         source_auth_path,
         proxy_port,
         opts.session_home,
         opts.isolated_session_store,
-    );
+        effective_mux_mode,
+    ) catch |e| switch (e) {
+        error.CanonicalCodexHomeRefused => {
+            try stderr.writeAll("oauth-mux codex: refusing to mux a session whose CODEX_HOME overlaps the canonical ~/.codex; the account needs a dedicated config_dir/secret.path under ~/.local/share/oauth-mux/codex/\n");
+            try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "canonical_codex_home_refused", "codex_home_setup", "CanonicalCodexHomeRefused", session_started_emitted);
+            return RunError.NoCodexHome;
+        },
+        error.UnauthenticatedCodexHome => {
+            try stderr.writeAll("oauth-mux codex: the account's managed home has no usable auth.json (and no recoverable shadow backup); run `CODEX_HOME=<home> codex login` to stage it\n");
+            try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "unauthenticated_codex_home", "codex_home_setup", "UnauthenticatedCodexHome", session_started_emitted);
+            return RunError.NoCodexHome;
+        },
+        else => return e,
+    };
     var codex_home_deinit_needed = true;
     defer if (codex_home_deinit_needed) codex_home.deinit(allocator);
     traceManagedOverlay(allocator, elected.id, launch_defaults.profile, proxy_port, &codex_home);
@@ -1999,13 +2067,261 @@ fn tickleProxy(port: u16) void {
     sock.close();
 }
 
+/// True when two filesystem paths are equal or one contains the other
+/// (separator-aware, trailing slashes ignored).
+fn codexHomePathsOverlap(a_in: []const u8, b_in: []const u8) bool {
+    const a = std.mem.trimRight(u8, a_in, "/");
+    const b = std.mem.trimRight(u8, b_in, "/");
+    if (a.len == 0 or b.len == 0) return false;
+    if (std.mem.eql(u8, a, b)) return true;
+    if (a.len > b.len and std.mem.startsWith(u8, a, b) and a[b.len] == '/') return true;
+    if (b.len > a.len and std.mem.startsWith(u8, b, a) and b[a.len] == '/') return true;
+    return false;
+}
+
+test "codexHomePathsOverlap detects equality and containment" {
+    try std.testing.expect(codexHomePathsOverlap("/home/u/.codex", "/home/u/.codex"));
+    try std.testing.expect(codexHomePathsOverlap("/home/u/.codex/", "/home/u/.codex"));
+    try std.testing.expect(codexHomePathsOverlap("/home/u/.codex/sessions", "/home/u/.codex"));
+    try std.testing.expect(codexHomePathsOverlap("/home/u/.codex", "/home/u/.codex/sessions"));
+    try std.testing.expect(!codexHomePathsOverlap("/home/u/.local/share/oauth-mux/codex/x", "/home/u/.codex"));
+    try std.testing.expect(!codexHomePathsOverlap("/home/u/.codex-backup", "/home/u/.codex"));
+}
+
+/// Best-effort symlink-resolved absolute path. realpath the path, or if it does
+/// not exist yet realpath its parent and re-join the final component. null when
+/// even the parent cannot be resolved. Caller owns the result.
+fn realpathLongestExisting(allocator: std.mem.Allocator, path: []const u8) !?[]u8 {
+    if (std.fs.realpathAlloc(allocator, path)) |rp| {
+        return rp;
+    } else |_| {}
+    const dir = std.fs.path.dirname(path) orelse return null;
+    const tail = path[dir.len..]; // includes the leading separator
+    if (std.fs.realpathAlloc(allocator, dir)) |rp| {
+        defer allocator.free(rp);
+        return try std.fmt.allocPrint(allocator, "{s}{s}", .{ rp, tail });
+    } else |_| {}
+    return null;
+}
+
+/// Fatal guard (TIN-1851): refuse a muxxed home that is, contains, or is contained
+/// by the user's real ~/.codex. Without it a misconfigured account (secret.path or
+/// config_dir under ~/.codex) would write the managed proxy config + session state
+/// INTO the canonical store — the exact poisoning class this fix removes.
+fn ensureNotCanonicalCodexHome(allocator: std.mem.Allocator, home: []const u8) !void {
+    const canonical = (try defaultCodexHome(allocator)) orelse return;
+    defer allocator.free(canonical);
+
+    // Lexical guard (paths need not exist yet).
+    if (codexHomePathsOverlap(home, canonical)) return error.CanonicalCodexHomeRefused;
+
+    // Symlink-resolved guard (covers a home or ~/.codex that points elsewhere).
+    const home_real = (try realpathLongestExisting(allocator, home)) orelse return;
+    defer allocator.free(home_real);
+    const canonical_real = (try realpathLongestExisting(allocator, canonical)) orelse return;
+    defer allocator.free(canonical_real);
+    if (codexHomePathsOverlap(home_real, canonical_real)) return error.CanonicalCodexHomeRefused;
+}
+
+fn authJsonParses(allocator: std.mem.Allocator, path: []const u8) bool {
+    const bytes = readFileAbsoluteOrCwd(allocator, path, 2 * 1024 * 1024) catch return false;
+    defer allocator.free(bytes);
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, bytes, .{}) catch return false;
+    defer parsed.deinit();
+    return parsed.value == .object;
+}
+
+fn writePersistentAuthShadow(allocator: std.mem.Allocator, auth_path: []const u8, bak_path: []const u8) !void {
+    const bytes = try readFileAbsoluteOrCwd(allocator, auth_path, 2 * 1024 * 1024);
+    defer allocator.free(bytes);
+    try writeFileReplaceBytes(allocator, bak_path, bytes);
+}
+
+/// Integrity preflight + crash recovery for the home-is-store auth.json. If the
+/// in-place file is missing/torn (codex killed mid-rewrite), restore the last
+/// known-good shadow backup. Refuse the launch when neither is usable rather than
+/// silently bootstrapping an empty/unauthenticated home.
+fn ensurePersistentAuthUsable(allocator: std.mem.Allocator, auth_path: []const u8, bak_path: []const u8) !void {
+    if (authJsonParses(allocator, auth_path)) return;
+    if (authJsonParses(allocator, bak_path)) {
+        const bytes = try readFileAbsoluteOrCwd(allocator, bak_path, 2 * 1024 * 1024);
+        defer allocator.free(bytes);
+        try writeFileReplaceBytes(allocator, auth_path, bytes);
+        return;
+    }
+    return error.UnauthenticatedCodexHome;
+}
+
+/// TIN-1851 home-is-store: use the account's own dedicated persistent home as
+/// CODEX_HOME. No auth copy, no canonical bridge, isolated sqlite. The home is a
+/// durable store (persist_scrub_config cleanup keeps auth/sessions/sqlite and only
+/// removes the per-session proxy config.toml + auth shadow on clean exit).
+fn createPersistentCodexHome(
+    allocator: std.mem.Allocator,
+    home: []const u8,
+    proxy_port: u16,
+) !SessionCodexHome {
+    try ensureNotCanonicalCodexHome(allocator, home);
+    try std.fs.cwd().makePath(home);
+
+    const home_auth_path = try std.fs.path.join(allocator, &.{ home, "auth.json" });
+    defer allocator.free(home_auth_path);
+    const bak_path = try std.fs.path.join(allocator, &.{ home, "auth.json.omux-bak" });
+    defer allocator.free(bak_path);
+
+    try ensurePersistentAuthUsable(allocator, home_auth_path, bak_path);
+    // Refresh the shadow to the current good auth so a torn mid-session rewrite is
+    // recoverable next launch. Best-effort: a shadow failure is not fatal.
+    writePersistentAuthShadow(allocator, home_auth_path, bak_path) catch {};
+
+    const auth_initial_hash = try hashFileContents(allocator, home_auth_path);
+
+    // Fresh managed config: only the proxy override + experimental defaults. Pass
+    // null for the config source so writeConfigPassthrough never re-reads the home's
+    // own (previously managed) config.toml — no self-read accumulation or stale port.
+    const config_observation = try writeManagedConfigToml(allocator, home, proxy_port, null);
+
+    return .{
+        .path = try allocator.dupe(u8, home),
+        .session_authority = .isolated,
+        .sqlite_authority = .isolated_overlay,
+        .authority_home = null,
+        .config_authority_home = null,
+        .auth_initial_hash = auth_initial_hash,
+        .cleanup_mode = .persist_scrub_config,
+        .config_source_present = config_observation.source_present,
+        .config_passthrough = config_observation.passthrough,
+        .config_overridden_keys = config_observation.overridden_keys,
+        .experimental_feature_defaults_injected = config_observation.experimental_feature_defaults_injected,
+        .mcp_stdio_unsupported_fields_removed = config_observation.mcp_stdio_unsupported_fields_removed,
+        .config_layout = config_observation.layout,
+    };
+}
+
+test "createPersistentCodexHome builds a home-is-store session and scrubs only the config on exit" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(root);
+    const home = try std.fs.path.join(a, &.{ root, "codex-acct" });
+    defer a.free(home);
+    try std.fs.cwd().makePath(home);
+    const auth_path = try std.fs.path.join(a, &.{ home, "auth.json" });
+    defer a.free(auth_path);
+    try writeFileReplaceBytes(a, auth_path, "{\"tokens\":{\"account_id\":\"acct-test\"}}");
+
+    var session = try createPersistentCodexHome(a, home, 45321);
+
+    // home-is-store: the durable home is used directly, isolated sqlite, no bridge.
+    try std.testing.expectEqualStrings(home, session.path);
+    try std.testing.expectEqual(SessionAuthorityMode.isolated, session.session_authority);
+    try std.testing.expectEqual(CodexSqliteAuthorityMode.isolated_overlay, session.sqlite_authority);
+    try std.testing.expectEqual(CodexHomeCleanupMode.persist_scrub_config, session.cleanup_mode);
+    try std.testing.expect(session.authority_home == null);
+
+    // Fresh managed config carries the session proxy port; shadow backup is staged.
+    const cfg_path = try std.fs.path.join(a, &.{ home, "config.toml" });
+    defer a.free(cfg_path);
+    const cfg_bytes = try std.fs.cwd().readFileAlloc(a, cfg_path, 1 << 20);
+    defer a.free(cfg_bytes);
+    try std.testing.expect(std.mem.indexOf(u8, cfg_bytes, "127.0.0.1:45321") != null);
+    const bak_path = try std.fs.path.join(a, &.{ home, "auth.json.omux-bak" });
+    defer a.free(bak_path);
+    try std.testing.expect(authJsonParses(a, bak_path));
+
+    // Clean exit scrubs the per-session config + shadow but keeps the durable store.
+    session.deinit(a);
+    try std.testing.expect(!pathExistsAbsolute(cfg_path));
+    try std.testing.expect(!pathExistsAbsolute(bak_path));
+    try std.testing.expect(pathExistsAbsolute(auth_path)); // the store survives
+}
+
+test "ensureNotCanonicalCodexHome refuses ~/.codex and its subtree, accepts a dedicated home" {
+    const a = std.testing.allocator;
+    const canonical = (try defaultCodexHome(a)) orelse return; // no HOME → skip
+    defer a.free(canonical);
+
+    try std.testing.expectError(error.CanonicalCodexHomeRefused, ensureNotCanonicalCodexHome(a, canonical));
+
+    const child = try std.fs.path.join(a, &.{ canonical, "sessions" });
+    defer a.free(child);
+    try std.testing.expectError(error.CanonicalCodexHomeRefused, ensureNotCanonicalCodexHome(a, child));
+
+    const home = std.process.getEnvVarOwned(a, "HOME") catch return;
+    defer a.free(home);
+    const dedicated = try std.fs.path.join(a, &.{ home, ".local", "share", "oauth-mux", "codex", "x" });
+    defer a.free(dedicated);
+    try ensureNotCanonicalCodexHome(a, dedicated); // dedicated oauth-mux home is allowed
+}
+
+test "ensurePersistentAuthUsable restores a torn auth.json from the shadow, else refuses" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(root);
+    const auth = try std.fs.path.join(a, &.{ root, "auth.json" });
+    defer a.free(auth);
+    const bak = try std.fs.path.join(a, &.{ root, "auth.json.omux-bak" });
+    defer a.free(bak);
+
+    // Torn in-place auth + good shadow → restored.
+    try writeFileReplaceBytes(a, auth, "{ this is not json");
+    try writeFileReplaceBytes(a, bak, "{\"tokens\":{\"account_id\":\"acct-test\"}}");
+    try ensurePersistentAuthUsable(a, auth, bak);
+    try std.testing.expect(authJsonParses(a, auth));
+
+    // Both unusable → refuse rather than bootstrap an empty home.
+    try writeFileReplaceBytes(a, auth, "broken");
+    try writeFileReplaceBytes(a, bak, "also broken");
+    try std.testing.expectError(error.UnauthenticatedCodexHome, ensurePersistentAuthUsable(a, auth, bak));
+}
+
+test "makeSessionCodexHome isolated_persistent dispatches to home-is-store at dirname(auth)" {
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(a, ".");
+    defer a.free(root);
+    const home = try std.fs.path.join(a, &.{ root, "acct" });
+    defer a.free(home);
+    try std.fs.cwd().makePath(home);
+    const auth = try std.fs.path.join(a, &.{ home, "auth.json" });
+    defer a.free(auth);
+    try writeFileReplaceBytes(a, auth, "{\"tokens\":{\"account_id\":\"acct-test\"}}");
+
+    var session = try makeSessionCodexHome(a, auth, 5000, null, false, .isolated_persistent);
+    defer session.deinit(a);
+    try std.testing.expectEqual(CodexHomeCleanupMode.persist_scrub_config, session.cleanup_mode);
+    try std.testing.expectEqualStrings(home, session.path);
+}
+
 fn makeSessionCodexHome(
     allocator: std.mem.Allocator,
     source_auth_path: []const u8,
     proxy_port: u16,
     session_home_override: ?[]const u8,
     isolated_session_store: bool,
+    mux_mode: MuxMode,
 ) !SessionCodexHome {
+    // TIN-1851: home-is-store is the default. The account's own dedicated
+    // persistent home (the directory that holds its auth.json) IS the CODEX_HOME
+    // — codex reads/writes auth.json, state_5.sqlite and sessions/ there directly,
+    // so nothing can be recorded into the canonical ~/.codex. Deriving the home
+    // from dirname(source_auth_path) guarantees home/auth.json == the exact file
+    // the refresh/identity locks key on. Skipped when the legacy canonical bridge
+    // is requested (shared_canonical / --session-home) or ephemeral isolation is
+    // forced (--isolated-session-store), or when the secret is not a $HOME/auth.json
+    // (codex only ever reads $CODEX_HOME/auth.json).
+    if (mux_mode == .isolated_persistent and !isolated_session_store and session_home_override == null) {
+        if (std.fs.path.dirname(source_auth_path)) |home| {
+            if (std.mem.eql(u8, std.fs.path.basename(source_auth_path), "auth.json")) {
+                return try createPersistentCodexHome(allocator, home, proxy_port);
+            }
+        }
+    }
+
     const session_authority_home = try resolveCodexSessionAuthorityHome(allocator, session_home_override, isolated_session_store);
     defer if (session_authority_home) |path| allocator.free(path);
     const config_authority_home = try resolveCodexConfigAuthorityHome(allocator);
@@ -2820,11 +3136,34 @@ fn deleteFileIfPresent(path: []const u8) void {
     }
 }
 
+fn pathExistsAbsolute(path: []const u8) bool {
+    std.fs.accessAbsolute(path, .{}) catch return false;
+    return true;
+}
+
 fn scrubDurableCodexHome(allocator: std.mem.Allocator, session_home: []const u8) void {
     const scrub_files = [_][]const u8{
         "auth.json",
         "installation_id",
         "config.toml",
+    };
+    for (scrub_files) |name| {
+        const path = std.fs.path.join(allocator, &.{ session_home, name }) catch continue;
+        defer allocator.free(path);
+        deleteFileIfPresent(path);
+    }
+}
+
+/// home-is-store cleanup (TIN-1851 isolated_persistent). The home is the account's
+/// DURABLE store, so keep auth.json, sessions/ and state_5.sqlite. Only remove the
+/// per-session managed config.toml — its baked-in proxy port is dead after exit, and
+/// leaving it would (a) route a later bare-codex run at a closed socket and (b) make
+/// isManagedCodexOverlayHome misclassify the home — and the auth shadow backup, which
+/// is only needed to recover a torn in-place write across a crash.
+fn scrubPersistentCodexHomeConfig(allocator: std.mem.Allocator, session_home: []const u8) void {
+    const scrub_files = [_][]const u8{
+        "config.toml",
+        "auth.json.omux-bak",
     };
     for (scrub_files) |name| {
         const path = std.fs.path.join(allocator, &.{ session_home, name }) catch continue;

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -1497,6 +1497,16 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
             try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "unauthenticated_codex_home", "codex_home_setup", "UnauthenticatedCodexHome", session_started_emitted);
             return RunError.NoCodexHome;
         },
+        error.CanonicalCodexHomeGuardUncheckable => {
+            try stderr.writeAll("oauth-mux codex: cannot verify CODEX_HOME does not overlap ~/.codex (HOME unset); refusing rather than risk poisoning the canonical store\n");
+            try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "canonical_guard_uncheckable", "codex_home_setup", "CanonicalCodexHomeGuardUncheckable", session_started_emitted);
+            return RunError.NoCodexHome;
+        },
+        error.UnsafePersistentAuthPath => {
+            try stderr.writeAll("oauth-mux codex: account secret.path is not a safe absolute .../auth.json; refusing to mux (fix the account's config_dir/secret.path)\n");
+            try writeManagedPreSpawnAbortStatus(status_writer, emit_status, "unsafe_persistent_auth_path", "codex_home_setup", "UnsafePersistentAuthPath", session_started_emitted);
+            return RunError.NoCodexHome;
+        },
         else => return e,
     };
     var codex_home_deinit_needed = true;
@@ -2109,7 +2119,9 @@ fn realpathLongestExisting(allocator: std.mem.Allocator, path: []const u8) !?[]u
 /// config_dir under ~/.codex) would write the managed proxy config + session state
 /// INTO the canonical store — the exact poisoning class this fix removes.
 fn ensureNotCanonicalCodexHome(allocator: std.mem.Allocator, home: []const u8) !void {
-    const canonical = (try defaultCodexHome(allocator)) orelse return;
+    // If we cannot determine the canonical home (HOME unset), we cannot prove the
+    // muxxed home does NOT overlap it — refuse rather than silently pass the guard.
+    const canonical = (try defaultCodexHome(allocator)) orelse return error.CanonicalCodexHomeGuardUncheckable;
     defer allocator.free(canonical);
 
     // Lexical guard (paths need not exist yet).
@@ -2152,6 +2164,18 @@ fn ensurePersistentAuthUsable(allocator: std.mem.Allocator, auth_path: []const u
     return error.UnauthenticatedCodexHome;
 }
 
+/// Reject a persistent home that is not a safe absolute directory. A relative path
+/// (e.g. a misconfigured secret.path of "auth.json") or the filesystem root ("/")
+/// must never become a managed CODEX_HOME: both escape the canonical-overlap guard
+/// (which only reasons about real absolute paths — "/" trims to empty and matches
+/// nothing) and could write managed state into an unintended location.
+fn validatePersistentCodexHome(home: []const u8) !void {
+    if (!std.fs.path.isAbsolute(home)) return error.UnsafePersistentAuthPath;
+    const trimmed = std.mem.trimRight(u8, home, "/");
+    // "/" (and "" after trim) leave no account-specific component — refuse.
+    if (trimmed.len == 0) return error.UnsafePersistentAuthPath;
+}
+
 /// TIN-1851 home-is-store: use the account's own dedicated persistent home as
 /// CODEX_HOME. No auth copy, no canonical bridge, isolated sqlite. The home is a
 /// durable store (persist_scrub_config cleanup keeps auth/sessions/sqlite and only
@@ -2161,6 +2185,7 @@ fn createPersistentCodexHome(
     home: []const u8,
     proxy_port: u16,
 ) !SessionCodexHome {
+    try validatePersistentCodexHome(home);
     try ensureNotCanonicalCodexHome(allocator, home);
     try std.fs.cwd().makePath(home);
 
@@ -2297,6 +2322,22 @@ test "makeSessionCodexHome isolated_persistent dispatches to home-is-store at di
     try std.testing.expectEqualStrings(home, session.path);
 }
 
+test "validatePersistentCodexHome rejects relative paths and the filesystem root" {
+    try std.testing.expectError(error.UnsafePersistentAuthPath, validatePersistentCodexHome("relative/home"));
+    try std.testing.expectError(error.UnsafePersistentAuthPath, validatePersistentCodexHome("/"));
+    try std.testing.expectError(error.UnsafePersistentAuthPath, validatePersistentCodexHome("///"));
+    try validatePersistentCodexHome("/Users/x/.local/share/oauth-mux/codex/acct");
+}
+
+test "makeSessionCodexHome refuses an unsafe (relative or root) auth path instead of bridging" {
+    const a = std.testing.allocator;
+    // Relative secret.path -> refuse at the dispatch; never silently bridge to canonical.
+    try std.testing.expectError(error.UnsafePersistentAuthPath, makeSessionCodexHome(a, "auth.json", 5000, null, false, .isolated_persistent));
+    // Root-level "/auth.json" -> dispatch passes (absolute + auth.json), then
+    // createPersistentCodexHome's validate rejects the "/" home before any fs write.
+    try std.testing.expectError(error.UnsafePersistentAuthPath, makeSessionCodexHome(a, "/auth.json", 5000, null, false, .isolated_persistent));
+}
+
 fn makeSessionCodexHome(
     allocator: std.mem.Allocator,
     source_auth_path: []const u8,
@@ -2315,11 +2356,17 @@ fn makeSessionCodexHome(
     // forced (--isolated-session-store), or when the secret is not a $HOME/auth.json
     // (codex only ever reads $CODEX_HOME/auth.json).
     if (mux_mode == .isolated_persistent and !isolated_session_store and session_home_override == null) {
-        if (std.fs.path.dirname(source_auth_path)) |home| {
-            if (std.mem.eql(u8, std.fs.path.basename(source_auth_path), "auth.json")) {
-                return try createPersistentCodexHome(allocator, home, proxy_port);
-            }
+        // Home-is-store requires a well-formed ABSOLUTE .../auth.json source so that
+        // home/auth.json == the exact file the refresh/identity locks key on. A
+        // relative or non-auth.json secret is a misconfiguration: refuse, rather
+        // than silently falling through to the canonical-bridge poisoning path.
+        if (!std.fs.path.isAbsolute(source_auth_path) or
+            !std.mem.eql(u8, std.fs.path.basename(source_auth_path), "auth.json"))
+        {
+            return error.UnsafePersistentAuthPath;
         }
+        const home = std.fs.path.dirname(source_auth_path).?; // absolute + has basename ⇒ has dirname
+        return try createPersistentCodexHome(allocator, home, proxy_port);
     }
 
     const session_authority_home = try resolveCodexSessionAuthorityHome(allocator, session_home_override, isolated_session_store);

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -48,12 +48,17 @@ pub const Command = union(enum) {
         capability: ?[]const u8 = null,
     };
 
+    /// TIN-1851 mux storage model, parsed from --mux-mode. null = not set on the
+    /// CLI (the adapter then resolves TINYLAND_CODEX_MUX_MODE, else the default).
+    pub const CodexMuxMode = enum { isolated_persistent, shared_canonical };
+
     pub const CodexAdapterArgs = struct {
         profile: ?[]const u8 = null,
         capability: ?[]const u8 = null,
         account: ?[]const u8 = null,
         session_home: ?[]const u8 = null,
         isolated_session_store: bool = false,
+        mux_mode: ?CodexMuxMode = null,
         json_status: bool = false,
         json_status_file: ?[]const u8 = null,
         invalid_option: ?[]const u8 = null,
@@ -411,6 +416,17 @@ fn parseCodexAdapter(args: []const []const u8, strict_run: bool) Command {
             result.session_home = args[i];
         } else if (eql(args[i], "--isolated-session-store")) {
             result.isolated_session_store = true;
+        } else if (eql(args[i], "--mux-mode") and i + 1 < args.len) {
+            i += 1;
+            if (eql(args[i], "isolated_persistent")) {
+                result.mux_mode = .isolated_persistent;
+            } else if (eql(args[i], "shared_canonical")) {
+                result.mux_mode = .shared_canonical;
+            } else {
+                result.invalid_option = args[i];
+                result.forward_argv = &.{};
+                break;
+            }
         } else if (eql(args[i], "--json-status")) {
             result.json_status = true;
         } else if (eql(args[i], "--json-status-file") and i + 1 < args.len) {

--- a/src/identity_hash.zig
+++ b/src/identity_hash.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+
+/// Stable, non-secret account-id hash: lowercase hex of the first 6 bytes of
+/// SHA-256 → 12 hex chars ("sha256_12hex"). Shared by the codex account
+/// inventory (src/main.zig) and the muxxing identity guard (the codex adapter,
+/// TIN-1851) so both compute the SAME identity key for an upstream account id.
+/// Golden vector: sha256_12hex("acct-test") == "660d25a9d7ee".
+pub fn sha256_12hex(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
+    var digest: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(value, &digest, .{});
+    const out = try allocator.alloc(u8, 12);
+    _ = std.fmt.bufPrint(out, "{x}", .{std.fmt.fmtSliceHexLower(digest[0..6])}) catch unreachable;
+    return out;
+}
+
+test "sha256_12hex golden vector" {
+    const h = try sha256_12hex(std.testing.allocator, "acct-test");
+    defer std.testing.allocator.free(h);
+    try std.testing.expectEqualStrings("660d25a9d7ee", h);
+}
+
+test "sha256_12hex is stable and distinct per input" {
+    const a = std.testing.allocator;
+    const h1 = try sha256_12hex(a, "account-one");
+    defer a.free(h1);
+    const h2 = try sha256_12hex(a, "account-one");
+    defer a.free(h2);
+    const h3 = try sha256_12hex(a, "account-two");
+    defer a.free(h3);
+    try std.testing.expectEqualStrings(h1, h2);
+    try std.testing.expect(!std.mem.eql(u8, h1, h3));
+    try std.testing.expectEqual(@as(usize, 12), h1.len);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -70,6 +70,10 @@ pub fn main() !void {
                 .account = adapter_args.account,
                 .session_home = adapter_args.session_home,
                 .isolated_session_store = adapter_args.isolated_session_store,
+                .mux_mode = if (adapter_args.mux_mode) |m| switch (m) {
+                    .isolated_persistent => codex_adapter.MuxMode.isolated_persistent,
+                    .shared_canonical => codex_adapter.MuxMode.shared_canonical,
+                } else null,
                 .json_status = adapter_args.json_status,
                 .json_status_file = adapter_args.json_status_file,
                 .forward_argv = adapter_args.forward_argv,

--- a/src/main.zig
+++ b/src/main.zig
@@ -18,6 +18,7 @@ const trace = @import("trace.zig");
 const broker = @import("broker/mod.zig");
 const broker_loader = @import("broker_loader.zig");
 const codex_adapter = @import("adapters/codex/main.zig");
+const identity_hash = @import("identity_hash.zig");
 
 comptime {
     // Pull broker + adapter modules into the test build.
@@ -771,11 +772,9 @@ fn maskEmailHint(allocator: std.mem.Allocator, email: []const u8) ![]u8 {
 }
 
 fn shortSha256HexAlloc(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
-    var digest: [32]u8 = undefined;
-    std.crypto.hash.sha2.Sha256.hash(value, &digest, .{});
-    const out = try allocator.alloc(u8, 12);
-    _ = std.fmt.bufPrint(out, "{x}", .{std.fmt.fmtSliceHexLower(digest[0..6])}) catch unreachable;
-    return out;
+    // Delegates to the shared module so the codex adapter's muxxing identity
+    // guard (TIN-1851) computes the SAME account-id hash as this inventory path.
+    return identity_hash.sha256_12hex(allocator, value);
 }
 
 test "maskEmailHint masks local part and keeps domain for account inventory" {

--- a/src/repair_state.zig
+++ b/src/repair_state.zig
@@ -28,15 +28,48 @@ pub const HandoffKey = struct {
     capability: ?[]const u8 = null,
 };
 
+// ── Process-local re-entrancy guard (TIN-1851) ───────────────────────────────
+// The repair lock is an OS flock (createFileAbsolute .lock=.exclusive), which is
+// per-open-file-description. A SECOND acquire of the same (provider,account) key
+// from the SAME process — e.g. the in-process proxy materializer thread refreshing
+// while the session main thread already holds the account's repair lock — opens a
+// new fd and flock() would block on itself: a self-deadlock. We therefore hold
+// exactly ONE real flock per key per process and refcount re-entrant acquires; a
+// condition variable serializes the first-acquire so two threads never race the
+// real flock for the same key. Cross-process serialization is unchanged: the OS
+// flock still blocks (or returns RepairInProgress) for a different process.
+
+const HeldLock = struct {
+    count: usize,
+    acquiring: bool,
+    file: ?std.fs.File = null,
+    path: ?[]const u8 = null, // held_gpa-owned absolute lockfile path
+};
+
+var held_mutex: std.Thread.Mutex = .{};
+var held_cond: std.Thread.Condition = .{};
+var held_locks: std.StringHashMapUnmanaged(HeldLock) = .{};
+const held_gpa = std.heap.page_allocator; // process-global; mutated only under held_mutex
+
 pub const RepairLock = struct {
     allocator: std.mem.Allocator,
-    path: []const u8,
-    file: std.fs.File,
+    key: []const u8, // caller-allocator-owned sanitized lock name
 
     pub fn release(self: *RepairLock) void {
-        self.file.close();
-        std.fs.deleteFileAbsolute(self.path) catch {};
-        self.allocator.free(self.path);
+        held_mutex.lock();
+        if (held_locks.getPtr(self.key)) |entry| {
+            if (entry.count > 0) entry.count -= 1;
+            if (entry.count == 0) {
+                if (entry.file) |f| f.close();
+                if (entry.path) |p| {
+                    std.fs.deleteFileAbsolute(p) catch {};
+                    held_gpa.free(p);
+                }
+                if (held_locks.fetchRemove(self.key)) |kv| held_gpa.free(kv.key);
+            }
+        }
+        held_mutex.unlock();
+        self.allocator.free(self.key);
     }
 };
 
@@ -375,12 +408,14 @@ pub fn acquireRepairLockBlocking(
     return acquireRepairLockWithMode(allocator, provider, account, false);
 }
 
-fn acquireRepairLockWithMode(
+const RealRepairLock = struct { file: std.fs.File, path: []const u8 };
+
+fn acquireRealRepairLock(
     allocator: std.mem.Allocator,
     provider: []const u8,
     account: []const u8,
     nonblocking: bool,
-) !RepairLock {
+) !RealRepairLock {
     const path = try lockPath(allocator, provider, account);
     errdefer allocator.free(path);
     try ensureParentDir(path);
@@ -406,11 +441,81 @@ fn acquireRepairLockWithMode(
     try std.json.stringify(account, .{}, writer);
     try writer.print(",\"started_at\":{d}}}\n", .{now});
 
-    return .{
-        .allocator = allocator,
-        .path = path,
-        .file = file,
+    return .{ .file = file, .path = path };
+}
+
+fn acquireRepairLockWithMode(
+    allocator: std.mem.Allocator,
+    provider: []const u8,
+    account: []const u8,
+    nonblocking: bool,
+) !RepairLock {
+    const key = try sanitizedLockFileName(allocator, provider, account);
+    errdefer allocator.free(key);
+
+    held_mutex.lock();
+    while (true) {
+        if (held_locks.getPtr(key)) |entry| {
+            if (entry.acquiring) {
+                // Another thread in this process is mid-flock for this key; wait.
+                held_cond.wait(&held_mutex);
+                continue;
+            }
+            // Already held by this process: re-entrant acquire, no new flock.
+            entry.count += 1;
+            held_mutex.unlock();
+            return .{ .allocator = allocator, .key = key };
+        }
+        break;
+    }
+    // Reserve the key as 'acquiring', then take the (possibly blocking) real
+    // flock OUTSIDE the mutex so other threads/keys are not stalled.
+    const reg_key = held_gpa.dupe(u8, key) catch {
+        held_mutex.unlock();
+        return error.OutOfMemory;
     };
+    held_locks.put(held_gpa, reg_key, .{ .count = 1, .acquiring = true }) catch {
+        held_gpa.free(reg_key);
+        held_mutex.unlock();
+        return error.OutOfMemory;
+    };
+    held_mutex.unlock();
+
+    const real = acquireRealRepairLock(allocator, provider, account, nonblocking) catch |e| {
+        held_mutex.lock();
+        if (held_locks.fetchRemove(key)) |kv| held_gpa.free(kv.key);
+        held_cond.broadcast();
+        held_mutex.unlock();
+        return e;
+    };
+
+    const owned_path = held_gpa.dupe(u8, real.path) catch {
+        real.file.close();
+        std.fs.deleteFileAbsolute(real.path) catch {};
+        allocator.free(real.path);
+        held_mutex.lock();
+        if (held_locks.fetchRemove(key)) |kv| held_gpa.free(kv.key);
+        held_cond.broadcast();
+        held_mutex.unlock();
+        return error.OutOfMemory;
+    };
+    allocator.free(real.path);
+
+    held_mutex.lock();
+    if (held_locks.getPtr(key)) |entry| {
+        entry.file = real.file;
+        entry.path = owned_path;
+        entry.acquiring = false;
+    } else {
+        // Should not happen (we own the 'acquiring' reservation), but stay safe.
+        real.file.close();
+        std.fs.deleteFileAbsolute(owned_path) catch {};
+        held_gpa.free(owned_path);
+    }
+    held_cond.broadcast();
+    held_mutex.unlock();
+
+    return .{ .allocator = allocator, .key = key };
 }
 
 pub fn probeRepairLock(
@@ -560,6 +665,24 @@ fn writeTextLines(writer: anytype, lines: []const []const u8) !void {
         try writer.writeAll(line);
         try writer.writeByte('\n');
     }
+}
+
+test "repair lock is re-entrant within a process (TIN-1851 no self-deadlock)" {
+    const a = std.testing.allocator;
+    // First acquire takes the real OS flock.
+    var l1 = try acquireRepairLockBlocking(a, "codex", "tin1851-reentrancy-test");
+    // A second acquire of the SAME key from THIS process must return immediately
+    // (re-entrant) rather than self-deadlock on the per-fd flock.
+    var l2 = try acquireRepairLockBlocking(a, "codex", "tin1851-reentrancy-test");
+    // A nonblocking acquire from this process is also re-entrant (already serialized
+    // by the held lock), NOT RepairInProgress.
+    var l3 = try acquireRepairLock(a, "codex", "tin1851-reentrancy-test");
+    l3.release();
+    l2.release();
+    l1.release();
+    // Fully released: a fresh acquire succeeds and the registry entry is gone.
+    var l4 = try acquireRepairLockBlocking(a, "codex", "tin1851-reentrancy-test");
+    l4.release();
 }
 
 test "parseStartedAt reads lock metadata timestamp" {


### PR DESCRIPTION
## Summary

This PR lands the **structural muxxing fix** for the Codex canonical-store poisoning vector (TIN-1851): moving from a canonical-bridge overlay (which wrote managed state into `~/.codex`, causing 3-week corruption) to **home-is-store**, where each muxxed session uses its dedicated per-account persistent home as `CODEX_HOME` with an isolated sqlite. No auth copy, no canonical bridge, no `$TMPDIR` dependency — structurally cannot poison the canonical store.

**⚠️ CODE LANDS; FEATURE STAYS DISABLED:**  
The implementation is production-ready (unit tests + design writeup), but muxxing remains **opt-in only**. `TINYLAND_CODEX_MUX_SESSIONS` stays unset in the installed build; no default behavior change until **TIN-1852 (live e2e: muxxed exec + resume + concurrent-distinct + 0 new canonical poison rows)** is complete.

## What lands (commits 052aa28..41fafbe)

**2a. Share sha256_12hex via identity_hash module** (`809b580`)  
- Promote the account-id hash (lowercase hex of first 6 SHA-256 bytes) into `src/identity_hash.zig`
- Codex adapter's muxxing identity guard computes the SAME key as the account inventory path
- Golden vector: `sha256_12hex("acct-test") == "660d25a9d7ee"`

**2b. Codex account-id extractor + identity-hash helper** (`2706313`)  
- `codexAccountIdFromAuthBytes()` extracts `tokens.account_id` from auth.json (the muxxing identity source)
- `codexIdentityHashForAuthFile()` resolves the upstream-identity hash for an account
- Returns null for absent/malformed account_id (refuse-with-diagnostic path); unit tests cover extraction, golden-hash parity, null branches

**2c. Per-account + duplicate-identity lock stack in run()** (`a509213`)  
- Session acquires (1) per-account repair lock (`repair_state.acquireRepairLockBlocking("codex", account)`) — the **same** key the warm-scheduler/proxy-materializer refresh takes, so a session and refresh of the same account are mutually exclusive
- Plus (2) nonblocking identity lock (`"codex-identity"`, sha256_12hex(tokens.account_id))
- Collision (another live session of the same upstream account) is **refused** with `duplicate_upstream_identity` abort (not self-revoke)
- Both released by defer across spawn → wait → finalize

**2d. Home-is-store muxxed CODEX_HOME (default isolated_persistent)** (`9544ebc`)  
- Per-account home is used **directly** as `CODEX_HOME` (dirname of auth.json path), no auth copy or canonical bridge
- Introduces `MuxMode` enum (isolated_persistent [default] vs. shared_canonical [legacy, opt-in])
- `resolveMuxMode()` honors CLI override > `TINYLAND_CODEX_MUX_MODE` env > safe default
- Guard set (load-bearing):
  - `ensureNotCanonicalCodexHome`: fatal if CODEX_HOME lexically or symlink-resolved overlaps `~/.codex`
  - Home derived from auth file; basename must be `auth.json`
  - Fresh managed config (no passthrough self-read), deleted on clean exit (`persist_scrub_config`)
  - Per-account + identity session flock (from 2c)
  - Auth integrity preflight + shadow backup (`auth.json.omux-bak`) for crash recovery
- Updates live e2e harness to expect `session_authority="isolated"` (override via `OMUX_LIVE_E2E_EXPECT_AUTHORITY`)
- Adds design writeup (`docs/writeups/2026-06-02-tin1851-home-is-store-muxxing.md`)

**2e. Harden home-is-store guards against 3 review-found bypasses** (`41fafbe`)  
Closes three ways the canonical-overlap guard could be skipped:  
1. HOME unset: `ensureNotCanonicalCodexHome` now returns `error.CanonicalCodexHomeGuardUncheckable` (refuse, don't silently bridge)
2. Unsafe home (relative path or "/" from misconfigured secret.path): new `validatePersistentCodexHome()` (absolute + non-root check) runs first
3. Dispatch fall-through: `makeSessionCodexHome` now refuses with `error.UnsafePersistentAuthPath` instead of silently bridging
- Both new errors map to clean pre-spawn aborts
- Unit tests for `validatePersistentCodexHome` and dispatch refusal

## What is NOT enabled

- `TINYLAND_CODEX_MUX_SESSIONS` remains unset; no muxxing launch in the production build
- The live e2e gate (`scripts/live-codex-mux-e2e.sh`) stays **unpassed** until TIN-1852 delivers a real muxxed `codex exec`, validates resume works, runs concurrent distinct accounts, and confirms **zero new canonical poison rows** in `~/.codex/state_5.sqlite`
- Legacy `shared_canonical` mode (canonical-bridge overlay) stays available via explicit `TINYLAND_CODEX_MUX_MODE=shared_canonical` for escape hatches, but is not the default

## How this prevents poisoning

**The root cause:** the old canonical-bridge overlay wrote `CODEX_SQLITE_HOME=~/.codex`, so `codex` recorded ephemeral rollout paths and session state into the **shared** canonical store. When the overlay or `$TMPDIR` was reaped, those rows dangled for ~3 weeks, corrupting the user's real Codex installation.

**The fix:** home-is-store uses the account's own durable persistent home (`dirname(auth.json)`) directly:
- `CODEX_HOME = ~/.local/share/oauth-mux/codex/max-1/` (or whatever account home is configured)
- No `CODEX_SQLITE_HOME` override; codex writes its own `state_5.sqlite` **in-home**
- The canonical `~/.codex` is **never a write target** — structurally unreachable
- Distinct accounts get fully disjoint stores (product goal: concurrent use of distinct $200 accounts)

## References

- **Design writeup:** `docs/writeups/2026-06-02-tin1851-home-is-store-muxxing.md` (traces the poisoning vector, guard set design, verification plan)
- **SOPS + canonical-bridge poisoning:** see codex-muxxing temp-home poisoning notes; this fix removes the sops class entirely
- **Unit tests:** all increments pass `zig build test`; full build green
- **Live e2e blocker:** TIN-1852 (muxxed exec + resume + concurrent-distinct + zero canonical-poison rows) must pass before any default change

## Testing

- `zig build test` — all increments pass (identity hash, account-id extraction, lock dispatch, home-is-store dispatch, overlap guard, config scrub, crash recovery)
- `scripts/live-codex-mux-e2e.sh` — **unpassed until TIN-1852** (requires real muxxed execution and canonical integrity check)
- Manual verification: the guard set closes all three review-found bypass paths
