### PR TITLE
reauth: macOS keychain write + suffixed Claude credential read (TIN-2070)

### DIFF
--- a/docs/spec/provider-proof-claude-credential-store-2026-06-12.md
+++ b/docs/spec/provider-proof-claude-credential-store-2026-06-12.md
@@ -43,20 +43,46 @@ credentials are NOT in `.claude.json`.
 
 ## Decisions for the Claude lane
 
-1. **Claude refresh writeback on macOS requires keychain WRITE.** `secret.zig`
-   currently returns `keychain_write_not_implemented`; the Claude keepalive
-   path cannot use file-backend standardization on macOS. **New work**:
-   implement keychain write (via `/usr/bin/security add-generic-password
-   -U` or the Security framework) targeting
-   `Claude Code-credentials-<sha256(config_dir)[:8]>`, and keychain READ of the
-   same suffixed service (today's reader targets a fixed service name).
-2. **Service-name derivation is a shared helper.** `sha256(config_dir)[:8]`
-   lowercase hex — add to the Claude provider definition / secret backend so
-   read and write agree; unit-test the two vectors above as golden vectors.
+1. **Claude refresh writeback on macOS requires keychain WRITE.**
+   **Implemented (TIN-2070)**: `secret.zig` `writeKeychain` shells
+   `/usr/bin/security add-generic-password -U` (the plan reason is now
+   `keychain_writeback_available` on macOS; other platforms refuse with
+   `keychain_write_unproven_on_platform`). Reads target the suffixed service
+   via config-load derivation. The keychain items additionally key on
+   `acct=<local username>` (verified live: both enrolled accounts carry
+   `acct="jess"`) — `-U` updates in place only when (service, account) both
+   match, so config derivation also defaults the account to `$USER`.
+2. **Service-name derivation is a shared helper.**
+   **Implemented (TIN-2070)**: `provider_schema.claudeKeychainService` —
+   `sha256(config_dir)[:8]` lowercase hex over the tilde-expanded absolute
+   dir (the exact string the launcher exports as `CLAUDE_CONFIG_DIR`), with
+   the two vectors above as golden-vector unit tests. Config load
+   (`applyClaudeKeychainDefaults`) derives service/account for claude
+   keychain accounts that omit them; explicit config always wins.
 3. **Linux**: unverified here (no secret-tool/keychain run on Linux in this
    proof). The Claude lane on Linux likely uses `<CLAUDE_CONFIG_DIR>/.credentials.json`
    (file backend) or `secret-tool` — must be proven before a Linux Claude
-   keepalive claim. Tracked as follow-up.
+   keepalive claim. Tracked as follow-up. TIN-2070's derivation is therefore
+   comptime-gated to macOS; other platforms keep failing fast at validation.
+
+### Known caveats in the implementation (TIN-2070 review)
+
+- **`$USER` is a proxy** for the passwd-database username Claude Code keys the
+  item on. It diverges under `sudo` and is unset in launchd contexts — set
+  `secret.account` explicitly in config for those; explicit always wins.
+- **`config_dir` pointing at the default `~/.claude` is an unverified edge**:
+  the proof did not establish whether the CLI uses the unsuffixed base when
+  `CLAUDE_CONFIG_DIR` is exported but equals the default dir, or hashes
+  whatever the env var holds. The derivation suffixes whenever `config_dir`
+  is present; if an account deliberately targets the canonical dir, pin
+  `secret.service` explicitly until this edge is proven.
+- **Accounts without `config_dir` derive nothing**: the launcher tmpdir-modes
+  them (`CLAUDE_CONFIG_DIR=<tmpdir>`), so no stable keychain identity exists;
+  such accounts keep requiring an explicit service. Note the deeper issue:
+  per this proof, macOS Claude Code ignores injected `.credentials.json`
+  entirely, so tmpdir mode cannot deliver credentials to the CLI on macOS at
+  all — that is the Claude adapter contract amendment (#354 lane), not a
+  TIN-2070 concern.
 
 ## Operational finding: manual-paste OAuth has a per-account session-bleed defect
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -1,7 +1,10 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const types = @import("types.zig");
 const paths = @import("paths.zig");
 const provider_schema = @import("provider_schema.zig");
+const env = @import("env.zig");
+const log = @import("log.zig");
 
 pub const Config = struct {
     version: u32 = 1,
@@ -63,6 +66,53 @@ pub const SecretConfig = struct {
     variable: ?[]const u8 = null,
     command: ?[]const []const u8 = null,
     identity: ?[]const u8 = null,
+    // TIN-2070: set by applyClaudeKeychainDefaults when service/account were
+    // derived at load rather than written by the operator. Derived values are
+    // re-derivable from (config_dir, local user), so serialization elides
+    // them — otherwise any enroll rewrite would freeze a load-time hash into
+    // the config file as a fake operator pin that goes stale if config_dir
+    // ever moves.
+    derived_service: bool = false,
+    derived_account: bool = false,
+
+    pub fn jsonStringify(self: SecretConfig, jws: anytype) !void {
+        try jws.beginObject();
+        try jws.objectField("backend");
+        try jws.write(self.backend);
+        if (self.service) |v| if (!self.derived_service) {
+            try jws.objectField("service");
+            try jws.write(v);
+        };
+        if (self.account) |v| if (!self.derived_account) {
+            try jws.objectField("account");
+            try jws.write(v);
+        };
+        if (self.path) |v| {
+            try jws.objectField("path");
+            try jws.write(v);
+        }
+        if (self.key) |v| {
+            try jws.objectField("key");
+            try jws.write(v);
+        }
+        if (self.key_path) |v| {
+            try jws.objectField("key_path");
+            try jws.write(v);
+        }
+        if (self.variable) |v| {
+            try jws.objectField("variable");
+            try jws.write(v);
+        }
+        if (self.command) |v| {
+            try jws.objectField("command");
+            try jws.write(v);
+        }
+        if (self.identity) |v| {
+            try jws.objectField("identity");
+            try jws.write(v);
+        }
+        try jws.endObject();
+    }
 };
 
 pub const QuotaConfig = struct {
@@ -113,10 +163,54 @@ pub fn loadFromPath(allocator: std.mem.Allocator, path: []const u8) !std.json.Pa
 }
 
 pub fn loadFromBytes(allocator: std.mem.Allocator, bytes: []const u8) !std.json.Parsed(Config) {
-    return std.json.parseFromSlice(Config, allocator, bytes, .{
+    var parsed = try std.json.parseFromSlice(Config, allocator, bytes, .{
         .ignore_unknown_fields = true,
         .allocate = .alloc_always,
     });
+    errdefer parsed.deinit();
+    try applyClaudeKeychainDefaults(&parsed.value, parsed.arena.allocator());
+    return parsed;
+}
+
+// TIN-2070: Claude Code keys its macOS keychain item on a per-config-dir
+// service name and the local username as the item account. When an enrolled
+// claude account with a config_dir omits keychain service/account, derive
+// them the same way the CLI does so reads and refresh writebacks target the
+// item the CLI actually uses. The hash input is the tilde-expanded config_dir
+// — the exact string the launcher exports as CLAUDE_CONFIG_DIR. Explicit
+// config always wins; accounts without a config_dir keep requiring an
+// explicit service (the launcher tmpdir-modes them, so no on-disk keychain
+// identity exists to derive). macOS only: the store contract is verified
+// there and nowhere else, so other platforms keep failing fast at validation.
+fn applyClaudeKeychainDefaults(cfg: *Config, arena: std.mem.Allocator) error{OutOfMemory}!void {
+    if (comptime builtin.os.tag != .macos) return;
+    var prov_it = cfg.providers.map.iterator();
+    while (prov_it.next()) |prov_entry| {
+        if (!std.mem.eql(u8, prov_entry.value_ptr.kind, "claude")) continue;
+        var acct_it = prov_entry.value_ptr.accounts.map.iterator();
+        while (acct_it.next()) |acct_entry| {
+            const acct = acct_entry.value_ptr;
+            if (!std.mem.eql(u8, acct.secret.backend, "keychain")) continue;
+            if (acct.secret.service == null) {
+                if (acct.config_dir) |dir| {
+                    const expanded = paths.expandTilde(arena, dir) catch return error.OutOfMemory;
+                    acct.secret.service = try provider_schema.claudeKeychainService(arena, expanded);
+                    acct.secret.derived_service = true;
+                }
+            }
+            if (acct.secret.account == null) {
+                // USER is a proxy for the passwd-database username Claude
+                // Code keys the item on; it diverges under sudo and is unset
+                // in launchd contexts — set secret.account explicitly there.
+                if (try env.get(arena, "USER")) |user| {
+                    acct.secret.account = user;
+                    acct.secret.derived_account = true;
+                } else {
+                    log.debug("config: USER unset; claude account '{s}' keychain account left for validation", .{acct_entry.key_ptr.*});
+                }
+            }
+        }
+    }
 }
 
 pub fn validate(cfg: Config, writer: anytype) !void {
@@ -1871,5 +1965,122 @@ test "resolveSecretBackend env" {
     switch (backend) {
         .env => |ref| try std.testing.expectEqualStrings("MY_TOKEN", ref.variable),
         else => return error.InvalidCharacter,
+    }
+}
+
+test "claude keychain accounts derive suffixed service from config_dir at load" {
+    if (comptime builtin.os.tag != .macos) return error.SkipZigTest;
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "claude": {
+        \\      "kind": "claude",
+        \\      "accounts": {
+        \\        "xoxd": {
+        \\          "secret": { "backend": "keychain" },
+        \\          "config_dir": "/Users/jess/.local/share/oauth-mux/claude/xoxd"
+        \\        },
+        \\        "canonical": {
+        \\          "secret": { "backend": "keychain" }
+        \\        },
+        \\        "pinned": {
+        \\          "secret": { "backend": "keychain", "service": "Custom Service", "account": "explicit" },
+        \\          "config_dir": "/Users/jess/.local/share/oauth-mux/claude/sulliwood"
+        \\        }
+        \\      }
+        \\    },
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "work": { "secret": { "backend": "keychain", "service": "Codex Auth", "account": "work" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+
+    var overrides = std.process.EnvMap.init(std.testing.allocator);
+    defer overrides.deinit();
+    try overrides.put("USER", "jess");
+    env.test_overrides = &overrides;
+    defer env.test_overrides = null;
+
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    const claude_accounts = parsed.value.providers.map.get("claude").?.accounts;
+
+    // TIN-2060 golden vector: derived from the absolute config_dir, and
+    // flagged derived so enroll rewrites never persist it as an operator pin.
+    const xoxd = claude_accounts.map.get("xoxd").?;
+    try std.testing.expectEqualStrings("Claude Code-credentials-26ae8e92", xoxd.secret.service.?);
+    try std.testing.expectEqualStrings("jess", xoxd.secret.account.?);
+    try std.testing.expect(xoxd.secret.derived_service);
+    try std.testing.expect(xoxd.secret.derived_account);
+
+    // No config_dir: nothing to derive a keychain identity from (the
+    // launcher tmpdir-modes such accounts) — service stays null and the
+    // account keeps failing validation loudly.
+    const canonical = claude_accounts.map.get("canonical").?;
+    try std.testing.expect(canonical.secret.service == null);
+
+    // Explicit service/account always win over derivation.
+    const pinned = claude_accounts.map.get("pinned").?;
+    try std.testing.expectEqualStrings("Custom Service", pinned.secret.service.?);
+    try std.testing.expectEqualStrings("explicit", pinned.secret.account.?);
+    try std.testing.expect(!pinned.secret.derived_service);
+    try std.testing.expect(!pinned.secret.derived_account);
+
+    // Non-claude providers are untouched.
+    const codex_work = parsed.value.providers.map.get("codex").?.accounts.map.get("work").?;
+    try std.testing.expectEqualStrings("Codex Auth", codex_work.secret.service.?);
+
+    // Round-trip: serializing a derived account elides the derived fields —
+    // the on-disk config stays pristine operator truth.
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.json.stringify(xoxd.secret, .{}, out.writer());
+    try std.testing.expectEqualStrings("{\"backend\":\"keychain\"}", out.items);
+
+    out.clearRetainingCapacity();
+    try std.json.stringify(pinned.secret, .{}, out.writer());
+    try std.testing.expectEqualStrings("{\"backend\":\"keychain\",\"service\":\"Custom Service\",\"account\":\"explicit\"}", out.items);
+}
+
+test "claude keychain derivation feeds resolveSecretBackend without explicit service" {
+    if (comptime builtin.os.tag != .macos) return error.SkipZigTest;
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "claude": {
+        \\      "kind": "claude",
+        \\      "accounts": {
+        \\        "sulliwood": {
+        \\          "secret": { "backend": "keychain", "account": "jess" },
+        \\          "config_dir": "/Users/jess/.local/share/oauth-mux/claude/sulliwood"
+        \\        }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    const acct = parsed.value.providers.map.get("claude").?.accounts.map.get("sulliwood").?;
+    const backend = try resolveSecretBackend(acct.secret);
+    switch (backend) {
+        .keychain => |ref| {
+            try std.testing.expectEqualStrings("Claude Code-credentials-cec7498b", ref.service);
+            try std.testing.expectEqualStrings("jess", ref.account);
+        },
+        else => return error.TestUnexpectedResult,
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1928,17 +1928,26 @@ fn writeClaudeStarterAccount(
 ) !void {
     const account_dir = try std.fs.path.join(allocator, &.{ config_root, account });
     defer allocator.free(account_dir);
-    const credentials_path = try std.fs.path.join(allocator, &.{ account_dir, ".credentials.json" });
-    defer allocator.free(credentials_path);
 
     try std.json.stringify(account, .{}, writer);
     try writer.writeAll(":{\"priority\":");
     try writer.print("{d}", .{priority});
     try writer.writeAll(",\"config_dir\":");
     try std.json.stringify(account_dir, .{}, writer);
-    try writer.writeAll(",\"secret\":{\"backend\":\"file\",\"path\":");
-    try std.json.stringify(credentials_path, .{}, writer);
-    try writer.writeAll("},\"tags\":[\"oauth\",\"claude\"]}");
+    if (comptime builtin.os.tag == .macos) {
+        // macOS Claude Code persists credentials only in the login keychain
+        // (TIN-2060 verified — .credentials.json is never written there);
+        // the suffixed service and item account derive from config_dir at
+        // load (TIN-2070), so the bare backend is the whole truth.
+        try writer.writeAll(",\"secret\":{\"backend\":\"keychain\"}");
+    } else {
+        const credentials_path = try std.fs.path.join(allocator, &.{ account_dir, ".credentials.json" });
+        defer allocator.free(credentials_path);
+        try writer.writeAll(",\"secret\":{\"backend\":\"file\",\"path\":");
+        try std.json.stringify(credentials_path, .{}, writer);
+        try writer.writeAll("}");
+    }
+    try writer.writeAll(",\"tags\":[\"oauth\",\"claude\"]}");
 }
 
 fn writeFigmaProviderWithEnrollment(
@@ -8799,6 +8808,17 @@ fn matchesProvider(key: []const u8, provider_filter: ?[]const u8) bool {
     return key.len > filter.len and key[filter.len] == ':';
 }
 
+// TIN-2070: on macOS the real keychain item carries acct=<local username>
+// (an explicit "default" never matches it), so the starter omits the account
+// and lets config load derive it. Elsewhere the keychain entry is
+// user-managed and keeps the historical explicit shape.
+const claude_starter_account_field = if (builtin.os.tag == .macos)
+    ""
+else
+    \\,
+    \\            "account": "default"
+;
+
 fn runInit(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.InitArgs) !void {
     const path = try paths.configFilePath(allocator);
     defer allocator.free(path);
@@ -8830,8 +8850,9 @@ fn runInit(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Init
         \\          "priority": 10,
         \\          "secret": {
         \\            "backend": "keychain",
-        \\            "service": "Claude Code-credentials",
-        \\            "account": "default"
+        \\            "service": "Claude Code-credentials"
+    ++ claude_starter_account_field ++
+        \\
         \\          }
         \\        }
         \\      }

--- a/src/provider_schema.zig
+++ b/src/provider_schema.zig
@@ -675,6 +675,23 @@ const codex_capabilities = [_]CapabilityDefinition{
     },
 };
 
+pub const claude_keychain_service_base = "Claude Code-credentials";
+
+// Claude Code keys its macOS login-keychain item on a per-config-dir service
+// name: the default dir (~/.claude) uses the unsuffixed base, and any other
+// CLAUDE_CONFIG_DIR appends "-<first 8 hex of sha256(absolute dir)>". The
+// input must be the same absolute string exported as CLAUDE_CONFIG_DIR
+// (tilde-expanded, not realpath'd) or the hash diverges from the CLI's own.
+// Verified live: docs/spec/provider-proof-claude-credential-store-2026-06-12.md.
+pub fn claudeKeychainService(allocator: std.mem.Allocator, config_dir_absolute: []const u8) error{OutOfMemory}![]u8 {
+    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(config_dir_absolute, &digest, .{});
+    return std.fmt.allocPrint(allocator, "{s}-{x}", .{
+        claude_keychain_service_base,
+        std.fmt.fmtSliceHexLower(digest[0..4]),
+    });
+}
+
 pub const claude_def = ProviderDefinition{
     .name = "claude",
     .display_name = "Claude Code",
@@ -2059,4 +2076,24 @@ test "classifyCodexAppServerJsonRpc usage limit as quota exhaustion" {
         .quota_exhausted => |quota| try std.testing.expectEqual(@as(u32, 7200), quota.retry_after_s),
         else => return error.TestUnexpectedResult,
     }
+}
+
+test "claudeKeychainService derives the TIN-2060 golden vectors" {
+    // Two real enrolled accounts, predicted-then-confirmed live against the
+    // macOS keychain (docs/spec/provider-proof-claude-credential-store-2026-06-12.md).
+    const xoxd = try claudeKeychainService(std.testing.allocator, "/Users/jess/.local/share/oauth-mux/claude/xoxd");
+    defer std.testing.allocator.free(xoxd);
+    try std.testing.expectEqualStrings("Claude Code-credentials-26ae8e92", xoxd);
+
+    const sulliwood = try claudeKeychainService(std.testing.allocator, "/Users/jess/.local/share/oauth-mux/claude/sulliwood");
+    defer std.testing.allocator.free(sulliwood);
+    try std.testing.expectEqualStrings("Claude Code-credentials-cec7498b", sulliwood);
+}
+
+test "claudeKeychainService distinct dirs never collide on the base service" {
+    const derived = try claudeKeychainService(std.testing.allocator, "/tmp/omux-claude-any");
+    defer std.testing.allocator.free(derived);
+    try std.testing.expect(!std.mem.eql(u8, derived, claude_keychain_service_base));
+    try std.testing.expect(std.mem.startsWith(u8, derived, "Claude Code-credentials-"));
+    try std.testing.expectEqual(claude_keychain_service_base.len + 1 + 8, derived.len);
 }

--- a/src/secret.zig
+++ b/src/secret.zig
@@ -83,10 +83,17 @@ pub fn writebackPlan(backend: types.SecretBackend, owner: types.RepairOwner) Wri
             .automatic_refresh_admitted = false,
             .reason = "command_write_contract_missing",
         },
-        .keychain_write => .{
+        // TIN-2070: macOS keychain write is implemented (security
+        // add-generic-password -U). Other platforms remain refused until a
+        // write path is proven there (Linux secret-tool write is untested).
+        .keychain_write => if (comptime builtin.os.tag == .macos) .{
+            .capability = capability,
+            .automatic_refresh_admitted = true,
+            .reason = "keychain_writeback_available",
+        } else .{
             .capability = capability,
             .automatic_refresh_admitted = false,
-            .reason = "keychain_write_not_implemented",
+            .reason = "keychain_write_unproven_on_platform",
         },
         .sops_write => .{
             .capability = capability,
@@ -104,7 +111,8 @@ pub fn writebackPlan(backend: types.SecretBackend, owner: types.RepairOwner) Wri
 pub fn writeReplace(backend: types.SecretBackend, bytes: []const u8, allocator: std.mem.Allocator) WriteError!void {
     return switch (backend) {
         .file => |ref| writeFileReplace(ref, bytes, allocator),
-        .keychain, .sops, .age, .env, .command, .stdin => error.UnsupportedBackend,
+        .keychain => |ref| writeKeychain(ref, bytes, allocator),
+        .sops, .age, .env, .command, .stdin => error.UnsupportedBackend,
     };
 }
 
@@ -188,10 +196,16 @@ fn readKeychainMacOS(ref: types.SecretBackend.KeychainRef, allocator: std.mem.Al
     }) catch return error.CommandFailed;
     defer if (result.stderr.len > 0) allocator.free(result.stderr);
 
-    if (result.term.Exited != 0) {
-        defer allocator.free(result.stdout);
-        log.debug("keychain: security exited {d}", .{result.term.Exited});
-        return error.NotFound;
+    switch (result.term) {
+        .Exited => |code| if (code != 0) {
+            defer allocator.free(result.stdout);
+            log.debug("keychain: security exited {d}", .{code});
+            return error.NotFound;
+        },
+        else => {
+            allocator.free(result.stdout);
+            return error.CommandFailed;
+        },
     }
 
     // Strip trailing newline
@@ -215,11 +229,69 @@ fn readKeychainLinux(ref: types.SecretBackend.KeychainRef, allocator: std.mem.Al
     }) catch return error.CommandFailed;
     defer if (result.stderr.len > 0) allocator.free(result.stderr);
 
-    if (result.term.Exited != 0) {
-        defer allocator.free(result.stdout);
-        return error.NotFound;
+    switch (result.term) {
+        .Exited => |code| if (code != 0) {
+            defer allocator.free(result.stdout);
+            return error.NotFound;
+        },
+        else => {
+            allocator.free(result.stdout);
+            return error.CommandFailed;
+        },
     }
     return result.stdout;
+}
+
+// TIN-2070: keychain write for refresh writeback. -U updates the existing
+// (service, account) item in place; the account must match the item's acct
+// attribute (Claude Code sets the local username) or -U mints a divergent
+// second item the CLI never reads. The secret travels as a direct argv
+// element — no shell, no quoting, never logged. (It is briefly visible to
+// same-user `ps`, the tradeoff TIN-2070 accepted over `security -i` stdin
+// quoting fragility.) Known gap for the refresh hot path: runProcess has no
+// deadline, so a locked keychain that prompts can wedge the caller — bounded
+// waits belong to the TIN-2058/2059 refresh-authority hardening that admits
+// this write path in the first place.
+fn writeKeychain(ref: types.SecretBackend.KeychainRef, bytes: []const u8, allocator: std.mem.Allocator) WriteError!void {
+    if (comptime builtin.os.tag != .macos) return error.UnsupportedBackend;
+
+    const result = runProcess(allocator, &.{
+        "/usr/bin/security",
+        "add-generic-password",
+        "-U",
+        "-s",
+        ref.service,
+        "-a",
+        ref.account,
+        "-w",
+        bytes,
+    }) catch return error.IoError;
+    defer allocator.free(result.stdout);
+    defer if (result.stderr.len > 0) allocator.free(result.stderr);
+
+    switch (result.term) {
+        .Exited => |code| if (code != 0) {
+            // Log only the exit code; stderr could name the service but the
+            // payload never appears in security's output.
+            log.debug("keychain: add-generic-password exited {d}", .{code});
+            return error.AccessDenied;
+        },
+        else => return error.IoError,
+    }
+}
+
+// Test/cleanup helper: best-effort removal of a (service, account) item.
+fn deleteKeychainMacOS(ref: types.SecretBackend.KeychainRef, allocator: std.mem.Allocator) void {
+    const result = runProcess(allocator, &.{
+        "/usr/bin/security",
+        "delete-generic-password",
+        "-s",
+        ref.service,
+        "-a",
+        ref.account,
+    }) catch return;
+    allocator.free(result.stdout);
+    if (result.stderr.len > 0) allocator.free(result.stderr);
 }
 
 fn readCommand(ref: types.SecretBackend.CommandRef, allocator: std.mem.Allocator) ReadError![]const u8 {
@@ -228,10 +300,16 @@ fn readCommand(ref: types.SecretBackend.CommandRef, allocator: std.mem.Allocator
     const result = runProcess(allocator, ref.argv) catch return error.CommandFailed;
     defer if (result.stderr.len > 0) allocator.free(result.stderr);
 
-    if (result.term.Exited != 0) {
-        defer allocator.free(result.stdout);
-        log.debug("command: exited {d}", .{result.term.Exited});
-        return error.CommandFailed;
+    switch (result.term) {
+        .Exited => |code| if (code != 0) {
+            defer allocator.free(result.stdout);
+            log.debug("command: exited {d}", .{code});
+            return error.CommandFailed;
+        },
+        else => {
+            allocator.free(result.stdout);
+            return error.CommandFailed;
+        },
     }
 
     // Strip trailing newline
@@ -257,10 +335,16 @@ fn readSops(ref: types.SecretBackend.SopsRef, allocator: std.mem.Allocator) Read
     };
     defer if (result.stderr.len > 0) allocator.free(result.stderr);
 
-    if (result.term.Exited != 0) {
-        defer allocator.free(result.stdout);
-        log.debug("sops: decrypt exited {d}", .{result.term.Exited});
-        return error.DecryptFailed;
+    switch (result.term) {
+        .Exited => |code| if (code != 0) {
+            defer allocator.free(result.stdout);
+            log.debug("sops: decrypt exited {d}", .{code});
+            return error.DecryptFailed;
+        },
+        else => {
+            allocator.free(result.stdout);
+            return error.DecryptFailed;
+        },
     }
 
     // If key_path specified, extract that JSON key from the decrypted output
@@ -431,4 +515,62 @@ test "writebackPlan requires oauth-mux refresh ownership" {
     try std.testing.expect(!env_owned.automatic_refresh_admitted);
     try std.testing.expect(env_owned.capability == .readonly);
     try std.testing.expectEqualStrings("secret_backend_is_readonly", env_owned.reason);
+}
+
+test "writebackPlan keychain write is platform-gated" {
+    const keychain_backend = types.SecretBackend{ .keychain = .{ .service = "oauth-mux-test", .account = "work" } };
+    const plan = writebackPlan(keychain_backend, .oauth_mux_refresh);
+    try std.testing.expect(plan.capability == .keychain_write);
+    if (comptime builtin.os.tag == .macos) {
+        try std.testing.expect(plan.automatic_refresh_admitted);
+        try std.testing.expectEqualStrings("keychain_writeback_available", plan.reason);
+    } else {
+        try std.testing.expect(!plan.automatic_refresh_admitted);
+        try std.testing.expectEqualStrings("keychain_write_unproven_on_platform", plan.reason);
+    }
+
+    // Ownership still trumps capability: claude-style upstream_cli_login
+    // accounts stay un-admitted even where write works (TIN-2058's gate).
+    const upstream = writebackPlan(keychain_backend, .upstream_cli_login);
+    try std.testing.expect(!upstream.automatic_refresh_admitted);
+    try std.testing.expectEqualStrings("provider_repair_owned_by_upstream_cli", upstream.reason);
+}
+
+test "keychain write/read/overwrite/delete round-trip (macOS)" {
+    if (comptime builtin.os.tag != .macos) return error.SkipZigTest;
+    const allocator = std.testing.allocator;
+
+    var nonce: [4]u8 = undefined;
+    std.crypto.random.bytes(&nonce);
+    const service = try std.fmt.allocPrint(allocator, "oauth-mux-test-keychain-rt-{x}", .{std.fmt.fmtSliceHexLower(&nonce)});
+    defer allocator.free(service);
+    const ref = types.SecretBackend.KeychainRef{ .service = service, .account = "omux-test" };
+    defer deleteKeychainMacOS(ref, allocator);
+
+    const backend = types.SecretBackend{ .keychain = ref };
+    // A locked login keychain (headless/SSH context) surfaces as
+    // AccessDenied on the first write; that's environmental, not a
+    // regression in our argv construction, so skip rather than fail. If the
+    // test binary dies before cleanup, the stranded item is clearly named
+    // oauth-mux-test-keychain-rt-* and holds only a fixture string.
+    writeReplace(backend, "fixture-keychain-rt-v1", allocator) catch |e| switch (e) {
+        error.AccessDenied => return error.SkipZigTest,
+        else => return e,
+    };
+    {
+        const got = try read(backend, allocator);
+        defer allocator.free(got);
+        try std.testing.expectEqualStrings("fixture-keychain-rt-v1", got);
+    }
+
+    // -U must update the existing item in place, not mint a second one.
+    try writeReplace(backend, "fixture-keychain-rt-v2", allocator);
+    {
+        const got = try read(backend, allocator);
+        defer allocator.free(got);
+        try std.testing.expectEqualStrings("fixture-keychain-rt-v2", got);
+    }
+
+    deleteKeychainMacOS(ref, allocator);
+    try std.testing.expectError(error.NotFound, read(backend, allocator));
 }


### PR DESCRIPTION
## Summary

Implements the mechanism half of Claude refresh writeback per the TIN-2060 verified contract (`docs/spec/provider-proof-claude-credential-store-2026-06-12.md`):

- **Derivation helper** — `provider_schema.claudeKeychainService`: `Claude Code-credentials-<sha256(config_dir)[:8]>`, golden-vector tested against both live-enrolled accounts (`26ae8e92` / `cec7498b`).
- **Suffixed READ** — config load (`applyClaudeKeychainDefaults`) derives keychain service/account for claude accounts that declare a `config_dir` and omit them. macOS-only (the contract is verified nowhere else); explicit config always wins. Derived values are flagged (`derived_service`/`derived_account`) and **elided from serialization** via a custom `SecretConfig.jsonStringify`, so enroll rewrites never freeze a load-time hash into `config.json` as a fake operator pin.
- **Keychain WRITE** — `secret.writeKeychain` shells `/usr/bin/security add-generic-password -U`; `writeReplace` routes keychain; `writebackPlan` reports `keychain_writeback_available` on macOS (`keychain_write_unproven_on_platform` elsewhere). **Claude stays un-admitted** via `repair.owner = .upstream_cli_login` until TIN-2058 deliberately flips refresh authority — this PR ships mechanism, not permission.
- **Enroll/init shapes** — `enroll claude` and the `omux init` starter emit the bare keychain backend on macOS (`.credentials.json` is never written there per the proof); the template's `"account": "default"` is dropped on macOS (real items key `acct=<local username>`).
- **Hardening** — read paths switch on process `term` instead of naked `.Exited` union access; live round-trip test (write→read→`-U` overwrite→delete→NotFound) runs on macOS, skips on locked keychains.

## Adversarial review

4-lens workflow (zig-correctness, secret-hygiene, contract-fidelity, blast-radius), 23 raw → 15 confirmed findings after per-finding refutation. All fixed in this PR except two dispositioned: the `security` no-deadline wedge risk (documented in-code, belongs to the TIN-2058/2059 hot-path hardening that admits this write path) and the `config_dir == ~/.claude` unverified edge (documented as a spec caveat; explicit-pin workaround).

## Live proof

Both real enrolled accounts (xoxd / sulliwood) migrated to the keychain backend and probe `ok:true` through the derived suffixed services. Counterfactual on the pre-migration file backend: `SecretReadFailed` — i.e., this PR is the difference between dead and live Claude credential reads.

## Test

`zig build test`: 517/517 (was 511), including the live keychain round-trip on macOS. No secret material in logs or test output.

Closes TIN-2070.