### PR TITLE
reauth: serialize + budget-gate pipeline proactive refresh (TIN-2073)

### DIFF
--- a/docs/provider-repair-contracts.md
+++ b/docs/provider-repair-contracts.md
@@ -69,13 +69,28 @@ non-interactive token refresh when BOTH hold:
 - the account's config carries explicit operator consent
   (`"allow_proactive_refresh": true` on the account).
 
-No builtin definition declares the grant yet — deliberately. The pipeline
-refresh write path is currently unserialized (no repair flock; a daemon
-probe tick could ride a probe budget into a mutating token rotation) and the
+No builtin definition declares the grant yet — deliberately. The refresh
+path is serialized (TIN-2073): `attemptRefresh` takes the same
+per-(provider,account) repair flock as every other **mux-owned** credential
+writer (upstream CLI logins are user-mediated writes outside this lock
+domain — lock-aware readiness for those is the TIN-1806 lane), revalidates
+the store **under the lock** (a peer rotation that completed first is
+adopted as `not_needed`/`concurrent_rotation_detected`; an actual rotation
+always uses the re-read refresh token, never a pre-lock snapshot), and
+defers typed with `refresh_lock_held` when another rotation is in flight —
+serving the still-valid token when merely inside the expiry skew, failing
+closed only when actually expired. The daemon's probe phase rotates only
+when daemon policy grants mutation (`policy.daemon.allow_mutating`, the
+same consent the repair phase requires); the default-deny tick defers with
+`refresh_requires_mutating_budget`. Batch revalidation surfaces
+(`codex revalidate-exhausted`, adapter auto-revalidation) never rotate.
+
+Remaining blockers before any builtin grant flips: TIN-2074 — the
 credential templates are lossy (claude drops `expiresAt`, codex drops
-`tokens.id_token` — the identity source). Each builtin's grant flips only
-after refresh-path locking and field-preserving writeback land; until then,
-opting an account in changes nothing for builtin providers.
+`tokens.id_token` — the identity source), so a refresh writeback would
+corrupt the native store; and a deadline on the token-endpoint call (the
+flock is held across it, and blocking acquirers have no timeout). Until
+both land, opting an account in changes nothing for builtin providers.
 
 Without consent the writeback plan refuses with
 `proactive_refresh_not_opted_in` (providers without the declared grant keep

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -966,6 +966,9 @@ fn maybeAutoRevalidateCodexRoutes(
         ctx.provider_name = "codex";
         ctx.account_name = route.account;
         ctx.capability_name = route.capability;
+        // Auto-revalidation is gated on spend consent, not mutation consent
+        // (TIN-2073): it must never rotate credentials mid-launch.
+        ctx.allow_refresh_mutation = false;
 
         const probe_result = pipeline.runProbe(&ctx);
         var recorded_provider_evidence = true;

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -102,6 +102,10 @@ pub const Command = union(enum) {
         account: ?[]const u8 = null,
         capability: ?[]const u8 = null,
         json: bool = false,
+        // TIN-2073: internal (not CLI-parsed). The daemon's probe phase sets
+        // this false so a probe-budget tick can never rotate tokens —
+        // rotation belongs to the repair phase under admission + lock.
+        allow_refresh_mutation: bool = true,
     };
 
     pub const DoctorMode = enum {

--- a/src/main.zig
+++ b/src/main.zig
@@ -5357,7 +5357,7 @@ fn executeDaemonTickActions(
         if (!decision.admitted) continue;
 
         if (std.mem.eql(u8, decision.phase, "probe")) {
-            return try executeDaemonProbe(allocator, args, evaluation, decision, executions);
+            return try executeDaemonProbe(allocator, cfg, args, evaluation, decision, executions);
         }
 
         if (std.mem.eql(u8, decision.phase, "repair") and
@@ -5373,6 +5373,7 @@ fn executeDaemonTickActions(
 
 fn executeDaemonProbe(
     allocator: std.mem.Allocator,
+    cfg: config.Config,
     args: cli.Command.DaemonTickArgs,
     evaluation: RouteEvaluation,
     decision: DaemonTickDecision,
@@ -5381,6 +5382,12 @@ fn executeDaemonProbe(
     var scratch = std.ArrayList(u8).init(allocator);
     defer scratch.deinit();
 
+    // TIN-2073: a probe-budget tick may rotate tokens only when daemon
+    // policy explicitly grants mutation — the same operator consent the
+    // repair phase requires. Default policy (allow_mutating=false) defers
+    // typed; rotation then needs a mutation-admitted tick.
+    const daemon_policy = config.effectiveDaemonPolicyForProvider(cfg.policy, evaluation.route.provider);
+
     var ok = true;
     var reason: []const u8 = "probe_completed";
     runProbe(allocator, scratch.writer(), .{
@@ -5388,6 +5395,7 @@ fn executeDaemonProbe(
         .account = evaluation.route.account,
         .capability = evaluation.route.capability,
         .json = true,
+        .allow_refresh_mutation = daemon_policy.allow_mutating,
     }) catch |e| {
         ok = false;
         reason = @errorName(e);
@@ -8338,6 +8346,7 @@ fn runProbe(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.Pro
     ctx.account_name = args.account;
     ctx.capability_name = args.capability;
     ctx.probe_recheck_blocked = args.account != null;
+    ctx.allow_refresh_mutation = args.allow_refresh_mutation;
 
     const result = pipeline.runProbe(&ctx);
     store.persist();
@@ -9289,6 +9298,9 @@ fn runCodexRevalidateExhausted(
         ctx.provider_name = route.provider;
         ctx.account_name = route.account;
         ctx.capability_name = route.capability;
+        // revalidate-exhausted's JSON contract declares
+        // mutates_user_config:false — a credential rotation would break it.
+        ctx.allow_refresh_mutation = false;
 
         const probe_result = pipeline.runProbe(&ctx);
         var probe_error: ?types.PipelineError = null;

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -34,6 +34,14 @@ pub const Context = struct {
     last_probe_executed: bool = false,
     last_probe_status: ?u16 = null,
     last_probe_decision: ?types.MuxDecision = null,
+    // TIN-2073: probe-budget callers (the daemon tick's probe phase) set
+    // this false — they must never rotate tokens; rotation belongs to the
+    // repair phase under admission + the per-account repair lock.
+    allow_refresh_mutation: bool = true,
+    // Diagnostics: the most recent refresh outcome/reason recorded for this
+    // context (also the assertable seam in tests, where events are skipped).
+    last_refresh_outcome: ?[]const u8 = null,
+    last_refresh_reason: ?[]const u8 = null,
 
     pub fn init(allocator: std.mem.Allocator, cfg: config_mod.Config, store: *health_mod.HealthStore) Context {
         return .{
@@ -387,6 +395,14 @@ fn resolveProvider(ctx: *Context) PipelineError!void {
 }
 
 fn readSecret(ctx: *Context) PipelineError!void {
+    ctx.token = try readTokenSnapshot(ctx);
+}
+
+// Reads + parses the account's credential store WITHOUT touching ctx.token.
+// Used both for the initial load (readSecret) and the under-lock
+// revalidation in attemptRefresh (TIN-2073), where the pre-lock ctx.token
+// must stay live while the fresh snapshot is examined.
+fn readTokenSnapshot(ctx: *Context) PipelineError!provider.TokenFields {
     const prov_name = ctx.provider_name orelse return error.ProviderNotFound;
     const acct_name = ctx.account_name orelse return error.AccountNotFound;
 
@@ -405,18 +421,22 @@ fn readSecret(ctx: *Context) PipelineError!void {
     const generic = provider_schema.parseTokenGeneric(def, raw, ctx.allocator) catch {
         log.debug("token: schema parse failed for {s}:{s}, trying legacy parser", .{ prov_name, acct_name });
         const kind = ctx.provider_kind orelse return error.ProviderNotFound;
-        ctx.token = provider.parseToken(kind, raw, ctx.allocator) catch {
+        return provider.parseToken(kind, raw, ctx.allocator) catch {
             log.err("token: parse failed for {s}:{s}", .{ prov_name, acct_name });
             return error.TokenParseFailed;
         };
-        return;
     };
-    ctx.token = .{
+    return .{
         .access_token = generic.access_token,
         .refresh_token = generic.refresh_token,
         .token_type = generic.token_type,
         .expires_at = generic.expires_at,
     };
+}
+
+fn freeTokenFields(allocator: std.mem.Allocator, tok: provider.TokenFields) void {
+    allocator.free(tok.access_token);
+    if (tok.refresh_token) |token_rt| allocator.free(token_rt);
 }
 
 fn validateToken(ctx: *Context) PipelineError!void {
@@ -437,8 +457,22 @@ fn validateToken(ctx: *Context) PipelineError!void {
         const now = std.time.timestamp();
         if (now >= exp - 30) {
             if (tok.refresh_token) |rt| {
-                log.info("token: expired for {s}:{s}, attempting refresh", .{ prov, acct });
-                try attemptRefresh(ctx, rt);
+                if (!ctx.allow_refresh_mutation) {
+                    // TIN-2073: a probe-budget caller must not rotate
+                    // tokens. Record the typed deferral; a token that is
+                    // merely inside the skew window stays usable, an
+                    // actually-expired one fails closed for the repair
+                    // phase to handle under admission + lock.
+                    log.info("token: refresh needed for {s}:{s} but caller budget is non-mutating; deferring", .{ prov, acct });
+                    const def = config_mod.resolveProviderDefinition(ctx.cfg, prov);
+                    if (refreshWritebackBackend(ctx, def)) |writeback| {
+                        recordRefreshEvent(ctx, writeback.plan, "deferred", "refresh_requires_mutating_budget", false, false);
+                    } else |_| {}
+                    if (now >= exp) return error.TokenExpired;
+                } else {
+                    log.info("token: expired for {s}:{s}, attempting refresh", .{ prov, acct });
+                    try attemptRefresh(ctx, rt);
+                }
             } else {
                 return error.TokenExpired;
             }
@@ -582,15 +616,77 @@ fn buildProbeEnv(
 
 fn attemptRefresh(ctx: *Context, rt: []const u8) PipelineError!void {
     const prov = ctx.provider_name orelse return error.ProviderNotFound;
+    const acct = ctx.account_name orelse return error.AccountNotFound;
     const def = config_mod.resolveProviderDefinition(ctx.cfg, prov);
     const writeback = try refreshWritebackBackend(ctx, def);
+
+    // TIN-2073: serialize against every other mux-owned writer to this
+    // account's credential store (repair run, daemon repair, broker, and
+    // adapter session flows take the same per-(provider,account) flock).
+    // Upstream CLI logins (e.g. `oauth-mux codex login` wrapping the vendor
+    // CLI) are user-mediated writes outside this lock domain — lock-aware
+    // readiness for those is the TIN-1806 lane. Nonblocking: a held lock
+    // means another rotation is in flight — racing it is the refresh-token
+    // self-revocation failure mode, so defer typed instead.
+    var refresh_lock = repair_state.acquireRepairLock(ctx.allocator, prov, acct) catch |e| switch (e) {
+        error.RepairInProgress => {
+            log.warn("token: refresh deferred for {s}:{s}: repair lock held", .{ prov, acct });
+            recordRefreshEvent(ctx, writeback.plan, "deferred", "refresh_lock_held", false, false);
+            // Inside the 30s skew the current token is still provider-valid:
+            // keep serving it so a benign in-flight peer rotation does not
+            // poison route health as an auth failure. Only an actually
+            // expired token fails closed.
+            if (ctx.token) |tok| {
+                if (tok.expires_at) |exp| {
+                    if (std.time.timestamp() < exp) return;
+                }
+            }
+            return error.TokenRefreshFailed;
+        },
+        else => {
+            recordRefreshEvent(ctx, writeback.plan, "lock_failed", @errorName(e), false, false);
+            return error.TokenRefreshFailed;
+        },
+    };
+    defer refresh_lock.release();
+
+    // TIN-2073 (review): revalidate under the lock — the broker's
+    // lock-then-revalidate pattern. The rt argument was read BEFORE the
+    // flock; a peer's rotation may have completed inside that window. If
+    // the re-read credential is already fresh, adopt it and skip the
+    // endpoint; otherwise rotate with the re-read refresh token, never the
+    // pre-lock snapshot.
+    const fresh_snapshot: ?provider.TokenFields = readTokenSnapshot(ctx) catch null;
+    var fresh_adopted = false;
+    defer if (fresh_snapshot) |f| {
+        if (!fresh_adopted) freeTokenFields(ctx.allocator, f);
+    };
+    if (fresh_snapshot) |f| {
+        if (f.expires_at) |exp| {
+            if (std.time.timestamp() < exp - 30) {
+                if (ctx.token) |old| freeTokenFields(ctx.allocator, old);
+                ctx.token = f;
+                fresh_adopted = true;
+                log.info("token: concurrent rotation detected for {s}:{s}; adopted fresh credential", .{ prov, acct });
+                recordRefreshEvent(ctx, writeback.plan, "not_needed", "concurrent_rotation_detected", true, false);
+                return;
+            }
+        }
+    }
+    const effective_rt = if (fresh_snapshot) |f| (f.refresh_token orelse rt) else rt;
+
     const url = def.auth.token_endpoint orelse fallbackRefreshUrl(ctx) orelse {
         log.warn("token: no refresh URL for {s}", .{prov});
         recordRefreshEvent(ctx, writeback.plan, "no_token_endpoint", "token_endpoint_missing", false, false);
         return error.TokenRefreshFailed;
     };
 
-    const result = oauth.refreshToken(ctx.allocator, url, rt, def.auth.client_id) catch |e| {
+    // Known residual (TIN-2074 gate): oauth.refreshToken has no deadline,
+    // so the flock is held across an unbounded network call; blocking
+    // acquirers of this key (adapter session start, broker) have no
+    // timeout. A deadline (or bounded blocking waits) must land before any
+    // builtin proactive_refresh grant flips.
+    const result = oauth.refreshToken(ctx.allocator, url, effective_rt, def.auth.client_id) catch |e| {
         log.err("token: refresh failed: {s}", .{@errorName(e)});
         recordRefreshEvent(ctx, writeback.plan, "token_endpoint_failed", @errorName(e), false, true);
         return error.TokenRefreshFailed;
@@ -604,7 +700,7 @@ fn attemptRefresh(ctx: *Context, rt: []const u8) PipelineError!void {
     if (result.refresh_token) |new_rt| {
         retained_refresh_token = new_rt;
     } else {
-        retained_refresh_token = ctx.allocator.dupe(u8, rt) catch return error.OutOfMemory;
+        retained_refresh_token = ctx.allocator.dupe(u8, effective_rt) catch return error.OutOfMemory;
         retained_refresh_token_from_old = true;
     }
     errdefer if (retained_refresh_token_from_old) {
@@ -683,6 +779,8 @@ fn recordRefreshEvent(
     ok: bool,
     executed: bool,
 ) void {
+    ctx.last_refresh_outcome = outcome;
+    ctx.last_refresh_reason = reason;
     if (comptime builtin.is_test) return;
     repair_state.appendEvent(ctx.allocator, .{
         .kind = "token_refresh",
@@ -698,7 +796,7 @@ fn recordRefreshEvent(
         .ok = ok,
         .executed = executed,
         .interactive = false,
-        .mutating = true,
+        .mutating = executed,
     }) catch {};
 }
 
@@ -1700,4 +1798,243 @@ test "refreshWritebackBackend admits opted-in proactive refresh under upstream l
         error.TokenRefreshFailed,
         refreshWritebackBackend(&default_ctx, config_mod.resolveProviderDefinition(defaulted.value, "toy")),
     );
+}
+
+test "validateToken defers refresh under a non-mutating budget (TIN-2073)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const auth_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/auth.json", .{root_path});
+    defer std.testing.allocator.free(auth_path);
+
+    const json = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "provider_definitions": {{
+        \\    "toy": {{
+        \\      "name": "toy",
+        \\      "repair": {{ "owner": "oauth_mux_refresh" }},
+        \\      "auth": {{ "token_endpoint": "http://127.0.0.1:9/token" }}
+        \\    }}
+        \\  }},
+        \\  "providers": {{
+        \\    "toy": {{
+        \\      "kind": "toy",
+        \\      "accounts": {{
+        \\        "default": {{ "secret": {{ "backend": "file", "path": "{s}" }} }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{}},
+        \\  "strategies": {{}}
+        \\}}
+    ,
+        .{auth_path},
+    );
+    defer std.testing.allocator.free(json);
+
+    const parsed = try config_mod.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    var ctx = Context.init(std.testing.allocator, parsed.value, &store);
+    defer ctx.deinit();
+    ctx.provider_name = "toy";
+    ctx.account_name = "default";
+    ctx.allow_refresh_mutation = false;
+
+    const now = std.time.timestamp();
+    ctx.token = .{
+        .access_token = try std.testing.allocator.dupe(u8, "at-skew"),
+        .refresh_token = try std.testing.allocator.dupe(u8, "rt-skew"),
+        .expires_at = now + 10,
+    };
+
+    // Inside the 30s skew but not expired: the token stays usable, the
+    // refresh is deferred typed, and the endpoint is never contacted
+    // (attemptRefresh is never entered).
+    try validateToken(&ctx);
+    try std.testing.expectEqualStrings("deferred", ctx.last_refresh_outcome.?);
+    try std.testing.expectEqualStrings("refresh_requires_mutating_budget", ctx.last_refresh_reason.?);
+
+    // Actually expired: fails closed for the repair phase, still no rotation.
+    ctx.token.?.expires_at = now - 10;
+    ctx.last_refresh_outcome = null;
+    ctx.last_refresh_reason = null;
+    try std.testing.expectError(error.TokenExpired, validateToken(&ctx));
+    try std.testing.expectEqualStrings("deferred", ctx.last_refresh_outcome.?);
+    try std.testing.expectEqualStrings("refresh_requires_mutating_budget", ctx.last_refresh_reason.?);
+}
+
+test "attemptRefresh defers typed when the repair flock is held by another process (TIN-2073)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const auth_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/auth.json", .{root_path});
+    defer std.testing.allocator.free(auth_path);
+
+    const json = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "provider_definitions": {{
+        \\    "toy": {{
+        \\      "name": "toy",
+        \\      "repair": {{ "owner": "oauth_mux_refresh" }},
+        \\      "auth": {{ "token_endpoint": "http://127.0.0.1:9/token" }}
+        \\    }}
+        \\  }},
+        \\  "providers": {{
+        \\    "toy": {{
+        \\      "kind": "toy",
+        \\      "accounts": {{
+        \\        "tin2073-lock": {{ "secret": {{ "backend": "file", "path": "{s}" }} }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{}},
+        \\  "strategies": {{}}
+        \\}}
+    ,
+        .{auth_path},
+    );
+    defer std.testing.allocator.free(json);
+
+    const parsed = try config_mod.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    var ctx = Context.init(std.testing.allocator, parsed.value, &store);
+    defer ctx.deinit();
+    ctx.provider_name = "toy";
+    ctx.account_name = "tin2073-lock";
+
+    ctx.token = .{
+        .access_token = try std.testing.allocator.dupe(u8, "at-lock"),
+        .refresh_token = try std.testing.allocator.dupe(u8, "rt-lock"),
+        .expires_at = std.time.timestamp() - 10,
+    };
+
+    // Simulate a FOREIGN process holding the account's repair flock: take
+    // the raw kernel flock on the lock file without this process's
+    // re-entrancy registry (the same technique as repair_state's own tests).
+    const lock_path = try repair_state.lockPath(std.testing.allocator, "toy", "tin2073-lock");
+    defer std.testing.allocator.free(lock_path);
+    if (std.fs.path.dirname(lock_path)) |dir| try std.fs.cwd().makePath(dir);
+    const holder = try std.fs.createFileAbsolute(lock_path, .{
+        .truncate = false,
+        .mode = 0o600,
+        .lock = .exclusive,
+        .lock_nonblocking = true,
+    });
+
+    {
+        defer holder.close();
+        try std.testing.expectError(error.TokenRefreshFailed, validateToken(&ctx));
+        try std.testing.expectEqualStrings("deferred", ctx.last_refresh_outcome.?);
+        try std.testing.expectEqualStrings("refresh_lock_held", ctx.last_refresh_reason.?);
+
+        // Within the skew window (expiring but not expired) a held lock
+        // defers WITHOUT failing the candidate: the token is still valid
+        // and health must not be poisoned by a benign peer rotation.
+        ctx.token.?.expires_at = std.time.timestamp() + 10;
+        ctx.last_refresh_outcome = null;
+        ctx.last_refresh_reason = null;
+        try validateToken(&ctx);
+        try std.testing.expectEqualStrings("deferred", ctx.last_refresh_outcome.?);
+        try std.testing.expectEqualStrings("refresh_lock_held", ctx.last_refresh_reason.?);
+        ctx.token.?.expires_at = std.time.timestamp() - 10;
+    }
+
+    // Holder released: the refresh proceeds past the lock to the token
+    // endpoint (a closed local port), proving the deferral above came from
+    // the flock and not the endpoint.
+    ctx.last_refresh_outcome = null;
+    ctx.last_refresh_reason = null;
+    try std.testing.expectError(error.TokenRefreshFailed, validateToken(&ctx));
+    try std.testing.expectEqualStrings("token_endpoint_failed", ctx.last_refresh_outcome.?);
+}
+
+test "attemptRefresh adopts a concurrent peer rotation under the lock (TIN-2073 TOCTOU)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const auth_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/auth.json", .{root_path});
+    defer std.testing.allocator.free(auth_path);
+
+    const json = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "provider_definitions": {{
+        \\    "toy": {{
+        \\      "name": "toy",
+        \\      "repair": {{ "owner": "oauth_mux_refresh" }},
+        \\      "auth": {{ "token_endpoint": "http://127.0.0.1:9/token" }},
+        \\      "credential": {{
+        \\        "access_token_path": "access_token",
+        \\        "refresh_token_path": "refresh_token",
+        \\        "expires_at_path": "expires_at"
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "providers": {{
+        \\    "toy": {{
+        \\      "kind": "toy",
+        \\      "accounts": {{
+        \\        "tin2073-toctou": {{ "secret": {{ "backend": "file", "path": "{s}" }} }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{}},
+        \\  "strategies": {{}}
+        \\}}
+    ,
+        .{auth_path},
+    );
+    defer std.testing.allocator.free(json);
+
+    const parsed = try config_mod.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    var ctx = Context.init(std.testing.allocator, parsed.value, &store);
+    defer ctx.deinit();
+    ctx.provider_name = "toy";
+    ctx.account_name = "tin2073-toctou";
+
+    // The store already holds a FRESH credential — a peer completed its
+    // rotation between this context's pre-lock read (simulated by the stale
+    // ctx.token below) and the lock acquisition.
+    const now = std.time.timestamp();
+    const fresh_credential = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "{{\"access_token\":\"at-peer-fresh\",\"refresh_token\":\"rt-peer-fresh\",\"expires_at\":{d}}}",
+        .{now + 3600},
+    );
+    defer std.testing.allocator.free(fresh_credential);
+    {
+        const f = try std.fs.createFileAbsolute(auth_path, .{});
+        defer f.close();
+        try f.writeAll(fresh_credential);
+    }
+
+    ctx.token = .{
+        .access_token = try std.testing.allocator.dupe(u8, "at-stale"),
+        .refresh_token = try std.testing.allocator.dupe(u8, "rt-stale"),
+        .expires_at = now - 10,
+    };
+
+    // Succeeds WITHOUT contacting the (dead) token endpoint: the under-lock
+    // revalidation adopts the peer's rotation instead of re-rotating with
+    // the superseded refresh token.
+    try validateToken(&ctx);
+    try std.testing.expectEqualStrings("not_needed", ctx.last_refresh_outcome.?);
+    try std.testing.expectEqualStrings("concurrent_rotation_detected", ctx.last_refresh_reason.?);
+    try std.testing.expectEqualStrings("at-peer-fresh", ctx.token.?.access_token);
+    try std.testing.expectEqualStrings("rt-peer-fresh", ctx.token.?.refresh_token.?);
 }

--- a/src/repair_state.zig
+++ b/src/repair_state.zig
@@ -539,7 +539,15 @@ fn acquireRepairLockWithMode(
     while (true) {
         if (held_locks.getPtr(key)) |entry| {
             if (entry.acquiring) {
-                // Another thread in this process is mid-flock for this key; wait.
+                if (nonblocking) {
+                    // A sibling thread is mid-flock for this key. Waiting
+                    // would silently turn the caller's typed
+                    // refuse-on-held contract into an unbounded block
+                    // behind the sibling's (possibly blocking) acquire.
+                    held_mutex.unlock();
+                    return error.RepairInProgress;
+                }
+                // Blocking caller: wait for the sibling's flock to resolve.
                 held_cond.wait(&held_mutex);
                 continue;
             }
@@ -627,7 +635,7 @@ fn locksDir(allocator: std.mem.Allocator) ![]const u8 {
     return std.fs.path.join(allocator, &.{ dir, "repair-locks" });
 }
 
-fn lockPath(allocator: std.mem.Allocator, provider: []const u8, account: []const u8) ![]const u8 {
+pub fn lockPath(allocator: std.mem.Allocator, provider: []const u8, account: []const u8) ![]const u8 {
     const dir = try locksDir(allocator);
     defer allocator.free(dir);
     const file_name = try sanitizedLockFileName(allocator, provider, account);


### PR DESCRIPTION
## Summary

Closes the TIN-2058-review major: `pipeline.attemptRefresh` was the only credential writer outside the repair-lock domain, and the daemon's probe phase could ride a probe budget into a mutating token rotation. Both are fixed, plus everything the adversarial review of this diff itself surfaced.

- **Flock + under-lock revalidation**: `attemptRefresh` takes the same per-(provider,account) repair flock as every other mux-owned writer, then **re-reads the credential store under the lock** (the broker's lock-then-revalidate pattern). A peer rotation that completed first is adopted (`not_needed`/`concurrent_rotation_detected`) without contacting the endpoint; an actual rotation uses the re-read refresh token, never the pre-lock snapshot — the TOCTOU the review caught.
- **Typed, health-honest deferral**: held lock → `deferred`/`refresh_lock_held`; inside the 30s skew the still-valid token keeps serving (a benign in-flight peer no longer poisons route health as `auth_failure`); actually expired fails closed.
- **Budget gating, complete**: the daemon probe tick rotates only under `policy.daemon.allow_mutating` (the same operator consent the repair phase requires — and the fix for the review's "deferral promised a repair-phase rotation that doesn't exist": mutation consent restores the daemon's scheduled refresh path, default stays deny with `refresh_requires_mutating_budget`). `codex revalidate-exhausted` (declares `mutates_user_config:false`) and adapter auto-revalidation (spend consent ≠ mutation consent) never rotate.
- **Lock registry**: a nonblocking acquire no longer waits behind a sibling thread's in-flight blocking acquire — `RepairInProgress` immediately, so the typed-refusal contract can't silently become an unbounded block.
- **Event honesty**: refresh events record `mutating = executed`; docs scope the lock-domain claim to mux-owned writers (upstream CLI logins are user-mediated, outside the domain — TIN-1806 lane).

## Adversarial review

2 lenses (concurrency, policy-paths), 11 raw → 10 confirmed after per-finding refutation. 8 fixed here. 2 dispositioned: (a) no deadline on the token-endpoint call while the flock is held — pinned to **TIN-2074's gate** (must land before any builtin grant flips; documented in-code and on the ticket); (b) the new typed reasons are asserted at the unit ctx seam, not the daemon-events e2e surface — the strings flow through the same writer the e2e already asserts, and the daemon tick's default plan-mode makes an executed-probe e2e leg disproportionate for a nit.

## Tests

- TOCTOU adoption: peer-rotated store under the lock → adopted, dead endpoint never contacted.
- Foreign-flock deferral (raw kernel flock): expired → typed fail-closed; **within-skew → typed deferral with success**; released → proceeds to endpoint (control).
- Deny-mutation both legs (within-skew usable, expired fail-closed).
- 522/522 `zig build test`; full `scripts/e2e-local.sh` green.

Builtin claude/codex remain refusal-only (no `proactive_refresh` grant declared) — this PR is the serialization half of the gate; TIN-2074 (field-preserving writeback + endpoint deadline) is the remaining half.

Closes TIN-2073.