### PR TITLE
reauth: field-preserving credential writeback + expiry-unit correctness (TIN-2074)

### DIFF
--- a/docs/provider-repair-contracts.md
+++ b/docs/provider-repair-contracts.md
@@ -85,12 +85,20 @@ same consent the repair phase requires); the default-deny tick defers with
 `refresh_requires_mutating_budget`. Batch revalidation surfaces
 (`codex revalidate-exhausted`, adapter auto-revalidation) never rotate.
 
-Remaining blockers before any builtin grant flips: TIN-2074 — the
-credential templates are lossy (claude drops `expiresAt`, codex drops
-`tokens.id_token` — the identity source), so a refresh writeback would
-corrupt the native store; and a deadline on the token-endpoint call (the
-flock is held across it, and blocking acquirers have no timeout). Until
-both land, opting an account in changes nothing for builtin providers.
+Writeback is field-preserving (TIN-2074): `mergeCredentialGeneric` rewrites
+only the token fields at the definition's declared paths and preserves
+everything else (claude `scopes`/`subscriptionType`/`rateLimitTier`, codex
+`tokens.id_token`/`last_refresh`), unit-aware for stores that keep expiry in
+epoch milliseconds (claude). It FAILS CLOSED — if the store is unreadable
+under the lock or the merge cannot apply, the refresh is refused rather than
+overwriting the canonical store with a lossy template. The token-endpoint
+call now carries a 30s post-connect socket deadline (posix; winsock DWORD on
+Windows), bounding the flock-held window against a server stall.
+
+Remaining blocker before any builtin grant flips: the dual-writer story
+(TIN-2059) — the native CLI also rotates the same refresh token, and two
+writers can revoke each other. Until it lands, opting an account in changes
+nothing for builtin providers.
 
 Without consent the writeback plan refuses with
 `proactive_refresh_not_opted_in` (providers without the declared grant keep

--- a/src/oauth.zig
+++ b/src/oauth.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const types = @import("types.zig");
 const log = @import("log.zig");
 
@@ -14,6 +15,22 @@ pub const RefreshResult = struct {
     refresh_token: ?[]const u8 = null,
     expires_in: ?i64 = null,
 };
+
+// Best-effort SO_RCVTIMEO/SO_SNDTIMEO on a connected socket. winsock takes
+// a DWORD of milliseconds; posix takes a timeval. Both platforms get a
+// real bound; any failure is swallowed (a missing timeout must never fail
+// the refresh).
+fn setSocketTimeout(handle: std.posix.socket_t, seconds: u32) void {
+    if (comptime builtin.os.tag == .windows) {
+        const millis: u32 = seconds * 1000;
+        _ = std.os.windows.ws2_32.setsockopt(handle, std.os.windows.ws2_32.SOL.SOCKET, std.os.windows.ws2_32.SO.RCVTIMEO, std.mem.asBytes(&millis), @sizeOf(u32));
+        _ = std.os.windows.ws2_32.setsockopt(handle, std.os.windows.ws2_32.SOL.SOCKET, std.os.windows.ws2_32.SO.SNDTIMEO, std.mem.asBytes(&millis), @sizeOf(u32));
+    } else {
+        const timeout = std.posix.timeval{ .sec = @intCast(seconds), .usec = 0 };
+        std.posix.setsockopt(handle, std.posix.SOL.SOCKET, std.posix.SO.RCVTIMEO, std.mem.asBytes(&timeout)) catch {};
+        std.posix.setsockopt(handle, std.posix.SOL.SOCKET, std.posix.SO.SNDTIMEO, std.mem.asBytes(&timeout)) catch {};
+    }
+}
 
 pub fn refreshToken(
     allocator: std.mem.Allocator,
@@ -45,6 +62,17 @@ pub fn refreshToken(
         },
     }) catch return error.NetworkError;
     defer req.deinit();
+
+    // TIN-2074: bound the send/recv legs so a stalled connection cannot
+    // wedge the caller — attemptRefresh holds the per-account repair flock
+    // across this call, and the flock's blocking acquirers (adapter session
+    // start, broker) have no timeout of their own. Socket-level deadlines
+    // turn a post-connect stall into a NetworkError within ~30s per leg.
+    // DNS/TCP-connect/TLS-handshake are bounded only by the OS TCP timeout.
+    // Best-effort: a setsockopt failure must never fail the refresh.
+    if (req.connection) |conn| {
+        setSocketTimeout(conn.stream.handle, 30);
+    }
 
     req.transfer_encoding = .{ .content_length = body_buf.items.len };
     req.send() catch return error.NetworkError;

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -403,6 +403,12 @@ fn readSecret(ctx: *Context) PipelineError!void {
 // revalidation in attemptRefresh (TIN-2073), where the pre-lock ctx.token
 // must stay live while the fresh snapshot is examined.
 fn readTokenSnapshot(ctx: *Context) PipelineError!provider.TokenFields {
+    const raw = try readSecretRaw(ctx);
+    defer ctx.allocator.free(raw);
+    return parseRawToken(ctx, raw);
+}
+
+fn readSecretRaw(ctx: *Context) PipelineError![]const u8 {
     const prov_name = ctx.provider_name orelse return error.ProviderNotFound;
     const acct_name = ctx.account_name orelse return error.AccountNotFound;
 
@@ -411,12 +417,15 @@ fn readTokenSnapshot(ctx: *Context) PipelineError!provider.TokenFields {
 
     const backend = config_mod.resolveSecretBackend(acct_cfg.secret) catch return error.ConfigParseError;
 
-    const raw = secret.read(backend, ctx.allocator) catch |e| {
+    return secret.read(backend, ctx.allocator) catch |e| {
         log.err("secret: {s}:{s}: {s}", .{ prov_name, acct_name, @errorName(e) });
         return error.SecretReadFailed;
     };
-    defer ctx.allocator.free(raw);
+}
 
+fn parseRawToken(ctx: *Context, raw: []const u8) PipelineError!provider.TokenFields {
+    const prov_name = ctx.provider_name orelse return error.ProviderNotFound;
+    const acct_name = ctx.account_name orelse return error.AccountNotFound;
     const def = config_mod.resolveProviderDefinition(ctx.cfg, prov_name);
     const generic = provider_schema.parseTokenGeneric(def, raw, ctx.allocator) catch {
         log.debug("token: schema parse failed for {s}:{s}, trying legacy parser", .{ prov_name, acct_name });
@@ -656,7 +665,9 @@ fn attemptRefresh(ctx: *Context, rt: []const u8) PipelineError!void {
     // the re-read credential is already fresh, adopt it and skip the
     // endpoint; otherwise rotate with the re-read refresh token, never the
     // pre-lock snapshot.
-    const fresh_snapshot: ?provider.TokenFields = readTokenSnapshot(ctx) catch null;
+    const existing_raw: ?[]const u8 = readSecretRaw(ctx) catch null;
+    defer if (existing_raw) |r| ctx.allocator.free(r);
+    const fresh_snapshot: ?provider.TokenFields = if (existing_raw) |r| (parseRawToken(ctx, r) catch null) else null;
     var fresh_adopted = false;
     defer if (fresh_snapshot) |f| {
         if (!fresh_adopted) freeTokenFields(ctx.allocator, f);
@@ -675,17 +686,32 @@ fn attemptRefresh(ctx: *Context, rt: []const u8) PipelineError!void {
     }
     const effective_rt = if (fresh_snapshot) |f| (f.refresh_token orelse rt) else rt;
 
+    // TIN-2074: the field-preserving writeback needs the existing store to
+    // merge into. If the under-lock re-read failed, refuse BEFORE spending
+    // a refresh-token rotation we could only persist by clobbering the
+    // canonical store the CLI reads with a lossy template. The refresh path
+    // always has a pre-existing credential (the refresh token came from
+    // it), so a null here is a transient store-read failure, not bootstrap.
+    const raw_for_merge = existing_raw orelse {
+        log.err("token: refusing refresh for {s}: credential store unreadable under lock", .{prov});
+        recordRefreshEvent(ctx, writeback.plan, "writeback_refused", "store_unreadable_refusing_lossy_write", false, false);
+        return error.TokenRefreshFailed;
+    };
+
     const url = def.auth.token_endpoint orelse fallbackRefreshUrl(ctx) orelse {
         log.warn("token: no refresh URL for {s}", .{prov});
         recordRefreshEvent(ctx, writeback.plan, "no_token_endpoint", "token_endpoint_missing", false, false);
         return error.TokenRefreshFailed;
     };
 
-    // Known residual (TIN-2074 gate): oauth.refreshToken has no deadline,
-    // so the flock is held across an unbounded network call; blocking
-    // acquirers of this key (adapter session start, broker) have no
-    // timeout. A deadline (or bounded blocking waits) must land before any
-    // builtin proactive_refresh grant flips.
+    // oauth.refreshToken bounds the post-connect send/recv legs with a
+    // 30s socket deadline (TIN-2074, posix only), so the dominant hang
+    // mode — server accepts then stalls — can no longer wedge the held
+    // flock indefinitely. Residual: DNS/TCP-connect/TLS-handshake are
+    // bounded only by the OS TCP timeout, and Windows has no deadline
+    // (winsock SO_RCVTIMEO takes DWORD ms, gated off). Acceptable while
+    // builtin grants stay off; revisit if a connect-phase stall proves
+    // material before the flip.
     const result = oauth.refreshToken(ctx.allocator, url, effective_rt, def.auth.client_id) catch |e| {
         log.err("token: refresh failed: {s}", .{@errorName(e)});
         recordRefreshEvent(ctx, writeback.plan, "token_endpoint_failed", @errorName(e), false, true);
@@ -707,16 +733,28 @@ fn attemptRefresh(ctx: *Context, rt: []const u8) PipelineError!void {
         if (retained_refresh_token) |old_rt| ctx.allocator.free(old_rt);
     };
 
-    const credential = provider_schema.buildCredentialGeneric(
-        def,
-        .{
-            .access_token = result.access_token,
-            .refresh_token = retained_refresh_token,
-            .expires_at = expires_at,
-        },
-        ctx.allocator,
-    ) catch {
-        recordRefreshEvent(ctx, writeback.plan, "credential_build_failed", "credential_template_failed", false, true);
+    // TIN-2074: field-preserving writeback. Merge the refreshed token
+    // fields into the existing credential so store fields the token
+    // response does not own (claude scopes/subscriptionType/rateLimitTier,
+    // codex tokens.id_token/last_refresh) survive the rotation.
+    //
+    // FAIL CLOSED, never lossy: if the merge cannot apply (non-object /
+    // unexpected-shape store — e.g. a flat claude store where a wrapper is
+    // declared), falling back to the bootstrap template would overwrite the
+    // canonical store the CLI reads with a blob missing every preserved
+    // field — the exact corruption TIN-2074 exists to prevent. Refuse and
+    // keep the store intact; the just-minted access token stays usable
+    // in-process for this run. (buildCredentialGeneric remains the
+    // legitimate writer only for first-time injection of a fresh tmpdir
+    // credential, in injectEnv — a different path with no existing store.)
+    const schema_token = provider_schema.TokenFields{
+        .access_token = result.access_token,
+        .refresh_token = retained_refresh_token,
+        .expires_at = expires_at,
+    };
+    const credential = provider_schema.mergeCredentialGeneric(def, raw_for_merge, schema_token, ctx.allocator) catch |e| {
+        log.err("token: refusing lossy writeback for {s}: merge failed ({s})", .{ prov, @errorName(e) });
+        recordRefreshEvent(ctx, writeback.plan, "writeback_refused", "merge_failed_refusing_lossy_write", false, false);
         return error.TokenRefreshFailed;
     };
     defer ctx.allocator.free(credential);
@@ -1949,9 +1987,18 @@ test "attemptRefresh defers typed when the repair flock is held by another proce
         ctx.token.?.expires_at = std.time.timestamp() - 10;
     }
 
-    // Holder released: the refresh proceeds past the lock to the token
-    // endpoint (a closed local port), proving the deferral above came from
-    // the flock and not the endpoint.
+    // Holder released: the refresh proceeds past the lock and the
+    // under-lock store re-read to the token endpoint (a closed local port),
+    // proving the deferral above came from the flock and not the endpoint.
+    // A real on-disk store is required so the TIN-2074 unreadable-store
+    // refusal does not short-circuit before the endpoint.
+    {
+        const f = try std.fs.createFileAbsolute(auth_path, .{});
+        defer f.close();
+        try f.writeAll(
+            \\{"access_token":"at-lock","refresh_token":"rt-lock","expires_at":1700000000}
+        );
+    }
     ctx.last_refresh_outcome = null;
     ctx.last_refresh_reason = null;
     try std.testing.expectError(error.TokenRefreshFailed, validateToken(&ctx));
@@ -2037,4 +2084,73 @@ test "attemptRefresh adopts a concurrent peer rotation under the lock (TIN-2073 
     try std.testing.expectEqualStrings("concurrent_rotation_detected", ctx.last_refresh_reason.?);
     try std.testing.expectEqualStrings("at-peer-fresh", ctx.token.?.access_token);
     try std.testing.expectEqualStrings("rt-peer-fresh", ctx.token.?.refresh_token.?);
+}
+
+test "attemptRefresh refuses lossy writeback when the store became unreadable under the lock (TIN-2074 review)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const auth_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/auth.json", .{root_path});
+    defer std.testing.allocator.free(auth_path);
+
+    const json = try std.fmt.allocPrint(
+        std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "provider_definitions": {{
+        \\    "toy": {{
+        \\      "name": "toy",
+        \\      "repair": {{ "owner": "oauth_mux_refresh" }},
+        \\      "auth": {{ "token_endpoint": "http://127.0.0.1:9/token" }},
+        \\      "credential": {{ "access_token_path": "access_token", "refresh_token_path": "refresh_token", "expires_at_path": "expires_at" }}
+        \\    }}
+        \\  }},
+        \\  "providers": {{
+        \\    "toy": {{
+        \\      "kind": "toy",
+        \\      "accounts": {{
+        \\        "default": {{ "secret": {{ "backend": "file", "path": "{s}" }} }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{}},
+        \\  "strategies": {{}}
+        \\}}
+    ,
+        .{auth_path},
+    );
+    defer std.testing.allocator.free(json);
+
+    const parsed = try config_mod.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    var ctx = Context.init(std.testing.allocator, parsed.value, &store);
+    defer ctx.deinit();
+    ctx.provider_name = "toy";
+    ctx.account_name = "default";
+
+    // ctx.token carries a refresh token (read earlier), but the on-disk
+    // store does NOT exist — simulating a transient read failure of the
+    // canonical store between the initial read and the under-lock re-read.
+    ctx.token = .{
+        .access_token = try std.testing.allocator.dupe(u8, "at-stale"),
+        .refresh_token = try std.testing.allocator.dupe(u8, "rt-stale"),
+        .expires_at = std.time.timestamp() - 10,
+    };
+
+    // The refresh must refuse rather than write a lossy template blob over
+    // the (absent, but in production canonical) store. The endpoint is
+    // never reached.
+    try std.testing.expectError(error.TokenRefreshFailed, validateToken(&ctx));
+    try std.testing.expectEqualStrings("writeback_refused", ctx.last_refresh_outcome.?);
+    try std.testing.expectEqualStrings("store_unreadable_refusing_lossy_write", ctx.last_refresh_reason.?);
+    // The store was not created by a fallback template write.
+    try std.testing.expect(!fileExists(auth_path));
+}
+
+fn fileExists(path: []const u8) bool {
+    std.fs.accessAbsolute(path, .{}) catch return false;
+    return true;
 }

--- a/src/provider.zig
+++ b/src/provider.zig
@@ -58,6 +58,15 @@ pub fn detectProvider(argv: []const []const u8) ?types.ProviderKind {
 // ── Claude Code ──
 // Format: {"accessToken":"...","refreshToken":"...","expiresAt":"2025-..."}
 
+// Claude Code stores expiresAt as 13-digit epoch MILLISECONDS (verified
+// live, TIN-2074); TokenFields carries epoch seconds. Values that are
+// plausibly ms (>= 1e12) are converted; anything smaller is already
+// seconds (or a test fixture).
+fn claudeExpiryToSeconds(raw_exp: ?i64) ?i64 {
+    const exp = raw_exp orelse return null;
+    return if (exp >= 1_000_000_000_000) @divTrunc(exp, 1000) else exp;
+}
+
 fn parseClaude(raw: []const u8, allocator: std.mem.Allocator) ParseError!TokenFields {
     // Try wrapped format first: {"claudeAiOauth":{"accessToken":"...",...}}
     if (std.json.parseFromSlice(ClaudeWrapped, allocator, raw, .{
@@ -72,7 +81,7 @@ fn parseClaude(raw: []const u8, allocator: std.mem.Allocator) ParseError!TokenFi
                     (allocator.dupe(u8, rt) catch return error.OutOfMemory)
                 else
                     null,
-                .expires_at = creds.expiresAt,
+                .expires_at = claudeExpiryToSeconds(creds.expiresAt),
             };
         }
     } else |_| {}
@@ -90,7 +99,7 @@ fn parseClaude(raw: []const u8, allocator: std.mem.Allocator) ParseError!TokenFi
             (allocator.dupe(u8, rt) catch return error.OutOfMemory)
         else
             null,
-        .expires_at = parsed.value.expiresAt,
+        .expires_at = claudeExpiryToSeconds(parsed.value.expiresAt),
     };
 }
 

--- a/src/provider_schema.zig
+++ b/src/provider_schema.zig
@@ -106,7 +106,37 @@ pub const CredentialFormat = struct {
     wrapper_key: ?[]const u8 = null,
     // Token type detection: if api_key_path resolves, treat as api_key
     token_type: []const u8 = "bearer",
+    // Unit of the value at expires_at_path IN THE STORE. TokenFields is
+    // always epoch seconds; reads convert from this unit and writes convert
+    // back to it. Claude Code stores epoch milliseconds (verified live,
+    // TIN-2074: 13-digit expiresAt) — without this, expiry math treats a
+    // Claude token as never expiring.
+    expires_at_unit: ExpiresAtUnit = .seconds,
 };
+
+pub const ExpiresAtUnit = enum { seconds, milliseconds };
+
+// Convert a stored expiry value into epoch seconds (TokenFields' unit).
+// For .milliseconds, a value that is implausibly small to be epoch-ms
+// (< 1e12 ≈ year 2001 in ms) is treated as already-seconds rather than
+// divided — so a legacy or hand-edited seconds-valued store is never
+// corrupted into year 1970.
+pub fn expiryStoreToSeconds(unit: ExpiresAtUnit, raw: i64) i64 {
+    return switch (unit) {
+        .seconds => raw,
+        .milliseconds => if (raw >= 1_000_000_000_000) @divTrunc(raw, 1000) else raw,
+    };
+}
+
+// Convert epoch seconds back into the store's unit. Saturating: a token
+// endpoint that returns an absurd expires_in must not overflow i64 and
+// panic while the repair flock is held.
+pub fn expirySecondsToStore(unit: ExpiresAtUnit, secs: i64) i64 {
+    return switch (unit) {
+        .seconds => secs,
+        .milliseconds => secs *| 1000,
+    };
+}
 
 pub const InjectionConfig = struct {
     // Config dir env var (e.g., CLAUDE_CONFIG_DIR, CODEX_HOME)
@@ -719,12 +749,17 @@ pub const claude_def = ProviderDefinition{
         .refresh_token_path = "refreshToken",
         .expires_at_path = "expiresAt",
         .wrapper_key = "claudeAiOauth",
+        // Verified live (TIN-2074): Claude Code stores 13-digit epoch ms.
+        .expires_at_unit = .milliseconds,
     },
     .injection = .{
         .config_dir_env = "CLAUDE_CONFIG_DIR",
         .credential_filename = ".credentials.json",
+        // Bootstrap-only: refresh writeback merges into the existing store
+        // (mergeCredentialGeneric) and never goes through this template
+        // when a credential already exists.
         .credential_template =
-        \\{"claudeAiOauth":{"accessToken":"{{access_token}}","refreshToken":"{{refresh_token}}"}}
+        \\{"claudeAiOauth":{"accessToken":"{{access_token}}","refreshToken":"{{refresh_token}}","expiresAt":{{expires_at}}}}
         ,
     },
     .detection = .{
@@ -735,11 +770,12 @@ pub const claude_def = ProviderDefinition{
         .env_vars = &.{"CLAUDE_CONFIG_DIR"},
     },
     // The refresh grant (.proactive_refresh = .oauth_refresh_token) is
-    // deliberately NOT declared yet: the pipeline refresh write path is
-    // unserialized (no repair flock) and the credential template is lossy
-    // (drops expiresAt/scopes), so an opted-in refresh would corrupt the
-    // live store the CLI reads. Declare the grant only once both follow-ups
-    // land (refresh-path locking + field-preserving writeback).
+    // deliberately NOT declared yet. Serialization (TIN-2073) and
+    // field-preserving writeback (TIN-2074: merge preserves expiresAt/
+    // scopes/subscriptionType, ms-unit aware) have landed. Remaining gate
+    // before the flip: the dual-writer story (TIN-2059) — the native
+    // Claude CLI also rotates this account's refresh token, and two
+    // writers rotating one token can revoke each other.
     .repair = .{
         .owner = .upstream_cli_login,
     },
@@ -783,9 +819,13 @@ pub const codex_def = ProviderDefinition{
         .writable_paths = &.{"CODEX_HOME"},
         .session_paths = &.{"CODEX_HOME/auth.json"},
     },
-    // Refresh grant intentionally undeclared — same gating as claude_def:
-    // the unserialized refresh path + lossy template (drops tokens.id_token,
-    // the codex identity source) must be fixed before opt-in can be honored.
+    // Refresh grant intentionally undeclared — same gating as claude_def.
+    // Serialization (TIN-2073) and field-preserving merge (TIN-2074:
+    // preserves tokens.id_token, the codex identity source) have landed.
+    // Remaining: the dual-writer story (TIN-2059) vs the native codex CLI,
+    // and codex stores expiry as tokens.expires_in (relative), which the
+    // merge does not rewrite — expiry tracking on writeback is via the JWT,
+    // verify before the flip.
     .repair = .{
         .owner = .upstream_cli_login,
     },
@@ -1454,9 +1494,11 @@ pub fn parseTokenGeneric(
         result.refresh_token = try allocator.dupe(u8, rt);
     }
 
-    // Resolve expiry
+    // Resolve expiry (store unit -> epoch seconds)
     if (def.credential.expires_at_path) |eap| {
-        result.expires_at = resolveJsonInt(root, eap);
+        if (resolveJsonInt(root, eap)) |raw_exp| {
+            result.expires_at = expiryStoreToSeconds(def.credential.expires_at_unit, raw_exp);
+        }
     }
     if (result.expires_at == null) {
         if (def.credential.expires_in_path) |eip| {
@@ -1476,6 +1518,94 @@ pub fn parseTokenGeneric(
 
 // ── Generic Credential Builder ──
 // Builds a credential file from a template + token fields.
+
+// ── Field-Preserving Credential Merge (TIN-2074) ──
+// Refresh writeback must not be lossy: the native store carries fields the
+// token response does not own (claude: scopes/subscriptionType/rateLimitTier;
+// codex: tokens.id_token/last_refresh — the identity source). Parse the
+// existing credential, replace ONLY the token fields at the definition's
+// declared paths, preserve everything else (including key order), and
+// serialize. Callers fall back to buildCredentialGeneric when there is no
+// existing credential to merge into.
+pub fn mergeCredentialGeneric(
+    def: ProviderDefinition,
+    existing_raw: []const u8,
+    token: TokenFields,
+    allocator: std.mem.Allocator,
+) ![]const u8 {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, existing_raw, .{}) catch
+        return error.InvalidCharacter;
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.InvalidCharacter;
+
+    const arena = parsed.arena.allocator();
+
+    // Resolve (creating if absent) the wrapper object the credential paths
+    // are relative to. A wrapped store (claude keychain, prior merge) is
+    // used in place; a flat store for a wrapper-declaring provider gets the
+    // wrapper established and tokens written into it. This is safe because
+    // every reader of a wrapper-declaring store — the upstream CLI and
+    // oauth-mux's own parseTokenGeneric (resolveJsonPath(root, wk) orelse
+    // root) — resolves the wrapper FIRST and ignores any stale top-level
+    // fields, so there is no dual-format ambiguity, and a flat custom
+    // oauth_mux_refresh provider is not falsely refused on its first
+    // refresh. ensureJsonObjectPath errors only if the path collides with a
+    // non-object (e.g. wrapper_key points at a string), where the caller
+    // fails closed rather than corrupt an unexpected shape.
+    var root: *std.json.Value = &parsed.value;
+    if (def.credential.wrapper_key) |wk| {
+        root = try ensureJsonObjectPath(root, wk, arena);
+    }
+
+    try setJsonPathString(root, def.credential.access_token_path, token.access_token, arena);
+    if (token.refresh_token) |rt| {
+        try setJsonPathString(root, def.credential.refresh_token_path, rt, arena);
+    }
+    if (def.credential.expires_at_path) |eap| {
+        if (token.expires_at) |ea| {
+            const store_exp = expirySecondsToStore(def.credential.expires_at_unit, ea);
+            try setJsonPath(root, eap, .{ .integer = store_exp }, arena);
+        }
+    }
+
+    var out = std.ArrayList(u8).init(allocator);
+    errdefer out.deinit();
+    try std.json.stringify(parsed.value, .{}, out.writer());
+    return out.toOwnedSlice();
+}
+
+// Walks a dot-separated path of objects below `root`, creating missing
+// intermediate objects, and returns a pointer to the object at the path.
+fn ensureJsonObjectPath(root: *std.json.Value, path: []const u8, arena: std.mem.Allocator) !*std.json.Value {
+    var current = root;
+    var it = std.mem.splitScalar(u8, path, '.');
+    while (it.next()) |segment| {
+        if (current.* != .object) return error.InvalidCharacter;
+        const gop = try current.object.getOrPut(try arena.dupe(u8, segment));
+        if (!gop.found_existing) {
+            gop.value_ptr.* = .{ .object = std.json.ObjectMap.init(arena) };
+        } else if (gop.value_ptr.* != .object) {
+            return error.InvalidCharacter;
+        }
+        current = gop.value_ptr;
+    }
+    return current;
+}
+
+fn setJsonPath(root: *std.json.Value, path: []const u8, value: std.json.Value, arena: std.mem.Allocator) !void {
+    const last_dot = std.mem.lastIndexOfScalar(u8, path, '.');
+    const parent = if (last_dot) |idx|
+        try ensureJsonObjectPath(root, path[0..idx], arena)
+    else
+        root;
+    if (parent.* != .object) return error.InvalidCharacter;
+    const leaf = if (last_dot) |idx| path[idx + 1 ..] else path;
+    try parent.object.put(try arena.dupe(u8, leaf), value);
+}
+
+fn setJsonPathString(root: *std.json.Value, path: []const u8, value: []const u8, arena: std.mem.Allocator) !void {
+    try setJsonPath(root, path, .{ .string = try arena.dupe(u8, value) }, arena);
+}
 
 pub fn buildCredentialGeneric(
     def: ProviderDefinition,
@@ -1516,7 +1646,13 @@ pub fn buildCredentialGeneric(
                 try w.writeAll(token.refresh_token orelse "");
             } else if (std.mem.eql(u8, key, "expires_at")) {
                 if (token.expires_at) |ea| {
-                    try w.print("{d}", .{ea});
+                    try w.print("{d}", .{expirySecondsToStore(def.credential.expires_at_unit, ea)});
+                } else {
+                    // Bare {{expires_at}} in a JSON template would emit
+                    // malformed output if elided; epoch 0 reads back as
+                    // long-expired, which forces a refresh — the honest
+                    // value for "unknown".
+                    try w.writeAll("0");
                 }
             }
             i = end + 2;
@@ -1581,7 +1717,7 @@ test "resolveJsonPath deep nesting" {
 
 test "parseTokenGeneric with claude def" {
     const json =
-        \\{"claudeAiOauth":{"accessToken":"sk-ant-123","refreshToken":"rt-456","expiresAt":9999999999}}
+        \\{"claudeAiOauth":{"accessToken":"sk-ant-123","refreshToken":"rt-456","expiresAt":9999999999000}}
     ;
     const result = try parseTokenGeneric(claude_def, json, std.testing.allocator);
     defer std.testing.allocator.free(result.access_token);
@@ -2118,4 +2254,173 @@ test "claudeKeychainService distinct dirs never collide on the base service" {
     try std.testing.expect(!std.mem.eql(u8, derived, claude_keychain_service_base));
     try std.testing.expect(std.mem.startsWith(u8, derived, "Claude Code-credentials-"));
     try std.testing.expectEqual(claude_keychain_service_base.len + 1 + 8, derived.len);
+}
+
+test "parseTokenGeneric converts millisecond expiresAt to epoch seconds (TIN-2074)" {
+    // The live claude store carries 13-digit epoch ms; without conversion
+    // the expiry math treats the token as never expiring.
+    const raw =
+        \\{"claudeAiOauth":{"accessToken":"at-ms-unit","refreshToken":"rt-ms-unit","expiresAt":1781400000000}}
+    ;
+    const result = try parseTokenGeneric(claude_def, raw, std.testing.allocator);
+    defer {
+        std.testing.allocator.free(result.access_token);
+        if (result.refresh_token) |rt| std.testing.allocator.free(rt);
+    }
+    try std.testing.expectEqual(@as(?i64, 1781400000), result.expires_at);
+}
+
+test "mergeCredentialGeneric preserves the claude store fields the token response does not own (TIN-2074)" {
+    // Field inventory verified live: accessToken, expiresAt, rateLimitTier,
+    // refreshToken, scopes, subscriptionType.
+    const existing =
+        \\{"claudeAiOauth":{"accessToken":"at-old","refreshToken":"rt-old","expiresAt":1781300000000,"scopes":["user:inference","user:profile"],"subscriptionType":"max","rateLimitTier":"default_claude_ai"}}
+    ;
+    const merged = try mergeCredentialGeneric(claude_def, existing, .{
+        .access_token = "at-rotated",
+        .refresh_token = "rt-rotated",
+        .expires_at = 1781400000,
+    }, std.testing.allocator);
+    defer std.testing.allocator.free(merged);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, merged, .{});
+    defer parsed.deinit();
+    const oa = parsed.value.object.get("claudeAiOauth").?.object;
+
+    try std.testing.expectEqualStrings("at-rotated", oa.get("accessToken").?.string);
+    try std.testing.expectEqualStrings("rt-rotated", oa.get("refreshToken").?.string);
+    // Written back in the STORE unit (ms).
+    try std.testing.expectEqual(@as(i64, 1781400000000), oa.get("expiresAt").?.integer);
+    // Every field the rotation does not own survives with value + order
+    // intact (string/int/array fidelity; the live claude store carries no
+    // floats, which std.json re-serializes in exponent form).
+    try std.testing.expectEqualStrings("max", oa.get("subscriptionType").?.string);
+    try std.testing.expectEqualStrings("default_claude_ai", oa.get("rateLimitTier").?.string);
+    try std.testing.expectEqual(@as(usize, 2), oa.get("scopes").?.array.items.len);
+    try std.testing.expectEqualStrings("user:inference", oa.get("scopes").?.array.items[0].string);
+    // Key order preserved: accessToken stays first.
+    try std.testing.expectEqualStrings("accessToken", oa.keys()[0]);
+}
+
+test "mergeCredentialGeneric preserves codex tokens.id_token and last_refresh (TIN-2074)" {
+    const existing =
+        \\{"auth_mode":"chatgpt","tokens":{"id_token":"idt-identity-source","access_token":"at-old","refresh_token":"rt-old","account_id":"acct-fixture"},"last_refresh":"2026-06-01T00:00:00Z"}
+    ;
+    const merged = try mergeCredentialGeneric(codex_def, existing, .{
+        .access_token = "at-rotated",
+        .refresh_token = "rt-rotated",
+        .expires_at = null,
+    }, std.testing.allocator);
+    defer std.testing.allocator.free(merged);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, merged, .{});
+    defer parsed.deinit();
+    const root = parsed.value.object;
+    const tokens = root.get("tokens").?.object;
+
+    try std.testing.expectEqualStrings("at-rotated", tokens.get("access_token").?.string);
+    try std.testing.expectEqualStrings("rt-rotated", tokens.get("refresh_token").?.string);
+    // The identity source and CLI metadata survive.
+    try std.testing.expectEqualStrings("idt-identity-source", tokens.get("id_token").?.string);
+    try std.testing.expectEqualStrings("acct-fixture", tokens.get("account_id").?.string);
+    try std.testing.expectEqualStrings("chatgpt", root.get("auth_mode").?.string);
+    try std.testing.expectEqualStrings("2026-06-01T00:00:00Z", root.get("last_refresh").?.string);
+}
+
+test "mergeCredentialGeneric creates missing token paths without disturbing siblings" {
+    const existing =
+        \\{"operator_note":"hand-managed","tokens":{}}
+    ;
+    const merged = try mergeCredentialGeneric(codex_def, existing, .{
+        .access_token = "at-bootstrap",
+        .refresh_token = "rt-bootstrap",
+        .expires_at = null,
+    }, std.testing.allocator);
+    defer std.testing.allocator.free(merged);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, merged, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("hand-managed", parsed.value.object.get("operator_note").?.string);
+    try std.testing.expectEqualStrings("at-bootstrap", parsed.value.object.get("tokens").?.object.get("access_token").?.string);
+}
+
+test "mergeCredentialGeneric refuses non-object stores (caller falls back to template)" {
+    try std.testing.expectError(error.InvalidCharacter, mergeCredentialGeneric(claude_def, "raw-api-key-not-json", .{
+        .access_token = "at-x",
+    }, std.testing.allocator));
+    try std.testing.expectError(error.InvalidCharacter, mergeCredentialGeneric(claude_def, "[1,2]", .{
+        .access_token = "at-x",
+    }, std.testing.allocator));
+}
+
+test "claude bootstrap template writes expiresAt in store milliseconds (TIN-2074)" {
+    const built = try buildCredentialGeneric(claude_def, .{
+        .access_token = "at-bootstrap",
+        .refresh_token = "rt-bootstrap",
+        .expires_at = 1781400000,
+    }, std.testing.allocator);
+    defer std.testing.allocator.free(built);
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, built, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqual(@as(i64, 1781400000000), parsed.value.object.get("claudeAiOauth").?.object.get("expiresAt").?.integer);
+}
+
+test "mergeCredentialGeneric establishes the wrapper for a flat wrapper-declaring store (TIN-2074 re-review)" {
+    // A flat store for a wrapper-declaring provider must NOT be refused
+    // (that would false-refuse a custom oauth_mux_refresh provider's first
+    // refresh, burning the rotated RT each attempt). The wrapper is
+    // established and the fresh tokens written into it; the reader resolves
+    // the wrapper first, so the new tokens win.
+    const flat =
+        \\{"accessToken":"at-flat-stale","refreshToken":"rt-flat-stale"}
+    ;
+    const merged = try mergeCredentialGeneric(claude_def, flat, .{
+        .access_token = "at-new",
+        .refresh_token = "rt-new",
+        .expires_at = 1781400000,
+    }, std.testing.allocator);
+    defer std.testing.allocator.free(merged);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, merged, .{});
+    defer parsed.deinit();
+    const oa = parsed.value.object.get("claudeAiOauth").?.object;
+    try std.testing.expectEqualStrings("at-new", oa.get("accessToken").?.string);
+    try std.testing.expectEqualStrings("rt-new", oa.get("refreshToken").?.string);
+    try std.testing.expectEqual(@as(i64, 1781400000000), oa.get("expiresAt").?.integer);
+
+    // parseTokenGeneric reads the wrapper, so the fresh tokens win over any
+    // inert top-level remnants.
+    const reparsed = try parseTokenGeneric(claude_def, merged, std.testing.allocator);
+    defer {
+        std.testing.allocator.free(reparsed.access_token);
+        if (reparsed.refresh_token) |rt| std.testing.allocator.free(rt);
+    }
+    try std.testing.expectEqualStrings("at-new", reparsed.access_token);
+    try std.testing.expectEqualStrings("rt-new", reparsed.refresh_token.?);
+
+    // A non-object wrapper collision still fails closed.
+    const collision =
+        \\{"claudeAiOauth":"not-an-object"}
+    ;
+    try std.testing.expectError(error.InvalidCharacter, mergeCredentialGeneric(claude_def, collision, .{
+        .access_token = "x",
+    }, std.testing.allocator));
+}
+
+test "expiryStoreToSeconds guards a seconds-valued store declared milliseconds (TIN-2074 review)" {
+    // 13-digit ms -> seconds.
+    try std.testing.expectEqual(@as(i64, 1781400000), expiryStoreToSeconds(.milliseconds, 1781400000000));
+    // A value too small to be epoch-ms is left alone, not divided into 1970.
+    try std.testing.expectEqual(@as(i64, 1781400000), expiryStoreToSeconds(.milliseconds, 1781400000));
+    // seconds unit passes through.
+    try std.testing.expectEqual(@as(i64, 1781400000), expiryStoreToSeconds(.seconds, 1781400000));
+}
+
+test "expirySecondsToStore saturates instead of overflowing i64 (TIN-2074 review)" {
+    // A normal value round-trips.
+    try std.testing.expectEqual(@as(i64, 1781400000000), expirySecondsToStore(.milliseconds, 1781400000));
+    // An absurd endpoint expires_in must not panic the writeback under the
+    // repair flock — saturate to i64 max.
+    try std.testing.expectEqual(std.math.maxInt(i64), expirySecondsToStore(.milliseconds, std.math.maxInt(i64)));
+    try std.testing.expectEqual(@as(i64, 1781400000), expirySecondsToStore(.seconds, 1781400000));
 }


### PR DESCRIPTION
## Summary

The last TIN-2058-review major before the builtin refresh-grant flip. Replaces lossy template substitution on the refresh path with a field-preserving merge, fixes a live-confirmed expiry-unit bug, and bounds the flock-held network call.

- **`mergeCredentialGeneric`** — read-merge-write: rewrites only the token fields at the definition's declared paths, preserves everything else (claude `scopes`/`subscriptionType`/`rateLimitTier`, codex `tokens.id_token`/`last_refresh` — the identity source), key order intact.
- **Fail closed, never lossy** — `attemptRefresh` re-reads under the lock and refuses **before** spending a rotation if the store is unreadable (`store_unreadable_refusing_lossy_write`), and refuses if the merge can't apply, rather than clobbering the canonical store with the template. Template stays the writer only for first-time tmpdir injection.
- **Expiry-unit correctness** — `CredentialFormat.expires_at_unit`; claude declares `.milliseconds` against the live-verified 13-digit `expiresAt` (without it the warm loop reads a Claude token as never-expiring). Guarded both ways: a too-small value isn't divided into 1970; seconds→ms saturates so an absurd `expires_in` can't overflow i64 and panic under the flock.
- **Socket deadline** — `oauth.refreshToken` gets a 30s post-connect deadline (posix timeval + winsock DWORD-ms), the TIN-2073 residual.

## Two-round adversarial review

Round 1 (3 lenses) drove the merge/unit/deadline fixes. Round 2 verified those fixes for regressions and confirmed exactly one minor: the wrapper-required merge guard I'd added would false-refuse — and burn the rotated RT on — a custom `oauth_mux_refresh` provider enrolled with a flat store (the endpoint rotates before the merge refusal). Reverted to wrapper-bootstrap, which is safe: every reader (the upstream CLI and oauth-mux's own parser) resolves the wrapper first and ignores stale top-level fields. All other round-2 findings rejected on inspection (e.g. the "winsock never compiled" claim — Windows is in the release matrix and both targets cross-compile clean).

## Tests

- Merge preserves claude (scopes/subscriptionType/rateLimitTier) and codex (id_token/last_refresh) fields; creates missing token paths; bootstraps the wrapper for a flat store and round-trips through the reader; fails closed on a non-object wrapper collision.
- Unit conversions: ms→s with the seconds-guard; s→ms saturating; claude bootstrap template writes ms.
- Pipeline: refuses lossy writeback when the store is unreadable under the lock (endpoint never reached, store not created).
- 532/532 `zig build test`; full `scripts/e2e-local.sh` green; 4-target cross-compile clean.

Builtin claude/codex still declare **no** `proactive_refresh` grant — the only remaining gate is the dual-writer story (TIN-2059). vercel/gemini expiry-unit verification filed as TIN-2079.

Closes TIN-2074.