### PR TITLE
reauth: warm/background refresh take the per-identity flock (TIN-2043)

### DIFF
--- a/src/broker_loader.zig
+++ b/src/broker_loader.zig
@@ -16,6 +16,8 @@ const oauth = @import("oauth.zig");
 const paths = @import("paths.zig");
 const repair_state = @import("repair_state.zig");
 const trace = @import("trace.zig");
+const provider_schema = @import("provider_schema.zig");
+const identity_hash = @import("identity_hash.zig");
 const types = @import("types.zig");
 
 /// Populate `pool` with one entry per `<provider>:<account>` defined in
@@ -375,11 +377,40 @@ fn refreshCodexAccountAuthFile(
         .needed => {},
     }
 
+    const def = config_mod.resolveProviderDefinition(cfg, provider);
+
+    // TIN-2043: defer if a live session of the same UPSTREAM IDENTITY holds
+    // the identity flock — even under a different config account (the
+    // max-1 == max-4 shape). The per-account blocking lock above does not
+    // cover a sibling config account sharing one single-use RT chain. Key
+    // it exactly as the managed session does; nonblocking, defer-on-held
+    // (background refresh is never urgent — the session holder rotates its
+    // own chain).
+    var identity_lock: ?repair_state.RepairLock = null;
+    defer if (identity_lock) |*l| l.release();
+    if (def.credential.identity_claim_path != null) {
+        const account_id = (provider_schema.identityClaimFromCredential(def, bytes, allocator) catch null) orelse
+            // Defensive: a store that reached here already parsed an
+            // account_id via refreshCodexAuthState above (a store without
+            // one bails as .not_needed before this point), so this refuse is
+            // belt-and-suspenders against future changes to that gate — never
+            // dodge the duplicate-identity guard on an unresolved id.
+            return error.NoIdentityClaim;
+        defer allocator.free(account_id);
+        const id_hash = try identity_hash.sha256_12hex(allocator, account_id);
+        defer allocator.free(id_hash);
+        const identity_domain = try std.fmt.allocPrint(allocator, "{s}-identity", .{provider});
+        defer allocator.free(identity_domain);
+        identity_lock = repair_state.acquireRepairLock(allocator, identity_domain, id_hash) catch |e| switch (e) {
+            error.RepairInProgress => return, // a live session owns the chain; skip this background refresh
+            else => return e,
+        };
+    }
+
     var material = try parseCodexAuthRefreshMaterial(allocator, bytes);
     defer material.deinit(allocator);
     const refresh_token = material.refresh_token orelse return error.NoRefreshToken;
 
-    const def = config_mod.resolveProviderDefinition(cfg, provider);
     const token_url = def.auth.token_endpoint orelse oauth.refreshUrl(.codex) orelse return error.NoTokenEndpoint;
     const result = try oauth.refreshToken(allocator, token_url, refresh_token, def.auth.client_id);
     defer allocator.free(result.access_token);

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -14,6 +14,7 @@ const probe = @import("probe.zig");
 const env = @import("env.zig");
 const repair_state = @import("repair_state.zig");
 const runtime = @import("runtime.zig");
+const identity_hash = @import("identity_hash.zig");
 
 pub const Context = struct {
     allocator: std.mem.Allocator,
@@ -697,6 +698,53 @@ fn attemptRefresh(ctx: *Context, rt: []const u8) PipelineError!void {
         recordRefreshEvent(ctx, writeback.plan, "writeback_refused", "store_unreadable_refusing_lossy_write", false, false);
         return error.TokenRefreshFailed;
     };
+
+    // TIN-2043: serialize against any LIVE SESSION (or background refresh)
+    // of the same UPSTREAM IDENTITY, even when it is enrolled under a
+    // different config account (the live max-1 == max-4 Apple-ID shape). The
+    // per-account flock above does not cover that — two config accounts map
+    // to two different account locks but one shared single-use RT chain. Key
+    // the identity flock exactly as the managed session does
+    // (`("<provider>-identity", sha256_12(account_id))`), nonblocking: a held
+    // lock means a live session owns the chain's rotation, so defer typed —
+    // a warm refresh is never urgent. Lock order matches the adapter:
+    // per-account (held) then identity, no inversion. Released by defer.
+    var identity_lock: ?repair_state.RepairLock = null;
+    defer if (identity_lock) |*l| l.release();
+    if (def.credential.identity_claim_path != null) {
+        const account_id = (provider_schema.identityClaimFromCredential(def, raw_for_merge, ctx.allocator) catch null) orelse {
+            // Declared an identity path but the store carries no id: refuse
+            // rather than skip the duplicate-identity guard (the managed
+            // session refuses launch on a missing id; match that posture so
+            // a malformed store cannot dodge the guard). claude declares no
+            // path and is unaffected.
+            log.err("token: refusing refresh for {s}:{s}: identity claim unresolved", .{ prov, acct });
+            recordRefreshEvent(ctx, writeback.plan, "writeback_refused", "identity_unresolved_refusing_refresh", false, false);
+            return error.TokenRefreshFailed;
+        };
+        defer ctx.allocator.free(account_id);
+        const id_hash = identity_hash.sha256_12hex(ctx.allocator, account_id) catch return error.OutOfMemory;
+        defer ctx.allocator.free(id_hash);
+        const identity_domain = std.fmt.allocPrint(ctx.allocator, "{s}-identity", .{prov}) catch return error.OutOfMemory;
+        defer ctx.allocator.free(identity_domain);
+        identity_lock = repair_state.acquireRepairLock(ctx.allocator, identity_domain, id_hash) catch |e| switch (e) {
+            error.RepairInProgress => {
+                log.warn("token: refresh deferred for {s}:{s}: identity lock held by a live session", .{ prov, acct });
+                recordRefreshEvent(ctx, writeback.plan, "deferred", "identity_lock_held", false, false);
+                // Token still valid inside the skew → keep serving it.
+                if (ctx.token) |tok| {
+                    if (tok.expires_at) |exp| {
+                        if (std.time.timestamp() < exp) return;
+                    }
+                }
+                return error.TokenRefreshFailed;
+            },
+            else => {
+                recordRefreshEvent(ctx, writeback.plan, "lock_failed", @errorName(e), false, false);
+                return error.TokenRefreshFailed;
+            },
+        };
+    }
 
     const url = def.auth.token_endpoint orelse fallbackRefreshUrl(ctx) orelse {
         log.warn("token: no refresh URL for {s}", .{prov});
@@ -2153,4 +2201,133 @@ test "attemptRefresh refuses lossy writeback when the store became unreadable un
 fn fileExists(path: []const u8) bool {
     std.fs.accessAbsolute(path, .{}) catch return false;
     return true;
+}
+
+test "attemptRefresh defers when the identity lock is held by a sibling-identity session (TIN-2043)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const auth_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/auth.json", .{root_path});
+    defer std.testing.allocator.free(auth_path);
+
+    // Two config accounts (tin2043-a, tin2043-b) sharing ONE upstream
+    // account_id — the max-1 == max-4 shape. We refresh tin2043-b while a
+    // foreign holder simulates tin2043-a's live session holding the shared
+    // identity flock.
+    const account_id = "shared-identity-uuid";
+    {
+        const f = try std.fs.createFileAbsolute(auth_path, .{});
+        defer f.close();
+        try f.writeAll(
+            \\{"auth_mode":"chatgpt","tokens":{"access_token":"at","refresh_token":"rt","account_id":"shared-identity-uuid"}}
+        );
+    }
+
+    const json = try std.fmt.allocPrint(std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "provider_definitions": {{
+        \\    "codex": {{ "name": "codex", "kind": "codex", "repair": {{ "owner": "oauth_mux_refresh" }}, "auth": {{ "token_endpoint": "http://127.0.0.1:9/token" }}, "credential": {{ "access_token_path": "tokens.access_token", "refresh_token_path": "tokens.refresh_token", "identity_claim_path": "tokens.account_id" }} }}
+        \\  }},
+        \\  "providers": {{
+        \\    "codex": {{ "kind": "codex", "accounts": {{ "tin2043-b": {{ "secret": {{ "backend": "file", "path": "{s}" }} }} }} }}
+        \\  }},
+        \\  "profiles": {{}},
+        \\  "strategies": {{}}
+        \\}}
+    , .{auth_path});
+    defer std.testing.allocator.free(json);
+
+    const parsed = try config_mod.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    var ctx = Context.init(std.testing.allocator, parsed.value, &store);
+    defer ctx.deinit();
+    ctx.provider_name = "codex";
+    ctx.account_name = "tin2043-b";
+    ctx.token = .{
+        .access_token = try std.testing.allocator.dupe(u8, "at"),
+        .refresh_token = try std.testing.allocator.dupe(u8, "rt"),
+        .expires_at = std.time.timestamp() - 10,
+    };
+
+    // Foreign holder on the IDENTITY lock (codex-identity-<hash>), keyed
+    // exactly as attemptRefresh will compute it.
+    const id_hash = try identity_hash.sha256_12hex(std.testing.allocator, account_id);
+    defer std.testing.allocator.free(id_hash);
+    const identity_domain = try std.fmt.allocPrint(std.testing.allocator, "codex-identity", .{});
+    defer std.testing.allocator.free(identity_domain);
+    const lock_path = try repair_state.lockPath(std.testing.allocator, identity_domain, id_hash);
+    defer std.testing.allocator.free(lock_path);
+    if (std.fs.path.dirname(lock_path)) |dir| try std.fs.cwd().makePath(dir);
+    const holder = try std.fs.createFileAbsolute(lock_path, .{ .truncate = false, .mode = 0o600, .lock = .exclusive, .lock_nonblocking = true });
+
+    {
+        defer holder.close();
+        // expired token + held identity lock → defer typed, fail closed (no endpoint).
+        try std.testing.expectError(error.TokenRefreshFailed, validateToken(&ctx));
+        try std.testing.expectEqualStrings("deferred", ctx.last_refresh_outcome.?);
+        try std.testing.expectEqualStrings("identity_lock_held", ctx.last_refresh_reason.?);
+    }
+
+    // Holder released: the refresh proceeds past BOTH locks to the endpoint
+    // (closed port), proving the deferral was the identity lock.
+    ctx.last_refresh_outcome = null;
+    ctx.last_refresh_reason = null;
+    try std.testing.expectError(error.TokenRefreshFailed, validateToken(&ctx));
+    try std.testing.expectEqualStrings("token_endpoint_failed", ctx.last_refresh_outcome.?);
+}
+
+test "attemptRefresh refuses when an identity path is declared but the store has no id (TIN-2043 missing-id policy)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root_path);
+    const auth_path = try std.fmt.allocPrint(std.testing.allocator, "{s}/auth.json", .{root_path});
+    defer std.testing.allocator.free(auth_path);
+
+    // Store declares the shape but carries NO account_id.
+    {
+        const f = try std.fs.createFileAbsolute(auth_path, .{});
+        defer f.close();
+        try f.writeAll(
+            \\{"auth_mode":"chatgpt","tokens":{"access_token":"at","refresh_token":"rt"}}
+        );
+    }
+
+    const json = try std.fmt.allocPrint(std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "provider_definitions": {{
+        \\    "codex": {{ "name": "codex", "kind": "codex", "repair": {{ "owner": "oauth_mux_refresh" }}, "auth": {{ "token_endpoint": "http://127.0.0.1:9/token" }}, "credential": {{ "access_token_path": "tokens.access_token", "refresh_token_path": "tokens.refresh_token", "identity_claim_path": "tokens.account_id" }} }}
+        \\  }},
+        \\  "providers": {{
+        \\    "codex": {{ "kind": "codex", "accounts": {{ "noid": {{ "secret": {{ "backend": "file", "path": "{s}" }} }} }} }}
+        \\  }},
+        \\  "profiles": {{}},
+        \\  "strategies": {{}}
+        \\}}
+    , .{auth_path});
+    defer std.testing.allocator.free(json);
+
+    const parsed = try config_mod.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    var ctx = Context.init(std.testing.allocator, parsed.value, &store);
+    defer ctx.deinit();
+    ctx.provider_name = "codex";
+    ctx.account_name = "noid";
+    ctx.token = .{
+        .access_token = try std.testing.allocator.dupe(u8, "at"),
+        .refresh_token = try std.testing.allocator.dupe(u8, "rt"),
+        .expires_at = std.time.timestamp() - 10,
+    };
+
+    // Refuses before the endpoint rather than dodging the identity guard.
+    try std.testing.expectError(error.TokenRefreshFailed, validateToken(&ctx));
+    try std.testing.expectEqualStrings("writeback_refused", ctx.last_refresh_outcome.?);
+    try std.testing.expectEqualStrings("identity_unresolved_refusing_refresh", ctx.last_refresh_reason.?);
 }

--- a/src/provider_schema.zig
+++ b/src/provider_schema.zig
@@ -108,6 +108,15 @@ pub const CredentialFormat = struct {
     expires_from_jwt_path: ?[]const u8 = null,
     // Alternative paths for API key mode
     api_key_path: ?[]const u8 = null,
+    // TIN-2043: JSON path (relative to wrapper) to the stable UPSTREAM
+    // account identity carried in the credential — e.g. codex
+    // "tokens.account_id". The refresh path hashes it (sha256_12hex) and
+    // takes the same per-identity flock the managed session does, so a warm
+    // refresh of one config account never rotates the single-use RT chain
+    // shared by a sibling config account's live session. null = the
+    // credential carries no in-band identity (claude's lives in
+    // .claude.json, not the keychain blob).
+    identity_claim_path: ?[]const u8 = null,
     // Wrapper key — if the credential JSON is nested under a top-level key
     wrapper_key: ?[]const u8 = null,
     // Token type detection: if api_key_path resolves, treat as api_key
@@ -809,6 +818,10 @@ pub const codex_def = ProviderDefinition{
         // JWT whose `exp` claim is the truth (TIN-2087). The previously
         // declared "tokens.expires_in" never existed in the real store.
         .expires_from_jwt_path = "tokens.access_token",
+        // TIN-2043: the duplicate-identity guard keys on this (the live
+        // max-1 == max-4 Apple-ID shape). Same id the managed session
+        // hashes for codex-identity-<hash>.
+        .identity_claim_path = "tokens.account_id",
         .api_key_path = "OPENAI_API_KEY",
     },
     .injection = .{
@@ -1484,6 +1497,23 @@ pub const TokenFields = struct {
     token_type: types.TokenType = .bearer,
     expires_at: ?i64 = null,
 };
+
+// TIN-2043: resolve the upstream account-identity string declared at
+// `identity_claim_path` from a raw credential. Returns an owned copy, or
+// null if the provider declares no identity path or the value is absent.
+// Hashing is the caller's job (keeps this module free of identity_hash).
+pub fn identityClaimFromCredential(def: ProviderDefinition, raw: []const u8, allocator: std.mem.Allocator) !?[]u8 {
+    const path = def.credential.identity_claim_path orelse return null;
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, raw, .{}) catch return null;
+    defer parsed.deinit();
+    var root = parsed.value;
+    if (def.credential.wrapper_key) |wk| {
+        root = resolveJsonPath(root, wk) orelse root;
+    }
+    const value = resolveJsonString(root, path) orelse return null;
+    if (value.len == 0) return null;
+    return try allocator.dupe(u8, value);
+}
 
 pub fn parseTokenGeneric(
     def: ProviderDefinition,
@@ -2559,4 +2589,25 @@ test "parseTokenGeneric leaves codex expiry null when the access token is not a 
         if (result.refresh_token) |rt| allocator.free(rt);
     }
     try std.testing.expectEqual(@as(?i64, null), result.expires_at);
+}
+
+test "identityClaimFromCredential resolves codex tokens.account_id (TIN-2043)" {
+    const raw =
+        \\{"auth_mode":"chatgpt","tokens":{"access_token":"at","refresh_token":"rt","account_id":"acct-uuid-xyz"}}
+    ;
+    const id = (try identityClaimFromCredential(codex_def, raw, std.testing.allocator)).?;
+    defer std.testing.allocator.free(id);
+    try std.testing.expectEqualStrings("acct-uuid-xyz", id);
+
+    // Absent account_id -> null (caller must not key a guard on a missing id).
+    const no_id =
+        \\{"auth_mode":"chatgpt","tokens":{"access_token":"at","refresh_token":"rt"}}
+    ;
+    try std.testing.expectEqual(@as(?[]u8, null), try identityClaimFromCredential(codex_def, no_id, std.testing.allocator));
+
+    // A provider that declares no identity_claim_path -> null (e.g. claude).
+    const claude_raw =
+        \\{"claudeAiOauth":{"accessToken":"at","refreshToken":"rt"}}
+    ;
+    try std.testing.expectEqual(@as(?[]u8, null), try identityClaimFromCredential(claude_def, claude_raw, std.testing.allocator));
 }


### PR DESCRIPTION
## Summary

Closes the **R4 double-spend** the TIN-2059 design review proved was unguarded — the second and final hard prerequisite (with TIN-2087) for the codex `proactive_refresh` grant flip.

`pipeline.attemptRefresh` and `broker_loader.refreshCodexAccountAuthFile` took only the per-**config-account** lock, never the identity lock the managed session takes. So a warm refresh of one config account could rotate the single-use RT chain shared by a sibling config account's live session — **the live `max-1 ≡ max-4` Apple-ID duplicate** — revoking the live session mid-flight. The store-invariant (TIN-2074) prevents corruption, but only the identity lock prevents the mid-session revocation.

- **`CredentialFormat.identity_claim_path`** (a forward-compatible slice of TIN-2078): the JSON path to the in-band upstream identity. `codex_def` declares `"tokens.account_id"`; claude declares none (its identity is in `.claude.json`, and keychain per-config-dir isolation already separates accounts).
- Both refresh paths acquire `("<provider>-identity", sha256_12hex(account_id))` — the **exact** key the adapter session takes — nonblocking, **after** the per-account lock (same order as the adapter, no inversion). Held → defer typed (`identity_lock_held`); acquired **before** the endpoint so a deferral never wastes a rotation.
- **Missing-id policy** made consistent + fail-closed: a provider declaring an identity path whose store carries no id is refused (`identity_unresolved_refusing_refresh`), matching the managed session's refuse-on-missing-id — a malformed store cannot dodge the guard.

## Adversarial review (2 lenses)

Zero real defects. The review verified the load-bearing claims: the lock keys produce the **same lock file cross-process** (so a held managed-session identity lock actually blocks the warm refresh), the order is deadlock-free, the **only two** `oauth.refreshToken` call sites are both now covered (no third path leaks), and the refuse cannot brick a real account (codex always writes `account_id` at login and re-emits it on every refresh; field-preserving writeback preserves it). One comment-accuracy nit (the broker's refuse is reachable only defensively behind the earlier state gate) addressed.

## Tests

- Identity resolver: codex `tokens.account_id`, absent → null, claude (no path) → null.
- Two config accounts sharing one `account_id` → a refresh of the idle account **defers** (`identity_lock_held`) while a foreign holder holds the shared `codex-identity-<hash>` lock; released → proceeds to the endpoint (proving the deferral was the identity lock, not the account lock).
- Declared-but-missing id → refuses before the endpoint.
- 539/539; full local e2e green.

Closes TIN-2043.