### PR TITLE
fix(claude): correct OAuth endpoints + add public client_id in claude_def and refreshUrl

### DIFF
--- a/src/oauth.zig
+++ b/src/oauth.zig
@@ -112,7 +112,7 @@ pub fn generatePkce() PkceChallenge {
 
 pub fn refreshUrl(kind: types.ProviderKind) ?[]const u8 {
     return switch (kind) {
-        .claude => "https://claude.ai/api/auth/oauth/token",
+        .claude => "https://console.anthropic.com/v1/oauth/token",
         .codex => "https://auth.openai.com/oauth/token",
         .gemini => "https://oauth2.googleapis.com/token",
         .vercel => null, // discovered via OIDC metadata
@@ -155,7 +155,7 @@ test "writeUrlEncoded" {
 
 test "refreshUrl returns expected endpoints" {
     try std.testing.expectEqualStrings(
-        "https://claude.ai/api/auth/oauth/token",
+        "https://console.anthropic.com/v1/oauth/token",
         refreshUrl(.claude).?,
     );
     try std.testing.expectEqualStrings(
@@ -163,4 +163,15 @@ test "refreshUrl returns expected endpoints" {
         refreshUrl(.codex).?,
     );
     try std.testing.expect(refreshUrl(.github) == null);
+}
+
+test "refreshUrl(.claude) stays consistent with claude_def token endpoint" {
+    // TIN-1817: both constants must point at the same verified endpoint so the
+    // schema and the refresh path can never drift apart. Constants only — no
+    // live HTTP.
+    const provider_schema = @import("provider_schema.zig");
+    try std.testing.expectEqualStrings(
+        provider_schema.claude_def.auth.token_endpoint.?,
+        refreshUrl(.claude).?,
+    );
 }

--- a/src/provider_schema.zig
+++ b/src/provider_schema.zig
@@ -680,7 +680,9 @@ pub const claude_def = ProviderDefinition{
     .display_name = "Claude Code",
     .extension_mode = .command_adapter,
     .auth = .{
-        .token_endpoint = "https://claude.ai/api/auth/oauth/token",
+        .token_endpoint = "https://console.anthropic.com/v1/oauth/token",
+        .authorization_endpoint = "https://console.anthropic.com/oauth/authorize",
+        .client_id = "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
     },
     .credential = .{
         .access_token_path = "accessToken",
@@ -1589,6 +1591,26 @@ test "buildCredentialGeneric with claude template" {
     // Should produce the wrapped format
     try std.testing.expect(std.mem.indexOf(u8, result, "claudeAiOauth") != null);
     try std.testing.expect(std.mem.indexOf(u8, result, "sk-test") != null);
+}
+
+test "claude_def pins verified Anthropic OAuth constants" {
+    // TIN-1817: the Claude OAuth endpoints live on console.anthropic.com,
+    // not claude.ai (verified against four independent sources in PR #354).
+    // Constants only — never perform live HTTP in tests.
+    try std.testing.expectEqualStrings(
+        "https://console.anthropic.com/v1/oauth/token",
+        claude_def.auth.token_endpoint.?,
+    );
+    try std.testing.expectEqualStrings(
+        "https://console.anthropic.com/oauth/authorize",
+        claude_def.auth.authorization_endpoint.?,
+    );
+    // Anthropic's token endpoint requires client_id, and oauth.refreshToken
+    // only sends client_id when the definition carries one (compare codex_def).
+    try std.testing.expectEqualStrings(
+        "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+        claude_def.auth.client_id.?,
+    );
 }
 
 test "findBuiltin" {


### PR DESCRIPTION
Linear: TIN-1817.

## The bug
`claude_def.auth.token_endpoint` and `oauth.refreshUrl(.claude)` both pointed at `claude.ai/api/auth/oauth/token`; the verified endpoints (four independent sources, per the parked PR #354) are `console.anthropic.com/v1/oauth/token` (token) and `console.anthropic.com/oauth/authorize` (authorize), with public client_id `9d1c250a-e61b-44d9-88ed-5944d1962f5e`. `claude_def` also carried no client_id at all, and `oauth.refreshToken` only sends one when configured.

## The fix
Constants only, existing schema fields only (matches codex/linear/figma defs — no new schema fields). Adds a drift guard: a test pinning `refreshUrl(.claude) == claude_def.auth.token_endpoint`, plus pinned-constant tests. No live HTTP anywhere.

## Behavior change: none (yet)
Claude refresh remains policy-gated OFF (`claude_def.repair.owner = .upstream_cli_login`; `writebackPlan` refuses), so this is correctness-of-constants with zero live effect until the reauth stack lands. It is the standalone prerequisite (A.1) for the fleet-unparking order (TIN-2053).

Note: TIN-1817's description also mentions `expires_at_path`/scopes/subscription_type schema additions — those are PR #354's fields and ride with the unparking train; this PR satisfies the ticket's stated acceptance (endpoint matches verified; tests green).