### PR TITLE
docs: require remote build proof

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,19 +65,24 @@ easier to generalize into the next harness adapter, it is probably out of scope.
 8. `build.zig` / `build.zig.zon` — Zig build system
 9. `src/` — implementation
 
-## Build
+## Build And Validation
 
-Zig 0.14+ via Nix flake. Always use `just` as the entrypoint:
+Remote-first rule: proof builds, test gates, release checks, and agent validation
+must use the GloriousFlywheel remote lanes. Do not use local `zig build`,
+`just build`, `just test`, or `just check-local` as the completion proof on a
+developer laptop.
 
 ```bash
-just build          # debug build
-just test           # run all tests
-just build-release  # ReleaseSafe optimized build
-just release        # cross-compile all 6 platform targets
-just check          # full validation (test suite)
+just remote-build   # build on the GloriousFlywheel runner
+just remote-test    # test on the GloriousFlywheel runner
+just remote-check   # full check on the GloriousFlywheel runner
+just remote-e2e     # e2e on the GloriousFlywheel runner
 ```
 
-Direct `zig build` is acceptable when iterating, but `just` is the canonical path.
+Local build commands remain available only for narrow debugging of a local
+toolchain, generated binary, or installer issue. If a local build is used for
+debugging, state that it is not validation and follow with the remote lane before
+making a completion or merge claim.
 
 ## Architecture
 
@@ -122,12 +127,13 @@ to avoid framework linking and keep the binary static.
 ## Testing
 
 ```bash
-just test           # unit tests via zig build test
-just test-verbose   # with output
+just remote-test    # unit tests on the GloriousFlywheel runner
+just remote-check   # full validation on the GloriousFlywheel runner
 ```
 
 Tests are in-file `test` blocks (Zig convention) plus `test/fixtures/` for
-provider token format samples.
+provider token format samples. Local `just test` and `just test-verbose` are
+debugging tools only; do not use them as completion proof.
 
 ## Distribution
 

--- a/README.md
+++ b/README.md
@@ -265,13 +265,16 @@ UX:
 DX:
 
 ```bash
-just build
-just test
-just check-local
+just remote-build
+just remote-test
+just remote-check
+just remote-e2e
 ```
 
-Use `just release-proof <version>` before any registry mutation. Direct
-`zig build` is fine for iteration, but `just` is the operator entrypoint.
+Use `just remote-release-proof <ref> <version>` before any registry mutation. Local
+`zig build`, `just build`, and `just check-local` are debugging tools only; they
+are not the proof path for PR, release, or dogfood readiness on low-power
+developer machines.
 
 AX:
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -128,9 +128,10 @@ Source checkouts prove the first-run path without touching real operator state:
 just first-run-e2e
 ```
 
-When checking unreleased behavior from source, use `just run -- ...` or
-`./zig-out/bin/oauth-mux` after `just build` so local observations match repo
-`main` rather than an older installed package.
+When checking unreleased behavior from source, use the remote validation lanes
+first (`just remote-build`, `just remote-check`, or `just remote-e2e`). Local
+`just run -- ...`, `just build`, or `./zig-out/bin/oauth-mux` are debugging
+tools only and should not be used as readiness proof on developer laptops.
 
 Live probes remain explicit because they can spend subscription calls:
 

--- a/docs/live-provider-qa.md
+++ b/docs/live-provider-qa.md
@@ -4,15 +4,16 @@ Live provider QA is manual and secret-scoped because provider probes can spend
 real subscription calls.
 The canonical route-state and handoff matrix is `docs/qa-handoff-matrix.md`.
 
-## Local Run
+## Remote-First Run
 
-Build first:
+Build/prove the checkout on the remote runner first:
 
 ```bash
-just build
+just remote-build
 ```
 
-Probe a profile:
+Then probe a profile from the intended operator machine, because live provider
+QA uses local account stores and may spend real subscription calls:
 
 ```bash
 OMUX_LIVE_QA_CONFIRM=spend-real-calls \

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -97,9 +97,12 @@ UX:
 
 DX:
 
-- `just build`, `just test`, and `just check-local` remain the local development
-  gates.
-- `just release-proof <version>` is required before any registry mutation.
+- `just remote-build`, `just remote-test`, `just remote-check`, and
+  `just remote-e2e` are the development proof gates.
+- `just remote-release-proof <ref> <version>` is required before any registry
+  mutation.
+- Local build/check commands are debugging tools only; do not use them as PR,
+  release, or dogfood readiness proof on developer laptops.
 - Installed-command dogfood must use `oauth-mux version --json`,
   `which -a oauth-mux`, `which -a codex`, and `codex preflight` to prove the
   exact binary and shim path under test.
@@ -196,14 +199,14 @@ browser is needed; local Playwright is not part of this CLI proof path.
   `doctor`, `providers list`, `accounts list`, `route explain`,
   `codex preflight`, `broker-session-plan`, `stay-afloat next`,
   `status-latest`, and `daemon status`.
-- Local validation passes: `zig build test`, targeted Codex smokes,
-  `nix develop --command just check-local`, and the hybrid `nix flake check`
-  package smoke.
+- Remote validation passes: `just remote-check`, plus targeted remote lanes such
+  as `just remote-test`, `just remote-build`, and `just remote-e2e` when the
+  change warrants them. Local validation commands are debugging aids only.
 - Dogfood process/memory concerns are backed by at least two redacted
   `dogfood-process-snapshot` artifacts before being called leaks.
-- Public release validation passes: `just release-proof <version>`, release
-  proof workflow, npm dry run/publish workflow as appropriate, Homebrew QA, and
-  system package QA.
+- Public release validation passes: `just remote-release-proof <ref> <version>`,
+  release proof workflow, npm dry run/publish workflow as appropriate, Homebrew
+  QA, and system package QA.
 - Homebrew release validation proves both installed binary output and
   `brew info --json=v2` stable version semantics for the public tap formula.
 - Public copy does not claim same-thread continuity, mid-turn recovery,

--- a/docs/qa-handoff-matrix.md
+++ b/docs/qa-handoff-matrix.md
@@ -73,8 +73,8 @@ capability, such as `codex:max-3#codex-max`.
 
 ## Coverage Reality
 
-`just check-local` already includes synthetic smokes for the two highest-value
-negative Codex UX lanes:
+`just remote-check` already runs the synthetic smokes for the two highest-value
+negative Codex UX lanes on the remote validation substrate:
 
 - `scripts/smoke-codex-all-exhausted.sh` covers the all-fallbacks terminal
   vector, typed `503` repair body, redaction, and stable managed child PID.

--- a/docs/registry-dry-runs-and-rollback.md
+++ b/docs/registry-dry-runs-and-rollback.md
@@ -1,9 +1,9 @@
 # Registry Dry-Runs and Rollback
 
 Registry publication is intentionally separate from release artifact proof.
-`just release-proof <version>` proves the release tree and handoff without
-publication credentials. Authenticated registry dry-runs are CI/operator gates
-and non-publishing.
+`just remote-release-proof <ref> <version>` proves the release tree and handoff
+without publication credentials on the remote runner. Authenticated registry
+dry-runs are CI/operator gates and non-publishing.
 For the DRY lane map across worktree, Nix, GitHub Release, npm, Homebrew,
 curl, deb, and rpm installers, see `docs/release-install-lanes.md`.
 
@@ -18,7 +18,8 @@ Stage and prove artifacts:
 
 ```bash
 version="$(scripts/project-version.sh)"
-just release-proof "$version"
+ref="$(git rev-parse --abbrev-ref HEAD)"
+just remote-release-proof "$ref" "$version"
 ```
 
 Run a plan-only dry-run report:
@@ -146,7 +147,8 @@ GitHub Release:
 
 1. Delete or mark the bad release as draft.
 2. Delete the tag only after consumers are notified.
-3. Re-run `just release-proof <version>` before publishing a replacement.
+3. Re-run `just remote-release-proof <ref> <version>` before publishing a
+   replacement.
 
 npm:
 

--- a/docs/release-install-lanes.md
+++ b/docs/release-install-lanes.md
@@ -2,7 +2,7 @@
 
 Updated: 2026-05-18
 
-This is the DRY map for installer, package, CI, and local dogfood lanes.
+This is the DRY map for installer, package, CI, and dogfood lanes.
 Detailed historical evidence stays in `docs/install-beta-matrix.md` and
 `docs/release-runbook.md`.
 
@@ -10,7 +10,7 @@ Detailed historical evidence stays in `docs/install-beta-matrix.md` and
 
 | Lane | User command | Source of artifact | Proof gate | Claim |
 | --- | --- | --- | --- | --- |
-| Worktree dogfood | `./zig-out/bin/oauth-mux ...` | current checkout | `zig build`, `just check-local` | unreleased behavior only |
+| Worktree dogfood | `./zig-out/bin/oauth-mux ...` | current checkout | `just remote-build`, `just remote-check`, plus hash/version proof for the local copied artifact | unreleased behavior only |
 | User-local dogfood | `oauth-mux ...` and managed `codex ...` with PATH resolving to `~/.local/bin` | copied worktree binary plus shared POSIX shim | hash match with `./zig-out/bin/oauth-mux`, version check, shim pass-through smoke, preflight check | installed-command dogfood for current checkout |
 | Nix package | `nix build .#` | flake package plus shared POSIX shim | `./result/bin/oauth-mux version`, `nix flake check` binary+shim smoke | package derivation proof |
 | GitHub Release | downloaded tarball | `dist/out/v*/artifacts` from release workflow | checksum verify, tarball binary+shim smoke | public raw binary lane |
@@ -70,7 +70,7 @@ Codex command resolution is unchanged by `brew install jesssullivan/omux/oauth-m
 | Surface | Workflow or command | Mutates registries? | Purpose |
 | --- | --- | --- | --- |
 | PR/push CI | `.github/workflows/ci.yml` | no | unit tests, example validation, local E2E, cross-compile, Nix build/check, optional GloriousFlywheel cache-first proof |
-| Release staging | `just release-proof <version>` / `.github/workflows/release-proof.yml` | no | build the release tree, smoke installers/packages, generate handoff |
+| Release staging | `just remote-release-proof <ref> <version>` / `.github/workflows/release-proof.yml` | no | build the release tree, smoke installers/packages, generate handoff on the remote runner |
 | GitHub Release | `.github/workflows/release.yml` on `v*` tag | GitHub release assets only | upload staged tarballs, npm tarballs, formula, checksums, installer, handoff |
 | Registry dry run | `.github/workflows/registry-dry-run.yml` | no | contact configured registries/taps with explicit non-publishing confirmation |
 | npm publish | `.github/workflows/npm-publish.yml` | yes, npm only | publish CI-generated npm tarballs after release proof |
@@ -82,11 +82,11 @@ Codex command resolution is unchanged by `brew install jesssullivan/omux/oauth-m
 
 - Use `scripts/project-version.sh` as the version source. Do not hand-edit
   package versions independently.
-- `just release-proof <version>` is the local release tree proof. It must pass
+- `just remote-release-proof <ref> <version>` is the release tree proof. It must pass
   before any registry mutation.
-- `nix flake check` is a hybrid package smoke, not the full shell smoke suite.
-  It must prove the flake package runs, reports the source version, and
-  validates no-secret examples.
+- `nix flake check` is a local package debugging smoke, not release proof.
+  Remote release proof must prove the package runs, reports the source version,
+  and validates no-secret examples.
 - npm publication is CI-only through `.github/workflows/npm-publish.yml`.
   Workstation `npm publish` is unsupported.
 - Release and registry scripts must use an isolated npm cache so root-owned or
@@ -178,10 +178,14 @@ UX gates:
 
 DX gates:
 
-- `just check-local` is the single no-network local validation chain;
-- `just release-proof <version>` is the local release validation chain;
-- `nix build .#` proves the flake package for the current checkout;
-- `nix flake check` runs the package smoke without replacing `just check-local`.
+- `just remote-check` is the default validation chain for PR and dogfood
+  readiness;
+- `just remote-build`, `just remote-test`, and `just remote-e2e` are the
+  targeted remote proof lanes;
+- `just remote-release-proof <ref> <version>` is required before any registry
+  mutation;
+- local `just check-local`, `just release-proof <version>`, `nix build .#`, and
+  `nix flake check` are debugging tools only and do not replace remote proof.
 
 AX gates:
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -95,11 +95,12 @@ Useful overrides:
 - `OMUX_RELEASE_ZIG_JOBS=<n>` sets Zig release concurrency explicitly.
 - `OMUX_RELEASE_SKIP_PREFLIGHT=1` disables the host-resource guard.
 
-Run the full build-plus-smoke proof:
+Run the full build-plus-smoke proof on the remote runner:
 
 ```bash
 version="$(scripts/project-version.sh)"
-just release-proof "$version"
+ref="$(git rev-parse --abbrev-ref HEAD)"
+just remote-release-proof "$ref" "$version"
 ```
 
 This runs `release-local` and then checks:
@@ -218,13 +219,12 @@ cache stalls fail with an explicit step diagnostic before the outer workflow
 timeout. CI uses `OMUX_GF_CHECK_TIMEOUT` with a default of `25m`; the manual
 release proof uses `OMUX_GF_RELEASE_PROOF_TIMEOUT` with a default of `40m`.
 
-During known lab or runner outages, do not block release staging on a queued
-`tinyland-nix` job alone. Use these signals together:
+During known lab or runner outages, keep the release blocked rather than
+substituting local laptop proof. Use these hosted signals together:
 
-- local `just check`
-- local `nix flake check`
-- local `just release-proof <version>`
 - hosted CI `test`, `nix`, and six cross-compile jobs
+- remote `just remote-check`
+- remote `just remote-release-proof <ref> <version>`
 
 Only claim GloriousFlywheel cache-first CI proof when the GF job actually runs
 the private action and completes.
@@ -284,10 +284,10 @@ Current release evidence:
 
 ## Before Marking A PR Ready
 
-- `just check` passes.
-- `just release-proof <version>` produces and smoke-checks the release tree.
-- `nix flake check` passes, preferably with an isolated cache such as
-  `XDG_CACHE_HOME=/tmp/oauth-mux-nix-cache` on sandboxed agent hosts.
+- `just remote-check` passes.
+- `just remote-release-proof <ref> <version>` produces and smoke-checks the release
+  tree when release outputs or packaging changed.
+- Hosted CI `test`, `nix`, cross-compile, and GloriousFlywheel jobs pass.
 - Hosted `System Package Install QA` passes after release assets exist when the
   release changes deb/rpm packaging.
 - Homebrew QA proves both binary output and parsed formula stable version.

--- a/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
+++ b/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
@@ -77,11 +77,12 @@ Because GitHub exposes manual dispatch workflows from the default branch, the
 remote validation workflow must land on `main` before branch/SHA validation can
 be requested through `just remote-*`.
 
-This is intentionally additive. `just check-local`, `just e2e-local`, and the
-direct Zig recipes remain available for tight local iteration and for debugging
-runner-specific failures. Remote validation is the preferred proof path when a
-developer only needs a trustworthy build/test/e2e answer and not local compiler
-feedback.
+This is intentionally remote-first. `just check-local`, `just e2e-local`, and
+direct Zig recipes remain available only for narrow local debugging and runner
+failure triage. They are not proof gates for PR readiness, release readiness, or
+dogfood readiness on developer laptops. Use `just remote-check`,
+`just remote-test`, `just remote-build`, `just remote-e2e`, and
+`just remote-release-proof` for completion claims.
 
 The remote workflow fails rather than silently falling back when the
 GloriousFlywheel action token is absent. A skipped or fallback local run is not
@@ -133,10 +134,10 @@ input:
 - npm package workspace and npm tarballs
 - nfpm configs and deb/rpm artifacts
 
-`just release-proof <version>` runs the same staging command and then validates
-the artifact tree, checksums, archive payloads, Homebrew rendering, local npm
-install path, local installer path, and non-publishing release handoff
-generation. The handoff captures GitHub Release attachments, npm publish order,
+`just remote-release-proof <ref> <version>` runs the same staging command on the
+remote runner and then validates the artifact tree, checksums, archive payloads,
+Homebrew rendering, npm install path, installer path, and non-publishing release
+handoff generation. The handoff captures GitHub Release attachments, npm publish order,
 Homebrew tap input, deb/rpm files, and full checksums under
 `dist/out/v<version>/handoff/`.
 

--- a/docs/spec/test-and-coverage-review-2026-05-05.md
+++ b/docs/spec/test-and-coverage-review-2026-05-05.md
@@ -30,9 +30,11 @@ flags, and synthetic smokes are not success.
 
 ## Current Evidence Stack
 
-`just check-local` delegates to `scripts/check-local.sh`. That script is the
-executable source of truth for the no-network local validation chain; do not
-copy its full command list into specs. At a high level it covers:
+`just remote-check` is the proof gate for merge/release claims. It dispatches
+the validation body to the GloriousFlywheel runner instead of asking developer
+laptops to compile and test the repo. The underlying local body is still
+`scripts/check-local.sh`; do not copy its full command list into specs. At a
+high level it covers:
 
 - `zig build test`, `zig build`, and config validation for every
   `examples/*.config.json`.
@@ -40,8 +42,8 @@ copy its full command list into specs. At a high level it covers:
   handoff, concurrent-session, child-refresh, tier, all-exhausted, 401,
   cassette replay/review, status-summary, and tracker-comment smokes.
 
-Run `just check-local` before merge/release claims when this review changes
-implementation or claim language.
+Run `just remote-check` before merge/release claims when this review changes
+implementation or claim language. Local `just check-local` is for debugging only.
 
 Repo-wide Zig test inventory is broad (`rg '^test "' src` finds 306
 in-file tests). The broker/Codex-adapter subset is materially covered by


### PR DESCRIPTION
## Summary
- make AGENTS/README point proof builds and validation at GloriousFlywheel remote lanes
- update release, dry-run, live QA, and coverage docs so local build/check is debugging only
- keep local account probes separate from build proof because they use operator-local credentials

## Validation
- git diff --check
- remote PR checks / GloriousFlywheel are the proof path