### PR TITLE
reauth: refresh-authority split — consent-gated proactive refresh (TIN-2058)

### DIFF
--- a/docs/provider-repair-contracts.md
+++ b/docs/provider-repair-contracts.md
@@ -58,6 +58,38 @@ The repair owner values are:
 - `null`: the action is not credential repair, such as waiting, probing,
   fixing runtime, or inspecting provider scope.
 
+### Refresh-authority split (TIN-2058)
+
+Login ownership and proactive-refresh authority are separate axes. A provider
+whose login is `upstream_cli_login` can still grant oauth-mux the
+non-interactive token refresh when BOTH hold:
+
+- the provider definition declares the grant
+  (`repair.proactive_refresh: "oauth_refresh_token"`), and
+- the account's config carries explicit operator consent
+  (`"allow_proactive_refresh": true` on the account).
+
+No builtin definition declares the grant yet — deliberately. The pipeline
+refresh write path is currently unserialized (no repair flock; a daemon
+probe tick could ride a probe budget into a mutating token rotation) and the
+credential templates are lossy (claude drops `expiresAt`, codex drops
+`tokens.id_token` — the identity source). Each builtin's grant flips only
+after refresh-path locking and field-preserving writeback land; until then,
+opting an account in changes nothing for builtin providers.
+
+Without consent the writeback plan refuses with
+`proactive_refresh_not_opted_in` (providers without the declared grant keep
+the historical `provider_repair_owned_by_upstream_cli`). Consent-admitted
+plans report `proactive_refresh_opted_in`; the capability field names the
+mechanism (`replace_file`, `keychain_write`, …). Consent never overrides
+`manual_only` / `external_secret_owner` boundaries, and capability gating
+still applies (a readonly backend stays refused). Interactive login remains
+upstream-owned in every case.
+
+Even after a grant flips on, leave accounts un-opted until the dual-writer
+serialization story (TIN-2059) covers your native CLI's own refresh behavior
+— two writers rotating one refresh token can revoke each other.
+
 ## Action Kinds
 
 The current typed action kinds are:

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -698,7 +698,8 @@ cat >"$reauth_config" <<EOF
       "name": "codex",
       "display_name": "Codex Test Harness",
       "repair": {
-        "owner": "upstream_cli_login"
+        "owner": "upstream_cli_login",
+        "proactive_refresh": "oauth_refresh_token"
       },
       "runtime": {
         "writable_paths": ["CODEX_HOME"],
@@ -1517,7 +1518,7 @@ expect_contains "$repair_reauth" '"confirmation_required":true' "repair run requ
 expect_contains "$repair_reauth" '"requires":"--confirm-repair"' "repair run reports required flag"
 expect_contains "$repair_reauth" '"command":"oauth-mux codex login-device max-1"' "repair run reports upstream command"
 expect_contains "$repair_reauth" '"daemon_repair":{"admitted":false,"reason":"interactive_not_allowed","budget":"interactive"}' "repair run reports daemon policy refusal"
-expect_contains "$repair_reauth" '"writeback":{"capability":"replace_file","automatic_refresh_admitted":false,"reason":"provider_repair_owned_by_upstream_cli"}' "repair run reports upstream-owned file writeback boundary"
+expect_contains "$repair_reauth" '"writeback":{"capability":"replace_file","automatic_refresh_admitted":false,"reason":"proactive_refresh_not_opted_in"}' "repair run reports refresh-consent writeback boundary (TIN-2058: codex declares the refresh grant; account has not opted in)"
 test ! -e "$tmp/reauth-home/auth.json"
 
 printf 'e2e: stay-afloat next returns provider-mediated handoff when not afloat\n'

--- a/src/config.zig
+++ b/src/config.zig
@@ -54,6 +54,13 @@ pub const AccountConfig = struct {
     config_dir: ?[]const u8 = null,
     quota: ?QuotaConfig = null,
     tags: ?[]const []const u8 = null,
+    // TIN-2058: explicit operator consent for oauth-mux to refresh this
+    // account's token proactively. Login stays upstream-CLI-owned; this
+    // only admits the non-interactive refresh writeback, and only for
+    // providers whose definition declares proactive_refresh support. Leave
+    // false until the dual-writer story (TIN-2059) covers your native CLI's
+    // own refresh behavior for this account.
+    allow_proactive_refresh: bool = false,
 };
 
 pub const SecretConfig = struct {

--- a/src/main.zig
+++ b/src/main.zig
@@ -3585,7 +3585,10 @@ fn routeWritebackPlan(
         .automatic_refresh_admitted = false,
         .reason = "secret_backend_invalid",
     };
-    return secret_mod.writebackPlan(backend, def.repair.owner);
+    return secret_mod.writebackPlan(backend, def.repair.owner, .{
+        .provider_supports_refresh = def.repair.proactive_refresh != .unsupported,
+        .account_opted_in = account.allow_proactive_refresh,
+    });
 }
 
 fn daemonProbeAdmission(policy: config.DaemonPolicyConfig, budget: ?types.ActionBudget) AdmissionDecision {
@@ -7401,7 +7404,10 @@ fn accountWritebackPlan(
         .automatic_refresh_admitted = false,
         .reason = "secret_backend_invalid",
     };
-    return secret_mod.writebackPlan(backend, def.repair.owner);
+    return secret_mod.writebackPlan(backend, def.repair.owner, .{
+        .provider_supports_refresh = def.repair.proactive_refresh != .unsupported,
+        .account_opted_in = account.allow_proactive_refresh,
+    });
 }
 
 fn runtimeAccountInfo(

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -660,7 +660,10 @@ fn refreshWritebackBackend(
     const prov_cfg = ctx.cfg.providers.map.get(prov) orelse return error.ProviderNotFound;
     const acct_cfg = prov_cfg.accounts.map.get(acct) orelse return error.AccountNotFound;
     const backend = config_mod.resolveSecretBackend(acct_cfg.secret) catch return error.ConfigValidationError;
-    const plan = secret.writebackPlan(backend, def.repair.owner);
+    const plan = secret.writebackPlan(backend, def.repair.owner, .{
+        .provider_supports_refresh = def.repair.proactive_refresh != .unsupported,
+        .account_opted_in = acct_cfg.allow_proactive_refresh,
+    });
     if (!plan.automatic_refresh_admitted) {
         log.warn("token: refresh writeback not admitted for {s}:{s}: {s}", .{ prov, acct, plan.reason });
         recordRefreshEvent(ctx, plan, "not_admitted", plan.reason, false, false);
@@ -1630,4 +1633,71 @@ fn expectMissingEnvValue(pairs: []const [2][]const u8, key: []const u8, value: [
             return error.TestUnexpectedResult;
         }
     }
+}
+
+test "refreshWritebackBackend admits opted-in proactive refresh under upstream login ownership" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const auth_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/auth.json", .{root_path});
+    defer std.testing.allocator.free(auth_path);
+
+    // Provider declares the refresh grant; login stays upstream-owned.
+    // Account consent is the only difference between the two configs.
+    const config_fmt =
+        \\{{
+        \\  "version": 1,
+        \\  "provider_definitions": {{
+        \\    "toy": {{
+        \\      "name": "toy",
+        \\      "repair": {{ "owner": "upstream_cli_login", "proactive_refresh": "oauth_refresh_token" }},
+        \\      "auth": {{ "token_endpoint": "https://example.invalid/token" }}
+        \\    }}
+        \\  }},
+        \\  "providers": {{
+        \\    "toy": {{
+        \\      "kind": "toy",
+        \\      "accounts": {{
+        \\        "default": {{ "secret": {{ "backend": "file", "path": "{s}" }}{s} }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{}},
+        \\  "strategies": {{}}
+        \\}}
+    ;
+
+    const opted_json = try std.fmt.allocPrint(std.testing.allocator, config_fmt, .{ auth_path, ", \"allow_proactive_refresh\": true" });
+    defer std.testing.allocator.free(opted_json);
+
+    const opted = try config_mod.loadFromBytes(std.testing.allocator, opted_json);
+    defer opted.deinit();
+    var opted_store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer opted_store.deinit();
+    var opted_ctx = Context.init(std.testing.allocator, opted.value, &opted_store);
+    defer opted_ctx.deinit();
+    opted_ctx.provider_name = "toy";
+    opted_ctx.account_name = "default";
+    const opted_writeback = try refreshWritebackBackend(&opted_ctx, config_mod.resolveProviderDefinition(opted.value, "toy"));
+    try std.testing.expect(opted_writeback.plan.automatic_refresh_admitted);
+    try std.testing.expectEqualStrings("proactive_refresh_opted_in", opted_writeback.plan.reason);
+
+    // Default mode (no consent): the same provider definition still refuses.
+    const default_json = try std.fmt.allocPrint(std.testing.allocator, config_fmt, .{ auth_path, "" });
+    defer std.testing.allocator.free(default_json);
+
+    const defaulted = try config_mod.loadFromBytes(std.testing.allocator, default_json);
+    defer defaulted.deinit();
+    var default_store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer default_store.deinit();
+    var default_ctx = Context.init(std.testing.allocator, defaulted.value, &default_store);
+    defer default_ctx.deinit();
+    default_ctx.provider_name = "toy";
+    default_ctx.account_name = "default";
+    try std.testing.expectError(
+        error.TokenRefreshFailed,
+        refreshWritebackBackend(&default_ctx, config_mod.resolveProviderDefinition(defaulted.value, "toy")),
+    );
 }

--- a/src/provider_schema.zig
+++ b/src/provider_schema.zig
@@ -137,6 +137,19 @@ pub const RuntimeConfig = struct {
 
 pub const RepairConfig = struct {
     owner: types.RepairOwner = .manual_only,
+    // TIN-2058: whether oauth-mux is technically able to drive a proactive
+    // token refresh for this provider (a refresh_token grant the mux can
+    // execute against the provider's token endpoint). This declares
+    // capability, not permission — admission additionally requires the
+    // account's explicit `allow_proactive_refresh` consent in config. Login
+    // ownership (`owner`) is unaffected: interactive re-auth stays with the
+    // upstream CLI.
+    proactive_refresh: ProactiveRefreshSupport = .unsupported,
+};
+
+pub const ProactiveRefreshSupport = enum {
+    unsupported,
+    oauth_refresh_token,
 };
 
 pub const CapabilityDefinition = struct {
@@ -721,6 +734,12 @@ pub const claude_def = ProviderDefinition{
         .required_binaries = &.{"claude"},
         .env_vars = &.{"CLAUDE_CONFIG_DIR"},
     },
+    // The refresh grant (.proactive_refresh = .oauth_refresh_token) is
+    // deliberately NOT declared yet: the pipeline refresh write path is
+    // unserialized (no repair flock) and the credential template is lossy
+    // (drops expiresAt/scopes), so an opted-in refresh would corrupt the
+    // live store the CLI reads. Declare the grant only once both follow-ups
+    // land (refresh-path locking + field-preserving writeback).
     .repair = .{
         .owner = .upstream_cli_login,
     },
@@ -764,6 +783,9 @@ pub const codex_def = ProviderDefinition{
         .writable_paths = &.{"CODEX_HOME"},
         .session_paths = &.{"CODEX_HOME/auth.json"},
     },
+    // Refresh grant intentionally undeclared — same gating as claude_def:
+    // the unserialized refresh path + lossy template (drops tokens.id_token,
+    // the codex identity source) must be fixed before opt-in can be honored.
     .repair = .{
         .owner = .upstream_cli_login,
     },

--- a/src/secret.zig
+++ b/src/secret.zig
@@ -29,6 +29,17 @@ pub const WritebackPlan = struct {
     reason: []const u8,
 };
 
+// TIN-2058: the refresh-authority split. Login ownership (RepairOwner) and
+// proactive-refresh authority are different axes: a provider whose login is
+// upstream-CLI-owned can still grant oauth-mux the non-interactive refresh,
+// but only when the provider definition declares the refresh grant AND the
+// account's config carries explicit operator consent. Defaults keep today's
+// refusal.
+pub const RefreshAuthority = struct {
+    provider_supports_refresh: bool = false,
+    account_opted_in: bool = false,
+};
+
 pub fn read(backend: types.SecretBackend, allocator: std.mem.Allocator) ReadError![]const u8 {
     return switch (backend) {
         .keychain => |ref| readKeychain(ref, allocator),
@@ -52,14 +63,24 @@ pub fn writeCapability(backend: types.SecretBackend) types.SecretWriteCapability
     };
 }
 
-pub fn writebackPlan(backend: types.SecretBackend, owner: types.RepairOwner) WritebackPlan {
+pub fn writebackPlan(backend: types.SecretBackend, owner: types.RepairOwner, authority: RefreshAuthority) WritebackPlan {
     const capability = writeCapability(backend);
-    if (owner != .oauth_mux_refresh) {
+    const authority_granted = switch (owner) {
+        .oauth_mux_refresh => true,
+        .upstream_cli_login => authority.provider_supports_refresh and authority.account_opted_in,
+        // manual_only / external_secret_owner exclude mux writes outright;
+        // account consent cannot override an operator/secret-owner boundary.
+        .external_secret_owner, .manual_only => false,
+    };
+    if (!authority_granted) {
         return .{
             .capability = capability,
             .automatic_refresh_admitted = false,
             .reason = switch (owner) {
-                .upstream_cli_login => "provider_repair_owned_by_upstream_cli",
+                .upstream_cli_login => if (authority.provider_supports_refresh)
+                    "proactive_refresh_not_opted_in"
+                else
+                    "provider_repair_owned_by_upstream_cli",
                 .external_secret_owner => "provider_repair_owned_by_external_secret",
                 .manual_only => "provider_repair_is_manual_only",
                 .oauth_mux_refresh => unreachable,
@@ -67,7 +88,7 @@ pub fn writebackPlan(backend: types.SecretBackend, owner: types.RepairOwner) Wri
         };
     }
 
-    return switch (capability) {
+    var plan: WritebackPlan = switch (capability) {
         .replace_file => .{
             .capability = capability,
             .automatic_refresh_admitted = true,
@@ -106,6 +127,13 @@ pub fn writebackPlan(backend: types.SecretBackend, owner: types.RepairOwner) Wri
             .reason = "secret_backend_writeback_unsupported",
         },
     };
+    // Consent-granted admission (vs mux-owned repair) is surfaced as its own
+    // reason so the audit trail records WHY the write was allowed; the
+    // capability field still names the mechanism.
+    if (owner != .oauth_mux_refresh and plan.automatic_refresh_admitted) {
+        plan.reason = "proactive_refresh_opted_in";
+    }
+    return plan;
 }
 
 pub fn writeReplace(backend: types.SecretBackend, bytes: []const u8, allocator: std.mem.Allocator) WriteError!void {
@@ -501,17 +529,17 @@ test "writeCapability classifies secret backend write surfaces" {
 
 test "writebackPlan requires oauth-mux refresh ownership" {
     const file_backend = types.SecretBackend{ .file = .{ .path = "/tmp/omux-auth.json" } };
-    const admitted = writebackPlan(file_backend, .oauth_mux_refresh);
+    const admitted = writebackPlan(file_backend, .oauth_mux_refresh, .{});
     try std.testing.expect(admitted.automatic_refresh_admitted);
     try std.testing.expect(admitted.capability == .replace_file);
     try std.testing.expectEqualStrings("replace_file_writeback_available", admitted.reason);
 
-    const upstream_owned = writebackPlan(file_backend, .upstream_cli_login);
+    const upstream_owned = writebackPlan(file_backend, .upstream_cli_login, .{});
     try std.testing.expect(!upstream_owned.automatic_refresh_admitted);
     try std.testing.expect(upstream_owned.capability == .replace_file);
     try std.testing.expectEqualStrings("provider_repair_owned_by_upstream_cli", upstream_owned.reason);
 
-    const env_owned = writebackPlan(.{ .env = .{ .variable = "OMUX_AUTH" } }, .oauth_mux_refresh);
+    const env_owned = writebackPlan(.{ .env = .{ .variable = "OMUX_AUTH" } }, .oauth_mux_refresh, .{});
     try std.testing.expect(!env_owned.automatic_refresh_admitted);
     try std.testing.expect(env_owned.capability == .readonly);
     try std.testing.expectEqualStrings("secret_backend_is_readonly", env_owned.reason);
@@ -519,7 +547,7 @@ test "writebackPlan requires oauth-mux refresh ownership" {
 
 test "writebackPlan keychain write is platform-gated" {
     const keychain_backend = types.SecretBackend{ .keychain = .{ .service = "oauth-mux-test", .account = "work" } };
-    const plan = writebackPlan(keychain_backend, .oauth_mux_refresh);
+    const plan = writebackPlan(keychain_backend, .oauth_mux_refresh, .{});
     try std.testing.expect(plan.capability == .keychain_write);
     if (comptime builtin.os.tag == .macos) {
         try std.testing.expect(plan.automatic_refresh_admitted);
@@ -529,9 +557,10 @@ test "writebackPlan keychain write is platform-gated" {
         try std.testing.expectEqualStrings("keychain_write_unproven_on_platform", plan.reason);
     }
 
-    // Ownership still trumps capability: claude-style upstream_cli_login
-    // accounts stay un-admitted even where write works (TIN-2058's gate).
-    const upstream = writebackPlan(keychain_backend, .upstream_cli_login);
+    // Ownership still trumps capability: an upstream_cli_login provider
+    // with no declared refresh grant (today's builtin claude/codex shape)
+    // stays un-admitted even where write works, with the historical reason.
+    const upstream = writebackPlan(keychain_backend, .upstream_cli_login, .{});
     try std.testing.expect(!upstream.automatic_refresh_admitted);
     try std.testing.expectEqualStrings("provider_repair_owned_by_upstream_cli", upstream.reason);
 }
@@ -573,4 +602,73 @@ test "keychain write/read/overwrite/delete round-trip (macOS)" {
 
     deleteKeychainMacOS(ref, allocator);
     try std.testing.expectError(error.NotFound, read(backend, allocator));
+}
+
+test "writebackPlan refresh-authority split: consent admits refresh under upstream login ownership" {
+    const file_backend = types.SecretBackend{ .file = .{ .path = "/tmp/omux-auth.json" } };
+
+    // Opted-in account + provider-declared refresh grant: admitted, with the
+    // consent basis in the audit reason; login ownership stays upstream.
+    const opted = writebackPlan(file_backend, .upstream_cli_login, .{
+        .provider_supports_refresh = true,
+        .account_opted_in = true,
+    });
+    try std.testing.expect(opted.automatic_refresh_admitted);
+    try std.testing.expect(opted.capability == .replace_file);
+    try std.testing.expectEqualStrings("proactive_refresh_opted_in", opted.reason);
+
+    // Provider supports refresh but the account has not consented: typed
+    // refusal that names the missing knob.
+    const not_opted = writebackPlan(file_backend, .upstream_cli_login, .{
+        .provider_supports_refresh = true,
+    });
+    try std.testing.expect(!not_opted.automatic_refresh_admitted);
+    try std.testing.expectEqualStrings("proactive_refresh_not_opted_in", not_opted.reason);
+
+    // Provider declares no refresh grant: consent alone changes nothing and
+    // the historical refusal reason is preserved.
+    const unsupported = writebackPlan(file_backend, .upstream_cli_login, .{
+        .account_opted_in = true,
+    });
+    try std.testing.expect(!unsupported.automatic_refresh_admitted);
+    try std.testing.expectEqualStrings("provider_repair_owned_by_upstream_cli", unsupported.reason);
+
+    // manual_only / external_secret_owner boundaries are not overridable by
+    // account consent.
+    const manual = writebackPlan(file_backend, .manual_only, .{
+        .provider_supports_refresh = true,
+        .account_opted_in = true,
+    });
+    try std.testing.expect(!manual.automatic_refresh_admitted);
+    try std.testing.expectEqualStrings("provider_repair_is_manual_only", manual.reason);
+
+    const external = writebackPlan(file_backend, .external_secret_owner, .{
+        .provider_supports_refresh = true,
+        .account_opted_in = true,
+    });
+    try std.testing.expect(!external.automatic_refresh_admitted);
+    try std.testing.expectEqualStrings("provider_repair_owned_by_external_secret", external.reason);
+
+    // Consent cannot bypass capability gating: a readonly backend stays
+    // refused on capability grounds.
+    const readonly = writebackPlan(.{ .env = .{ .variable = "OMUX_AUTH" } }, .upstream_cli_login, .{
+        .provider_supports_refresh = true,
+        .account_opted_in = true,
+    });
+    try std.testing.expect(!readonly.automatic_refresh_admitted);
+    try std.testing.expectEqualStrings("secret_backend_is_readonly", readonly.reason);
+
+    // TIN-2070 mechanism composes: consent admits the keychain write on
+    // macOS and keeps the platform refusal elsewhere.
+    const keychain = writebackPlan(.{ .keychain = .{ .service = "oauth-mux-test", .account = "work" } }, .upstream_cli_login, .{
+        .provider_supports_refresh = true,
+        .account_opted_in = true,
+    });
+    if (comptime builtin.os.tag == .macos) {
+        try std.testing.expect(keychain.automatic_refresh_admitted);
+        try std.testing.expectEqualStrings("proactive_refresh_opted_in", keychain.reason);
+    } else {
+        try std.testing.expect(!keychain.automatic_refresh_admitted);
+        try std.testing.expectEqualStrings("keychain_write_unproven_on_platform", keychain.reason);
+    }
 }


### PR DESCRIPTION
## Summary

Models the refresh-authority split: login ownership (`RepairOwner`, unchanged) and proactive-refresh authority become **separate axes**, ending the all-or-nothing scalar that made the keepalive warm loop impossible by policy.

- **Provider grant**: `RepairConfig.proactive_refresh` (`unsupported` | `oauth_refresh_token`) — declares the *capability*, not permission.
- **Account consent**: `AccountConfig.allow_proactive_refresh` (default `false`) — the explicit operator opt-in.
- **`writebackPlan` admission**: `upstream_cli_login` + grant + consent → admitted, audit reason `proactive_refresh_opted_in`; grant without consent → typed `proactive_refresh_not_opted_in`; no grant → historical `provider_repair_owned_by_upstream_cli`; `manual_only`/`external_secret_owner` never consent-overridable; capability gating (readonly/sops/command, keychain macOS gate) still applies after authority.

## Why no builtin declares the grant yet

The adversarial review (2 lenses + per-finding refutation) confirmed two majors in the generic refresh path that must land before any builtin grant flips:

1. **TIN-2073** — `pipeline.attemptRefresh` is unserialized (no repair flock, unlike every other credential writer), and the daemon **probe** path can ride a probe budget into a mutating token rotation.
2. **TIN-2074** — credential writeback is lossy template substitution: claude's template drops `expiresAt` (disabling future expiry detection), codex's drops `tokens.id_token` (the identity source). First opted-in refresh would corrupt the live store the upstream CLI reads.

Both tickets block the grant flip and are documented in-code and in `provider-repair-contracts.md`. Until they land, opting in changes **nothing** for builtin providers — default behavior is byte-identical (acceptance: "no behavior change until an account opts in" holds strictly).

## Coverage

- Unit: the full authority matrix (opted/not-opted/no-grant/manual/external/readonly/keychain-platform-composition) in `secret.zig`.
- Pipeline smoke: JSON-config consent → `refreshWritebackBackend` admission both ways, via `provider_definitions` fixtures.
- e2e: codex fixture declares the grant → exercises `proactive_refresh_not_opted_in` through the `repair run` surface; toy fixture keeps covering the no-grant historical reason. Full `scripts/e2e-local.sh` green.
- 519/519 `zig build test`.

Closes TIN-2058.