### PR TITLE
fix(repair_state): stop unlinking lock files on release (flock race) + move macOS runtime dir off /tmp

### DIFF
--- a/docs/spec/stay-afloat-supervisor-contract-2026-05-01.md
+++ b/docs/spec/stay-afloat-supervisor-contract-2026-05-01.md
@@ -137,7 +137,9 @@ State:
 Runtime:
 
 - `XDG_RUNTIME_DIR/oauth-mux` when `XDG_RUNTIME_DIR` is set.
-- `/tmp/oauth-mux-$UID` on macOS when no XDG runtime dir is present.
+- `$HOME/Library/Application Support/oauth-mux/runtime` on macOS when no XDG
+  runtime dir is present (`/tmp` is periodically cleaned and can unlink held
+  lock files — TIN-2041).
 - `$HOME/.local/state/oauth-mux` on other platforms as the current fallback.
 - The socket path is `daemon.sock` under the runtime directory.
 - Repair locks are under `repair-locks` in the runtime directory.

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -156,10 +156,9 @@ pub fn start(allocator: std.mem.Allocator) DaemonError!void {
 
 fn ensureRuntimeDir(sock_path: []const u8) !void {
     if (std.fs.path.dirname(sock_path)) |dir| {
-        std.fs.makeDirAbsolute(dir) catch |e| switch (e) {
-            error.PathAlreadyExists => {},
-            else => return e,
-        };
+        // The macOS runtime dir lives under ~/Library/Application Support and
+        // is more than one level deep (TIN-2041); create the full path.
+        try std.fs.cwd().makePath(dir);
     }
 }
 
@@ -496,12 +495,7 @@ fn currentPid() Pid {
 }
 
 fn writePidFile(path: []const u8, pid: Pid) !void {
-    if (std.fs.path.dirname(path)) |dir| {
-        std.fs.makeDirAbsolute(dir) catch |e| switch (e) {
-            error.PathAlreadyExists => {},
-            else => return e,
-        };
-    }
+    try ensureParentDir(path);
     const file = try std.fs.createFileAbsolute(path, .{ .mode = 0o600 });
     defer file.close();
     try file.writer().print("{d}", .{pid});
@@ -582,10 +576,9 @@ fn hasStayAfloatMetadata(allocator: std.mem.Allocator) bool {
 
 fn ensureParentDir(path: []const u8) !void {
     if (std.fs.path.dirname(path)) |dir| {
-        std.fs.makeDirAbsolute(dir) catch |e| switch (e) {
-            error.PathAlreadyExists => {},
-            else => return e,
-        };
+        // The macOS runtime dir lives under ~/Library/Application Support and
+        // is more than one level deep (TIN-2041); create the full path.
+        try std.fs.cwd().makePath(dir);
     }
 }
 

--- a/src/paths.zig
+++ b/src/paths.zig
@@ -27,9 +27,15 @@ pub fn runtimeDir(allocator: std.mem.Allocator) ![]const u8 {
         return std.fs.path.join(allocator, &.{ dir, app_name });
     }
     if (comptime builtin.os.tag == .macos) {
-        const uid = (try env.get(allocator, "UID")) orelse try allocator.dupe(u8, "501");
-        defer allocator.free(uid);
-        return std.fmt.allocPrint(allocator, "/tmp/{s}-{s}", .{ app_name, uid });
+        // TIN-2041: the old fallback /tmp/oauth-mux-<uid> was subject to
+        // periodic /tmp cleaning, which can unlink HELD repair-lock files and
+        // break flock mutual exclusion (the same failure mode as
+        // unlink-on-release, OS-triggered). Use a persistent per-user runtime
+        // dir instead; it also hosts the daemon unix socket — that move is
+        // intended.
+        const home = (try env.get(allocator, "HOME")) orelse return error.OutOfMemory;
+        defer allocator.free(home);
+        return std.fs.path.join(allocator, &.{ home, "Library", "Application Support", app_name, "runtime" });
     }
     const home = (try env.get(allocator, "HOME")) orelse try allocator.dupe(u8, "/tmp");
     defer allocator.free(home);
@@ -136,6 +142,21 @@ test "absolutePath keeps absolute and expands relative paths" {
         try std.testing.expect(std.fs.path.isAbsolute(result));
         try std.testing.expect(std.mem.endsWith(u8, result, "relative/path"));
     }
+}
+
+test "runtimeDir macOS fallback avoids periodically-cleaned /tmp (TIN-2041)" {
+    if (comptime builtin.os.tag != .macos) return error.SkipZigTest;
+    const allocator = std.testing.allocator;
+    const dir = try runtimeDir(allocator);
+    defer allocator.free(dir);
+    if (try env.get(allocator, "XDG_RUNTIME_DIR")) |base| {
+        defer allocator.free(base);
+        // Explicit XDG runtime dir stays honored.
+        try std.testing.expect(std.mem.startsWith(u8, dir, base));
+        return;
+    }
+    try std.testing.expect(!std.mem.startsWith(u8, dir, "/tmp/"));
+    try std.testing.expect(std.mem.endsWith(u8, dir, "Library/Application Support/oauth-mux/runtime"));
 }
 
 test "socketPathFromRuntimeDir keeps Unix socket paths under the platform limit" {

--- a/src/repair_state.zig
+++ b/src/repair_state.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const paths = @import("paths.zig");
 const types = @import("types.zig");
 
@@ -43,7 +44,6 @@ const HeldLock = struct {
     count: usize,
     acquiring: bool,
     file: ?std.fs.File = null,
-    path: ?[]const u8 = null, // held_gpa-owned absolute lockfile path
 };
 
 var held_mutex: std.Thread.Mutex = .{};
@@ -60,11 +60,17 @@ pub const RepairLock = struct {
         if (held_locks.getPtr(self.key)) |entry| {
             if (entry.count > 0) entry.count -= 1;
             if (entry.count == 0) {
+                // Real-lock teardown: closing the fd drops the OS flock, and the
+                // lock FILE deliberately persists (TIN-2041). Unlinking it here
+                // raced waiters: a waiter blocked on the old inode acquires the
+                // kernel flock the instant the fd closes, the unlink then orphans
+                // the name it holds, and a later acquirer creates a NEW inode at
+                // the same path and locks immediately — two concurrent holders.
+                // flock(2) state is the only mutual-exclusion authority: stale
+                // lock files are simply re-locked on the next acquire, and
+                // probeRepairLock reports unlocked files as no repair in
+                // progress.
                 if (entry.file) |f| f.close();
-                if (entry.path) |p| {
-                    std.fs.deleteFileAbsolute(p) catch {};
-                    held_gpa.free(p);
-                }
                 if (held_locks.fetchRemove(self.key)) |kv| held_gpa.free(kv.key);
             }
         }
@@ -564,28 +570,16 @@ fn acquireRepairLockWithMode(
         return e;
     };
 
-    const owned_path = held_gpa.dupe(u8, real.path) catch {
-        real.file.close();
-        std.fs.deleteFileAbsolute(real.path) catch {};
-        allocator.free(real.path);
-        held_mutex.lock();
-        if (held_locks.fetchRemove(key)) |kv| held_gpa.free(kv.key);
-        held_cond.broadcast();
-        held_mutex.unlock();
-        return error.OutOfMemory;
-    };
     allocator.free(real.path);
 
     held_mutex.lock();
     if (held_locks.getPtr(key)) |entry| {
         entry.file = real.file;
-        entry.path = owned_path;
         entry.acquiring = false;
     } else {
         // Should not happen (we own the 'acquiring' reservation), but stay safe.
+        // Close only — the lock file itself persists (see release()).
         real.file.close();
-        std.fs.deleteFileAbsolute(owned_path) catch {};
-        held_gpa.free(owned_path);
     }
     held_cond.broadcast();
     held_mutex.unlock();
@@ -758,6 +752,61 @@ test "repair lock is re-entrant within a process (TIN-1851 no self-deadlock)" {
     // Fully released: a fresh acquire succeeds and the registry entry is gone.
     var l4 = try acquireRepairLockBlocking(a, "codex", "tin1851-reentrancy-test");
     l4.release();
+}
+
+test "lock file path persists after acquire+release (TIN-2041 no unlink-on-release)" {
+    const a = std.testing.allocator;
+    const path = try lockPath(a, "codex", "tin2041-lockfile-persists");
+    defer a.free(path);
+    std.fs.deleteFileAbsolute(path) catch {}; // start from a clean slate
+
+    var lock = try acquireRepairLockBlocking(a, "codex", "tin2041-lockfile-persists");
+    try std.fs.accessAbsolute(path, .{});
+    lock.release();
+    // The lock file must STILL exist: release only drops the flock. Unlinking
+    // here is what orphaned the inode under a waiter (TIN-2041).
+    try std.fs.accessAbsolute(path, .{});
+}
+
+test "release hands the SAME inode to the next acquirer under kernel flock conflict (TIN-2041)" {
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+    const a = std.testing.allocator;
+    const provider = "codex";
+    const account = "tin2041-ofd-conflict";
+
+    const path = try lockPath(a, provider, account);
+    defer a.free(path);
+    std.fs.deleteFileAbsolute(path) catch {}; // start from a clean slate
+
+    // A: public-API acquire takes the real OS flock for this process.
+    var lock_a = try acquireRepairLock(a, provider, account);
+
+    const ino_before = blk: {
+        const f = try std.fs.openFileAbsolute(path, .{});
+        defer f.close();
+        break :blk (try f.stat()).inode;
+    };
+
+    // B: a second, distinct open-file-description on the same path. flock is
+    // per-OFD, so this conflicts even within one process; the public API would
+    // refcount-share, so go below it to create a real kernel conflict.
+    try std.testing.expectError(error.RepairInProgress, acquireRealRepairLock(a, provider, account, true));
+
+    lock_a.release();
+
+    // B now acquires — and must get the SAME inode A held. The old
+    // unlink-on-release orphaned A's inode under any blocked waiter and a
+    // fresh acquire created a new inode at the path: two concurrent holders.
+    const lock_b = try acquireRealRepairLock(a, provider, account, true);
+    defer {
+        lock_b.file.close();
+        a.free(lock_b.path);
+    }
+    try std.testing.expectEqual(ino_before, (try lock_b.file.stat()).inode);
+
+    // Mutual exclusion holds while B owns the lock: a third distinct-OFD
+    // try-acquire fails.
+    try std.testing.expectError(error.RepairInProgress, acquireRealRepairLock(a, provider, account, true));
 }
 
 test "parseStartedAt reads lock metadata timestamp" {


### PR DESCRIPTION
Fixes #373. Linear: TIN-2041.

## The bug
`RepairLock.release()` closed the lock fd then unlinked the path. A waiter blocked on the old inode acquires the kernel flock the instant the fd closes; the unlink orphans the name it holds; a later acquirer creates a new inode at the same path and locks immediately — **two concurrent holders of the same account/identity lock**, re-enabling the concurrent-same-account refresh-chain self-revocation the lock regime exists to prevent.

## The fix
- `release()` only closes the fd; lock files persist. flock(2) state is the sole mutual-exclusion authority (stale files are re-locked on next acquire; `probeRepairLock` reports unlocked files as no-repair). The two ancillary unlink sites in the acquire error paths had the identical orphan-inode race and are removed; the TIN-1851 in-process refcount registry semantics are untouched.
- macOS fallback runtime dir moves from `/tmp/oauth-mux-<uid>` to `~/Library/Application Support/oauth-mux/runtime` — periodic /tmp cleaning could unlink *held* lock files (same break, OS-triggered). XDG_RUNTIME_DIR stays honored; Linux fallback unchanged. `daemon.zig` dir creation switches to `makePath` for the multi-level path.

## Proof
- New test: lock file path persists across acquire+release.
- New kernel-conflict test (two distinct open-file-descriptions, which genuinely conflict in-process): A holds → B try-fails → A releases → B acquires the **same inode** (stat-compared) → third try-acquire fails while B holds. Revert-verified: with the unlink restored, exactly these tests fail (FileNotFound; inode mismatch).
- Full `zig build test`: 456/456.

## Notes for review
- **Upgrade window**: an old binary holding a lock under the old /tmp path is invisible to the new binary during a mixed-version window (intrinsic to the dir move) — worth a release-note line in v0.1.13.
- Pre-existing and unchanged: the daemon-socket long-path fallback can still land in /tmp for unusually long $HOME; lock files are unaffected (no length fallback).