### PR TITLE
cleanup: runtime-dir test seam, doc truth, dead code (2026-06-12 audit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Zig
 zig-out/
 .zig-cache/
+*.o
 
 # Nix
 result
@@ -20,6 +21,7 @@ token.json
 # Claude/AI state
 .claude/
 memory/
+.huskycat/
 
 # OS
 .DS_Store

--- a/docs/spec/codex-live-acceptance-checklist-2026-05-08.md
+++ b/docs/spec/codex-live-acceptance-checklist-2026-05-08.md
@@ -37,7 +37,12 @@ Requirements:
 The status artifact must show all of the following in order:
 
 1. `session_started` with `claim_level:"broker_owned"` and
-   `session_authority:"canonical_bridge"`.
+   `session_authority:"isolated"` (the default `isolated_persistent` /
+   home-is-store mode). A run that instead shows
+   `session_authority:"canonical_bridge"` is the labeled legacy
+   `shared_canonical` variant and is closeable only when the opt-in
+   (`TINYLAND_CODEX_MUX_MODE=shared_canonical` or `--mux-mode
+   shared_canonical`) is recorded with the evidence.
 2. A normal `200` provider turn on account A before exhaustion.
 3. Provider-originated quota evidence on account A:
    - `kind:"proxy_turn"`

--- a/docs/spec/harness-session-authority-bridge-2026-05-05.md
+++ b/docs/spec/harness-session-authority-bridge-2026-05-05.md
@@ -330,10 +330,13 @@ Current default after TIN-1851:
   session namespace for tests/privacy.
 - `--session-home <path>` is an advanced override for operators who keep
   Codex sessions outside `~/.codex` and select bridge-style authority.
-- Normal output reports booleans such as
-  `session_authority:"isolated_persistent"` or `"shared_canonical"` and
-  `canonical_session_paths_printed:false`. It does not print session ids,
-  full paths, or transcript content.
+- Normal output reports `session_authority:"isolated"` (the
+  `isolated_persistent` / home-is-store default mode) or
+  `session_authority:"canonical_bridge"` (the legacy `shared_canonical` mode),
+  plus `sqlite_authority:"isolated_overlay"` (default) or `"canonical_env"`
+  (legacy), and `session_paths_printed:false`. The emitted values
+  are the authority names, not the mux-mode names. It does not print session
+  ids, full paths, or transcript content.
 
 This default matches the current safety bar: muxed Codex must not corrupt or
 fork canonical native Codex state. Native/canonical resume sharing is an

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -129,21 +129,30 @@ pub const MuxMode = enum {
 /// TINYLAND_CODEX_MUX_MODE=shared_canonical opts into the legacy bridge, else
 /// the safe default (isolated_persistent / home-is-store).
 fn resolveMuxMode(allocator: std.mem.Allocator, override: ?MuxMode) MuxMode {
+    const env_value = std.process.getEnvVarOwned(allocator, "TINYLAND_CODEX_MUX_MODE") catch null;
+    defer if (env_value) |v| allocator.free(v);
+    return resolveMuxModeFrom(override, env_value);
+}
+
+/// Pure mode resolution over an explicit env value; resolveMuxMode supplies
+/// the real TINYLAND_CODEX_MUX_MODE so unit tests stay hermetic.
+fn resolveMuxModeFrom(override: ?MuxMode, env_value: ?[]const u8) MuxMode {
     if (override) |m| return m;
-    const env = std.process.getEnvVarOwned(allocator, "TINYLAND_CODEX_MUX_MODE") catch return .isolated_persistent;
-    defer allocator.free(env);
-    if (std.mem.eql(u8, env, "shared_canonical")) return .shared_canonical;
+    if (env_value) |v| {
+        if (std.mem.eql(u8, v, "shared_canonical")) return .shared_canonical;
+    }
     return .isolated_persistent;
 }
 
 test "resolveMuxMode honors explicit override over env/default" {
-    try std.testing.expectEqual(MuxMode.shared_canonical, resolveMuxMode(std.testing.allocator, .shared_canonical));
-    try std.testing.expectEqual(MuxMode.isolated_persistent, resolveMuxMode(std.testing.allocator, .isolated_persistent));
+    try std.testing.expectEqual(MuxMode.shared_canonical, resolveMuxModeFrom(.shared_canonical, null));
+    try std.testing.expectEqual(MuxMode.isolated_persistent, resolveMuxModeFrom(.isolated_persistent, "shared_canonical"));
 }
 
 test "resolveMuxMode defaults to isolated_persistent when unset" {
-    // The test environment does not set TINYLAND_CODEX_MUX_MODE.
-    try std.testing.expectEqual(MuxMode.isolated_persistent, resolveMuxMode(std.testing.allocator, null));
+    try std.testing.expectEqual(MuxMode.isolated_persistent, resolveMuxModeFrom(null, null));
+    try std.testing.expectEqual(MuxMode.isolated_persistent, resolveMuxModeFrom(null, "garbage"));
+    try std.testing.expectEqual(MuxMode.shared_canonical, resolveMuxModeFrom(null, "shared_canonical"));
 }
 
 const CodexHomeCleanupMode = enum {
@@ -2272,7 +2281,8 @@ test "createPersistentCodexHome builds a home-is-store session and scrubs only t
 
 test "ensureNotCanonicalCodexHome refuses ~/.codex and its subtree, accepts a dedicated home" {
     const a = std.testing.allocator;
-    const canonical = (try defaultCodexHome(a)) orelse return; // no HOME → skip
+    // A HOME-less environment must be a visible skip, never a silent pass.
+    const canonical = (try defaultCodexHome(a)) orelse return error.SkipZigTest;
     defer a.free(canonical);
 
     try std.testing.expectError(error.CanonicalCodexHomeRefused, ensureNotCanonicalCodexHome(a, canonical));
@@ -2281,7 +2291,7 @@ test "ensureNotCanonicalCodexHome refuses ~/.codex and its subtree, accepts a de
     defer a.free(child);
     try std.testing.expectError(error.CanonicalCodexHomeRefused, ensureNotCanonicalCodexHome(a, child));
 
-    const home = std.process.getEnvVarOwned(a, "HOME") catch return;
+    const home = std.process.getEnvVarOwned(a, "HOME") catch return error.SkipZigTest;
     defer a.free(home);
     const dedicated = try std.fs.path.join(a, &.{ home, ".local", "share", "oauth-mux", "codex", "x" });
     defer a.free(dedicated);

--- a/src/broker_loader.zig
+++ b/src/broker_loader.zig
@@ -10,6 +10,7 @@ const std = @import("std");
 const config_mod = @import("config.zig");
 const broker = @import("broker/mod.zig");
 const broker_types = @import("broker/types.zig");
+const env = @import("env.zig");
 const health_mod = @import("health.zig");
 const oauth = @import("oauth.zig");
 const paths = @import("paths.zig");
@@ -98,61 +99,6 @@ const RouteHealthMatch = struct {
     health: health_mod.AccountHealth,
     capability: ?[]const u8 = null,
 };
-
-pub const CodexAuthRepairSummary = struct {
-    attempted: usize = 0,
-    refreshed: usize = 0,
-    failed: usize = 0,
-    skipped: usize = 0,
-};
-
-/// Repair Codex auth-dead durable health when the account store still has a
-/// refresh token. Codex's native child can refresh only the account it starts
-/// under; proxy fallback accounts need this preflight or an expired access
-/// token is misclassified as a permanently dead route.
-pub fn repairRefreshableCodexAuthFailures(
-    allocator: std.mem.Allocator,
-    cfg: config_mod.Config,
-    store: *health_mod.HealthStore,
-) CodexAuthRepairSummary {
-    var summary = CodexAuthRepairSummary{};
-    const provider_cfg = cfg.providers.map.get("codex") orelse return summary;
-
-    var it = provider_cfg.accounts.map.iterator();
-    while (it.next()) |entry| {
-        const account_name = entry.key_ptr.*;
-        const account_cfg = entry.value_ptr.*;
-
-        // The unmanaged default store is refreshed by the Codex child itself.
-        // oauth-mux should preflight-refresh only route-local account stores.
-        if (account_cfg.config_dir == null) {
-            summary.skipped += 1;
-            continue;
-        }
-
-        const key = health_mod.accountKey("codex", account_name);
-        const health = store.accounts.get(key.slice()) orelse {
-            summary.skipped += 1;
-            continue;
-        };
-        if (!authHealthCanBeRefreshRepaired(health)) {
-            summary.skipped += 1;
-            continue;
-        }
-
-        summary.attempted += 1;
-        refreshCodexAccountAuthFile(allocator, cfg, "codex", account_name, account_cfg) catch {
-            summary.failed += 1;
-            continue;
-        };
-
-        markAuthRefreshRepaired(store, key.slice());
-        summary.refreshed += 1;
-    }
-
-    if (summary.refreshed != 0) store.persist();
-    return summary;
-}
 
 fn applyRouteHealth(
     pool: *broker.AccountPool,
@@ -405,30 +351,6 @@ fn accountAuthMaterialPath(
         return try std.fs.path.join(allocator, &.{ dir, "auth.json" });
     }
     return error.FileNotFound;
-}
-
-fn authHealthCanBeRefreshRepaired(health: health_mod.AccountHealth) bool {
-    if (health.last_probe_hint_class) |hint| {
-        if (hint == .auth_dead) return true;
-    }
-    return switch (health.liveness) {
-        .dead => true,
-        .live, .degraded => false,
-    };
-}
-
-fn markAuthRefreshRepaired(store: *health_mod.HealthStore, key: []const u8) void {
-    const health = store.getOrCreate(key) catch return;
-    health.liveness = .{ .live = .{ .availability = .available } };
-    health.last_http_status = null;
-    health.last_probe_source = .credential_validation;
-    health.last_probe_observed_at = std.time.timestamp();
-    health.last_probe_retry_after_s = null;
-    health.last_probe_hint_class = .none;
-    health.last_probe_decision = .use_this;
-    health.consecutive_failures = 0;
-    health.quota_exhausted_until = null;
-    health.rate_limited_until = null;
 }
 
 fn refreshCodexAccountAuthFile(
@@ -1010,6 +932,14 @@ test "codex refresh rechecks auth file before spending refresh token" {
     const config_dir = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
     defer std.testing.allocator.free(config_dir);
 
+    // refreshCodexAccountAuthFile takes a real BLOCKING repair lock; scope the
+    // lock file to this test's tmp dir instead of the user's real runtime dir.
+    var overrides = std.process.EnvMap.init(std.testing.allocator);
+    defer overrides.deinit();
+    try overrides.put("OMUX_RUNTIME_DIR", config_dir);
+    env.test_overrides = &overrides;
+    defer env.test_overrides = null;
+
     const cfg_json = try std.fmt.allocPrint(
         std.testing.allocator,
         \\{{
@@ -1114,6 +1044,15 @@ test "materializeChatgpt refuses stale codex token when refresh fails" {
     defer std.testing.allocator.free(auth_path);
     const config_dir = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
     defer std.testing.allocator.free(config_dir);
+
+    // The stale-token path calls refreshCodexAccountAuthFile, which takes a
+    // real BLOCKING repair lock for codex:max-1 — the same lock name a live
+    // operator session uses. Scope it to this test's tmp dir.
+    var overrides = std.process.EnvMap.init(std.testing.allocator);
+    defer overrides.deinit();
+    try overrides.put("OMUX_RUNTIME_DIR", config_dir);
+    env.test_overrides = &overrides;
+    defer env.test_overrides = null;
 
     const cfg_json = try std.fmt.allocPrint(
         std.testing.allocator,

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -1428,6 +1428,7 @@ pub fn printUsage(writer: anytype) !void {
         \\  OMUX_CONFIG        Override config file path
         \\  OMUX_CONFIG_DIR    Override config directory
         \\  OMUX_STATE_DIR     Override state directory
+        \\  OMUX_RUNTIME_DIR   Override runtime directory (locks, daemon socket)
         \\  OMUX_SHELL         Override shell detection
         \\  OMUX_DEBUG         Enable debug logging
         \\  NO_COLOR           Disable colored output

--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const env = @import("env.zig");
 const health_mod = @import("health.zig");
 const paths = @import("paths.zig");
 const log = @import("log.zig");
@@ -582,11 +583,66 @@ fn ensureParentDir(path: []const u8) !void {
     }
 }
 
+/// Test helper: point the runtime and state dirs at a per-test tmp dir via
+/// the OMUX_RUNTIME_DIR / OMUX_STATE_DIR seams so daemon tests assert a
+/// synthetic state instead of the developer's real machine state.
+const TestDaemonDirScope = struct {
+    tmp: std.testing.TmpDir,
+    root: []const u8,
+    overrides: std.process.EnvMap,
+
+    fn init(allocator: std.mem.Allocator) !TestDaemonDirScope {
+        var tmp = std.testing.tmpDir(.{});
+        errdefer tmp.cleanup();
+        const root = try tmp.dir.realpathAlloc(allocator, ".");
+        errdefer allocator.free(root);
+        var overrides = std.process.EnvMap.init(allocator);
+        errdefer overrides.deinit();
+        try overrides.put("OMUX_RUNTIME_DIR", root);
+        try overrides.put("OMUX_STATE_DIR", root);
+        return .{ .tmp = tmp, .root = root, .overrides = overrides };
+    }
+
+    fn activate(self: *TestDaemonDirScope) void {
+        env.test_overrides = &self.overrides;
+    }
+
+    fn deinit(self: *TestDaemonDirScope, allocator: std.mem.Allocator) void {
+        env.test_overrides = null;
+        self.overrides.deinit();
+        allocator.free(self.root);
+        self.tmp.cleanup();
+    }
+};
+
 test "isRunning returns false when no daemon" {
+    var scope = try TestDaemonDirScope.init(std.testing.allocator);
+    defer scope.deinit(std.testing.allocator);
+    scope.activate();
+
     try std.testing.expect(!isRunning(std.testing.allocator));
 }
 
+test "isRunning returns true for a live pid in the runtime pid file" {
+    if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
+    const a = std.testing.allocator;
+    var scope = try TestDaemonDirScope.init(a);
+    defer scope.deinit(a);
+    scope.activate();
+
+    // Synthetic pid file carrying this test process's own (live) pid.
+    const pid_path = try pidPath(a);
+    defer a.free(pid_path);
+    try writePidFile(pid_path, currentPid());
+
+    try std.testing.expect(isRunning(a));
+}
+
 test "status json exposes socket daemon contract" {
+    var scope = try TestDaemonDirScope.init(std.testing.allocator);
+    defer scope.deinit(std.testing.allocator);
+    scope.activate();
+
     var buf = std.ArrayList(u8).init(std.testing.allocator);
     defer buf.deinit();
 

--- a/src/env.zig
+++ b/src/env.zig
@@ -1,6 +1,20 @@
 const std = @import("std");
+const builtin = @import("builtin");
+
+/// Test-only env injection seam. Zig cannot portably mutate the real process
+/// environment in-process (setenv needs libc), so unit tests that need the
+/// OMUX_CONFIG_DIR / OMUX_STATE_DIR / OMUX_RUNTIME_DIR path seams inject
+/// overrides here instead of writing into the developer's real directories.
+/// Keys absent from the map fall through to the real environment. Always
+/// null outside `zig build test`; release builds never consult it.
+pub var test_overrides: ?*const std.process.EnvMap = null;
 
 pub fn get(allocator: std.mem.Allocator, name: []const u8) !?[]u8 {
+    if (comptime builtin.is_test) {
+        if (test_overrides) |map| {
+            if (map.get(name)) |value| return try allocator.dupe(u8, value);
+        }
+    }
     return std.process.getEnvVarOwned(allocator, name) catch |e| switch (e) {
         error.EnvironmentVariableNotFound => null,
         error.OutOfMemory => error.OutOfMemory,

--- a/src/main.zig
+++ b/src/main.zig
@@ -19538,7 +19538,7 @@ test "Codex status summary keeps quota account across parsed lines" {
     var file = try tmp.dir.createFile("status.ndjson", .{});
     defer file.close();
     try file.writeAll(
-        \\{"kind":"session_started","claim_level":"broker_owned","selected_account":"codex:max-2","session_authority":"canonical_bridge"}
+        \\{"kind":"session_started","claim_level":"broker_owned","selected_account":"codex:max-2","session_authority":"isolated","sqlite_authority":"isolated_overlay"}
         \\{"kind":"proxy_turn","account":"codex:max-2","method":"POST","path_kind":"responses","status":429,"classification":"quota_exhausted","body_class":"usage_limit_reached","delivered_to_codex":false}
         \\{"kind":"proxy_same_turn_retry","from":"codex:max-2","to":"codex:max-3"}
         \\{"kind":"proxy_turn","account":"codex:max-3","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","delivered_to_codex":true}
@@ -19567,8 +19567,12 @@ test "Codex status summary preserves child signal terminal evidence" {
 
     var file = try tmp.dir.createFile("status.ndjson", .{});
     defer file.close();
+    // Deliberate legacy-shape coverage: this fixture keeps the
+    // session_authority:"canonical_bridge" (legacy shared_canonical mode)
+    // frame so the summary still parses opt-in bridge sessions. The other
+    // status-summary fixtures carry the default isolated / isolated_overlay shape.
     try file.writeAll(
-        \\{"kind":"session_started","claim_level":"broker_owned","selected_account":"codex:max-3","session_authority":"canonical_bridge"}
+        \\{"kind":"session_started","claim_level":"broker_owned","selected_account":"codex:max-3","session_authority":"canonical_bridge","sqlite_authority":"canonical_env"}
         \\{"kind":"proxy_turn","account":"codex:max-3","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","delivered_to_codex":true}
         \\{"kind":"session_aborted","adapter":"codex","reason":"child_signal","exit_code":-1,"term_kind":"signal","term_code":9,"signal_name":"SIGKILL","final_claim_level":"broker_owned","synthetic_swap_observed":false}
         \\
@@ -19600,7 +19604,7 @@ test "Codex status summary reports transport fallback recovery" {
     var file = try tmp.dir.createFile("status.ndjson", .{});
     defer file.close();
     try file.writeAll(
-        \\{"kind":"session_started","claim_level":"broker_owned","selected_account":"codex:max-1","session_authority":"canonical_bridge"}
+        \\{"kind":"session_started","claim_level":"broker_owned","selected_account":"codex:max-1","session_authority":"isolated","sqlite_authority":"isolated_overlay"}
         \\{"kind":"proxy_upstream_failed","account":"codex:max-1","err":"ConnectionResetByPeer"}
         \\{"kind":"proxy_provider_same_turn_retry","from":"codex:max-1","to":"codex:max-2","reason":"provider_5xx"}
         \\{"kind":"proxy_turn","account":"codex:max-2","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","delivered_to_codex":true}
@@ -19632,7 +19636,7 @@ test "Codex status summary reports local transport retry recovery" {
     var file = try tmp.dir.createFile("status.ndjson", .{});
     defer file.close();
     try file.writeAll(
-        \\{"kind":"session_started","claim_level":"broker_owned","selected_account":"codex:max-1","session_authority":"canonical_bridge"}
+        \\{"kind":"session_started","claim_level":"broker_owned","selected_account":"codex:max-1","session_authority":"isolated","sqlite_authority":"isolated_overlay"}
         \\{"kind":"proxy_transport_local_retry","account":"codex:max-1","method":"POST","path_kind":"responses","err":"ConnectionResetByPeer","attempt":1,"max_attempts":2,"backoff_ms":150,"delivered_to_codex":false}
         \\{"kind":"proxy_transport_local_retry_recovered","account":"codex:max-1","method":"POST","path_kind":"responses","attempts":1,"status":200,"classification":"ok","delivered_to_codex":true}
         \\{"kind":"proxy_turn","account":"codex:max-1","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","delivered_to_codex":true}
@@ -19665,7 +19669,7 @@ test "Codex status summary flags historical responses GET 405 ok regression" {
     var file = try tmp.dir.createFile("status.ndjson", .{});
     defer file.close();
     try file.writeAll(
-        \\{"kind":"session_started","claim_level":"broker_owned","selected_account":"codex:max-1","session_authority":"canonical_bridge"}
+        \\{"kind":"session_started","claim_level":"broker_owned","selected_account":"codex:max-1","session_authority":"isolated","sqlite_authority":"isolated_overlay"}
         \\{"kind":"proxy_turn","account":"codex:max-1","method":"GET","path_kind":"responses","status":405,"classification":"ok","body_class":"json_error","delivered_to_codex":true}
         \\{"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":false}
         \\

--- a/src/paths.zig
+++ b/src/paths.zig
@@ -22,6 +22,10 @@ pub fn stateDir(allocator: std.mem.Allocator) ![]const u8 {
 }
 
 pub fn runtimeDir(allocator: std.mem.Allocator) ![]const u8 {
+    if (try env.get(allocator, "OMUX_RUNTIME_DIR")) |dir| {
+        defer allocator.free(dir);
+        return absolutePath(allocator, dir);
+    }
     if (try env.get(allocator, "XDG_RUNTIME_DIR")) |dir| {
         defer allocator.free(dir);
         return std.fs.path.join(allocator, &.{ dir, app_name });
@@ -144,11 +148,35 @@ test "absolutePath keeps absolute and expands relative paths" {
     }
 }
 
+test "runtimeDir honors OMUX_RUNTIME_DIR override (test seam, 2026-06-12 audit)" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+
+    var overrides = std.process.EnvMap.init(allocator);
+    defer overrides.deinit();
+    try overrides.put("OMUX_RUNTIME_DIR", root);
+    env.test_overrides = &overrides;
+    defer env.test_overrides = null;
+
+    const dir = try runtimeDir(allocator);
+    defer allocator.free(dir);
+    try std.testing.expectEqualStrings(root, dir);
+}
+
 test "runtimeDir macOS fallback avoids periodically-cleaned /tmp (TIN-2041)" {
     if (comptime builtin.os.tag != .macos) return error.SkipZigTest;
     const allocator = std.testing.allocator;
     const dir = try runtimeDir(allocator);
     defer allocator.free(dir);
+    if (try env.get(allocator, "OMUX_RUNTIME_DIR")) |base| {
+        defer allocator.free(base);
+        // Explicit override stays honored; the fallback contract is untestable here.
+        try std.testing.expect(std.fs.path.isAbsolute(dir));
+        return;
+    }
     if (try env.get(allocator, "XDG_RUNTIME_DIR")) |base| {
         defer allocator.free(base);
         // Explicit XDG runtime dir stays honored.

--- a/src/repair_state.zig
+++ b/src/repair_state.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
+const env = @import("env.zig");
 const paths = @import("paths.zig");
 const types = @import("types.zig");
 
@@ -736,8 +737,42 @@ fn writeTextLines(writer: anytype, lines: []const []const u8) !void {
     }
 }
 
+/// Test helper: scope lock files to a per-test tmp runtime dir via the
+/// OMUX_RUNTIME_DIR seam so unit tests never write into the user's real
+/// runtime dir (locks persist after TIN-2041, so stray writes are permanent).
+const TestRuntimeDirScope = struct {
+    tmp: std.testing.TmpDir,
+    root: []const u8,
+    overrides: std.process.EnvMap,
+
+    fn init(allocator: std.mem.Allocator) !TestRuntimeDirScope {
+        var tmp = std.testing.tmpDir(.{});
+        errdefer tmp.cleanup();
+        const root = try tmp.dir.realpathAlloc(allocator, ".");
+        errdefer allocator.free(root);
+        var overrides = std.process.EnvMap.init(allocator);
+        errdefer overrides.deinit();
+        try overrides.put("OMUX_RUNTIME_DIR", root);
+        return .{ .tmp = tmp, .root = root, .overrides = overrides };
+    }
+
+    fn activate(self: *TestRuntimeDirScope) void {
+        env.test_overrides = &self.overrides;
+    }
+
+    fn deinit(self: *TestRuntimeDirScope, allocator: std.mem.Allocator) void {
+        env.test_overrides = null;
+        self.overrides.deinit();
+        allocator.free(self.root);
+        self.tmp.cleanup();
+    }
+};
+
 test "repair lock is re-entrant within a process (TIN-1851 no self-deadlock)" {
     const a = std.testing.allocator;
+    var scope = try TestRuntimeDirScope.init(a);
+    defer scope.deinit(a);
+    scope.activate();
     // First acquire takes the real OS flock.
     var l1 = try acquireRepairLockBlocking(a, "codex", "tin1851-reentrancy-test");
     // A second acquire of the SAME key from THIS process must return immediately
@@ -756,6 +791,9 @@ test "repair lock is re-entrant within a process (TIN-1851 no self-deadlock)" {
 
 test "lock file path persists after acquire+release (TIN-2041 no unlink-on-release)" {
     const a = std.testing.allocator;
+    var scope = try TestRuntimeDirScope.init(a);
+    defer scope.deinit(a);
+    scope.activate();
     const path = try lockPath(a, "codex", "tin2041-lockfile-persists");
     defer a.free(path);
     std.fs.deleteFileAbsolute(path) catch {}; // start from a clean slate
@@ -771,6 +809,9 @@ test "lock file path persists after acquire+release (TIN-2041 no unlink-on-relea
 test "release hands the SAME inode to the next acquirer under kernel flock conflict (TIN-2041)" {
     if (comptime builtin.os.tag == .windows) return error.SkipZigTest;
     const a = std.testing.allocator;
+    var scope = try TestRuntimeDirScope.init(a);
+    defer scope.deinit(a);
+    scope.activate();
     const provider = "codex";
     const account = "tin2041-ofd-conflict";
 

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -77,11 +77,6 @@ pub fn execTarget(argv: []const []const u8, env_map: *std.process.EnvMap) error{
     };
 }
 
-test "detect returns a valid ShellKind" {
-    const shell = detect();
-    _ = shell;
-}
-
 test "shellFromPath" {
     try std.testing.expectEqual(types.ShellKind.fish, shellFromPath("/usr/bin/fish"));
     try std.testing.expectEqual(types.ShellKind.zsh, shellFromPath("/bin/zsh"));


### PR DESCRIPTION
Part of the zero-to-adoption roadmap (#377); implements the verified kill list from the 2026-06-12 false-test/cleanup audit. Adversarially reviewed pre-push (pass; the one minor — a false `canonical_session_paths_printed` key name in the rewritten doc sentence — is fixed in this revision).

## Test seams (the headline)
- `OMUX_RUNTIME_DIR` override in `paths.runtimeDir`, mirroring the existing `OMUX_CONFIG_DIR`/`OMUX_STATE_DIR` idiom (operator-visible; documented in CLI help).
- New comptime-test-gated env-injection seam in `env.zig` (Zig can't portably setenv without libc; injection at the single `env.get` chokepoint, real-env fallthrough, never consulted in release builds).
- Tmp-scoped every test that touched the REAL user runtime dir: the TIN-1851 re-entrancy + both TIN-2041 lock tests, the broker_loader blocking-lock refresh test, both daemon tests — **plus a bonus catch beyond the audit**: `materializeChatgpt refuses stale codex token` was taking the real blocking lock on the operator-live `codex-max-1` name (proved by lock-file mtime delta across a test run).
- Added the missing daemon positive-branch test (synthetic pid file → `isRunning` true).
- **Proof**: full `zig build test` leaves `~/Library/Application Support/oauth-mux/runtime` byte-for-byte untouched (mtime-verified).

## Doc truth
- harness-session-authority-bridge spec now states the actually-emitted wire values (`session_authority:"isolated"`/`"canonical_bridge"`, `sqlite_authority:"isolated_overlay"`/`"canonical_env"`) — fixing a false shape shipped in #382.
- Live-acceptance checklist: `"isolated"` is now the default closeable evidence shape; `canonical_bridge` closeable only as labeled legacy with recorded opt-in.

## Hygiene + dead code
- Canonical-home guard test: silent passes on missing HOME → visible `error.SkipZigTest`.
- `resolveMuxMode` split pure (`resolveMuxModeFrom`) — hermetic tests incl. garbage-value + override-beats-env.
- Status-summary unit fixtures: majority flipped to the default-mode shape; one labeled canonical_bridge fixture retained (legacy coverage shrinks-to-labeled, never deleted).
- Vacuous assertion-free `shell.detect` test deleted (real coverage is the adjacent `shellFromPath` test).
- Dead `broker_loader` cluster removed (`repairRefreshableCodexAuthFailures` + 3 satellites; zero references repo-wide, docs already describe it as removed).
- `.gitignore`: `*.o`, `.huskycat/`.

461/461 tests; `zig fmt --check src/` clean.