### PR TITLE
smokes: make default home-is-store mode the primary coverage; legacy bridge shrinks to labeled cases

### DIFF
--- a/scripts/live-codex-mux-e2e.sh
+++ b/scripts/live-codex-mux-e2e.sh
@@ -29,6 +29,7 @@ VERSION_FILE="$EVIDENCE_DIR/version.json"
 SUMMARY_FILE="$EVIDENCE_DIR/status-summary.json"
 COUNTS_FILE="$EVIDENCE_DIR/sqlite-counts.json"
 SCRUB_FILE="$EVIDENCE_DIR/scrub-check.json"
+ROUTE_HOME_SHAPE_FILE="$EVIDENCE_DIR/route-home-shape.json"
 
 if [[ "$CONFIRM" != "real-provider-calls" ]]; then
     cat >&2 <<'EOF'
@@ -99,6 +100,81 @@ print(json.dumps({
     "durable_session_bridges": bridges,
     "ok": len(leaks) == 0,
 }, sort_keys=True))
+PY
+}
+
+# Resolve the route-local persistent home (home-is-store CODEX_HOME) for the
+# elected account by mirroring the binary's config resolution order:
+# OMUX_CONFIG, then OMUX_CONFIG_DIR, then XDG config dir / macOS Application
+# Support. Prints the dirname of the account's secret.path.
+resolve_route_home() {
+    local selected="$1"
+    local acct="${selected#codex:}"
+    local cfg="${OMUX_CONFIG:-}"
+    if [[ -z "$cfg" ]]; then
+        local cfg_dir="${OMUX_CONFIG_DIR:-}"
+        if [[ -z "$cfg_dir" ]]; then
+            # Mirror the binary's xdgOrMacOS order (src/paths.zig): explicit
+            # XDG_CONFIG_HOME wins; otherwise macOS uses Application Support
+            # (never ~/.config); other platforms use ~/.config.
+            if [[ -n "${XDG_CONFIG_HOME:-}" && -f "$XDG_CONFIG_HOME/oauth-mux/config.json" ]]; then
+                cfg_dir="$XDG_CONFIG_HOME/oauth-mux"
+            elif [[ "$(uname -s)" == "Darwin" && -f "$HOME/Library/Application Support/oauth-mux/config.json" ]]; then
+                cfg_dir="$HOME/Library/Application Support/oauth-mux"
+            elif [[ -f "$HOME/.config/oauth-mux/config.json" ]]; then
+                cfg_dir="$HOME/.config/oauth-mux"
+            fi
+        fi
+        [[ -n "$cfg_dir" ]] || return 1
+        cfg="$cfg_dir/config.json"
+    fi
+    [[ -f "$cfg" ]] || return 1
+    local auth
+    auth="$(jq -r --arg a "$acct" '.providers.codex.accounts[$a].secret.path // empty' "$cfg")"
+    [[ -n "$auth" ]] || return 1
+    auth="${auth/#\~/$HOME}"
+    printf '%s\n' "${auth%/*}"
+}
+
+# home-is-store shape check for the route-local persistent home: auth.json must
+# persist, and no stray managed config.toml pointing at a dead proxy port may
+# survive the exit (a live port means another managed session legitimately owns
+# the home right now).
+route_home_shape_check() {
+    python3 - "$1" <<'PY'
+import json
+import pathlib
+import re
+import socket
+import sys
+
+home = pathlib.Path(sys.argv[1])
+result = {
+    "route_home_exists": home.is_dir(),
+    "auth_json_present": (home / "auth.json").is_file(),
+    "stray_config_toml": False,
+    "stray_config_proxy_port_dead": False,
+}
+cfg = home / "config.toml"
+if cfg.is_file():
+    text = cfg.read_text(encoding="utf-8", errors="replace")
+    m = re.search(r'openai_base_url\s*=\s*"http://127\.0\.0\.1:(\d+)', text)
+    if m:
+        result["stray_config_toml"] = True
+        port = int(m.group(1))
+        s = socket.socket()
+        s.settimeout(0.5)
+        try:
+            alive = s.connect_ex(("127.0.0.1", port)) == 0
+        finally:
+            s.close()
+        result["stray_config_proxy_port_dead"] = not alive
+result["ok"] = (
+    result["route_home_exists"]
+    and result["auth_json_present"]
+    and not result["stray_config_proxy_port_dead"]
+)
+print(json.dumps(result, sort_keys=True))
 PY
 }
 
@@ -217,10 +293,52 @@ if [[ "$(jq -r '.after.ok' "$SCRUB_FILE")" != "true" ]]; then
     exit 1
 fi
 
+if [[ "$EXPECT_AUTHORITY" == "isolated" ]]; then
+    # TIN-1851/TIN-1852 default-mode gate: a home-is-store run must not record
+    # any new canonical threads through managed bridge homes (rollout_path like
+    # '%omux-managed-codex%' is the exact TIN-1851 poisoning signature) and must
+    # not (re)create the legacy bridge root under ~/.codex/.oauth-mux.
+    if [[ "$(jq -r '.after.managed_bridge' "$COUNTS_FILE")" != "$(jq -r '.before.managed_bridge' "$COUNTS_FILE")" ]]; then
+        echo "live-codex-mux-e2e: managed-bridge sqlite thread count changed during an isolated run (TIN-1851 poisoning signature)" >&2
+        exit 1
+    fi
+    if [[ "$(jq -r '.before.root_exists' "$SCRUB_FILE")" != "$(jq -r '.after.root_exists' "$SCRUB_FILE")" ]]; then
+        echo "live-codex-mux-e2e: legacy bridge root was created during an isolated run" >&2
+        exit 1
+    fi
+    if [[ "$(jq -r '.after.root_exists' "$SCRUB_FILE")" == "true" ]]; then
+        echo "live-codex-mux-e2e: warning: legacy bridge root pre-exists from older shared_canonical runs (unchanged by this run)" >&2
+    fi
+fi
+
 if [[ -s "$NDJSON" ]]; then
     jq -e 'select(.kind == "session_started") | .runtime_identity.binary_sha256' "$NDJSON" >/dev/null
     jq -e --arg a "$EXPECT_AUTHORITY" 'select(.kind == "session_started") | select(.session_authority == $a)' "$NDJSON" >/dev/null
     jq -e 'select(.kind == "session_ended") | select(.exit_code == 0)' "$NDJSON" >/dev/null
+    if [[ "$EXPECT_AUTHORITY" == "isolated" ]]; then
+        jq -e 'select(.kind == "session_started") | select(.sqlite_authority == "isolated_overlay")' "$NDJSON" >/dev/null
+
+        # Route-local persistent home shape: auth.json persists, and no stray
+        # managed config.toml with a dead proxy port survives the exit.
+        SELECTED_ACCOUNT="$(jq -r 'select(.kind == "session_started") | .selected_account // empty' "$NDJSON" | head -n 1)"
+        if [[ -z "$SELECTED_ACCOUNT" ]]; then
+            echo "live-codex-mux-e2e: session_started carried no selected_account; cannot verify route home" >&2
+            exit 1
+        fi
+        if ! ROUTE_HOME="$(resolve_route_home "$SELECTED_ACCOUNT")"; then
+            echo "live-codex-mux-e2e: could not resolve the route-local persistent home for the elected account" >&2
+            exit 1
+        fi
+        route_home_shape_check "$ROUTE_HOME" >"$ROUTE_HOME_SHAPE_FILE"
+        if [[ "$(jq -r '.ok' "$ROUTE_HOME_SHAPE_FILE")" != "true" ]]; then
+            echo "live-codex-mux-e2e: route-local persistent home shape check failed (auth.json missing or stray managed config.toml with dead proxy port)" >&2
+            cat "$ROUTE_HOME_SHAPE_FILE" >&2
+            exit 1
+        fi
+    else
+        # Legacy bridge runs keep the canonical sqlite authority.
+        jq -e 'select(.kind == "session_started") | select(.sqlite_authority == "canonical_env")' "$NDJSON" >/dev/null
+    fi
 fi
 
 echo "live-codex-mux-e2e: PASS"

--- a/scripts/smoke-codex-acceptance.sh
+++ b/scripts/smoke-codex-acceptance.sh
@@ -28,6 +28,13 @@
 #
 # Plus: stub-codex.report.pid_stable == true, proving this smoke did
 # not rely on child restart/relaunch behavior.
+#
+# Runs two adapter passes:
+#   1. legacy bridge (TINYLAND_CODEX_MUX_MODE=shared_canonical, explicit
+#      opt-in): canonical session bridge + websocket fallback wiring
+#   2. default isolated_persistent (home-is-store, TIN-1851; no mode var):
+#      the same proxy_turn -> 429 -> same-turn swap sequence against the
+#      route-local persistent home, asserting session_authority "isolated"
 
 set -euo pipefail
 
@@ -65,6 +72,10 @@ cleanup() {
     if [[ -n "${UPSTREAM_PID:-}" ]] && kill -0 "$UPSTREAM_PID" 2>/dev/null; then
         kill "$UPSTREAM_PID" 2>/dev/null || true
         wait "$UPSTREAM_PID" 2>/dev/null || true
+    fi
+    if [[ -n "${DM_UPSTREAM_PID:-}" ]] && kill -0 "$DM_UPSTREAM_PID" 2>/dev/null; then
+        kill "$DM_UPSTREAM_PID" 2>/dev/null || true
+        wait "$DM_UPSTREAM_PID" 2>/dev/null || true
     fi
     rm -rf "$TMP"
 }
@@ -121,7 +132,7 @@ OMUX_STUB_PORT=0 \
   python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$TMP/upstream.stderr" &
 UPSTREAM_PID=$!
 
-for i in {1..40}; do
+for _ in {1..40}; do
     [[ -s "$PORTFILE" ]] && break
     sleep 0.05
 done
@@ -133,10 +144,12 @@ fi
 UPSTREAM_PORT="$(cat "$PORTFILE" | tr -d '[:space:]')"
 echo "smoke-codex-acceptance: stub upstream pid=$UPSTREAM_PID port=$UPSTREAM_PORT"
 
-# 3. Run oauth-mux codex run
-echo "smoke-codex-acceptance: running adapter..."
-# This smoke exercises legacy canonical-bridge proxy/quota wiring. TIN-1851's
-# default home-is-store mode is covered by smoke-codex-cli-ux.
+# 3. Run oauth-mux codex run — legacy bridge pass.
+echo "smoke-codex-acceptance: running adapter (legacy bridge pass, shared_canonical opt-in)..."
+# This pass pins the legacy shared_canonical canonical-bridge mode explicitly
+# to keep the bridge proxy/quota wiring covered. The TIN-1851 default
+# isolated_persistent (home-is-store) mode gets its own acceptance pass below
+# with the same proxy_turn/swap sequence.
 TINYLAND_CODEX_MUX_MODE=shared_canonical \
   OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_STATE_DIR="$STATE_DIR" \
@@ -188,7 +201,7 @@ assert_no_grep() {
     fi
 }
 
-echo "smoke-codex-acceptance: assertions"
+echo "smoke-codex-acceptance: legacy bridge assertions"
 
 assert_grep "session_started"           '"kind":"session_started"'           "$NDJSON"
 assert_grep "session_started has proxy_port" '"proxy_port":[0-9]+'           "$NDJSON"
@@ -196,7 +209,7 @@ assert_grep "session_started has managed_frame_id" '"managed_frame_id":"omux-cod
 assert_grep "session_started has adapter version" '"adapter_version":"[0-9]+\.[0-9]+\.[0-9]+"' "$NDJSON"
 assert_grep "session_started redacts CODEX_HOME path" '"codex_home_path_printed":false' "$NDJSON"
 assert_grep "session_started records status file" '"status_file_present":true' "$NDJSON"
-assert_grep "session_started reports canonical session bridge" '"session_authority":"canonical_bridge"' "$NDJSON"
+assert_grep "legacy bridge session_started reports canonical session bridge" '"session_authority":"canonical_bridge"' "$NDJSON"
 assert_grep "session_started redacts session paths" '"session_paths_printed":false' "$NDJSON"
 assert_grep "session_started records runtime identity" '"runtime_identity":\{' "$NDJSON"
 assert_grep "runtime identity marks repo-local binary" '"binary_source":"repo_local"' "$NDJSON"
@@ -343,8 +356,187 @@ else
     exit 1
 fi
 
+# 5. Default-mode acceptance pass (TIN-1851 isolated_persistent / home-is-store,
+# no mode var). The proxy_turn -> quota 429 -> same-turn swap sequence is
+# mode-independent and must hold identically while the elected account's own
+# durable home serves as CODEX_HOME with an isolated sqlite overlay.
 echo
-echo "smoke-codex-acceptance: all 25 assertions passed."
-echo "  full ndjson: $NDJSON"
-echo "  stub upstream log: $UPLOG"
-echo "  stub codex report: $STUB_REPORT"
+echo "smoke-codex-acceptance: running adapter (default home-is-store pass)..."
+DM_PORTFILE="$TMP/upstream-dm.port"
+DM_UPLOG="$TMP/upstream-dm.log"
+DM_NDJSON="$TMP/adapter-dm.ndjson"
+DM_ADAPTER_STDERR="$TMP/adapter-dm.stderr"
+DM_STUB_PIDFILE="$TMP/stub-codex-dm.pid"
+DM_STUB_REPORT="$TMP/stub-codex-dm.report"
+DM_STATE_DIR="$TMP/dm-state"
+
+mkdir -p "$TMP/dm-account-A" "$TMP/dm-account-B" "$DM_STATE_DIR"
+cat >"$TMP/dm-account-A/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"AT-acceptance-dm-A","refresh_token":"RT-dm-A","account_id":"acc-dm-A-id"},"auth_mode":"Chatgpt"}
+EOF
+cat >"$TMP/dm-account-B/auth.json" <<EOF
+{"OPENAI_API_KEY":null,"tokens":{"id_token":"$ID_TOKEN","access_token":"AT-acceptance-dm-B","refresh_token":"RT-dm-B","account_id":"acc-dm-B-id"},"auth_mode":"Chatgpt"}
+EOF
+
+cat >"$TMP/oauth-mux-dm.config.json" <<EOF
+{
+  "version": 1,
+  "providers": {
+    "codex": {
+      "kind": "codex",
+      "accounts": {
+        "max-1": { "priority": 30, "secret": { "backend": "file", "path": "$TMP/dm-account-A/auth.json" } },
+        "max-2": { "priority": 20, "secret": { "backend": "file", "path": "$TMP/dm-account-B/auth.json" } }
+      }
+    }
+  },
+  "profiles": {
+    "codex-max": { "providers": ["codex:max-1#codex-max", "codex:max-2#codex-max"] }
+  }
+}
+EOF
+
+cat >"$DM_STATE_DIR/health.json" <<'EOF'
+{"version":2,"accounts":[
+  {"key":"codex:max-1#codex-max","last_probe_source":"capability_probe","last_probe_hint_class":"none","last_probe_decision":"use_this","liveness":{"state":"live","availability":"available"}},
+  {"key":"codex:max-2#codex-max","last_probe_source":"capability_probe","last_probe_hint_class":"none","last_probe_decision":"use_this","liveness":{"state":"live","availability":"available"}}
+]}
+EOF
+
+OMUX_STUB_PORT=0 \
+  OMUX_STUB_PORTFILE="$DM_PORTFILE" \
+  OMUX_STUB_OK_BEFORE_429=2 \
+  OMUX_STUB_LOGFILE="$DM_UPLOG" \
+  python3 "$ROOT/scripts/test-stub-upstream.py" 2>"$TMP/upstream-dm.stderr" &
+DM_UPSTREAM_PID=$!
+
+for _ in {1..40}; do
+    [[ -s "$DM_PORTFILE" ]] && break
+    sleep 0.05
+done
+if [[ ! -s "$DM_PORTFILE" ]]; then
+    echo "smoke-codex-acceptance: default-mode stub upstream did not write port" >&2
+    cat "$TMP/upstream-dm.stderr" >&2
+    exit 1
+fi
+DM_UPSTREAM_PORT="$(cat "$DM_PORTFILE" | tr -d '[:space:]')"
+echo "smoke-codex-acceptance: default-mode stub upstream pid=$DM_UPSTREAM_PID port=$DM_UPSTREAM_PORT"
+
+env -u TINYLAND_CODEX_MUX_MODE \
+  OMUX_CONFIG="$TMP/oauth-mux-dm.config.json" \
+  OMUX_STATE_DIR="$DM_STATE_DIR" \
+  OMUX_UPSTREAM_HOST="127.0.0.1:$DM_UPSTREAM_PORT" \
+  OMUX_UPSTREAM_SCHEME="http" \
+  OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+  OMUX_STUB_CODEX_TURNS=3 \
+  OMUX_STUB_CODEX_PIDFILE="$DM_STUB_PIDFILE" \
+  OMUX_STUB_CODEX_REPORT="$DM_STUB_REPORT" \
+  "$BIN" codex run --profile codex-max --json-status-file "$DM_NDJSON" 2>"$DM_ADAPTER_STDERR" || {
+    echo "smoke-codex-acceptance: default-mode adapter exited nonzero" >&2
+    echo "---NDJSON---" >&2
+    cat "$DM_NDJSON" >&2
+    echo "---stderr---" >&2
+    cat "$DM_ADAPTER_STDERR" >&2
+    echo "---upstream log---" >&2
+    cat "$DM_UPLOG" >&2 || true
+    exit 1
+}
+
+echo "smoke-codex-acceptance: default home-is-store assertions"
+
+assert_grep "default session_started" '"kind":"session_started"' "$DM_NDJSON"
+assert_grep "default session authority is isolated" '"kind":"session_started".*"session_authority":"isolated"' "$DM_NDJSON"
+assert_grep "default sqlite authority is isolated overlay" '"kind":"session_started".*"sqlite_authority":"isolated_overlay"' "$DM_NDJSON"
+assert_grep "default cleanup persists the route home" '"kind":"session_started".*"session_home_cleanup":"persist_scrub_config"' "$DM_NDJSON"
+assert_grep "default session_started redacts session paths" '"session_paths_printed":false' "$DM_NDJSON"
+assert_grep "default proxy_turn 200 ok" '"kind":"proxy_turn".*"status":200.*"classification":"ok"' "$DM_NDJSON"
+assert_grep "default proxy_turn 429 quota_exhausted" '"kind":"proxy_turn".*"status":429.*"classification":"quota_exhausted"' "$DM_NDJSON"
+assert_grep "default quota 429 was not delivered to Codex" '"kind":"proxy_turn".*"status":429.*"delivered_to_codex":false' "$DM_NDJSON"
+assert_grep "default proxy_same_turn_retry fired" '"kind":"proxy_same_turn_retry"' "$DM_NDJSON"
+assert_grep "default same-turn retry dropped x-codex-turn-state" '"dropped":"x-codex-turn-state"' "$DM_NDJSON"
+assert_grep "default claim_level remains broker_owned" '"claim_level":"broker_owned"' "$DM_NDJSON"
+assert_grep "default session_ended final_claim_level broker_owned" '"kind":"session_ended".*"final_claim_level":"broker_owned"' "$DM_NDJSON"
+assert_grep "default session_ended records synthetic swap" '"kind":"session_ended".*"synthetic_swap_observed":true' "$DM_NDJSON"
+assert_no_grep "default pass never bridges canonical authority" '"session_authority":"canonical_bridge"' "$DM_NDJSON"
+
+if grep -q '"kind":"session_started"' "$DM_ADAPTER_STDERR"; then
+    echo "  ✗ default pass leaked adapter status frames to stderr" >&2
+    exit 1
+else
+    echo "  ✓ default pass keeps adapter status frames out of stderr"
+fi
+
+DM_ACCOUNT_HITS=$(grep -oE '"account":"codex:max-[12]"' "$DM_NDJSON" | sort -u | wc -l | tr -d ' ')
+if [[ "$DM_ACCOUNT_HITS" -ge 2 ]]; then
+    echo "  ✓ default pass elected both accounts max-1 and max-2"
+else
+    echo "  ✗ default pass expected both accounts elected; saw distinct=$DM_ACCOUNT_HITS" >&2
+    exit 1
+fi
+
+if [[ ! -s "$DM_STUB_REPORT" ]]; then
+    echo "  ✗ default pass stub-codex report missing" >&2
+    exit 1
+fi
+if [[ "$(jq -r .pid_stable "$DM_STUB_REPORT")" == "true" ]]; then
+    echo "  ✓ default pass stub-codex PID stable across swap"
+else
+    echo "  ✗ default pass stub-codex PID changed" >&2
+    cat "$DM_STUB_REPORT" >&2
+    exit 1
+fi
+if jq -e 'all(.turns[]; .status == 200)' "$DM_STUB_REPORT" >/dev/null; then
+    echo "  ✓ default pass stub-codex saw only 200 turns; quota 429 stayed inside proxy"
+else
+    echo "  ✗ default pass stub-codex saw a non-200 turn" >&2
+    cat "$DM_STUB_REPORT" >&2
+    exit 1
+fi
+
+DM_UPSTREAM_ACCT_COUNT=$(jq -r .account_id "$DM_UPLOG" 2>/dev/null | sort -u | wc -l | tr -d ' ' || echo 0)
+if [[ "$DM_UPSTREAM_ACCT_COUNT" -ge 2 ]]; then
+    echo "  ✓ default pass upstream saw 2+ distinct ChatGPT-Account-IDs (proxy substituted both)"
+else
+    echo "  ✗ default pass upstream saw only $DM_UPSTREAM_ACCT_COUNT distinct account-ids" >&2
+    cat "$DM_UPLOG" >&2
+    exit 1
+fi
+
+# home-is-store shape: the route-local persistent homes keep auth.json while a
+# clean exit scrubs the managed config.toml + auth shadow; no canonical bridge
+# root may appear next to the route homes.
+for dm_home in "$TMP/dm-account-A" "$TMP/dm-account-B"; do
+    if [[ ! -f "$dm_home/auth.json" ]]; then
+        echo "  ✗ default pass route home lost auth.json: $(basename "$dm_home")" >&2
+        ls -la "$dm_home" >&2 || true
+        exit 1
+    fi
+    if [[ -e "$dm_home/config.toml" || -e "$dm_home/auth.json.omux-bak" ]]; then
+        echo "  ✗ default pass route home kept managed config/auth shadow: $(basename "$dm_home")" >&2
+        ls -la "$dm_home" >&2 || true
+        exit 1
+    fi
+    if [[ -d "$dm_home/.oauth-mux/managed-codex-homes" ]]; then
+        echo "  ✗ default pass route home grew a canonical managed bridge root: $(basename "$dm_home")" >&2
+        find "$dm_home/.oauth-mux" -maxdepth 3 -print >&2 || true
+        exit 1
+    fi
+done
+echo "  ✓ default pass route homes kept auth.json and scrubbed managed config/auth shadow"
+
+if jq -e '.accounts[] | select(.key == "codex:max-2#codex-max" and .last_http_status == 200 and .last_probe_source == "broker_run_live" and .last_probe_decision == "use_this" and .liveness.state == "live" and .liveness.availability == "available")' "$DM_STATE_DIR/health.json" >/dev/null; then
+    echo "  ✓ default pass persisted capability route health after the swap"
+else
+    echo "  ✗ default pass did not persist capability route health" >&2
+    jq . "$DM_STATE_DIR/health.json" >&2
+    exit 1
+fi
+
+echo
+echo "smoke-codex-acceptance: all assertions passed (legacy bridge + default home-is-store)."
+echo "  legacy ndjson: $NDJSON"
+echo "  legacy stub upstream log: $UPLOG"
+echo "  legacy stub codex report: $STUB_REPORT"
+echo "  default ndjson: $DM_NDJSON"
+echo "  default stub upstream log: $DM_UPLOG"
+echo "  default stub codex report: $DM_STUB_REPORT"

--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -14,6 +14,14 @@
 #   oauth-mux codex run resume --last
 #
 # That path must fail helpfully rather than silently dropping args.
+#
+# Coverage runs in two mux modes:
+#   - default isolated_persistent (home-is-store, TIN-1851): the primary
+#     coverage, including the default-mode resume/chooser family and every
+#     mode-neutral section below the legacy block
+#   - legacy shared_canonical bridge: clearly labeled "legacy bridge" cases
+#     that pin TINYLAND_CODEX_MUX_MODE=shared_canonical explicitly and are
+#     scoped so the opt-in never leaks into later sections
 
 set -euo pipefail
 
@@ -216,12 +224,15 @@ else
     echo "  ✓ default home-is-store did not create a canonical managed bridge"
 fi
 
-# The resume/chooser assertions below intentionally exercise the legacy
-# canonical bridge. TIN-1851 makes home-is-store the default, so this block must
-# opt into the bridge instead of relying on ambient defaults.
+# The legacy-bridge resume/chooser assertions below intentionally exercise the
+# legacy canonical bridge. TIN-1851 makes home-is-store the default, so this
+# block must opt into the bridge instead of relying on ambient defaults. The
+# opt-in is scoped: it is unset immediately after the legacy
+# run_legacy_bridge_case calls so every later section runs in the default
+# isolated_persistent mode unless it pins the bridge explicitly.
 export TINYLAND_CODEX_MUX_MODE=shared_canonical
 
-run_case() {
+run_legacy_bridge_case() {
     local mode=$1 label=$2 expected_argv=$3
     shift 3
     local dir="$TMP/$label"
@@ -271,7 +282,7 @@ run_case() {
     assert_grep "$label no pre-spawn network refresh" '"pre_spawn_network_refresh":false' "$ndjson"
     assert_grep "$label child spawn timing" '"kind":"launch_timing".*"phase":"child_spawn"' "$ndjson"
     assert_grep "$label resume preflight" '"kind":"resume_preflight"' "$ndjson"
-    if [[ "$label" == "resume-chooser" ]]; then
+    if [[ "$label" == "legacy-bridge-resume-chooser" ]]; then
         assert_grep "$label resume authority check" '"kind":"resume_authority_check".*"ok":true' "$ndjson"
         assert_grep "$label state db authority" '"kind":"resume_authority_check".*"resume_authority_state_db_bridged":true' "$ndjson"
         assert_grep "$label logs db authority" '"kind":"resume_authority_check".*"resume_authority_logs_db_bridged":true' "$ndjson"
@@ -279,7 +290,7 @@ run_case() {
         assert_grep "$label no chooser rollout scan before spawn" '"kind":"resume_preflight".*"mode":"chooser".*"rollouts_before":0' "$ndjson"
         assert_grep "$label chooser lookup not scanned" '"kind":"resume_preflight".*"mode":"chooser".*"resume_lookup_source":"not_scanned"' "$ndjson"
         assert_grep "$label resume writeback" '"kind":"resume_writeback".*"mode":"chooser"' "$ndjson"
-    elif [[ "$label" == "resume-id" ]]; then
+    elif [[ "$label" == "legacy-bridge-resume-id" ]]; then
         assert_grep "$label explicit state-db lookup" '"kind":"resume_preflight".*"mode":"explicit".*"resume_lookup_source":"state_db"' "$ndjson"
         assert_grep "$label resume writeback" '"kind":"resume_writeback".*"changed_existing":[1-9]' "$ndjson"
     else
@@ -364,17 +375,144 @@ run_case() {
     fi
 }
 
-echo "smoke-codex-cli-ux: first-class resume aliases"
-run_case top "resume-last" '["resume","--last"]' resume --last
-run_case top "resume-id" '["resume","managed-good-session"]' resume managed-good-session
-run_case top "resume-chooser" '["resume"]' resume
-run_case raw "raw-run" '["resume","--last"]' resume --last
+echo "smoke-codex-cli-ux: legacy bridge resume aliases (shared_canonical opt-in)"
+run_legacy_bridge_case top "legacy-bridge-resume-last" '["resume","--last"]' resume --last
+run_legacy_bridge_case top "legacy-bridge-resume-id" '["resume","managed-good-session"]' resume managed-good-session
+run_legacy_bridge_case top "legacy-bridge-resume-chooser" '["resume"]' resume
+run_legacy_bridge_case raw "legacy-bridge-raw-run" '["resume","--last"]' resume --last
 
-echo "smoke-codex-cli-ux: isolated session store keeps sqlite authority local"
+# Legacy bridge coverage ends here. Everything below runs in the TIN-1851
+# default isolated_persistent (home-is-store) mode unless a section pins
+# TINYLAND_CODEX_MUX_MODE=shared_canonical explicitly for canonical-bridge
+# diagnostics.
+unset TINYLAND_CODEX_MUX_MODE
+
+# Default-mode resume coverage: no mode var, the elected account's own durable
+# home (home-is-store) is the CODEX_HOME, sqlite stays isolated, and a clean
+# exit scrubs only the managed config.toml + auth shadow.
+DEFAULT_ROUTE_HOME="$TMP/account-A"
+
+run_default_case() {
+    local mode=$1 label=$2 expected_argv=$3
+    shift 3
+    local dir="$TMP/$label"
+    local ndjson="$dir/status/nested/adapter.ndjson"
+    local stderr="$dir/adapter.stderr"
+    local report="$dir/stub.report"
+    local -a cmd
+
+    mkdir -p "$dir"
+    if [[ "$mode" == "top" ]]; then
+        cmd=( "$BIN" codex --profile codex-max --json-status-file "$ndjson" "$@" )
+    else
+        cmd=( "$BIN" codex run --profile codex-max --json-status-file "$ndjson" -- "$@" )
+    fi
+
+    env -u TINYLAND_CODEX_MUX_MODE \
+      OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+      OMUX_STATE_DIR="$STATE_DIR" \
+      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
+      CODEX_HOME="$CANONICAL_SESSION_HOME" \
+      CODEX_SQLITE_HOME="$CANONICAL_SESSION_HOME" \
+      OMUX_STUB_APPEND_SESSION="sessions/2026/05/06/rollout-managed-good-session.jsonl" \
+      OMUX_STUB_CODEX_TURNS=0 \
+      OMUX_STUB_CODEX_REPORT="$report" \
+      "${cmd[@]}" 2>"$stderr"
+
+    if [[ ! -s "$ndjson" ]]; then
+        echo "  ✗ $label status file was not created at nested path" >&2
+        cat "$stderr" >&2 || true
+        exit 1
+    fi
+    if [[ ! -s "$report" ]]; then
+        echo "  ✗ $label stub report missing" >&2
+        cat "$stderr" >&2 || true
+        exit 1
+    fi
+
+    assert_grep "$label session_started" '"kind":"session_started"' "$ndjson"
+    assert_grep "$label isolated session authority" '"kind":"session_started".*"session_authority":"isolated"' "$ndjson"
+    assert_grep "$label isolated sqlite authority" '"kind":"session_started".*"sqlite_authority":"isolated_overlay"' "$ndjson"
+    assert_grep "$label persistent home cleanup" '"kind":"session_started".*"session_home_cleanup":"persist_scrub_config"' "$ndjson"
+    assert_grep "$label no pre-spawn network refresh" '"pre_spawn_network_refresh":false' "$ndjson"
+    assert_grep "$label resume preflight" '"kind":"resume_preflight"' "$ndjson"
+    if [[ "$label" == "default-resume-chooser" ]]; then
+        assert_grep "$label resume authority check ok" '"kind":"resume_authority_check".*"ok":true' "$ndjson"
+        assert_grep "$label persistent store chooser diagnostic" '"kind":"resume_authority_check".*"diagnostic":"isolated_persistent_store"' "$ndjson"
+    fi
+    assert_grep "$label resume writeback" '"kind":"resume_writeback"' "$ndjson"
+    assert_grep "$label resume status redacts paths" '"kind":"resume_writeback".*"session_id_printed":false,"path_printed":false' "$ndjson"
+    assert_grep "$label session_ended" '"kind":"session_ended".*"exit_code":0' "$ndjson"
+
+    if grep -q '"kind":"session_started"' "$stderr"; then
+        echo "  ✗ $label leaked adapter status frames to stderr" >&2
+        cat "$stderr" >&2
+        exit 1
+    fi
+
+    local actual_argv
+    actual_argv="$(jq -c .argv "$report")"
+    if [[ "$actual_argv" == "$expected_argv" ]]; then
+        echo "  ✓ $label forwarded argv $expected_argv"
+    else
+        echo "  ✗ $label argv mismatch: expected $expected_argv actual $actual_argv" >&2
+        cat "$report" >&2
+        exit 1
+    fi
+
+    if [[ "$(jq -r .sqlite_env.codex_sqlite_home_env_set "$report")" == "false" \
+          && "$(jq -r .sqlite_env.path_printed "$report")" == "false" ]]; then
+        echo "  ✓ $label scrubbed inherited CODEX_SQLITE_HOME"
+    else
+        echo "  ✗ $label leaked CODEX_SQLITE_HOME" >&2
+        cat "$report" >&2
+        exit 1
+    fi
+
+    if [[ "$(jq -r .session_append.checked "$report")" == "true" \
+          && "$(jq -r .session_append.path_printed "$report")" == "false" ]]; then
+        echo "  ✓ $label appended into the persistent route home"
+    else
+        echo "  ✗ $label persistent route home append evidence failed" >&2
+        cat "$report" >&2
+        exit 1
+    fi
+
+    if [[ -f "$DEFAULT_ROUTE_HOME/auth.json" \
+          && ! -e "$DEFAULT_ROUTE_HOME/config.toml" \
+          && ! -e "$DEFAULT_ROUTE_HOME/auth.json.omux-bak" ]]; then
+        echo "  ✓ $label persistent route home kept auth.json and scrubbed managed config"
+    else
+        echo "  ✗ $label persistent route home shape failed (auth.json must persist; config.toml and auth shadow must be scrubbed)" >&2
+        ls -la "$DEFAULT_ROUTE_HOME" >&2 || true
+        exit 1
+    fi
+}
+
+count_canonical_bridge_homes() {
+    find "$CANONICAL_SESSION_HOME/.oauth-mux/managed-codex-homes" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' '
+}
+
+echo "smoke-codex-cli-ux: default home-is-store resume aliases"
+DEFAULT_FAMILY_BRIDGE_BEFORE="$(count_canonical_bridge_homes)"
+run_default_case top "default-resume-last" '["resume","--last"]' resume --last
+run_default_case top "default-resume-id" '["resume","managed-good-session"]' resume managed-good-session
+run_default_case top "default-resume-chooser" '["resume"]' resume
+run_default_case raw "default-raw-run" '["resume","--last"]' resume --last
+DEFAULT_FAMILY_BRIDGE_AFTER="$(count_canonical_bridge_homes)"
+if [[ "$DEFAULT_FAMILY_BRIDGE_BEFORE" == "$DEFAULT_FAMILY_BRIDGE_AFTER" ]]; then
+    echo "  ✓ default resume aliases created no canonical managed bridge homes"
+else
+    echo "  ✗ default resume aliases grew canonical managed bridge homes: before=$DEFAULT_FAMILY_BRIDGE_BEFORE after=$DEFAULT_FAMILY_BRIDGE_AFTER" >&2
+    find "$CANONICAL_SESSION_HOME/.oauth-mux" -maxdepth 3 -print >&2 || true
+    exit 1
+fi
+
+echo "smoke-codex-cli-ux: isolated session store keeps sqlite authority local (default mode, explicit --isolated-session-store)"
 ISOLATED_NDJSON="$TMP/isolated-status.ndjson"
 ISOLATED_STDERR="$TMP/isolated.stderr"
 ISOLATED_REPORT="$TMP/isolated.report"
-env \
+env -u TINYLAND_CODEX_MUX_MODE \
   OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
   OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_STATE_DIR="$STATE_DIR" \
@@ -396,7 +534,7 @@ else
     exit 1
 fi
 
-echo "smoke-codex-cli-ux: capability-scoped route election matches broker-session-plan"
+echo "smoke-codex-cli-ux: capability-scoped route election matches broker-session-plan (default mode)"
 MIXED_CONFIG="$TMP/mixed-capability.config.json"
 MIXED_STATE="$TMP/mixed-capability-state"
 mkdir -p "$MIXED_STATE"
@@ -434,12 +572,11 @@ OMUX_CONFIG="$MIXED_CONFIG" \
   CODEX_HOME="$CANONICAL_SESSION_HOME" \
   OMUX_CODEX_SESSION_HOME="$CANONICAL_SESSION_HOME" \
   OMUX_CODEX_CONFIG_HOME="$CANONICAL_SESSION_HOME" \
-  OMUX_STUB_CANONICAL_SESSION_HOME="$CANONICAL_SESSION_HOME" \
-  OMUX_STUB_APPEND_SESSION="sessions/2026/05/06/rollout-managed-good-session.jsonl" \
   OMUX_STUB_CODEX_TURNS=0 \
   OMUX_STUB_CODEX_REPORT="$MIXED_REPORT" \
   "$BIN" codex --profile mixed --capability codex-max --json-status-file "$MIXED_NDJSON" resume --last 2>"$MIXED_STDERR"
 assert_grep "mixed capability selected max-2" '"kind":"session_started".*"selected_account":"codex:max-2"' "$MIXED_NDJSON"
+assert_grep "mixed capability default-mode session authority" '"kind":"session_started".*"session_authority":"isolated"' "$MIXED_NDJSON"
 if [[ "$(jq -r .active_account_at_start "$MIXED_REPORT")" == "max-2" ]]; then
     echo "  ✓ mixed capability launch used the codex-max selectable route"
 else
@@ -500,13 +637,17 @@ else
     echo "  ✓ ambiguous mixed-capability profile fails before child spawn"
 fi
 
-echo "smoke-codex-cli-ux: resume chooser missing authority fails before spawn"
+# Legacy bridge diagnostic: a missing canonical session authority only exists
+# in shared_canonical mode (the default isolated_persistent chooser lists the
+# durable route home instead), so this case pins the bridge explicitly.
+echo "smoke-codex-cli-ux: legacy bridge resume chooser missing canonical authority fails before spawn"
 BAD_AUTHORITY_HOME="$TMP/bad-canonical-codex"
 BAD_AUTHORITY_NDJSON="$TMP/bad-authority/status.ndjson"
 BAD_AUTHORITY_STDERR="$TMP/bad-authority.stderr"
 BAD_AUTHORITY_REPORT="$TMP/bad-authority.report"
 mkdir -p "$BAD_AUTHORITY_HOME/sessions" "$(dirname "$BAD_AUTHORITY_NDJSON")"
-if OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+if TINYLAND_CODEX_MUX_MODE=shared_canonical \
+     OMUX_CONFIG="$TMP/oauth-mux.config.json" \
      OMUX_STATE_DIR="$STATE_DIR" \
      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
      OMUX_CODEX_SESSION_HOME="$BAD_AUTHORITY_HOME" \
@@ -535,7 +676,10 @@ if grep -q -E 'managed-good-session|'"$BAD_AUTHORITY_HOME" "$BAD_AUTHORITY_NDJSO
     exit 1
 fi
 
-echo "smoke-codex-cli-ux: locked canonical sqlite authority is diagnostic by default"
+# Legacy bridge diagnostic: only shared_canonical sessions adopt the canonical
+# sqlite authority (sqlite_authority:"canonical_env"), so the lock checks pin
+# the bridge explicitly.
+echo "smoke-codex-cli-ux: legacy bridge locked canonical sqlite authority is diagnostic by default"
 SQLITE_AUTH_LOCK_NDJSON="$TMP/sqlite-authority-lock/status.ndjson"
 SQLITE_AUTH_LOCK_STDERR="$TMP/sqlite-authority-lock.stderr"
 SQLITE_AUTH_LOCK_REPORT="$TMP/sqlite-authority-lock.report"
@@ -583,7 +727,8 @@ if [[ ! -e "$SQLITE_LOCK_READY" ]]; then
     exit 1
 fi
 
-OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+TINYLAND_CODEX_MUX_MODE=shared_canonical \
+     OMUX_CONFIG="$TMP/oauth-mux.config.json" \
      OMUX_STATE_DIR="$STATE_DIR" \
      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
      CODEX_HOME="$CANONICAL_SESSION_HOME" \
@@ -608,7 +753,8 @@ if grep -q '"kind":"session_aborted"' "$SQLITE_AUTH_LOCK_NDJSON"; then
     cat "$SQLITE_AUTH_LOCK_NDJSON" >&2
     exit 1
 fi
-if OMUX_CODEX_STRICT_SQLITE_LOCK_GUARD=1 \
+if TINYLAND_CODEX_MUX_MODE=shared_canonical \
+     OMUX_CODEX_STRICT_SQLITE_LOCK_GUARD=1 \
      OMUX_CONFIG="$TMP/oauth-mux.config.json" \
      OMUX_STATE_DIR="$STATE_DIR" \
      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
@@ -650,14 +796,17 @@ if grep -q -E 'managed-good-session|'"$CANONICAL_SESSION_HOME" "$SQLITE_AUTH_LOC
 fi
 echo "  ✓ locked canonical sqlite authority is diagnostic unless strict guard is set"
 
-echo "smoke-codex-cli-ux: sqlite lock shaped child startup failure records abort"
+# Legacy bridge diagnostic: asserts canonical_env sqlite authority and durable
+# bridge scrub behavior, so it pins the bridge explicitly.
+echo "smoke-codex-cli-ux: legacy bridge sqlite lock shaped child startup failure records abort"
 SQLITE_LOCK_NDJSON="$TMP/sqlite-lock/status.ndjson"
 SQLITE_LOCK_STDERR="$TMP/sqlite-lock.stderr"
 SQLITE_LOCK_REPORT="$TMP/sqlite-lock.report"
 SQLITE_LOCK_HEALTH_BEFORE="$TMP/sqlite-lock.health.before"
 mkdir -p "$(dirname "$SQLITE_LOCK_NDJSON")"
 cp "$STATE_DIR/health.json" "$SQLITE_LOCK_HEALTH_BEFORE"
-if OMUX_CONFIG="$TMP/oauth-mux.config.json" \
+if TINYLAND_CODEX_MUX_MODE=shared_canonical \
+     OMUX_CONFIG="$TMP/oauth-mux.config.json" \
      OMUX_STATE_DIR="$STATE_DIR" \
      OMUX_CODEX_BIN="$ROOT/scripts/test-stub-codex.py" \
      CODEX_HOME="$CANONICAL_SESSION_HOME" \
@@ -695,7 +844,7 @@ fi
 assert_durable_bridge_homes_scrubbed "sqlite lock nonzero child cleanup"
 echo "  ✓ sqlite lock shaped startup failure records abort without route-health mutation"
 
-echo "smoke-codex-cli-ux: forwarded config provider override fails before spawn"
+echo "smoke-codex-cli-ux: forwarded config provider override fails before spawn (default mode)"
 BAD_CONFIG_NDJSON="$TMP/bad-config/status.ndjson"
 BAD_CONFIG_STDERR="$TMP/bad-config.stderr"
 BAD_CONFIG_REPORT="$TMP/bad-config.report"
@@ -729,21 +878,20 @@ if grep -q -E 'model_provider="openai"|profile_provider|https://example.invalid|
     exit 1
 fi
 
-echo "smoke-codex-cli-ux: bare codex resolution from PATH"
+echo "smoke-codex-cli-ux: bare codex resolution from PATH (default mode)"
 PATH_STUB_DIR="$TMP/path-bin"
 PATH_NDJSON="$TMP/path-resolution/status.ndjson"
 PATH_STDERR="$TMP/path-resolution.stderr"
 PATH_REPORT="$TMP/path-resolution.report"
 mkdir -p "$PATH_STUB_DIR" "$(dirname "$PATH_NDJSON")"
 ln -s "$ROOT/scripts/test-stub-codex.py" "$PATH_STUB_DIR/codex"
-env -u OMUX_CODEX_BIN \
+env -u OMUX_CODEX_BIN -u TINYLAND_CODEX_MUX_MODE \
   PATH="$PATH_STUB_DIR:$PATH" \
   OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_STATE_DIR="$STATE_DIR" \
   CODEX_HOME="$CANONICAL_SESSION_HOME" \
   OMUX_CODEX_SESSION_HOME="$CANONICAL_SESSION_HOME" \
   OMUX_CODEX_CONFIG_HOME="$CANONICAL_SESSION_HOME" \
-  OMUX_STUB_CANONICAL_SESSION_HOME="$CANONICAL_SESSION_HOME" \
   OMUX_STUB_APPEND_SESSION="sessions/2026/05/06/rollout-managed-good-session.jsonl" \
   OMUX_STUB_CODEX_TURNS=0 \
   OMUX_STUB_CODEX_REPORT="$PATH_REPORT" \
@@ -945,19 +1093,18 @@ else
     echo "  ✓ login-status-all --json is redacted structured inspection"
 fi
 
-echo "smoke-codex-cli-ux: no-profile codex election is provider-scoped"
+echo "smoke-codex-cli-ux: no-profile codex election is provider-scoped (default mode)"
 NO_PROFILE_NDJSON="$TMP/no-profile/status.ndjson"
 NO_PROFILE_STDERR="$TMP/no-profile.stderr"
 NO_PROFILE_REPORT="$TMP/no-profile.report"
 mkdir -p "$(dirname "$NO_PROFILE_NDJSON")"
-env -u OMUX_CODEX_BIN \
+env -u OMUX_CODEX_BIN -u TINYLAND_CODEX_MUX_MODE \
   PATH="$PATH_STUB_DIR:$PATH" \
   OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_STATE_DIR="$STATE_DIR" \
   CODEX_HOME="$CANONICAL_SESSION_HOME" \
   OMUX_CODEX_SESSION_HOME="$CANONICAL_SESSION_HOME" \
   OMUX_CODEX_CONFIG_HOME="$CANONICAL_SESSION_HOME" \
-  OMUX_STUB_CANONICAL_SESSION_HOME="$CANONICAL_SESSION_HOME" \
   OMUX_STUB_APPEND_SESSION="sessions/2026/05/06/rollout-managed-good-session.jsonl" \
   OMUX_STUB_CODEX_TURNS=0 \
   OMUX_STUB_CODEX_REPORT="$NO_PROFILE_REPORT" \
@@ -972,19 +1119,18 @@ else
     exit 1
 fi
 
-echo "smoke-codex-cli-ux: default status artifact without extra flags"
+echo "smoke-codex-cli-ux: default status artifact without extra flags (default mode)"
 DEFAULT_STATUS_DIR="$STATE_DIR/codex/status"
 DEFAULT_STDERR="$TMP/default-status.stderr"
 DEFAULT_REPORT="$TMP/default-status.report"
 rm -rf "$DEFAULT_STATUS_DIR"
-env -u OMUX_CODEX_BIN \
+env -u OMUX_CODEX_BIN -u TINYLAND_CODEX_MUX_MODE \
   PATH="$PATH_STUB_DIR:$PATH" \
   OMUX_CONFIG="$TMP/oauth-mux.config.json" \
   OMUX_STATE_DIR="$STATE_DIR" \
   CODEX_HOME="$CANONICAL_SESSION_HOME" \
   OMUX_CODEX_SESSION_HOME="$CANONICAL_SESSION_HOME" \
   OMUX_CODEX_CONFIG_HOME="$CANONICAL_SESSION_HOME" \
-  OMUX_STUB_CANONICAL_SESSION_HOME="$CANONICAL_SESSION_HOME" \
   OMUX_STUB_APPEND_SESSION="sessions/2026/05/06/rollout-managed-good-session.jsonl" \
   OMUX_STUB_CODEX_TURNS=0 \
   OMUX_STUB_CODEX_REPORT="$DEFAULT_REPORT" \

--- a/scripts/smoke-codex-status-summary.sh
+++ b/scripts/smoke-codex-status-summary.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # Smoke-test the Codex status summarizer against brokered-only and fallback
 # shaped NDJSON artifacts.
+#
+# Fixture authority shapes: the default TIN-1851 home-is-store mode
+# (session_authority:"isolated", sqlite_authority:"isolated_overlay") is the
+# primary fixture shape; the SIGNALED stream is kept as clearly labeled legacy
+# shared_canonical bridge coverage.
 
 set -euo pipefail
 
@@ -30,14 +35,14 @@ BAD_405="$TMP/bad-405.ndjson"
 cat >"$BROKERED" <<'EOF'
 {"kind":"launch_timing","phase":"config_health_load","duration_ms":4,"elapsed_ms":4,"path_printed":false,"token_material_printed":false,"session_id_printed":false}
 {"kind":"launch_timing","phase":"child_spawn","duration_ms":3,"elapsed_ms":19,"path_printed":false,"token_material_printed":false,"session_id_printed":false}
-{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"isolated","sqlite_authority":"isolated_overlay"}
 {"kind":"proxy_turn","account":"codex:max-1","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true}
 {"kind":"proxy_turn","account":"codex:max-1","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true}
 {"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":false}
 EOF
 
 cat >"$FALLBACK" <<'EOF'
-{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"isolated","sqlite_authority":"isolated_overlay"}
 {"kind":"proxy_turn","account":"codex:max-1","method":"POST","path_kind":"responses","status":429,"classification":"quota_exhausted","body_class":"usage_limit_reached","delivered_to_codex":false}
 {"kind":"proxy_same_turn_retry","from":"codex:max-1","to":"codex:max-2","reason":"quota_exhausted","dropped":"x-codex-turn-state"}
 {"kind":"proxy_turn","account":"codex:max-2","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true}
@@ -47,7 +52,7 @@ cat >"$FALLBACK" <<'EOF'
 EOF
 
 cat >"$FAILED_QUOTA" <<'EOF'
-{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"isolated","sqlite_authority":"isolated_overlay"}
 {"kind":"proxy_turn","account":"codex:max-1","method":"GET","path_kind":"codex_other","status":401,"classification":"auth_unauthorized","body_class":"json_error","claim_level":"broker_owned","streamed":false,"delivered_to_codex":false}
 {"kind":"proxy_auth_same_turn_retry","from":"codex:max-1","to":"codex:max-2","reason":"auth_unauthorized","dropped":"x-codex-turn-state"}
 {"kind":"proxy_turn","account":"codex:max-2","method":"GET","path_kind":"codex_other","status":401,"classification":"auth_unauthorized","body_class":"json_error","claim_level":"broker_owned","streamed":false,"delivered_to_codex":false}
@@ -63,7 +68,7 @@ cat >"$FAILED_QUOTA" <<'EOF'
 EOF
 
 cat >"$AUTH_FAILED" <<'EOF'
-{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"isolated","sqlite_authority":"isolated_overlay"}
 {"kind":"proxy_observed_401_codex_handles","account":"codex:max-1"}
 {"kind":"proxy_turn","account":"codex:max-1","method":"GET","path_kind":"codex_other","status":401,"classification":"auth_unauthorized","body_class":"none","claim_level":"broker_owned","streamed":true,"delivered_to_codex":true}
 {"kind":"proxy_observed_401_codex_handles","account":"codex:max-1"}
@@ -73,7 +78,7 @@ cat >"$AUTH_FAILED" <<'EOF'
 EOF
 
 cat >"$AUTH_FALLBACK" <<'EOF'
-{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"isolated","sqlite_authority":"isolated_overlay"}
 {"kind":"proxy_turn","account":"codex:max-1","method":"POST","path_kind":"responses","status":401,"classification":"auth_unauthorized","body_class":"json_error","claim_level":"broker_owned","streamed":false,"delivered_to_codex":false}
 {"kind":"proxy_auth_same_turn_retry","from":"codex:max-1","to":"codex:max-2","reason":"auth_unauthorized","dropped":"x-codex-turn-state"}
 {"kind":"proxy_turn","account":"codex:max-2","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true,"delivered_to_codex":true}
@@ -82,7 +87,7 @@ cat >"$AUTH_FALLBACK" <<'EOF'
 EOF
 
 cat >"$AUTH_FALLBACK_CHAIN" <<'EOF'
-{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"isolated","sqlite_authority":"isolated_overlay"}
 {"kind":"proxy_turn","account":"codex:max-1","method":"GET","path_kind":"codex_other","status":401,"classification":"auth_unauthorized","body_class":"json_error","claim_level":"broker_owned","streamed":false,"delivered_to_codex":false}
 {"kind":"proxy_auth_same_turn_retry","from":"codex:max-1","to":"codex:max-2","reason":"auth_unauthorized","dropped":"x-codex-turn-state"}
 {"kind":"proxy_turn","account":"codex:max-2","method":"GET","path_kind":"codex_other","status":401,"classification":"auth_unauthorized","body_class":"json_error","claim_level":"broker_owned","streamed":false,"delivered_to_codex":false}
@@ -91,12 +96,16 @@ cat >"$AUTH_FALLBACK_CHAIN" <<'EOF'
 EOF
 
 cat >"$INCOMPLETE" <<'EOF'
-{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"isolated","sqlite_authority":"isolated_overlay"}
 {"kind":"proxy_turn","account":"codex:max-1","method":"POST","path_kind":"responses","status":401,"classification":"auth_unauthorized","body_class":"empty","claim_level":"broker_owned","streamed":true,"delivered_to_codex":true}
 EOF
 
+# Legacy coverage: this stream intentionally stays on the legacy
+# shared_canonical bridge shape (session_authority:"canonical_bridge") so the
+# summarizer keeps reproducing legacy-bridge artifacts; every other fixture is
+# the TIN-1851 default home-is-store shape ("isolated" + "isolated_overlay").
 cat >"$SIGNALED" <<'EOF'
-{"kind":"session_started","selected_account":"codex:max-3","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"session_started","selected_account":"codex:max-3","claim_level":"broker_owned","session_authority":"canonical_bridge","sqlite_authority":"canonical_env"}
 {"kind":"proxy_turn","account":"codex:max-3","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true}
 {"kind":"session_aborted","adapter":"codex","reason":"child_signal","exit_code":-1,"term_kind":"signal","term_code":9,"signal_name":"SIGKILL","final_claim_level":"broker_owned","synthetic_swap_observed":false}
 EOF
@@ -107,7 +116,7 @@ cat >"$PRE_SPAWN" <<'EOF'
 EOF
 
 cat >"$TRANSPORT_RECOVERY" <<'EOF'
-{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"isolated","sqlite_authority":"isolated_overlay"}
 {"kind":"proxy_upstream_failed","account":"codex:max-1","err":"ConnectionResetByPeer"}
 {"kind":"proxy_provider_same_turn_retry","from":"codex:max-1","to":"codex:max-2","reason":"provider_5xx","dropped":"x-codex-turn-state"}
 {"kind":"proxy_turn","account":"codex:max-2","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true,"delivered_to_codex":true}
@@ -116,7 +125,7 @@ cat >"$TRANSPORT_RECOVERY" <<'EOF'
 EOF
 
 cat >"$LOCAL_TRANSPORT_RECOVERY" <<'EOF'
-{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"isolated","sqlite_authority":"isolated_overlay"}
 {"kind":"proxy_transport_local_retry","account":"codex:max-1","method":"POST","path_kind":"responses","err":"ConnectionResetByPeer","attempt":1,"max_attempts":2,"backoff_ms":150,"delivered_to_codex":false}
 {"kind":"proxy_transport_local_retry_recovered","account":"codex:max-1","method":"POST","path_kind":"responses","attempts":1,"status":200,"classification":"ok","delivered_to_codex":true}
 {"kind":"proxy_turn","account":"codex:max-1","method":"POST","path_kind":"responses","status":200,"classification":"ok","body_class":"none","claim_level":"broker_owned","streamed":true,"delivered_to_codex":true}
@@ -124,7 +133,7 @@ cat >"$LOCAL_TRANSPORT_RECOVERY" <<'EOF'
 EOF
 
 cat >"$BAD_405" <<'EOF'
-{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"canonical_bridge"}
+{"kind":"session_started","selected_account":"codex:max-1","claim_level":"broker_owned","session_authority":"isolated","sqlite_authority":"isolated_overlay"}
 {"kind":"proxy_turn","account":"codex:max-1","method":"GET","path_kind":"responses","status":405,"classification":"ok","body_class":"json_error","claim_level":"broker_owned","streamed":false,"delivered_to_codex":true}
 {"kind":"proxy_turn","account":"codex:max-1","method":"GET","path_kind":"responses_websocket","status":405,"classification":"ok","body_class":"json_error","claim_level":"broker_owned","streamed":false,"delivered_to_codex":true}
 {"kind":"session_ended","adapter":"codex","exit_code":0,"final_claim_level":"broker_owned","synthetic_swap_observed":false}
@@ -133,6 +142,11 @@ EOF
 BROKERED_SUMMARY="$(python3 "$ROOT/scripts/summarize-codex-status.py" "$BROKERED" --require-brokered)"
 if [[ "$(jq -r .verdict <<<"$BROKERED_SUMMARY")" != "brokered_without_fallback" ]]; then
     echo "brokered verdict mismatch" >&2
+    echo "$BROKERED_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .session_authority <<<"$BROKERED_SUMMARY")" != "isolated" ]]; then
+    echo "brokered summary should reproduce the default isolated session authority" >&2
     echo "$BROKERED_SUMMARY" >&2
     exit 1
 fi
@@ -320,6 +334,11 @@ if [[ "$(jq -r .terminal_event.signal_name <<<"$SIGNALED_SUMMARY")" != "SIGKILL"
     echo "$SIGNALED_SUMMARY" >&2
     exit 1
 fi
+if [[ "$(jq -r .session_authority <<<"$SIGNALED_SUMMARY")" != "canonical_bridge" ]]; then
+    echo "signaled legacy-bridge artifact should reproduce canonical_bridge authority" >&2
+    echo "$SIGNALED_SUMMARY" >&2
+    exit 1
+fi
 
 PRE_SPAWN_SUMMARY="$(python3 "$ROOT/scripts/summarize-codex-status.py" "$PRE_SPAWN")"
 if [[ "$(jq -r .session_aborted_observed <<<"$PRE_SPAWN_SUMMARY")" != "true" ]]; then
@@ -373,6 +392,11 @@ if [[ "$(jq -r .verdict <<<"$TRANSPORT_RECOVERY_NATIVE_SUMMARY")" != "transport_
 fi
 if [[ "$(jq -r .transport_recovery_observed <<<"$TRANSPORT_RECOVERY_NATIVE_SUMMARY")" != "true" ]]; then
     echo "native transport-recovery should report recovery" >&2
+    echo "$TRANSPORT_RECOVERY_NATIVE_SUMMARY" >&2
+    exit 1
+fi
+if [[ "$(jq -r .session_authority <<<"$TRANSPORT_RECOVERY_NATIVE_SUMMARY")" != "isolated" ]]; then
+    echo "native summary should reproduce the default isolated session authority" >&2
     echo "$TRANSPORT_RECOVERY_NATIVE_SUMMARY" >&2
     exit 1
 fi


### PR DESCRIPTION
Part of the zero-to-adoption roadmap (#377); implements the smoke half of the 2026-06-12 false-test audit kill list. Adversarially reviewed pre-push (pass; the macOS config-dir probe-order divergence flagged as minor is fixed in this revision — the e2e helper now mirrors the binary's `xdgOrMacOS` order exactly).

Before this PR, **every** resume/chooser/acceptance smoke ran exclusively under the legacy `shared_canonical` opt-in — the shipped default had no smoke coverage at all, and a leaked `export` silently ran even 'mode-neutral' sections in legacy mode.

- **smoke-codex-cli-ux.sh**: new `run_default_case` family (resume --last / <id> / chooser / raw run) asserting `session_authority:"isolated"`, `sqlite_authority:"isolated_overlay"`, `persist_scrub_config` cleanup, the #380 chooser diagnostic `isolated_persistent_store`, argv forwarding, inherited `CODEX_SQLITE_HOME` scrub, and post-exit route-home shape. Legacy family renamed `run_legacy_bridge_case` with `legacy-bridge-*` labels; the leaked export is unset immediately after its four calls.
- **smoke-codex-acceptance.sh**: full default-mode acceptance pass (same proxy_turn/swap sequence, isolated authority) + the existing run relabeled legacy-bridge; the false 'default covered elsewhere' comment fixed.
- **live-codex-mux-e2e.sh** (TIN-1852 gate): now asserts the `managed_bridge` poison counter (computed-but-never-checked = the exact TIN-1851 poisoning signature), bridge-root non-creation, route-local home shape post-exit (auth.json kept, no dead-proxy config.toml), and `sqlite_authority:"isolated_overlay"`; legacy assertions retained for `EXPECT_AUTHORITY=canonical_bridge` runs. Refusal path verified (exit 64 without the confirm env); no live calls in CI.
- **smoke-codex-status-summary.sh**: oracle fixtures majority-flipped to the default shape; one labeled canonical_bridge stream retained.

All three smoke scripts executed locally green + full `zig build test`. Note: this branch will be rebased after the test-seam PR merges (its suite intentionally relies on that PR's runtime-dir isolation).