### PR TITLE
release: bump version to 0.1.13 (TIN-2038)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,7 +10,7 @@ on:
       version:
         description: "Version to stage and publish"
         required: false
-        default: "0.1.12"
+        default: "0.1.13"
         type: string
       dry_run:
         description: "Run npm publish --dry-run instead of publishing"

--- a/.github/workflows/registry-dry-run.yml
+++ b/.github/workflows/registry-dry-run.yml
@@ -10,7 +10,7 @@ on:
       version:
         description: "Version to stage and dry-run"
         required: false
-        default: "0.1.12"
+        default: "0.1.13"
         type: string
       lanes:
         description: "Comma-separated lanes: plan,github,npm,homebrew,system"

--- a/.github/workflows/release-proof.yml
+++ b/.github/workflows/release-proof.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: "Release version to stage and smoke-test"
         required: false
-        default: "0.1.12"
+        default: "0.1.13"
         type: string
 
 permissions:

--- a/.github/workflows/remote-validate.yml
+++ b/.github/workflows/remote-validate.yml
@@ -17,7 +17,7 @@ on:
       version:
         description: "Release version for release-proof"
         required: false
-        default: "0.1.12"
+        default: "0.1.13"
         type: string
 
 permissions:

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .oauth_mux,
-    .version = "0.1.12",
+    .version = "0.1.13",
     .fingerprint = 0x21c445132f61984e,
     .minimum_zig_version = "0.14.0",
     .paths = .{


### PR DESCRIPTION
Linear: TIN-2038. Step 2 of the v0.1.13 cut (docs truthing #382 merged; remote proof lanes green on main; #366 retested+closed with committed evidence).

Bumps `build.zig.zon` (the truth source read by `scripts/project-version.sh`) plus the four workflow-dispatch version defaults. Historical wire-fixture captures keep their recorded versions.

After merge: `just remote-release-proof main 0.1.13` on the GloriousFlywheel runner per the #372 policy, then tag `v0.1.13` (triggers release.yml), verify lane assets, then a follow-up PR updates README/adoption public version claims to *verified shipped* truth — per the ledger rule against claiming versions before lanes verify.

Release-note items staged for the GH release body:
- macOS runtime dir moved off /tmp (`~/Library/Application Support/oauth-mux/runtime`): one-time mixed-version mutual-exclusion window while old binaries hold locks under the old path — restart long-lived sessions after upgrade.
- Default managed authority is home-is-store (canonical bridge now explicit opt-in) — first release where canonical `~/.codex` is structurally never a muxed write target.