### PR TITLE
Truth Codex mux architecture and add remote validation dispatch

### DIFF
--- a/.github/workflows/remote-validate.yml
+++ b/.github/workflows/remote-validate.yml
@@ -1,0 +1,129 @@
+name: Remote Validate
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Validation target to run on the GloriousFlywheel runner"
+        required: true
+        default: "check"
+        type: choice
+        options:
+          - check
+          - test
+          - build
+          - e2e
+          - release-proof
+      version:
+        description: "Release version for release-proof"
+        required: false
+        default: "0.1.12"
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  remote-validate:
+    name: ${{ inputs.target }} on GloriousFlywheel
+    runs-on: tinyland-nix
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect GloriousFlywheel action access
+        id: gf
+        shell: bash
+        env:
+          GF_ACTIONS_TOKEN: ${{ secrets.GF_ACTIONS_TOKEN || '' }}
+        run: |
+          if [ -n "${GF_ACTIONS_TOKEN:-}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Require remote runner substrate
+        if: steps.gf.outputs.enabled != 'true'
+        shell: bash
+        run: |
+          echo "GF_ACTIONS_TOKEN is required for remote validation." >> "$GITHUB_STEP_SUMMARY"
+          echo "This workflow is a remote-first validation lane, not a silent local fallback." >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
+      - name: Checkout GloriousFlywheel action
+        uses: actions/checkout@v4
+        with:
+          repository: tinyland-inc/GloriousFlywheel
+          ref: main
+          path: .gloriousflywheel
+          token: ${{ secrets.GF_ACTIONS_TOKEN }}
+          persist-credentials: false
+
+      - name: Run selected target
+        uses: ./.gloriousflywheel/.github/actions/nix-job
+        env:
+          ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN || '' }}
+          OMUX_REMOTE_TARGET: ${{ inputs.target }}
+          OMUX_REMOTE_RELEASE_VERSION: ${{ inputs.version }}
+        with:
+          attic-public-key: ${{ vars.ATTIC_PUBLIC_KEY || '' }}
+          push-cache: "false"
+          command: |
+            set -euxo pipefail
+            test -n "${ATTIC_SERVER:-}"
+            test -n "${ATTIC_CACHE:-}"
+            test -n "${NIX_CONFIG:-}"
+
+            run_with_timeout() {
+              local label="$1"
+              local duration="$2"
+              shift 2
+
+              if ! command -v timeout >/dev/null 2>&1; then
+                echo "::warning::GNU timeout is unavailable; running ${label} without an inner timeout"
+                "$@"
+                return
+              fi
+
+              set +e
+              timeout --foreground "${duration}" "$@"
+              local status=$?
+              set -e
+
+              if [ "${status}" -eq 124 ]; then
+                echo "::error::${label} timed out after ${duration}"
+              fi
+
+              return "${status}"
+            }
+
+            case "${OMUX_REMOTE_TARGET}" in
+              check)
+                run_with_timeout "remote check" "${OMUX_REMOTE_CHECK_TIMEOUT:-30m}" \
+                  nix develop --command just check-local
+                ;;
+              test)
+                run_with_timeout "remote test" "${OMUX_REMOTE_TEST_TIMEOUT:-20m}" \
+                  nix develop --command zig build test
+                ;;
+              build)
+                run_with_timeout "remote build" "${OMUX_REMOTE_BUILD_TIMEOUT:-20m}" \
+                  nix develop --command zig build
+                ;;
+              e2e)
+                run_with_timeout "remote e2e" "${OMUX_REMOTE_E2E_TIMEOUT:-20m}" \
+                  nix develop --command just e2e-local
+                ;;
+              release-proof)
+                run_with_timeout "remote release proof" "${OMUX_REMOTE_RELEASE_PROOF_TIMEOUT:-40m}" \
+                  nix develop --command just release-proof-local "${OMUX_REMOTE_RELEASE_VERSION}"
+                ;;
+              *)
+                echo "::error::unsupported remote validation target: ${OMUX_REMOTE_TARGET}"
+                exit 2
+                ;;
+            esac

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -73,7 +73,7 @@ refreshed when release truth, route evidence, or tracker state changes.
 | --- | --- | --- |
 | Managed Codex launch/resume | Live-proven | Reference adapter path for `oauth-mux codex` and `oauth-mux codex resume`. |
 | Codex quota handoff | Live-proven for managed Codex | Strongest preserved proof lives in `docs/evidence/codex-engineered-quota-handoff-20260509/`. |
-| Session authority bridge | Implemented | Managed auth/config overlays bridge canonical Codex session authority, including `state_5.sqlite*` and `logs_2.sqlite*` when present, with canonical `CODEX_SQLITE_HOME` for Codex 0.132+. |
+| Session authority bridge | Codex-implemented | Managed auth/config overlays bridge canonical Codex session authority, including `state_5.sqlite*` and `logs_2.sqlite*` when present, with canonical `CODEX_SQLITE_HOME` for Codex 0.132+. |
 | Resume picker namespace parity | Published | PR #295 keeps managed Codex on the built-in `openai` provider namespace while routing through mux via `openai_base_url`, so native and managed `codex resume` enumerate the same provider-filtered session rows. Published in `0.1.12`. |
 | Config/TOML preservation | Implemented | Root-partitioned Codex config passthrough keeps user settings, MCP servers, profiles, model defaults, approval/sandbox policy, and non-managed provider definitions. |
 | Experimental Codex settings injection | Implemented | Defaults can be injected without treating user config as disposable. |
@@ -82,8 +82,8 @@ refreshed when release truth, route evidence, or tracker state changes.
 | Route-health recovery | Implemented | Transient provider degradation can recover after retry windows without becoming permanent auth death. Source after PR #279 also separates downstream client disconnects from upstream/provider failures so client `BrokenPipe` does not poison route health. |
 | Redacted diagnostics and tracing | Implemented | JSON diagnostics and `OMUX_TRACE=1` support route/session/auth/runtime debugging without token, raw account id, session id, or path leakage. |
 | Agent-safe reauth mediation | Contracted, partial surfaces | CLI JSON exposes consent/action fields and safe handoff-plan commands for upstream-owned login surfaces; future MCP tools must mirror CLI semantics. |
-| Beta daemon | Experimental | Foreground tick engine and daemon-hosted beta may mediate status/handoffs; not a hidden dependency and not unmanaged hot-swap. |
-| Claude adapter | Provider-proof only | `auth-status` and account-store isolation are the first proof lane; no Claude stay-afloat claim. |
+| Beta daemon | Socket stub (non-functional) | Foreground tick engine and daemon-hosted beta may mediate status/handoffs; not a hidden dependency and not unmanaged hot-swap. |
+| Claude adapter | Synthetic smoke only | `auth-status` and account-store isolation are the first proof lane; no Claude stay-afloat claim. |
 | OMO, Pi, OpenCode, Kimi | Adapter-candidate only | Adjacent agent-control-plane proof does not equal oauth-mux keepalive support. |
 
 ## UX, DX, AX Stance
@@ -181,11 +181,11 @@ browser is needed; local Playwright is not part of this CLI proof path.
 | Codex next-turn broker switch | TIN-916 | #131 | Closed for the proven managed Codex live handoff. Remaining negative/permutation work lives in #212/#176; same-thread, mid-turn, and unmanaged daemon behavior remain separate non-claims. |
 | Upstream Codex usage-limit hook | TIN-939 | #164 | Draft proposal written; use it to request a first-class external-auth usage-limit handoff hook while keeping oauth-mux claims scoped to proven managed-proxy behavior. |
 | Live Codex account-swap acceptance | TIN-951 | #177 | Done for managed Codex; strongest preserved proof is `docs/evidence/codex-engineered-quota-handoff-20260509/`. |
-| Wire cassette coverage | TIN-950 | #176 | PR #299 promoted a scrubbed current-release auth-failure fixture and replay smoke. Quota/rate-limit and all-fallbacks-exhausted cassette evidence is still needed before treating negative permutations as stable release proof. Linear currently marks TIN-950 Done while GitHub #176 remains open; reconcile only after real cassette acceptance or an explicit tracker correction. |
+| Wire cassette coverage | TIN-950 | #176 | PR #299 promoted a scrubbed current-release auth-failure fixture and replay smoke. Quota/rate-limit and all-fallbacks-exhausted cassette evidence is still needed before treating negative permutations as stable release proof. Linear currently marks TIN-950 Done while GitHub #176 remains open; reconcile this tracker inconsistency immediately — real cassette acceptance is a separate release-readiness gate, not a precondition for the tracker correction. |
 | Harness session authority bridge | TIN-979 / TIN-1624 | #191 / #288 | Closed for the original Codex bridge, with TIN-1624/#288 covering the Codex 0.132 `logs_2.sqlite*` / `CODEX_SQLITE_HOME` parity regression. Managed auth/config overlays bridge canonical session authority and root config while rejecting silent session-store import/copy. Future cross-harness authority work stays under #67/#68. |
 | Codex session-store portability | TIN-936 | #161 | Policy is explicit: canonical bridge is supported; silent route-local session import/copy is rejected until a separate confirmed import command exists. |
 | OTEL-friendly tracing | TIN-1148 | PR #225/#226 lineage | Implemented trace schema should become the standard support-bundle path. |
-| Package parity and install lanes | TIN-1255 | #252 | `0.1.12` is published and verified across GitHub Release, Homebrew, curl installer assets, deb/rpm release assets, user-local dogfood, and lab Home Manager source pin; npm remains stale at `0.1.9`. |
+| Package parity and install lanes | TIN-1255 | #252 | `0.1.12` is published and verified across GitHub Release, Homebrew, curl installer assets, deb/rpm release assets, user-local dogfood, and lab Home Manager source pin; npm as of 2026-05-26 remains at `0.1.9` — verify before recommending. |
 | Home Manager and Windows shim parity | not assigned | #257 | Home Manager source lane is implemented with opt-in shim; Windows raw tarballs stay binary-only and npm is the managed-shim lane. |
 | Provider proof beyond Codex | TIN-736 | #68 | Claude next; other agents stay adapter-candidate only. |
 | Website truth refresh | TIN-734 / TIN-925 | external site repo | `omux.xoxd.ai` source lives outside this repo and must be refreshed from the ledger, QA matrix, and install-lane docs. |

--- a/docs/qa-handoff-matrix.md
+++ b/docs/qa-handoff-matrix.md
@@ -53,7 +53,7 @@ capability, such as `codex:max-3#codex-max`.
 | Managed last resume | `oauth-mux codex resume --last` | canonical session bridge, writeback check | covered by CLI smoke |
 | Labeled reauth | `oauth-mux codex login-device <account>` | action says `user_handoff`, route label named, no raw identity | live operator flow |
 | Auth fallback | selected route 401, fallback 200 | `proxy_auth_same_turn_retry`, `auth_health_observed quota_claim:false` | live and smoke evidence |
-| Quota handoff | selected route `usage_limit_reached`, fallback 200 | `proxy_turn 429`, durable quota evidence, `proxy_same_turn_retry`, fallback `200` | live-proven for managed Codex |
+| Quota handoff | selected route `usage_limit_reached`, fallback 200 | `proxy_turn 429`, durable quota evidence, `proxy_same_turn_retry`, fallback `200` | captured evidence in `docs/evidence/codex-engineered-quota-handoff-20260509/` — route truth volatile |
 | All fallbacks unavailable | every candidate rejected | `quota_handoff_failed_no_account_selectable` with redacted vector | synthetic and managed cassette harness covered; publishable provider cassette/live target |
 | Tier selected-route classification | selected route returns `usage_not_included` | route marked `tier_insufficient`; no quota classification or same-turn quota retry | synthetic covered; live/cassette target |
 | Tier before fallback election | already-tier-blocked B precedes credited C in route pool | B is not elected; C selected | unit matrix covered; live/cassette target |

--- a/docs/reference/codex-0.135-auth-internals.md
+++ b/docs/reference/codex-0.135-auth-internals.md
@@ -11,17 +11,26 @@
 
 ## Overview
 
-Codex 0.135 is a subscription-aware CLI for Claude and other AI models. It stores authentication state in `$CODEX_HOME/auth.json`, runs a managed session authority in SQLite databases, and implements a provider-independent `AuthManager` that handles credential refresh, account switching, and quota observation. oauth-mux mediates Codex sessions via a wire-layer proxy and account pool to enable seamless quota-driven account rotation.
+Codex 0.135 is a subscription-aware OpenAI Codex CLI. It stores authentication
+state in `$CODEX_HOME/auth.json`, runs a managed session authority in SQLite
+databases, and implements an `AuthManager` that handles credential refresh,
+account switching, and quota observation. oauth-mux mediates Codex sessions via
+a wire-layer proxy and account pool to enable seamless quota-driven account
+rotation.
 
 ## 1. Authentication Model: auth.json
 
 ### 1.1 File Location and Discovery
 
 - **Primary**: `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`)
-- **Override**: `CODEX_AUTH_FILE` environment variable (exported by shim at runtime)
-- **Discovery order**: CODEX_AUTH_FILE → CODEX_HOME/auth.json → ~/.codex/auth.json
+- **Native override**: no supported `CODEX_AUTH_FILE` override has been proven
+  in the raw Codex 0.135 binary.
+- **Observed discovery order**: CODEX_HOME/auth.json → ~/.codex/auth.json
 
-The shim (`codex-shim.sh`) wraps the native Codex binary. When invoked as `codex` or through `oauth-mux codex`, it sets `CODEX_AUTH_FILE` to the managed overlay's auth.json and passes control to native Codex.
+The local Home Manager wrapper observed on `neo` exports `CODEX_AUTH_FILE`, but
+that is wrapper behavior, not native Codex evidence. Do not design oauth-mux
+around `CODEX_AUTH_FILE` until a raw-binary live proof shows Codex honoring it.
+As of this audit, managed auth still has to flow through `CODEX_HOME/auth.json`.
 
 ### 1.2 File Schema
 
@@ -573,7 +582,7 @@ Keeping this header when switching accounts risks upstream server-side session s
 |-----|---------|--------|---------|
 | CODEX_HOME | Auth/config home | User or shim | ~/.codex |
 | CODEX_SQLITE_HOME | Session DB home | oauth-mux (managed) | ~/.codex |
-| CODEX_AUTH_FILE | Explicit auth.json path | Shim | ~/.codex/auth.json |
+| CODEX_AUTH_FILE | Wrapper-local variable observed on neo; native Codex support unproven | Home Manager wrapper | ~/.codex/auth.json |
 | CODEX_SESSION_HOME | Session files home | Managed flag | ~/.codex or <custom> |
 
 ### 8.2 oauth-mux Managed Codex Variables
@@ -667,9 +676,9 @@ Never print token material, file paths, or full account IDs in status output.
 
 1. **auth.json is single-source of truth** for Codex: read/write by Codex process, imported post-exit by oauth-mux. Keys: access_token (wire auth), id_token (claims), refresh_token (renewal).
 
-2. **refresh_token is single-use**: Each successful refresh consumes it. oauth-mux broker serializes refresh calls per account to prevent reuse races (OAuth 2.1 §4.3.1).
+2. **refresh_token is single-use**: Each successful refresh consumes it. oauth-mux broker serialization is the intended mitigation against reuse races (OAuth 2.1 §4.3.1); verify the live code path before relying on this draft as canonical.
 
-3. **Session state is canonical**: state_5.sqlite and logs_2.sqlite live in canonical ~/.codex; managed overlays symlink them. Multiple managed sessions can safely share session authority because Codex reads/writes SQLite atomically.
+3. **Session state authority is the product boundary**: canonical-bridge mode stores state_5.sqlite and logs_2.sqlite in canonical ~/.codex through managed homes. The 2026-06-02 TIN-1851 investigation found that this model is fragile unless the managed home is durable and path-stable. The safer candidate default is home-is-store / isolated persistent account homes, where muxed Codex sessions never write canonical ~/.codex.
 
 4. **Quota is per-account, per-period**: 429 usage_limit_reached includes plan_type (SKU) and resets_at (reset time). oauth-mux swaps accounts if fallback available; otherwise returns error to Codex.
 
@@ -679,4 +688,4 @@ Never print token material, file paths, or full account IDs in status output.
 
 7. **Sticky routing token (x-codex-turn-state) must be dropped on swap**: Keeping it when switching accounts risks session state pinning to the wrong account upstream.
 
-8. **Managed homes are temporary but session-aware**: As of 2026-06-02, overlays created under ~/.oauth-mux/managed-codex-homes/, symlink canonical SQLite, scrub on exit but keep symlinks for path resolvability.
+8. **Managed homes must be durable when they can appear in Codex state**: overlays created under ~/.oauth-mux/managed-codex-homes/ improve on disposable `$TMPDIR` homes because recorded rollout paths remain resolvable after scrub. The stronger TIN-1851 home-is-store branch removes canonical sqlite bridging for muxed sessions entirely and should be treated as the trustable architecture candidate until live e2e proves otherwise.

--- a/docs/reference/codex-0.135-auth-internals.md
+++ b/docs/reference/codex-0.135-auth-internals.md
@@ -1,0 +1,682 @@
+<!-- AUDIT-GENERATED DRAFT (2026-06-03 architecture audit workflow wf_a60ca68c).
+     Grounded in repo evidence but NOT line-by-line human-verified — treat as a
+     strong draft; verify specifics against source before citing as canonical. -->
+
+# Codex 0.135 Auth/Home/Refresh Internals — oauth-mux Engineering Reference
+
+**Version**: Codex CLI 0.135.0 (macos-aarch64)  
+**Status**: Binary-only; source extracted from strings output, wire captures (codex-rs refs), and oauth-mux adapter evidence  
+**Audience**: oauth-mux engineers implementing Codex broker and refresh semantics  
+**Date**: 2026-06-03  
+
+## Overview
+
+Codex 0.135 is a subscription-aware CLI for Claude and other AI models. It stores authentication state in `$CODEX_HOME/auth.json`, runs a managed session authority in SQLite databases, and implements a provider-independent `AuthManager` that handles credential refresh, account switching, and quota observation. oauth-mux mediates Codex sessions via a wire-layer proxy and account pool to enable seamless quota-driven account rotation.
+
+## 1. Authentication Model: auth.json
+
+### 1.1 File Location and Discovery
+
+- **Primary**: `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`)
+- **Override**: `CODEX_AUTH_FILE` environment variable (exported by shim at runtime)
+- **Discovery order**: CODEX_AUTH_FILE → CODEX_HOME/auth.json → ~/.codex/auth.json
+
+The shim (`codex-shim.sh`) wraps the native Codex binary. When invoked as `codex` or through `oauth-mux codex`, it sets `CODEX_AUTH_FILE` to the managed overlay's auth.json and passes control to native Codex.
+
+### 1.2 File Schema
+
+```json
+{
+  "auth_mode": "chatgpt",
+  "OPENAI_API_KEY": null,
+  "tokens": {
+    "access_token": "<JWT; used as Authorization bearer>",
+    "id_token": "<JWT; contains chatgpt claims>",
+    "refresh_token": "rt.1.<opaque; OAuth 2.0 grant token>",
+    "account_id": "<UUID from id_token claim>"
+  },
+  "last_refresh": "2026-06-03T01:51:47.750809Z"
+}
+```
+
+**Field semantics:**
+- `auth_mode`: Enum {chatgpt | openai_api_key | agent_identity | ...}. Defines which token source is active.
+- `OPENAI_API_KEY`: Only set if auth_mode=openai_api_key. Codex out-of-scope for muxing (static key; no quota per-account).
+- `tokens.access_token`: JWT, opaque to Codex; passed as `Authorization: Bearer <token>`. NOT used for code generation itself; only wire auth.
+- `tokens.id_token`: JWT, decoded client-side via Codex's TokenData parser. Contains custom claim `https://api.openai.com/auth` with:
+  - `chatgpt_account_id`: UUID (same as tokens.account_id)
+  - `chatgpt_plan_type`: String ∈ {free, plus, pro, business, enterprise, edu}
+  - `chatgpt_user_id`: User UUID
+  - `chatgpt_account_is_fedramp`: Boolean
+  - `chatgpt_subscription_active_start`: ISO8601 timestamp
+  - `chatgpt_subscription_active_until`: ISO8601 timestamp
+  - `groups`: Array (typically empty)
+- `tokens.refresh_token`: Opaque OAuth 2.0 refresh grant. Format: `rt.1.` prefix followed by base64url content. **Single-use per OAuth 2.1 §4.3.1**: Each refresh consumes this token; provider issues a new one in response.
+- `tokens.account_id`: UUID matching id_token.chatgpt_account_id. Redundant for Codex; used by oauth-mux for account routing.
+- `last_refresh`: ISO8601 timestamp of last successful credential/refresh call.
+
+### 1.3 When Codex Writes auth.json
+
+Codex writes via `AuthManager.persist_tokens()` → `storage.save()`:
+
+1. **Startup refresh** (if token not present or expired)
+2. **UnauthorizedRecovery RefreshToken step** (after 401 on /responses request)
+3. **Explicit refresh** via Codex TUI / exec / app-server (user-initiated or broker-mediated)
+
+**Not written by Codex:**
+- Config overrides (those remain in config.toml)
+- Session state (that lives in state_5.sqlite, logs_2.sqlite, history.jsonl)
+
+**oauth-mux writeback** (post-exit): Compares managed overlay auth.json with selected account source. If Codex modified tokens during the session (e.g., successful refresh inside the overlay), oauth-mux atomic-compares back to the source (failing gracefully if another process wrote first).
+
+---
+
+## 2. Home and Session Authority: CODEX_HOME vs CODEX_SQLITE_HOME
+
+### 2.1 Directory Structure (Codex 0.135)
+
+**CODEX_HOME** (auth/config authority):
+```
+~/.codex/
+├── auth.json                 # ← Codex reads/writes auth state here
+├── config.toml              # ← Behavior config (MCP, features, model defaults, etc.)
+├── installation_id          # ← Stable per-install identifier
+├── version.json             # ← Cache of latest available version
+├── config.json              # ← Legacy/migration format (not actively used)
+├── app-server-daemon/       # ← App-server state (not in managed overlay)
+├── cache/                   # ← HTTP cache, embeddings, etc.
+├── log/                     # ← CLI logs (separate from session logs)
+├── memories/                # ← Memory databases (goals_1.sqlite, memories_1.sqlite)
+├── backups/                 # ← Credential/session backups (not in managed overlay)
+├── plugins/                 # ← Custom MCP plugins
+└── sessions/                # ← LEGACY: pre-0.132 rollout store
+    ├── 2026/
+    │   └── <thread-id>.jsonl  # ← Conversation history (migrated to state_5.sqlite in 0.132+)
+    └── ...
+```
+
+**CODEX_SQLITE_HOME** (session authority, Codex 0.132+):
+```
+~/.codex/
+├── state_5.sqlite           # ← Thread metadata, resume state
+├── state_5.sqlite-wal       # ← Write-ahead log
+├── state_5.sqlite-shm       # ← Shared memory for concurrent reads
+├── logs_2.sqlite            # ← Session logs, transcript
+├── logs_2.sqlite-wal
+├── logs_2.sqlite-shm
+├── goals_1.sqlite           # ← Goals database
+├── goals_1.sqlite-wal
+├── goals_1.sqlite-shm
+└── memories_1.sqlite        # ← Memories database
+    ├── memories_1.sqlite-wal
+    └── memories_1.sqlite-shm
+```
+
+### 2.2 oauth-mux Managed Home (Canonical Bridge Mode)
+
+**Goal**: Keep mux-owned auth/config while preserving native session authority.
+
+**Managed overlay structure:**
+```
+<canonical_authority>/.oauth-mux/managed-codex-homes/omux-managed-codex-<hash>/
+├── auth.json                    # ← MUXED: selected account's tokens
+├── config.toml                  # ← MUXED: generated proxy config + preserved user settings
+├── installation_id              # ← MUXED: copied from selected account
+├── state_5.sqlite → <symlink>   # ← CANONICAL: points to ~/.codex/state_5.sqlite
+├── state_5.sqlite-wal → <symlink>
+├── state_5.sqlite-shm → <symlink>
+├── logs_2.sqlite → <symlink>    # ← CANONICAL: points to ~/.codex/logs_2.sqlite
+├── logs_2.sqlite-wal → <symlink>
+└── logs_2.sqlite-shm → <symlink>
+```
+
+**Env set for child Codex:**
+- `CODEX_HOME=<managed_overlay_path>` — points to mux-owned auth/config
+- `CODEX_SQLITE_HOME=<canonical_authority>` — points to real session store
+
+This means:
+- Codex reads auth from mux overlay (session-specific tokens)
+- Codex reads/writes session to canonical location (shared across managed sessions)
+- Native `codex resume` sees all sessions (same canonical authority)
+- SQLite lock contention checked on spawn (diagnostic; not fatal by default as of 2026-06-02)
+
+### 2.3 Legacy Session Authority (pre-0.132)
+
+If state_5.sqlite not present, Codex falls back to:
+- `~/.codex/sessions/` — JSONL conversation histories
+- `~/.codex/history.jsonl` — CLI command history
+- `~/.codex/session_index.jsonl` — Session metadata index
+- `~/.codex/shell_snapshots/` — Shell env snapshots
+
+oauth-mux symlinks these legacy files when present, preserving backward compatibility.
+
+### 2.4 Managed Home Lifecycle (as of 2026-06-02)
+
+**Creation:**
+1. oauth-mux selects an account (route)
+2. Creates `~/.oauth-mux/managed-codex-homes/omux-managed-codex-<hash>/`
+3. Copies selected account's auth.json into overlay
+4. Generates config.toml (preserving user tables, stripping oauth-mux routing conflicts)
+5. Symlinks state_5.sqlite*, logs_2.sqlite*, etc. to canonical authority
+6. Sets CODEX_HOME and CODEX_SQLITE_HOME for child
+
+**On exit:**
+1. Scrubs auth.json, installation_id, generated config.toml from overlay
+2. Leaves symlinks and bridge directory intact (so any recorded session paths remain resolvable to native Codex)
+3. If isolated-session-store flag: removes entire overlay (disposable mode)
+
+This avoids poisoning canonical SQLite rows with temp paths that don't exist after session exit.
+
+---
+
+## 3. Refresh Flow and Token Rotation
+
+### 3.1 Codex AuthManager Lifecycle
+
+**AuthManager** is an in-process cached snapshot of auth state. Key invariants:
+
+- **Loaded once** at process start from CODEX_HOME/auth.json
+- **Reloaded on demand** via `reload()` (checks disk file; ignores external mutations by default)
+- **reload_if_account_id_matches()** refuses cross-account swaps (guards work/personal boundaries)
+- **UnauthorizedRecovery** step machine handles 401 (Reload → RefreshToken → ExternalRefresh)
+
+### 3.2 Refresh Workflow
+
+**Trigger**: 401 Unauthorized on any /backend-api/codex/responses request.
+
+**Steps** (per AuthManager.UnauthorizedRecovery, codex-rs release 0.128.0+):
+
+1. **Reload**
+   - Re-reads auth.json from disk (in case external mutation)
+   - Compares account_id; refuses if mismatched (cross-account guard)
+
+2. **RefreshToken**
+   - POSTs to `https://auth.openai.com/oauth/token`
+   - Grant: `refresh_token=<tokens.refresh_token>`
+   - Receives new `access_token`, `id_token`, `refresh_token` (new RT issued by provider)
+   - Calls `auth_manager.persist_tokens()` → writes updated auth.json
+   - Returns new access_token to caller
+
+3. **ExternalRefresh**
+   - **Available only in brokered app-server mode** (JSON-RPC `chatgptAuthTokens/refresh`)
+   - **NOT available in TUI or exec** (per codex-rs/tui/src/app/app_server_requests.rs:136 + exec/src/lib.rs:1580–1588)
+   - Emits `account/chatgptAuthTokens/refresh` to external client (e.g., oauth-mux broker)
+   - Waits 10s (EXTERNAL_AUTH_REFRESH_TIMEOUT) for response with new tokens
+   - If timeout, falls back to RefreshToken path
+
+**Key insight**: In the current oauth-mux `codex run` child+proxy topology, Codex receives 401s directly and runs RefreshToken internally. oauth-mux does not intercept the refresh; it observes the result and imports changed tokens post-exit.
+
+### 3.3 Refresh Token Rotation (OAuth 2.1 §4.3.1)
+
+**Single-use enforcement**:
+- Each successful refresh **consumes** the old refresh_token
+- Provider issues a **new refresh_token** in the response
+- Codex atomically updates auth.json with new token
+- Old token becomes invalid (reuse yields `refresh_token_reused` error)
+
+**Race prevention** (oauth-mux broker):
+- Per-account mutex serializes RefreshToken calls
+- Before consuming refresh_token, re-reads auth.json under lock
+- Detects if another process already refreshed
+- Prevents concurrent double-refresh (race tracked in openai/codex#9634)
+
+**Failure modes** (typed errors from broker.credential/refresh):
+- `refresh_token_expired`: Token past expiration (provider-defined window, typically months)
+- `refresh_token_reused`: Token already consumed in prior refresh (race or replay)
+- `refresh_token_invalidated`: Explicit revocation (user action, security event, logout)
+- `provider_5xx`: Upstream auth service error (transient; retry policy applies)
+- `policy_denied`: oauth-mux policy forbids refresh (e.g., account disabled locally)
+
+**Post-session writeback** (oauth-mux):
+- Compares managed overlay auth.json (possibly modified by Codex) with selected account source
+- If changed: imports new tokens via compare-and-swap (fails gracefully if source changed in parallel)
+- Redacted status frame reports `changed:true`, `written:true` without printing path or token material
+- Next launch uses refreshed token from source (no stale token reuse)
+
+### 3.4 Refresh Token Locking: In-Process vs Cross-Process
+
+**In-process** (within oauth-mux broker):
+- File-backed mutex per account (via broker_loader.zig)
+- Serializes multiple refresh calls on same account
+- Atomic compare-and-swap when re-reading file under lock
+
+**Cross-process**:
+- Codex 0.135 manages its own refresh via UnauthorizedRecovery (runs inside Codex process)
+- oauth-mux does NOT hold the Codex process during refresh; Codex refreshes independently
+- oauth-mux imports the result post-exit (atomic writeback)
+- Two concurrent managed sessions on same account:
+  - Session A: runs Codex, hits 401, performs RefreshToken internally
+  - Session B: runs Codex, different overlay, hits 401, performs RefreshToken independently
+  - Both may win the race and import to the same source (later import wins compare-and-swap)
+  - No data loss; refresh token always moves forward (monotonic)
+
+---
+
+## 4. Quota and Entitlement Signals
+
+### 4.1 Plan Type (Entitlement)
+
+**Source**: id_token JWT claim `https://api.openai.com/auth.chatgpt_plan_type`
+
+**Values**: free | plus | pro | business | enterprise | edu
+
+**Usage in Codex**:
+- Decoded client-side (not used for wire auth; wire only uses access_token bearer)
+- Passed to oauth-mux via id_token claim parsing
+- Used by broker to classify account capability (e.g., "pro can use Codex; free cannot")
+
+**Not a usage counter**: Plan type is a SKU identifier, not a rate limit. It does not decrease or reset. It indicates whether the account tier includes Codex access.
+
+### 4.2 Quota Exhaustion (429 + usage_limit_reached)
+
+**Trigger**: Weekly/monthly usage limit reached on Codex requests.
+
+**HTTP response**:
+```
+HTTP/1.1 429 Too Many Requests
+Content-Type: application/json
+
+{
+  "error": {
+    "type": "usage_limit_reached",
+    "plan_type": "pro",
+    "resets_at": 1788000000
+  }
+}
+```
+
+**Fields**:
+- `type`: Always `usage_limit_reached` for quota exhaustion
+- `plan_type`: Current tier (free, plus, pro, etc.) — same as id_token claim
+- `resets_at`: Unix seconds (i64) when limit resets. Decoded via `DateTime::<Utc>::from_timestamp(resets_at, 0)`
+
+**Headers on 429**:
+- `Retry-After`: Seconds to wait before retry (standard HTTP; may be absent)
+- `x-codex-active-limit`: Identifier of which limit was hit (parsing via api_bridge)
+- `x-codex-rate-limit-*`: Per-limit details (request count, window, etc.)
+
+**Codex behavior**:
+- Receives error as typed `CodexErr::UsageLimitReached`
+- Does NOT retry
+- Does NOT call ExternalRefresh (auth is valid; quota is the issue)
+- Surfaces error to user (UI prompt to upgrade or wait)
+
+**oauth-mux wire-proxy response**:
+- Buffers the 429 response body (small JSON)
+- Classifies as `quota_exhausted`
+- Calls `pool.markQuotaExhausted(account_id, resets_at)`
+- If fallback account selectable: swaps immediately, retries request, returns 200 to Codex
+- If no fallback: returns buffered 429 to Codex (Codex surfaces to user)
+- Logs as `proxy_same_turn_retry` (when swapped) or `proxy_same_turn_retry_unavailable` (when not)
+
+### 4.3 Tier Insufficient (usage_not_included)
+
+**Condition**: Account's plan does not include Codex (e.g., free tier).
+
+**HTTP response**:
+```
+HTTP/1.1 429 Too Many Requests
+Content-Type: application/json
+
+{
+  "error": {
+    "type": "usage_not_included",
+    "plan_type": "free"
+  }
+}
+```
+
+**Key difference from usage_limit_reached**:
+- No `resets_at` (tier cannot be upgraded by waiting)
+- Means: account must upgrade SKU or use a different account with Codex access
+
+**oauth-mux wire-proxy response**:
+- Classifies as `tier_insufficient`
+- Does NOT call `pool.markQuotaExhausted()` (not temporary; tier gap doesn't fix itself)
+- Does NOT swap accounts (rotating won't help)
+- Returns 429 unchanged to Codex
+- Codex surfaces upgrade prompt to user
+
+**Broker observability** (via quota/observe MCP):
+- `kind: tier_insufficient` or `kind: quota_exhausted` (depending on error.type)
+- Broker records account as unavailable (tier_insufficient) or quota-blocked (quota_exhausted)
+- Different remediation: tier_insufficient requires user action; quota_exhausted auto-resets at resets_at
+
+### 4.4 Rate Limited (bare 429)
+
+**Condition**: Transient rate limit (not quota; burst protection).
+
+**HTTP response**:
+```
+HTTP/1.1 429 Too Many Requests
+Retry-After: 60
+
+(body may be empty or non-JSON)
+```
+
+**Codex behavior**:
+- Receives as `CodexErr::RateLimited`
+- May respect Retry-After
+- May retry (up to policy)
+
+**oauth-mux classification**:
+- `kind: rate_limited`
+- Does not mark account quota-exhausted
+- May optionally swap if Retry-After > policy threshold (Phase 2.2+; currently propagates)
+
+### 4.5 Broker Quota Observability Contract
+
+**MCP method**: `quota/observe`
+
+**Params**:
+```json
+{
+  "session_id": "<session-uuid>",
+  "account": "<account-name>",
+  "capability": "<capability-name>",
+  "kind": "quota_exhausted" | "rate_limited" | "auth_unauthorized" | "ok",
+  "http_status": 429,
+  "headers": {
+    "x-codex-active-limit": "...",
+    "retry_after": "..."
+  },
+  "body_class": "usage_limit_reached" | "usage_not_included" | ...,
+  "resets_at": 1788000000
+}
+```
+
+**Returns**:
+```json
+{
+  "recorded": true,
+  "now_selectable": false,
+  "next_eligible_at": 1788000000
+}
+```
+
+**Broker side effects**:
+- Records quota evidence in route health log
+- Marks account unavailable (based on kind and resets_at)
+- Subsequent account/select calls exclude unavailable accounts (unless forced)
+- Status summary shows which accounts are quota-blocked and when they reset
+
+---
+
+## 5. Wire Protocol: Headers and Requests
+
+### 5.1 Auth-Bound Headers (Proxy Substitutes Per-Account)
+
+```
+Authorization: Bearer <access_token>
+ChatGPT-Account-ID: <account_id>
+X-OpenAI-Fedramp: true  # Only when account.fedramp
+```
+
+**Codex sources these from**:
+- Authorization: tokens.access_token (JWT)
+- ChatGPT-Account-ID: id_token.chatgpt_account_id claim (or tokens.account_id)
+- X-OpenAI-Fedramp: id_token.chatgpt_account_is_fedramp claim
+
+**oauth-mux proxy behavior**:
+- Rewrites Authorization and ChatGPT-Account-ID for fallback accounts
+- Drops X-OpenAI-Fedramp if fallback account does not have fedramp enabled
+
+### 5.2 Forward-Unchanged Headers (Proxy Must Not Rewrite)
+
+```
+User-Agent: <originator>/<version> (<os> <ver>; <arch>) <terminal> (<suffix>)
+originator: codex_cli_rs
+x-codex-installation-id: <stable-per-install>
+x-codex-turn-state: <STICKY-ROUTING-TOKEN>  # ← LOAD-BEARING; dropped on retry/swap
+OpenAI-Beta: responses_websockets=2026-02-06
+traceparent: <W3C-trace-id>
+tracestate: <W3C-trace-state>
+x-openai-internal-codex-residency: us  # Conditional
+```
+
+**Critical**: `x-codex-turn-state` is a sticky routing token. oauth-mux drops this header on:
+- Same-turn retry (after account swap)
+- Post-swap turns (new account, new thread)
+
+Keeping this header when switching accounts risks upstream server-side session state corruption (thread pinning to wrong account).
+
+### 5.3 Endpoints
+
+**Source-confirmed** (per codex-rs/core/src/client.rs):
+
+| Method | Path | Purpose | Streaming | Auth |
+|--------|------|---------|-----------|------|
+| GET | /backend-api/codex/responses | Upgrade for WebSocket | bidirectional WS | Bearer, Account-ID |
+| POST | /backend-api/codex/responses | Normal turn (SSE fallback) | event-stream | Bearer, Account-ID |
+| POST | /backend-api/codex/responses/compact | Conversation compaction | likely SSE | Bearer, Account-ID |
+| POST | /backend-api/codex/memories/trace_summarize | Memory summarization | likely SSE | Bearer, Account-ID |
+| GET | /backend-api/codex/models | Model availability | JSON | Bearer, Account-ID |
+| POST | /backend-api/codex/analytics-events/events | Telemetry | JSON | Bearer, Account-ID |
+
+**WebSocket upgrade** (Codex 0.132+):
+- HTTP GET with `Upgrade: websocket` header
+- OpenAI-Beta header: `responses_websockets=2026-02-06` (NOT Sec-WebSocket-Protocol)
+- Server responds HTTP 101 Switching Protocols
+- oauth-mux 0.1.12 returns HTTP 426 Upgrade Required (WS not yet supported; Codex falls back to SSE)
+
+---
+
+## 6. Secrets and Redaction Policy
+
+### 6.1 Token Materials (Never Log)
+
+- `access_token` (JWT)
+- `id_token` (JWT)
+- `refresh_token` (opaque rt.1.* string)
+- HTTP Authorization header value (full bearer token)
+
+**Safe to log** (redacted):
+- Token JWT claims (e.g., account_id, plan_type, iat, exp) — decode and log claim values only
+- Token length or type identifier (e.g., "JWT access_token" vs "refresh_token")
+- First/last 4 chars of token (for correlation, never full token)
+
+### 6.2 Account Identifiers (Redactable)
+
+- `account_id` (UUID)
+- `chatgpt_user_id` (UUID)
+- `chatgpt_account_is_fedramp` (boolean, safe)
+
+**Policy**: Redact in normal output. Include only as correlated pairs in logs (e.g., "account_1 → account_2 swap").
+
+### 6.3 File Paths (Redactable)
+
+- `CODEX_HOME` path
+- Managed overlay paths
+- Session file paths (rollout JSONL, SQLite, etc.)
+
+**Policy**: Log as labels (e.g., "canonical_authority", "managed_overlay_path", "state_db_bridged") without full paths. Include paths in operator-only diagnostic logs with per-log consent.
+
+### 6.4 Session Content (Redactable)
+
+- Conversation transcripts
+- Shell snapshots
+- Memory content
+
+**Policy**: Never log in default mode. Operator-only diagnostic logs may include (with explicit flag and user confirmation).
+
+---
+
+## 7. Error Cases and Recovery
+
+### 7.1 401 Unauthorized (Invalid or Expired Token)
+
+**Detection**: HTTP 401 on /backend-api/codex/responses
+
+**Codex recovery** (AuthManager.UnauthorizedRecovery):
+1. Reload auth.json from disk
+2. POST refresh_token to OAuth endpoint
+3. Persist new tokens to auth.json
+4. Retry original request with new access_token
+
+**Success indicator**: Retry returns HTTP 200; Codex sees response as if 401 never happened.
+
+**oauth-mux additional handling** (wire-proxy):
+- Buffers 401 response (may be evidence)
+- If account marked as selectable and fallback exists: marks failed account unauthorized, swaps, retries
+- Otherwise: passes 401 to Codex (Codex runs its own refresh)
+- Post-exit: imports refreshed tokens from overlay to account source
+
+### 7.2 429 Quota Exhausted
+
+**Detection**: HTTP 429 with `error.type: usage_limit_reached`
+
+**Codex behavior**: Surfacesto user as non-retryable error. Suggests upgrade or retry after reset.
+
+**oauth-mux handling**:
+- Buffers 429 response
+- Classifies as quota_exhausted
+- Calls pool.markQuotaExhausted(account_id, resets_at)
+- If fallback account selectable: swaps, drops x-codex-turn-state, retries
+- If no fallback: returns buffered 429 to Codex
+
+**Recovery timeline**: Account becomes selectable again at resets_at timestamp (provider resets weekly/monthly).
+
+### 7.3 Refresh Token Consumed (refresh_token_reused)
+
+**Trigger**: Two processes attempt refresh simultaneously; second one reuses already-consumed token.
+
+**Error**: Provider returns `invalid_grant` or `refresh_token_reused` from /oauth/token endpoint
+
+**oauth-mux broker response**:
+- Detects via credential/refresh error analysis
+- Marks account as `auth_unready` (requires manual re-enrollment)
+- Does not swap (can't fix via muxing)
+- Raises `refresh_failed` error with typed reason
+- Operator must enroll account again (full OAuth code flow)
+
+**Prevention**: Broker holds per-account mutex during RefreshToken; re-reads auth.json under lock to detect if another process already consumed the token.
+
+### 7.4 Refresh Token Expired
+
+**Trigger**: Token past provider's expiration window (typically months; provider-specific).
+
+**Error**: Provider returns `invalid_grant` from /oauth/token endpoint
+
+**oauth-mux broker response**:
+- Detects via error analysis
+- Marks account as `auth_unready`
+- Raises credential/refresh error with reason `refresh_token_expired`
+- Operator must re-enroll account
+
+---
+
+## 8. Configuration and Environment Variables
+
+### 8.1 Codex Environment Variables
+
+| Var | Purpose | Set by | Example |
+|-----|---------|--------|---------|
+| CODEX_HOME | Auth/config home | User or shim | ~/.codex |
+| CODEX_SQLITE_HOME | Session DB home | oauth-mux (managed) | ~/.codex |
+| CODEX_AUTH_FILE | Explicit auth.json path | Shim | ~/.codex/auth.json |
+| CODEX_SESSION_HOME | Session files home | Managed flag | ~/.codex or <custom> |
+
+### 8.2 oauth-mux Managed Codex Variables
+
+| Var | Purpose | Example |
+|-----|---------|---------|
+| OMUX_CODEX_BIN | Native Codex binary path | /nix/store/.../bin/codex |
+| OMUX_CODEX_SHIM | Set to 1 by shim during managed entry | 1 |
+| OMUX_CODEX_CONFIG_HOME | Override config home discovery | ~/.codex or <custom> |
+| OMUX_CODEX_SESSION_HOME | Override session home | ~/.codex or <custom> |
+| OMUX_CODEX_STRICT_SQLITE_LOCK_GUARD | Fail if SQLite lock held (diagnostic) | 0 or 1 |
+
+---
+
+## 9. Verification and Diagnostic Outputs
+
+### 9.1 `codex doctor` Output
+
+Key fields for oauth-mux engineers:
+
+```
+Auth
+  ✓ auth is configured
+      auth storage mode        File
+      auth file                ~/.codex/auth.json
+      stored auth mode         chatgpt
+      stored API key           false
+      stored ChatGPT tokens    true
+      
+State
+  ✓ state databases healthy
+      CODEX_HOME               ~/.codex (dir)
+      sqlite home              ~/.codex (dir)
+      state DB                 ~/.codex/state_5.sqlite (file) · integrity ok
+      log DB                   ~/.codex/logs_2.sqlite (file) · integrity ok
+```
+
+Confirm:
+- `stored auth mode: chatgpt` (not openai_api_key)
+- `stored ChatGPT tokens: true` (access_token, id_token, refresh_token present)
+- SQLite DB files exist and pass integrity check
+
+### 9.2 Session Status Artifacts
+
+**oauth-mux managed session status** (JSON):
+
+```json
+{
+  "mode": "codex_broker_owned_session_live_run",
+  "claim": {
+    "level": "broker_owned_app_server",
+    "broker_owned_session": true,
+    "current_process_auth_broker": false
+  },
+  "auth": {
+    "mode": "chatgpt",
+    "tokens_present": true,
+    "refresh_triggered": false
+  },
+  "quota": {
+    "observed": false,
+    "evidence": null
+  },
+  "session": {
+    "selected_account": "codex:max-1",
+    "selected_capability": "codex-max",
+    "fallback_ready": true,
+    "home_type": "canonical_bridge"
+  }
+}
+```
+
+**On auth writeback** (post-exit):
+```json
+{
+  "event": "auth_writeback",
+  "account": "<redacted>",
+  "changed": true,
+  "written": true,
+  "source_conflict": false
+}
+```
+
+Never print token material, file paths, or full account IDs in status output.
+
+---
+
+## 10. Summary for oauth-mux Engineers
+
+### Key Takeaways
+
+1. **auth.json is single-source of truth** for Codex: read/write by Codex process, imported post-exit by oauth-mux. Keys: access_token (wire auth), id_token (claims), refresh_token (renewal).
+
+2. **refresh_token is single-use**: Each successful refresh consumes it. oauth-mux broker serializes refresh calls per account to prevent reuse races (OAuth 2.1 §4.3.1).
+
+3. **Session state is canonical**: state_5.sqlite and logs_2.sqlite live in canonical ~/.codex; managed overlays symlink them. Multiple managed sessions can safely share session authority because Codex reads/writes SQLite atomically.
+
+4. **Quota is per-account, per-period**: 429 usage_limit_reached includes plan_type (SKU) and resets_at (reset time). oauth-mux swaps accounts if fallback available; otherwise returns error to Codex.
+
+5. **Entitlement (plan_type) is SKU, not rate**: A free account cannot use Codex (usage_not_included); no amount of swapping fixes that. pro account can use Codex but may hit weekly quota exhaustion.
+
+6. **Bearer tokens are wire-portable**: No DPoP/cnf claims; access_token moves across processes. oauth-mux can substitute Authorization and ChatGPT-Account-ID headers per request.
+
+7. **Sticky routing token (x-codex-turn-state) must be dropped on swap**: Keeping it when switching accounts risks session state pinning to the wrong account upstream.
+
+8. **Managed homes are temporary but session-aware**: As of 2026-06-02, overlays created under ~/.oauth-mux/managed-codex-homes/, symlink canonical SQLite, scrub on exit but keep symlinks for path resolvability.

--- a/docs/reference/oauth-mux-algorithms-and-complexity.md
+++ b/docs/reference/oauth-mux-algorithms-and-complexity.md
@@ -1,0 +1,448 @@
+<!-- AUDIT-GENERATED DRAFT (2026-06-03 architecture audit workflow wf_a60ca68c).
+     Grounded in repo evidence but NOT line-by-line human-verified — treat as a
+     strong draft; verify specifics against source before citing as canonical. -->
+
+# oauth-mux Algorithmic Complexity Analysis
+
+## System Architecture Overview
+
+The oauth-mux system implements a multi-account OAuth token broker with load balancing, health tracking, and automatic failover. Key components:
+
+- **HealthStore** (`src/health.zig`): StringHashMap-based health tracking per account and capability
+- **AccountPool** (`src/broker/account_pool.zig`): In-memory account list with liveness and availability filtering
+- **Wire Proxy** (`src/adapters/codex/wire_proxy.zig`): Request-level account election and quota/retry logic
+- **Repair State** (`src/repair_state.zig`): Handoff coordination and lock-based refresh serialization
+- **Identity** (`src/main.zig`): SHA256-12hex account ID dedup for inventory
+
+## Core Algorithmic Patterns
+
+### 1. Route Election (Health-Weighted Strategy)
+
+**Location**: `src/broker/account_pool.zig:187-204`
+
+Selects next available account via linear scan:
+```
+elect(profile, capability, exclude[]):
+  for each account in pool.accounts:
+    if not selectable: skip
+    if not available: skip
+    if in exclude[]: skip  
+    return this account
+  throw NoAccountSelectable
+```
+
+**Time Complexity**: **O(n)** where n = pool size
+- Single linear pass; no sorting or priority queue
+- Subsequent attempts add linear rescans to skip tried accounts
+
+**Space Complexity**: **O(1)** per election
+- Stateless scan; no auxiliary data structure
+
+**Concern**: When r retries occur, worst case is O(r·n) if election is called per attempt without amortized skip tracking.
+
+---
+
+### 2. Account Pool State Refresh (Time-Window Expiration)
+
+**Location**: `src/broker/account_pool.zig:155-167`
+
+Recovery of expired transient states:
+```
+refreshTimeBased(now_unix):
+  for each account in pool.accounts:
+    if account.next_eligible_at <= now:
+      restore availability.available
+      restore liveness.live (if not dead)
+      restore selectability (unless dead)
+```
+
+**Time Complexity**: **O(n)** per refresh call
+- Full scan on every serve loop iteration
+- No early-exit or incremental approach
+
+**Space Complexity**: **O(1)**
+
+**Risk**: If called per request in a high-throughput scenario with large pools (e.g., 100+ accounts), this O(n) scan adds overhead. Consider: indexed next_eligible_at min-heap or lazy evaluation on first access.
+
+---
+
+### 3. HealthStore: StringHashMap Account:Capability Keying
+
+**Location**: `src/health.zig:245-265`
+
+Dual-level health keying:
+- Account-level: `provider:account` → AccountHealth
+- Capability-level: `provider:account#capability` → AccountHealth (per route)
+
+```
+HealthStore {
+  accounts: StringHashMap(AccountHealth)  // O(1) amortized lookup
+}
+
+accountKey(provider, account) → "codex:max-1"
+capabilityKey(provider, account, capability) → "codex:max-1#codex-max"
+```
+
+**Time Complexity**: 
+- getOrCreate: **O(1)** amortized
+- Iteration (passiveRecovery, persist): **O(n)** where n = |entries| (both account and capability keys)
+
+**Space Complexity**: **O(n)** for n entries
+- Each entry: key string + AccountHealth struct (~300 bytes)
+- Unbounded growth unless pruned
+
+**Concern**: No automatic eviction. If thousands of capability-level entries accumulate (e.g., per provider × account × capability combinations), the hashmap becomes a memory liability. Current design relies on application lifecycle to bound this.
+
+---
+
+### 4. Circuit Breaker State Machine
+
+**Location**: `src/health.zig:284-401, 991-997`
+
+Per-account state: Closed → Open → Half-Open → Closed
+
+Transitions:
+- **Closed → Open**: 3 failures within 60s window
+- **Open → Half-Open**: After 30s timeout
+- **Half-Open → Closed**: After configured success threshold
+
+**Time Complexity**: **O(1)** per failure/success record
+- State check and transition are constant-time
+
+**Space Complexity**: **O(1)** per circuit
+- Fixed struct: opened_at, failure_count, successes_so_far
+
+**Design Note**: Window is sliding based on `health.score.window_start`; resets on 60s boundary. Per-account isolation ensures one bad route doesn't block others.
+
+---
+
+### 5. Token Bucket Rate Limiter
+
+**Location**: `src/health.zig:436` + `types.zig` (TokenBucket)
+
+Per-account request throttling:
+```
+bucket.tryConsume(now_ns):
+  refill(now_ns)  // clock-based, no queue
+  if tokens > 0:
+    tokens -= 1
+    return true
+  return false
+```
+
+**Time Complexity**: **O(1)** per tryConsume
+- No queue traversal; clock-based token math
+
+**Space Complexity**: **O(1)** per bucket
+- Last refill timestamp + current tokens
+
+**Note**: No queuing; requests either succeed or fail immediately. Appropriate for strict rate enforcement (refuse-fast on limit) rather than fair queueing.
+
+---
+
+### 6. Per-Account Refresh Serialization (TIN-1851)
+
+**Location**: `src/repair_state.zig:378-414`
+
+Mutual exclusion via OS file locks:
+```
+acquireRepairLock(provider, account, nonblocking):
+  path = ~/.cache/oauth-mux/repair-locks/provider-account.lock
+  file = createFileAbsolute(path, {
+    .lock = .exclusive,
+    .lock_nonblocking = nonblocking
+  })
+  write metadata (started_at) to file
+  return RepairLock { file, path }
+```
+
+**Time Complexity**: 
+- Lock acquire: **O(1)** (kernel op)
+- Lock contention: **blocking or error.WouldBlock** (immediate, no retry loop in the tool itself)
+
+**Space Complexity**: **O(1)** per lock
+- Single file handle + path string
+
+**Safety**: Ensures only one refresh runs per (provider, account) pair. No deadlock risk (single lock per account). Scope is well-defined: prevents concurrent token refresh that would lose state.
+
+---
+
+### 7. Repair Event JSONL Scan + Handoff Queue Replay
+
+**Location**: `src/repair_state.zig:98-124, 186-241`
+
+Pending handoff state rebuilt via full file scan:
+```
+hasPendingHandoff(key: HandoffKey):
+  bytes = file.readToEndAlloc(events_path, 1MB)
+  pending = false
+  for each line in bytes.split('\n'):
+    trimmed = trim(line)
+    if eventLineMatchesKind(trimmed, "daemon_handoff"):
+      if isQueuedHandoffEvent(trimmed):
+        pending = true if route matches key
+      else if eventResolvesHandoff(trimmed):
+        pending = false if route matches key
+  return pending
+```
+
+**Time Complexity**: **O(m)** where m = |events file lines|
+- Single-pass scan; no index
+- File readToEndAlloc: O(m) I/O + O(m) memory
+- **Pathological risk**: Events file grows unbounded; each check re-reads entire file
+
+**Space Complexity**: **O(m)** 
+- Full file into memory: up to 1 MB cap
+- Pending queue: O(p) where p ≤ m (filtered list)
+
+**Concern**: **SUPERLINEAR RISK** — Repeated calls to hasPendingHandoff() scale linearly with total events ever recorded. If repair.log logs every daemon handoff ever attempted, file grows indefinitely and every poll stalls. Mitigation: rotate log, index pending state, or move to transactional event store.
+
+---
+
+### 8. Handoff Route Key Matching (JSON Field Parsing)
+
+**Location**: `src/repair_state.zig:288-300, 317-360`
+
+Compare pending handoff against incoming key:
+```
+eventRouteKeyMatches(a, b):
+  return eventOptionalFieldEquals(a, b, "profile") &&
+         eventOptionalFieldEquals(a, b, "provider") &&
+         eventOptionalFieldEquals(a, b, "account") &&
+         eventOptionalFieldEquals(a, b, "capability")
+
+eventFieldString(line, field):
+  search for "field": in JSON
+  extract quoted value
+  return substring
+```
+
+**Time Complexity**: **O(1)** per field if line length is bounded
+- String search + regex extraction: O(line_len)
+- **Issue**: No JSON parser; ad-hoc string scanning
+- Repeated scans across all lines: O(m·line_len)
+
+**Space Complexity**: **O(1)** per comparison
+- No auxiliary allocation beyond substrings
+
+**Risk**: Hand-written JSON parsing is fragile and O(n) without tokenization. Recommend JSON streaming parser or structured event store.
+
+---
+
+### 9. SHA256-12hex Account ID Dedup
+
+**Location**: `src/main.zig:773-779`
+
+Identity compression:
+```
+shortSha256HexAlloc(account_id):
+  digest = Sha256.hash(account_id)
+  hex_out = bufPrint(digest[0..6], "{x}")  // first 6 bytes → 12 hex chars
+  return hex_out  // "660d25a9d7ee"
+```
+
+**Time Complexity**: **O(1)**
+- SHA256: constant time (~ns per call on modern CPU)
+- hex encode: O(6) = O(1)
+
+**Space Complexity**: **O(1)**
+- Output: 12-byte string
+- Temporary: 32-byte digest + 12-byte buf = O(1)
+
+**Design**: Non-reversible identifier for account dedup in inventory telemetry. 12 hex = 48-bit collision space; acceptable for dedup (birthday bound ~16M before 50% collision).
+
+---
+
+### 10. Wire Proxy Serve Loop: Request Routing + Retry
+
+**Location**: `src/adapters/codex/wire_proxy.zig:432-722`
+
+Single-request routing with same-turn retry:
+```
+serveOne():
+  req = parseRequest(reader)
+  attempted = []
+  while True:
+    elected = electProxyRouteAfterTimeRefresh(pool, profile, attempted, now)
+    tokens = materialize(elected.id)
+    out_headers = buildOutboundHeaders(req, tokens)
+    status_class = forwardAndStream(req, out_headers)
+    
+    if should_retry(status_class.classification):
+      attempted.append(elected.id)
+      continue
+    else:
+      break
+  return response
+```
+
+**Time Complexity**: 
+- Per attempt: **O(n)** elect + **O(k)** header build + **O(r)** response classify
+  - n = pool size
+  - k = header count (constant, ~50)
+  - r = response size (can be large for streaming 200/streaming OK; small for buffered 4xx)
+- Worst case r retries: **O(r·(n + k + r))** = **O(r·n + r²)**
+  - Example: 10 retries × 100 accounts = 1000 elections; network I/O dominates in practice
+
+**Space Complexity**:
+- Arena allocator per request: O(r·(headers + attempted_list))
+  - Buffered response (4xx/5xx only): O(64 KiB cap)
+  - Attempted list: O(r) entries
+
+**Design Note**: Same-turn retry is *inline* (no queue), so reattempt is synchronous. Helps account swap within a single Codex turn without blocking. Risk: If upstream is slow, all retries serialize (no pipelining).
+
+---
+
+### 11. Account Exclusion on Retry
+
+**Location**: `src/adapters/codex/wire_proxy.zig:472-576`
+
+Attempted account tracking:
+```
+attempted = ArrayListUnmanaged([]const u8){}
+
+loop:
+  elected = pool.elect(profile, null, attempted.items)  // O(n)
+  attempted.append(elected.id)
+  // if retry:
+  //   continue; next elect skips all in attempted[]
+```
+
+**Time Complexity**:
+- Per election: **O(n)** scan of pool + **O(r)** scan of attempted list
+  - Worst case r retries: **O(r·(n + r))**
+
+**Space Complexity**: **O(r)** for attempted list
+
+**Optimization opportunity**: Pre-sort pool by availability or use a bitmask for tried accounts if n is bounded and small (< 64).
+
+---
+
+### 12. Health Store Passive Recovery (Score Decay)
+
+**Location**: `src/health.zig:439-451`
+
+Opportunistic health score recovery:
+```
+passiveRecovery():
+  for each health in accounts.values():
+    elapsed_hours = floor((now - last_updated) / 3600)
+    if elapsed_hours > 0:
+      score += decay_per_hour * min(elapsed_hours, 100)
+      score.clamp()
+```
+
+**Time Complexity**: **O(n)**
+- Iterate all entries; no sorting or priority structure
+- Called once per poll iteration or explicit recovery trigger
+
+**Space Complexity**: **O(1)**
+
+**Note**: Cap at 100 hours prevents integer overflow and limits max recovery. Not called in hot path; safe for correctness.
+
+---
+
+### 13. Health Store Serialization (Persist to JSON)
+
+**Location**: `src/health.zig:484-535`
+
+Atomic write of HealthStore state:
+```
+persist():
+  path = ~/.cache/oauth-mux/health.json
+  file = createFileAbsolute(path, {.truncate = true})
+  writeJson(file.writer(), self)
+  // manual JSON generation, not std.json
+
+fn writeJson(writer, store):
+  for each entry in accounts.iterator():
+    write JSON object: key, score, circuit_state, liveness, etc.
+```
+
+**Time Complexity**: **O(n·s)** where s = avg size per entry
+- Iterate all accounts + serialize each as JSON string
+- Manual JSON generation (no buffer overhead if streaming)
+
+**Space Complexity**: **O(n·s)** 
+- JSON file size; no in-memory buffer (streaming write if file-backed)
+
+**Frequency**: On-demand (not per-request); typically called during shutdown or periodic checkpoints.
+
+---
+
+## Complexity Summary Table
+
+| Pattern | Location | Time Big-O | Space Big-O | Risk Level |
+|---------|----------|-----------|------------|-----------|
+| Route Election | account_pool.zig:187 | O(n) | O(1) | Medium |
+| Time-Based Refresh | account_pool.zig:155 | O(n) per call | O(1) | Medium |
+| HealthStore Lookup | health.zig:245 | O(1) amortized | O(n) entries | Low |
+| Circuit Breaker | health.zig:284 | O(1) | O(1) | Low |
+| Token Bucket | health.zig:436 | O(1) | O(1) | Low |
+| Repair Lock | repair_state.zig:378 | O(1) blocking | O(1) | Low |
+| Handoff Queue Scan | repair_state.zig:98 | O(m) file size | O(m) buffer | **HIGH** |
+| Route Key Match | repair_state.zig:288 | O(line_len) | O(1) | Medium |
+| SHA256-12hex | main.zig:773 | O(1) | O(1) | Low |
+| Proxy Serve Loop | wire_proxy.zig:432 | O(r·n) retries | O(r) + 64KiB | Medium |
+| Account Exclusion | wire_proxy.zig:472 | O(r·n + r²) | O(r) list | Medium |
+| Passive Recovery | health.zig:439 | O(n) | O(1) | Low |
+| Health Persist | health.zig:484 | O(n·s) | O(n·s) | Low |
+
+---
+
+## Scaling Concerns & Recommendations
+
+### 1. **Events File Growth (CRITICAL)**
+- **Issue**: `repair_state.zig` appends JSONL indefinitely; `hasPendingHandoff()` re-reads entire file per check
+- **Current State**: 1 MB file cap; no rotation or index
+- **Recommendation**: 
+  - Implement log rotation (e.g., split at 100MB, keep last 10 files)
+  - Add in-memory pending queue index (update on append, not on read)
+  - Or move to transactional event store (e.g., SQLite) with indexed pending state
+
+### 2. **Account Pool Scan**
+- **Issue**: `refreshTimeBased()` O(n) on every serve; `elect()` O(n) per attempt
+- **Current State**: No optimization for large pools (e.g., 1000 accounts)
+- **Recommendation**:
+  - Lazy recovery: only check expiration on election candidates, not all
+  - Heap of next_eligible_at timestamps for fast min recovery
+  - Pre-filter pool by tier (tier 1 live accounts checked first)
+
+### 3. **HealthStore Unbounded Growth**
+- **Issue**: Capability-level entries (provider:account#cap) accumulate without eviction
+- **Current State**: No TTL or cleanup
+- **Recommendation**:
+  - Add LRU or time-based expiration for cold entries
+  - Prune in background (post-persist) if entry untouched for 7 days
+  - Or switch to limited-size ring buffer per account
+
+### 4. **Wire Proxy Retry Serialization**
+- **Issue**: Same-turn retries are synchronous; 3 retries × 30s upstream timeout = 90s stall
+- **Current State**: Backoff is 150ms, 500ms (short); no long-term queueing
+- **Recommendation**:
+  - Add configurable max retries per turn (currently unbounded by pool size)
+  - Consider request pipelining for Phase 3+ to avoid serial retry latency
+
+### 5. **Hash Collision on 12-Bit Identity**
+- **Issue**: 12 hex chars = 48 bits; ~16M accounts before 50% birthday collision risk
+- **Current State**: Acceptable for inventory dedup; not cryptographic
+- **Recommendation**: Monitor collision rate in telemetry; extend to 16 chars if needed
+
+---
+
+## Performance Profile (Estimated)
+
+- **Per-request overhead**: ~5–10ms (1 election O(n) scan + header build + classify)
+  - Dominated by network I/O, not algorithmic complexity
+  - Scanning 100 accounts (linear search) ≈ negligible vs. network latency
+- **Per-refresh polling**: ~1ms (O(n) scan, all local)
+- **Handoff check on retry**: Up to 50–100ms if events file is 1 MB (worst case O(m))
+- **Persist to disk**: ~10–50ms depending on HealthStore size
+
+No pathological O(n²) or O(n³) patterns observed in core request path. Primary risk is **events file unbounded growth** causing O(m) blocking on handoff checks.
+
+---
+
+## Conclusion
+
+The oauth-mux system exhibits **linear complexity** in account pool size and entry counts, with **acceptable amortized performance** for typical deployments (< 100 accounts, < 100K health entries). The **critical risk** is in repair event log accumulation, which should be addressed with log rotation or indexing. All core algorithmic patterns (circuit breaker, token bucket, route election) are **O(1) or O(n) with small constants**, making the system scalable to mid-sized deployments. For 10K+ accounts or 1M+ events, consider the recommendations above.

--- a/docs/spec/codex-mux-trustable-architecture-2026-06-03.md
+++ b/docs/spec/codex-mux-trustable-architecture-2026-06-03.md
@@ -1,0 +1,77 @@
+# Codex Mux Trustable Architecture Gate
+
+Status: planning gate, 2026-06-03.
+
+## Product Bar
+
+`oauth-mux codex` is successful only when it keeps the managed Codex harness
+usable across account auth, quota, tier, and local runtime changes without
+corrupting native Codex state or requiring the user to relaunch the harness.
+
+The gate is not satisfied by login success, green route preflight, synthetic
+unit tests, or a provider answer that leaves the child process hung.
+
+## Current Reality
+
+Main contains the durable canonical bridge lineage through #365. That lineage is
+better than the older disposable `$TMPDIR` bridge, but it still treats canonical
+Codex session authority as part of the muxed session path.
+
+The stronger TIN-1851 branch at `/private/tmp/omux-tin1851` implements the
+home-is-store candidate architecture:
+
+- selected account home is used directly as `CODEX_HOME`;
+- no auth copy is buffered through an overlay;
+- no canonical `CODEX_SQLITE_HOME` bridge is set by default;
+- canonical `~/.codex` is not a muxed session write target;
+- same-account and duplicate-upstream-identity session locks serialize refresh
+  token rotation.
+
+That branch is unmerged. Linear marking TIN-1851 Done must not be interpreted as
+mainline production readiness until the branch, or an equivalent design, lands
+and passes live e2e.
+
+Open GitHub #366 remains a release blocker for dogfooding because the live mux
+e2e can receive a successful provider answer and still hang during child
+shutdown/finalization. Provider success is not session lifecycle success.
+
+## Dogfood Gate
+
+Managed oauth-mux Codex dogfooding can resume only after a live e2e artifact
+proves all of:
+
+1. `oauth-mux codex` completes a real Codex transaction.
+2. `oauth-mux codex resume` completes against a previously created muxed
+   session.
+3. Two distinct managed account sessions can run concurrently without refresh
+   token reuse or sqlite authority poisoning.
+4. The child process reaches a terminal frame and exits cleanly.
+5. No new canonical `~/.codex/state_5.sqlite` rows point at disposable or
+   scrubbed oauth-mux homes.
+6. Canonical sqlite lock holders are gone after the harness exits.
+7. Status output identifies the session authority model honestly.
+
+Until then, native Codex is the safe default for day-to-day engineering work and
+muxed Codex remains a gated test path.
+
+## Worktree Hygiene
+
+Keep these worktrees until their changes are explicitly reconciled:
+
+- `/private/tmp/omux-tin1851`: home-is-store muxing architecture candidate.
+- `.claude/worktrees/wf_40577f82-730-4`: UX/default profile and in-session
+  fallback refresh work.
+
+Park stale greenfield reauth, identity, keepalive, web UI, and Claude adapter
+PRs until the Codex state model is safe. They may be valuable, but they do not
+fix the state-authority failure.
+
+## Remote Proof
+
+Low-power developer machines should not carry full proof burden. Use
+`just remote-check`, `just remote-test`, `just remote-build`, `just remote-e2e`,
+and `just remote-release-proof` to dispatch the existing Just/Nix validation
+bodies onto the GloriousFlywheel runner substrate.
+
+Bazel is not the next step for this repo unless a real oauth-mux target graph or
+consumer need exists. Remote-first validation rides the Just/Nix contract first.

--- a/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
+++ b/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
@@ -55,6 +55,38 @@ diagnostics can run.
 The existing GitHub-hosted lane remains as a portability check. It still builds
 and tests with Zig directly, and now validates all example configs too.
 
+## Remote-First Operator Dispatch
+
+Update, 2026-06-03: low-power developer machines should not have to prove the
+full repo locally. The repo now exposes an explicit remote validation lane:
+
+- `.github/workflows/remote-validate.yml`
+- `scripts/remote-validate.sh`
+- `just remote-check`
+- `just remote-test`
+- `just remote-build`
+- `just remote-e2e`
+- `just remote-release-proof`
+
+These commands dispatch a `workflow_dispatch` run on `tinyland-nix` and, by
+default, watch the resulting GitHub Actions run. The workflow uses the same
+private GloriousFlywheel `nix-job` composite action as the cache-first CI lane,
+requires `GF_ACTIONS_TOKEN`, requires the Nix/Attic environment variables, and
+then runs the existing Just/Zig validation bodies inside `nix develop`.
+Because GitHub exposes manual dispatch workflows from the default branch, the
+remote validation workflow must land on `main` before branch/SHA validation can
+be requested through `just remote-*`.
+
+This is intentionally additive. `just check-local`, `just e2e-local`, and the
+direct Zig recipes remain available for tight local iteration and for debugging
+runner-specific failures. Remote validation is the preferred proof path when a
+developer only needs a trustworthy build/test/e2e answer and not local compiler
+feedback.
+
+The remote workflow fails rather than silently falling back when the
+GloriousFlywheel action token is absent. A skipped or fallback local run is not
+remote validation.
+
 ## What This Proves
 
 When `GF_ACTIONS_TOKEN` and the Attic settings are present, this proves that
@@ -72,6 +104,7 @@ It does not yet prove:
 - cache-first CI execution when the private action checkout token is absent;
 - full remote execution for every local developer action;
 - Bazel remote-cache behavior, because this repo has no Bazel targets;
+- Bazel remote execution, because `oauth-mux` still has no Bazel target graph;
 - package publication to npm, Homebrew, deb, rpm, or GitHub Releases;
 - live OAuth provider route health, except when explicit operator probe jobs
   are run with real credentials.
@@ -130,7 +163,9 @@ available for focused iteration.
    pre-publication self-hosted gate once `tinyland-nix` capacity is stable
    enough to block releases on it.
 3. Keep Bazel out until there is a real target graph or downstream adoption
-   reason; if added later, copy the GloriousFlywheel shape:
-   `cache-contract-strict` before any cache-backed Bazel command.
+   reason. Remote-first validation should ride the existing Just/Nix contract
+   first. If Bazel is added later, copy the GloriousFlywheel shape:
+   `cache-contract-strict` before any cache-backed Bazel command, and require
+   explicit executor-backed evidence before claiming remote execution.
 4. Add a scheduled or manual live-provider QA workflow only after secret
    scoping is explicit; route probes spend real subscription calls.

--- a/justfile
+++ b/justfile
@@ -215,6 +215,26 @@ first-run-e2e-local:
 live-qa:
     nix develop --command ./scripts/live-provider-qa.sh
 
+# ── Remote validation (GloriousFlywheel runner dispatch) ──
+
+remote-validate TARGET="check" REF="":
+    ./scripts/remote-validate.sh {{TARGET}} {{REF}}
+
+remote-check REF="":
+    ./scripts/remote-validate.sh check {{REF}}
+
+remote-test REF="":
+    ./scripts/remote-validate.sh test {{REF}}
+
+remote-build REF="":
+    ./scripts/remote-validate.sh build {{REF}}
+
+remote-e2e REF="":
+    ./scripts/remote-validate.sh e2e {{REF}}
+
+remote-release-proof REF="" VERSION=release_version:
+    OMUX_REMOTE_RELEASE_VERSION={{VERSION}} ./scripts/remote-validate.sh release-proof {{REF}}
+
 # ── Broker MCP smoke (provider-neutral regression catch-net) ──
 
 smoke-broker:

--- a/scripts/codex-canonical-auth-canary.sh
+++ b/scripts/codex-canonical-auth-canary.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# codex-canonical-auth-canary: regression guard for the system-wide Codex auth
+# poisoning that killed the dev accounts (2026-05/06). Asserts the four invariants
+# that must hold for canonical ~/.codex to stay working. Exits non-zero on any
+# violation so it can gate a switch, a cron alert, or a pre-flight check.
+#
+# It NEVER prints token/credential contents — only presence/shape and markers.
+#
+#   1. ~/.codex/auth.json exists and parses (codex login wrote a real credential).
+#   2. ~/.codex/.oauth-mux does NOT exist (oauth-mux canonical-bridge muxxing has
+#      not run against the real home — that bridge is what recorded/scrubbed state
+#      into ~/.codex and is the poisoning vector).
+#   3. The sops-nix codex/auth blob stays renamed/absent, so a home-manager switch
+#      cannot re-materialize a stale auth.json over the live rotated tokens
+#      (the 995b72d8 vector). Rotating OAuth tokens must never live in sops.
+#   4. ~/.codex/config.toml carries no oauth-mux proxy override (a dead 127.0.0.1
+#      port left in the canonical config bricks native codex).
+
+set -uo pipefail
+
+CODEX_HOME_DIR="${CODEX_HOME:-$HOME/.codex}"
+LAB_SOPS_BLOB="${OMUX_LAB_SOPS_CODEX_BLOB:-$HOME/git/lab/nix/secrets/codex/auth.json}"
+fail=0
+
+check() { # name, ok(0/1), detail
+  if [ "$2" = "0" ]; then
+    printf 'PASS  %-34s %s\n' "$1" "${3:-}"
+  else
+    printf 'FAIL  %-34s %s\n' "$1" "${3:-}"
+    fail=1
+  fi
+}
+
+# 1. canonical auth.json present + parses
+auth="$CODEX_HOME_DIR/auth.json"
+if [ -f "$auth" ] && python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if isinstance(d,dict) and d.get('tokens') else 1)" "$auth" 2>/dev/null; then
+  check "canonical_auth_present" 0 "$auth ok"
+else
+  check "canonical_auth_present" 1 "$auth MISSING or unparseable -> run: codex login"
+fi
+
+# 2. no oauth-mux bridge target inside the canonical home
+if [ -e "$CODEX_HOME_DIR/.oauth-mux" ]; then
+  check "no_canonical_bridge_residue" 1 "$CODEX_HOME_DIR/.oauth-mux exists -> muxxing ran against canonical; quarantine it"
+else
+  check "no_canonical_bridge_residue" 0 "no $CODEX_HOME_DIR/.oauth-mux"
+fi
+
+# 3. sops codex/auth materialization stays disabled (blob absent at the gated path)
+if [ -e "$LAB_SOPS_BLOB" ]; then
+  check "sops_codex_auth_disabled" 1 "$LAB_SOPS_BLOB present -> sops will clobber ~/.codex/auth.json on switch; keep it renamed/.DISABLED"
+else
+  check "sops_codex_auth_disabled" 0 "sops codex/auth blob absent (gate off)"
+fi
+
+# 4. canonical config.toml has no dead proxy override
+cfg="$CODEX_HOME_DIR/config.toml"
+if [ -f "$cfg" ] && grep -qE 'Managed by oauth-mux|oauth_mux_openai|127\.0\.0\.1.*backend-api' "$cfg" 2>/dev/null; then
+  check "config_no_proxy_poison" 1 "$cfg carries an oauth-mux proxy override -> native codex routes to a dead port"
+else
+  check "config_no_proxy_poison" 0 "$cfg clean"
+fi
+
+echo
+if [ "$fail" = "0" ]; then
+  echo "codex-canonical-auth-canary: OK (canonical ~/.codex auth invariants hold)"
+else
+  echo "codex-canonical-auth-canary: REGRESSION DETECTED (see FAILs above)" >&2
+fi
+exit "$fail"

--- a/scripts/remote-validate.sh
+++ b/scripts/remote-validate.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: scripts/remote-validate.sh <target> [ref] [--no-watch]
+
+Targets:
+  check          Run just check-local on the GloriousFlywheel runner.
+  test           Run zig build test on the GloriousFlywheel runner.
+  build          Run zig build on the GloriousFlywheel runner.
+  e2e            Run just e2e-local on the GloriousFlywheel runner.
+  release-proof  Run just release-proof-local on the GloriousFlywheel runner.
+
+The workflow file must already exist on the repository default branch. After
+that, pass a branch or SHA as [ref] to validate it remotely.
+USAGE
+}
+
+case "${1:-}" in
+  -h|--help|help)
+    usage
+    exit 0
+    ;;
+esac
+
+target="${1:-check}"
+shift || true
+
+watch=1
+ref=""
+version="${OMUX_REMOTE_RELEASE_VERSION:-}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --no-watch)
+      watch=0
+      ;;
+    --watch)
+      watch=1
+      ;;
+    --version)
+      shift
+      version="${1:-}"
+      if [ -z "$version" ]; then
+        echo "remote-validate: --version requires a value" >&2
+        exit 2
+      fi
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    "")
+      ;;
+    *)
+      if [ -z "$ref" ]; then
+        ref="$1"
+      else
+        echo "remote-validate: unexpected argument: $1" >&2
+        usage
+        exit 2
+      fi
+      ;;
+  esac
+  shift || true
+done
+
+case "$target" in
+  check|test|build|e2e|release-proof)
+    ;;
+  *)
+    echo "remote-validate: unsupported target: $target" >&2
+    usage
+    exit 2
+    ;;
+esac
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "remote-validate: gh is required to dispatch remote validation" >&2
+  exit 127
+fi
+
+if [ -z "$ref" ]; then
+  ref="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  if [ -z "$ref" ] || [ "$ref" = "HEAD" ]; then
+    ref="$(git rev-parse HEAD 2>/dev/null || true)"
+  fi
+fi
+
+if [ -z "$ref" ]; then
+  echo "remote-validate: could not infer git ref; pass one explicitly" >&2
+  exit 2
+fi
+
+repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+workflow="remote-validate.yml"
+
+echo "remote-validate: dispatching ${target} on ${repo}@${ref}"
+
+args=(workflow run "$workflow" --repo "$repo" --ref "$ref" -f "target=$target")
+if [ -n "$version" ]; then
+  args+=(-f "version=$version")
+fi
+gh "${args[@]}"
+
+if [ "$watch" != "1" ]; then
+  echo "remote-validate: dispatched; watch with: gh run list --repo ${repo} --workflow ${workflow}"
+  exit 0
+fi
+
+echo "remote-validate: locating latest workflow_dispatch run"
+run_id="$(gh run list \
+  --repo "$repo" \
+  --workflow "$workflow" \
+  --branch "$ref" \
+  --event workflow_dispatch \
+  --json databaseId,status,createdAt \
+  --jq 'sort_by(.createdAt) | reverse | .[0].databaseId // empty' \
+  --limit 10)"
+
+if [ -z "$run_id" ]; then
+  echo "remote-validate: dispatched, but GitHub has not exposed the run yet" >&2
+  echo "remote-validate: check: gh run list --repo ${repo} --workflow ${workflow}" >&2
+  exit 1
+fi
+
+echo "remote-validate: watching run ${run_id}"
+gh run watch "$run_id" --repo "$repo" --exit-status


### PR DESCRIPTION
## Summary

- Correct generated Codex auth/home internals docs so `CODEX_AUTH_FILE` is wrapper-observed, not native Codex truth.
- Add a trustable Codex mux architecture gate covering TIN-1851, #366, dogfood criteria, and worktree hygiene.
- Add remote-first validation dispatch through GloriousFlywheel: `remote-validate.yml`, `scripts/remote-validate.sh`, and `just remote-*` recipes.
- Document that manual remote dispatch becomes usable after the workflow file lands on `main`; branch validation can then pass a ref/SHA.

## Validation

- `bash -n scripts/remote-validate.sh`
- Ruby YAML parse for `.github/workflows/remote-validate.yml`
- `just --summary`
- `git diff --check`

## Notes

This does not claim oauth-mux Codex dogfooding is safe. The new architecture gate keeps TIN-1851/#366 explicit: muxed Codex remains gated until home-is-store or equivalent lands and live e2e proves clean transaction, resume, concurrency, shutdown, and zero canonical sqlite poisoning.