### PR TITLE
docs: retire the npm install lane (Bazel SSOT derived lanes exclude npm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Homebrew tap. It is the first release carrying the home-is-store managed-Codex
 session-authority default (canonical bridge is explicit opt-in), the flock
 unlink-on-release race fix with the macOS runtime-dir move (restart long-lived
 managed sessions after upgrading), the default-mode native resume chooser, and
-corrected Claude OAuth endpoint constants. npm still reports `0.1.9` until the
-registry token is rotated — prefer Homebrew or the curl installer until the npm
-lane catches up. Homebrew remains binary-only by default:
+corrected Claude OAuth endpoint constants. The npm lane is retired as of
+2026-06-12 (the published package remains stale at `0.1.9`); install via
+Homebrew, the curl installer, or system packages. Homebrew remains binary-only by default:
 `brew install jesssullivan/omux/oauth-mux` installs `oauth-mux` and must not
 install or link a managed `codex` shim.
 
@@ -38,8 +38,8 @@ What works today:
 - Managed Codex launch and resume through `oauth-mux codex` and
   `oauth-mux codex resume`, including the native resume chooser against the
   selected account's route-local persistent home in the default mode.
-- Current source/user-local dogfood and the npm wrapper lane can include a
-  managed `codex` shim, so a bare `codex` command is managed only when PATH
+- Current source/user-local dogfood can include a managed `codex` shim, so a
+  bare `codex` command is managed only when PATH
   resolves that shim. Admin commands such as `codex login` and
   `codex --version` must pass through to native Codex. Direct native Codex
   binaries and already-running native sessions are not globally protected.
@@ -125,12 +125,10 @@ Public install lanes:
 
 ```bash
 brew install jesssullivan/omux/oauth-mux
-# or (npm lane currently lags at 0.1.9 pending a registry token rotation)
-npm install -g oauth-mux
 ```
 
 The Homebrew formula is intentionally binary-only. It should not change
-`command -v codex`; use the explicit local, npm, Nix, or future opt-in package
+`command -v codex`; use the explicit local, Nix, or future opt-in package
 shim lanes when testing managed bare-`codex` behavior.
 
 Nix users can choose the binary-only package or the managed-shim package:

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -25,7 +25,6 @@ deep evidence or architecture:
 Recommended first-screen command block:
 
 ```bash
-npm install -g oauth-mux
 oauth-mux init --codex-max
 oauth-mux doctor
 oauth-mux route explain --profile codex-max --capability codex-max --json
@@ -52,7 +51,6 @@ then proof and provider-author material.
 
 Target install surfaces:
 
-- npm: `npm install -g oauth-mux`
 - Homebrew public tap:
   `brew tap jesssullivan/omux https://github.com/Jesssullivan/homebrew-omux.git && brew install jesssullivan/omux/oauth-mux`
 - curl installer: `curl -fsSL ... | sh`
@@ -67,7 +65,8 @@ The DRY release/install lane contract is `docs/release-install-lanes.md`; keep
 new UX/DX/AX installer copy aligned with that file rather than duplicating
 package-state tables here. As of the 2026-06-12 v0.1.13 release, public GitHub
 Release, Homebrew tap, curl installer assets, and system package assets resolve
-to `0.1.13`; npm remains stale at `0.1.9` pending a registry token rotation
+to `0.1.13`; the npm lane is retired (2026-06-12; the stale `0.1.9` package
+is abandoned in place)
 (see the productionization ledger for per-lane truth). Package-lane QA proves
 installability and metadata, not live provider handoff behavior.
 
@@ -87,9 +86,10 @@ checks remain package-lane QA and should not be used as evidence for unreleased
 worktree behavior unless the local formula has been explicitly rebuilt and
 installed.
 
-Each release artifact should be derived from the same CI release tree. npm is
-published only from CI tarballs; workstation `npm publish` is not supported.
-Use npm provenance when the GitHub source repository is public.
+Each release artifact should be derived from the same CI release tree. The
+npm lane is retired (2026-06-12): the future single source of truth for
+package derivation is the Bazel SSOT (TIN-2046), whose derived lanes are
+Homebrew, deb/rpm, and a darwin pkg — npm is deliberately excluded.
 
 ## First User Experience
 

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -18,12 +18,14 @@ refreshed when release truth, route evidence, or tracker state changes.
   clean-lineage live e2e (`docs/evidence/codex-live-e2e-clean-lineage-20260612/`).
 - CI/release state: GitHub Actions is the live source for release proof. Release
   workflow `27432964644` published `v0.1.13` with the full 23-asset matrix;
-  the public GitHub Release is non-draft/non-prerelease. npm publish remains
-  blocked on a registry token rotation; npm `latest` still reports `0.1.9`
-  (diagnosis on TIN-2042: SOPS pipeline healthy, token 401s on `npm whoami`).
+  the public GitHub Release is non-draft/non-prerelease. The npm lane is
+  RETIRED (operator decision 2026-06-12, TIN-2042): packaging truth moves to
+  the Bazel SSOT and its derived lanes, which exclude npm; the published npm
+  package remains stale at `0.1.9` and cannot be deprecated until/unless a
+  registry token is ever rotated.
 - Version truth: source version is `0.1.13`. GitHub Release, curl installer
   assets, deb/rpm assets, and the public Homebrew tap resolve to `0.1.13`.
-  npm remains stale at `0.1.9`. The Homebrew formula remains binary-only by
+  The npm lane is retired. The Homebrew formula remains binary-only by
   default and must not install or link a managed `codex` shim.
 - Installed provenance: continue checking `which -a oauth-mux`, `which -a
   codex`, `oauth-mux version --json`, and `codex preflight` before treating
@@ -152,12 +154,12 @@ mutation, and release workflow `26469045026` published GitHub Release
 `v0.1.12` as non-draft/non-prerelease with 23 assets. The public Homebrew tap
 is updated to `0.1.12`, `brew fetch --force jesssullivan/omux/oauth-mux`
 passes, and the local Homebrew keg reports `0.1.12`. Lab PR #507 pins the Home
-Manager source lane to the same release commit with `codexShim` disabled. npm
-publication remains blocked/stale; npm `latest` still reports `0.1.9`.
+Manager source lane to the same release commit with `codexShim` disabled.
 Negative Codex cassettes, broader adapter proof, and daemon beta truth remain
 follow-up work.
-Windows managed-`codex` parity is intentionally assigned to the npm wrapper
-lane rather than raw tarballs until a native Windows operator need is proven.
+Windows managed-`codex` parity is unassigned since the npm wrapper lane was
+retired (2026-06-12); a Windows lane decision rides the Bazel SSOT work
+(TIN-2046/TIN-2050) if a native Windows operator need is ever proven.
 Future public install copy must avoid claiming a version or lane behavior until
 that version is actually published and verified.
 
@@ -166,7 +168,6 @@ The release lanes remain:
 - worktree dogfood;
 - user-local dogfood;
 - Nix package;
-- npm;
 - Homebrew;
 - deb/rpm packages;
 - Home Manager.

--- a/docs/release-install-lanes.md
+++ b/docs/release-install-lanes.md
@@ -14,7 +14,7 @@ Detailed historical evidence stays in `docs/install-beta-matrix.md` and
 | User-local dogfood | `oauth-mux ...` and managed `codex ...` with PATH resolving to `~/.local/bin` | copied worktree binary plus shared POSIX shim | hash match with `./zig-out/bin/oauth-mux`, version check, shim pass-through smoke, preflight check | installed-command dogfood for current checkout |
 | Nix package | `nix build .#` | flake package plus shared POSIX shim | `./result/bin/oauth-mux version`, `nix flake check` binary+shim smoke | package derivation proof |
 | GitHub Release | downloaded tarball | `dist/out/v*/artifacts` from release workflow | checksum verify, tarball binary+shim smoke | public raw binary lane |
-| npm | `npm install -g oauth-mux` / `npx oauth-mux` | CI-generated npm tarballs plus JS `codex` shim | npm install smoke, shim pass-through smoke, and `npm view` | public JS package lane |
+| npm (RETIRED 2026-06-12) | — | lane retired; stale `0.1.9` package abandoned in place | none | excluded from the Bazel SSOT derived lanes (TIN-2046/2050) |
 | Homebrew | `brew install jesssullivan/omux/oauth-mux` | public tap formula from release checksums | `just homebrew-qa <version>`, formula test proves no `codex` install, parsed version check | public macOS/Linux tap lane |
 | curl installer | `curl .../install.sh \| sh` | GitHub Release `install.sh` + tarballs | local file URL binary+shim smoke and public installer smoke | shell installer lane |
 | deb/rpm | system package install | GitHub Release `.deb` / `.rpm` | hosted container install QA for `/usr/bin/oauth-mux`; set `OMUX_EXPECT_CODEX_SHIM=1` for releases that should include `/usr/bin/codex` | distro package lane |

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -135,12 +135,12 @@ The handoff lists GitHub Release attachments, npm publish order, Homebrew tap
 input, deb/rpm files, and full checksums. It does not use registry credentials
 or publish anything.
 
-npm publication is intentionally separate and CI-only. Use
-`.github/workflows/npm-publish.yml`; it reuses the release derivation, resolves
-auth at runtime, and publishes only the generated tarballs. Keep npm provenance
-enabled when the source repository is public; npm rejects GitHub Actions
-provenance from private repositories. Do not publish npm packages from a
-workstation.
+The npm lane is RETIRED (operator decision 2026-06-12, TIN-2042). The release
+graph still stages npm tarballs as inert artifacts until the Bazel SSOT work
+(TIN-2046/TIN-2050) reshapes the derivation; do NOT dispatch
+`.github/workflows/npm-publish.yml`. The stale public `0.1.9` npm package is
+abandoned in place (deprecation requires a registry token that no longer
+exists). Future derived lanes are Homebrew, deb/rpm, and a darwin pkg.
 
 ## Release Workflow
 


### PR DESCRIPTION
Operator decision 2026-06-12: strip the npm lane for the foreseeable future — questionable risk without a mature package in place. Packaging direction is the **Bazel SSOT** (TIN-2046) with derived lanes **Homebrew / deb+rpm / darwin pkg**; npm deliberately excluded (TIN-2050 updated).

- README install + current-truth: npm removed; lane stated retired.
- Ledger / adoption / release-install-lanes / release-runbook: retirement recorded with the why and the SSOT pointer; the stale `0.1.9` public npm package is abandoned in place (deprecating it requires a registry token that no longer exists — recorded on TIN-2042, no rotation planned).
- Workflows `npm-publish.yml` / `npm-deprecate.yml` left dormant with do-not-dispatch guidance (removal can ride the TIN-2050 derivation reshape).
- Windows-parity lane assignment (previously npm) moves to the SSOT decision.

Roadmap: #377.