### PR TITLE
Guard real-store command probes with account locks

### DIFF
--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -35,12 +35,14 @@ short_runtime_dir() {
 
 config="$tmp/config.json"
 state_dir="$tmp/state"
+runtime_dir="$tmp/runtime"
 exec_out="$tmp/exec.out"
 probe_cmd="$tmp/probe-harness.sh"
 probe_mode_file="$tmp/probe-mode"
 reauth_probe_cmd="$tmp/reauth-probe-harness.sh"
 
-mkdir -p "$state_dir" "$tmp/a1-home" "$tmp/a2-home"
+mkdir -p "$state_dir" "$runtime_dir" "$tmp/a1-home" "$tmp/a2-home"
+export OMUX_RUNTIME_DIR="$runtime_dir"
 
 cat >"$probe_cmd" <<'EOF'
 #!/usr/bin/env sh
@@ -215,6 +217,7 @@ auth_a2='{"access_token":"omux-e2e-a2"}'
 omux() {
   OMUX_CONFIG="$config" \
     OMUX_STATE_DIR="$state_dir" \
+    OMUX_RUNTIME_DIR="$runtime_dir" \
     OMUX_E2E_A1_AUTH="$auth_a1" \
     OMUX_E2E_A2_AUTH="$auth_a2" \
     OMUX_E2E_PROBE_MODE_FILE="$probe_mode_file" \
@@ -577,12 +580,12 @@ daemon_log="$tmp/daemon.log"
 mkdir -p "$daemon_state"
 OMUX_CONFIG="$config" \
   OMUX_STATE_DIR="$daemon_state" \
-  XDG_RUNTIME_DIR="$daemon_runtime" \
+  OMUX_RUNTIME_DIR="$daemon_runtime" \
   "$bin" daemon run >"$daemon_log" 2>&1 &
 daemon_pid=$!
 daemon_status=""
 for _ in $(seq 1 200); do
-  daemon_status="$(OMUX_STATE_DIR="$daemon_state" XDG_RUNTIME_DIR="$daemon_runtime" "$bin" daemon status --json || true)"
+  daemon_status="$(OMUX_STATE_DIR="$daemon_state" OMUX_RUNTIME_DIR="$daemon_runtime" "$bin" daemon status --json || true)"
   case "$daemon_status" in
     *'"status":"running"'*) break ;;
   esac
@@ -599,7 +602,7 @@ expect_contains "$daemon_status" '"status":"running"' "daemon status reports for
 expect_contains "$daemon_status" '"socket":' "daemon status reports socket path"
 expect_contains "$daemon_status" '"contract":"experimental_socket_stub"' "daemon status reports socket contract"
 expect_contains "$daemon_status" '"hosts_stay_afloat":false' "daemon status does not claim to host stay-afloat"
-OMUX_STATE_DIR="$daemon_state" XDG_RUNTIME_DIR="$daemon_runtime" "$bin" daemon stop >/dev/null 2>&1
+OMUX_STATE_DIR="$daemon_state" OMUX_RUNTIME_DIR="$daemon_runtime" "$bin" daemon stop >/dev/null 2>&1
 set +e
 wait "$daemon_pid" 2>/dev/null
 daemon_wait_status=$?
@@ -613,7 +616,7 @@ case "$daemon_wait_status" in
     exit 1
     ;;
 esac
-daemon_stopped="$(OMUX_STATE_DIR="$daemon_state" XDG_RUNTIME_DIR="$daemon_runtime" "$bin" daemon status --json)"
+daemon_stopped="$(OMUX_STATE_DIR="$daemon_state" OMUX_RUNTIME_DIR="$daemon_runtime" "$bin" daemon status --json)"
 expect_contains "$daemon_stopped" '"status":"not_running"' "daemon status reports stopped foreground daemon"
 expect_contains "$daemon_stopped" '"wrapper_contract":"foreground_tick"' "daemon status reports wrapper contract when stopped"
 
@@ -622,12 +625,12 @@ loop_runtime="$(short_runtime_dir)"
 loop_log="$tmp/foreground-loop-daemon.log"
 OMUX_CONFIG="$config" \
   OMUX_STATE_DIR="$state_dir" \
-  XDG_RUNTIME_DIR="$loop_runtime" \
+  OMUX_RUNTIME_DIR="$loop_runtime" \
   "$bin" daemon run --stay-afloat --profile expensive --capability expensive --iterations 200 --interval-ms 50 >"$loop_log" 2>&1 &
 daemon_pid=$!
 loop_status=""
 for _ in $(seq 1 200); do
-  loop_status="$(OMUX_STATE_DIR="$state_dir" XDG_RUNTIME_DIR="$loop_runtime" "$bin" daemon status --json || true)"
+  loop_status="$(OMUX_STATE_DIR="$state_dir" OMUX_RUNTIME_DIR="$loop_runtime" "$bin" daemon status --json || true)"
   case "$loop_status" in
     *'"status":"running"'*'"stay_afloat_loop":{"hosted":true'*'"stay_afloat":{"version":'*'"current_loop_observed":true'*) break ;;
   esac
@@ -649,7 +652,7 @@ expect_contains "$loop_status" '"execution_mode":"execute"' "foreground loop dae
 expect_contains "$loop_status" '"transport":"foreground_tick_loop"' "foreground loop daemon status reports foreground loop transport"
 expect_contains "$loop_status" '"socket":null' "foreground loop daemon does not claim a socket transport"
 expect_contains "$loop_status" '"selected":{"provider":"toy","account":"a2"' "foreground loop daemon snapshot carries selected fallback route"
-OMUX_STATE_DIR="$state_dir" XDG_RUNTIME_DIR="$loop_runtime" "$bin" daemon stop >/dev/null 2>&1
+OMUX_STATE_DIR="$state_dir" OMUX_RUNTIME_DIR="$loop_runtime" "$bin" daemon stop >/dev/null 2>&1
 set +e
 wait "$daemon_pid" 2>/dev/null
 loop_wait_status=$?
@@ -663,7 +666,7 @@ case "$loop_wait_status" in
     exit 1
     ;;
 esac
-loop_stopped="$(OMUX_STATE_DIR="$state_dir" XDG_RUNTIME_DIR="$loop_runtime" "$bin" daemon status --json)"
+loop_stopped="$(OMUX_STATE_DIR="$state_dir" OMUX_RUNTIME_DIR="$loop_runtime" "$bin" daemon status --json)"
 expect_contains "$loop_stopped" '"status":"not_running"' "foreground loop daemon status reports stopped"
 expect_contains "$loop_stopped" '"stay_afloat_loop":{"hosted":false' "foreground loop daemon clears hosted loop metadata after stop"
 expect_contains "$loop_stopped" '"stay_afloat":{"version":' "foreground loop daemon leaves latest redacted snapshot visible after stop"

--- a/src/main.zig
+++ b/src/main.zig
@@ -8543,6 +8543,8 @@ fn writeProbeJson(writer: anytype, allocator: std.mem.Allocator, store: *health_
     }
     try writer.writeAll(",\"probe_executed\":");
     try writer.writeAll(if (ctx.last_probe_executed) "true" else "false");
+    try writer.writeAll(",\"lock_busy\":");
+    try writer.writeAll(if (ctx.last_probe_lock_busy) "true" else "false");
     try writer.writeAll(",\"probe_status\":");
     if (ctx.last_probe_status) |status| {
         try writer.print("{d}", .{status});

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -35,6 +35,11 @@ pub const Context = struct {
     last_probe_executed: bool = false,
     last_probe_status: ?u16 = null,
     last_probe_decision: ?types.MuxDecision = null,
+    // TIN-2039: set when a command-transport probe of a real account store
+    // was skipped because the per-account lock was held by a live session —
+    // the probe did NOT touch the store (codex could otherwise rewrite
+    // auth.json under the live session). Surfaced as "lock_busy" in JSON.
+    last_probe_lock_busy: bool = false,
     // TIN-2073: probe-budget callers (the daemon tick's probe phase) set
     // this false — they must never rotate tokens; rotation belongs to the
     // repair phase under admission + the per-account repair lock.
@@ -507,12 +512,44 @@ fn probeCapability(ctx: *Context) PipelineError!types.MuxDecision {
         else => return error.TokenParseFailed,
     };
 
+    // TIN-2039: a command-transport probe spawns the native CLI (codex exec)
+    // INSIDE the account's real store when the account has a config_dir, and
+    // the CLI may refresh + rewrite auth.json mid-probe. ACQUIRE the
+    // per-account lock and HOLD it across the probe so it never races a live
+    // managed session of the same account in another process (the lock is
+    // the same key the session/refresh paths use → cross-process). Acquired
+    // BEFORE the readiness check so a held lock is reported authoritatively
+    // as lock_busy (not the advisory repair_in_progress, which is a
+    // check-then-release with a TOCTOU window). Held → skip entirely: no
+    // store access, no health poison. HTTP-transport probes touch no store
+    // and are unaffected.
+    var probe_store_lock: ?repair_state.RepairLock = null;
+    defer if (probe_store_lock) |*l| l.release();
     if (plan.transport == .command) {
-        const readiness = runtime.routeReadiness(ctx.allocator, ctx.cfg, .{
-            .provider = prov,
-            .account = acct,
-            .capability = capability,
-        }, def) catch |e| switch (e) {
+        const store_guarded = probeTargetsRealAccountStore(ctx, prov, acct, def);
+        if (store_guarded) {
+            probe_store_lock = repair_state.acquireRepairLock(ctx.allocator, prov, acct) catch |e| switch (e) {
+                error.RepairInProgress => {
+                    log.warn("probe: {s}:{s} store lock held by a live session; skipping store probe (lock_busy)", .{ prov, acct });
+                    ctx.last_probe_executed = false;
+                    ctx.last_probe_lock_busy = true;
+                    // No store access, no new evidence — preserve the
+                    // account's existing recorded decision rather than poison
+                    // health on a benign "busy" outcome.
+                    const decision = ctx.health.muxDecisionFor(prov, acct, capability);
+                    ctx.last_probe_decision = decision;
+                    return decision;
+                },
+                else => return error.RuntimeNotReady,
+            };
+        }
+        // Readiness check: skip the advisory repair-lock probe when we
+        // already hold the lock (it would falsely conflict with ourselves).
+        const route_ref = runtime.RouteRef{ .provider = prov, .account = acct, .capability = capability };
+        const readiness = (if (store_guarded)
+            runtime.routeReadinessHoldingLock(ctx.allocator, ctx.cfg, route_ref, def)
+        else
+            runtime.routeReadiness(ctx.allocator, ctx.cfg, route_ref, def)) catch |e| switch (e) {
             error.OutOfMemory => return error.OutOfMemory,
             else => return error.RuntimeNotReady,
         };
@@ -592,6 +629,18 @@ const ProbeEnv = struct {
         self.pairs.append(.{ key, value }) catch return error.OutOfMemory;
     }
 };
+
+// TIN-2039: true when a command-transport probe will run the native CLI in
+// the account's real store (config_dir set + a config-dir env to point it
+// there) — i.e. the CLI can mutate that store's auth.json mid-probe and must
+// be serialized against a live session. Mirrors buildProbeEnv's config-dir
+// gate so the lock is taken exactly when the store would be touched.
+fn probeTargetsRealAccountStore(ctx: *Context, prov: []const u8, acct: []const u8, def: provider_schema.ProviderDefinition) bool {
+    const prov_cfg = ctx.cfg.providers.map.get(prov) orelse return false;
+    const acct_cfg = prov_cfg.accounts.map.get(acct) orelse return false;
+    if (acct_cfg.config_dir == null) return false;
+    return providerConfigDirEnv(prov_cfg, def, ctx.provider_kind) != null;
+}
 
 fn buildProbeEnv(
     ctx: *Context,
@@ -1013,6 +1062,10 @@ test "splitProviderAccount" {
 }
 
 test "runEnv uses configured provider definition" {
+
+    var rt_scope = try repair_state.TestRuntimeDirScope.init(std.testing.allocator);
+    defer rt_scope.deinit(std.testing.allocator);
+    rt_scope.activate();
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -1204,6 +1257,10 @@ test "refreshWritebackBackend admits only oauth-mux owned file writeback" {
 }
 
 test "runEnv honors capability route health from profile" {
+
+    var rt_scope = try repair_state.TestRuntimeDirScope.init(std.testing.allocator);
+    defer rt_scope.deinit(std.testing.allocator);
+    rt_scope.activate();
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -1279,6 +1336,10 @@ test "runEnv honors capability route health from profile" {
 }
 
 test "runEnv routes around degraded capability without poisoning account" {
+
+    var rt_scope = try repair_state.TestRuntimeDirScope.init(std.testing.allocator);
+    defer rt_scope.deinit(std.testing.allocator);
+    rt_scope.activate();
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -1373,6 +1434,10 @@ test "runEnv routes around degraded capability without poisoning account" {
 }
 
 test "runProbe honors explicit account filter without a configured probe plan" {
+
+    var rt_scope = try repair_state.TestRuntimeDirScope.init(std.testing.allocator);
+    defer rt_scope.deinit(std.testing.allocator);
+    rt_scope.activate();
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -1438,6 +1503,10 @@ test "runProbe honors explicit account filter without a configured probe plan" {
 }
 
 test "runProbe executes auth none command probe without reading missing secret" {
+
+    var rt_scope = try repair_state.TestRuntimeDirScope.init(std.testing.allocator);
+    defer rt_scope.deinit(std.testing.allocator);
+    rt_scope.activate();
     const json =
         \\{
         \\  "version": 1,
@@ -1503,6 +1572,10 @@ test "runProbe executes auth none command probe without reading missing secret" 
 }
 
 test "runProbe with explicit account rechecks previously degraded command route" {
+
+    var rt_scope = try repair_state.TestRuntimeDirScope.init(std.testing.allocator);
+    defer rt_scope.deinit(std.testing.allocator);
+    rt_scope.activate();
     const json =
         \\{
         \\  "version": 1,
@@ -1565,6 +1638,10 @@ test "runProbe with explicit account rechecks previously degraded command route"
 }
 
 test "runProbe does not poison liveness when command probe binary is missing" {
+
+    var rt_scope = try repair_state.TestRuntimeDirScope.init(std.testing.allocator);
+    defer rt_scope.deinit(std.testing.allocator);
+    rt_scope.activate();
     const missing_binary = "omux-definitely-missing-probe-runtime";
     const json = try std.fmt.allocPrint(
         std.testing.allocator,
@@ -1628,6 +1705,10 @@ test "runProbe does not poison liveness when command probe binary is missing" {
 }
 
 test "runProbe does not poison liveness when command account runtime is unavailable" {
+
+    var rt_scope = try repair_state.TestRuntimeDirScope.init(std.testing.allocator);
+    defer rt_scope.deinit(std.testing.allocator);
+    rt_scope.activate();
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -1717,6 +1798,10 @@ fn expectUnpoisonedRuntimeHealth(health: health_mod.AccountHealth) !void {
 }
 
 test "runEnv skips remaining accounts for degraded provider" {
+
+    var rt_scope = try repair_state.TestRuntimeDirScope.init(std.testing.allocator);
+    defer rt_scope.deinit(std.testing.allocator);
+    rt_scope.activate();
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -1887,6 +1972,10 @@ test "refreshWritebackBackend admits opted-in proactive refresh under upstream l
 }
 
 test "validateToken defers refresh under a non-mutating budget (TIN-2073)" {
+
+    var rt_scope = try repair_state.TestRuntimeDirScope.init(std.testing.allocator);
+    defer rt_scope.deinit(std.testing.allocator);
+    rt_scope.activate();
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
@@ -1955,6 +2044,10 @@ test "validateToken defers refresh under a non-mutating budget (TIN-2073)" {
 }
 
 test "attemptRefresh defers typed when the repair flock is held by another process (TIN-2073)" {
+    var rt_scope = try repair_state.TestRuntimeDirScope.init(std.testing.allocator);
+    defer rt_scope.deinit(std.testing.allocator);
+    rt_scope.activate();
+
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
@@ -2054,6 +2147,10 @@ test "attemptRefresh defers typed when the repair flock is held by another proce
 }
 
 test "attemptRefresh adopts a concurrent peer rotation under the lock (TIN-2073 TOCTOU)" {
+    var rt_scope = try repair_state.TestRuntimeDirScope.init(std.testing.allocator);
+    defer rt_scope.deinit(std.testing.allocator);
+    rt_scope.activate();
+
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
@@ -2135,6 +2232,10 @@ test "attemptRefresh adopts a concurrent peer rotation under the lock (TIN-2073 
 }
 
 test "attemptRefresh refuses lossy writeback when the store became unreadable under the lock (TIN-2074 review)" {
+    var rt_scope = try repair_state.TestRuntimeDirScope.init(std.testing.allocator);
+    defer rt_scope.deinit(std.testing.allocator);
+    rt_scope.activate();
+
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
@@ -2204,6 +2305,10 @@ fn fileExists(path: []const u8) bool {
 }
 
 test "attemptRefresh defers when the identity lock is held by a sibling-identity session (TIN-2043)" {
+    var rt_scope = try repair_state.TestRuntimeDirScope.init(std.testing.allocator);
+    defer rt_scope.deinit(std.testing.allocator);
+    rt_scope.activate();
+
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
@@ -2281,6 +2386,10 @@ test "attemptRefresh defers when the identity lock is held by a sibling-identity
 }
 
 test "attemptRefresh refuses when an identity path is declared but the store has no id (TIN-2043 missing-id policy)" {
+    var rt_scope = try repair_state.TestRuntimeDirScope.init(std.testing.allocator);
+    defer rt_scope.deinit(std.testing.allocator);
+    rt_scope.activate();
+
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const root_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
@@ -2330,4 +2439,97 @@ test "attemptRefresh refuses when an identity path is declared but the store has
     try std.testing.expectError(error.TokenRefreshFailed, validateToken(&ctx));
     try std.testing.expectEqualStrings("writeback_refused", ctx.last_refresh_outcome.?);
     try std.testing.expectEqualStrings("identity_unresolved_refusing_refresh", ctx.last_refresh_reason.?);
+}
+
+test "probeTargetsRealAccountStore gates on config_dir + a config-dir env (TIN-2039)" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "codex": {
+        \\      "kind": "codex",
+        \\      "config_dir_env": "CODEX_HOME",
+        \\      "accounts": {
+        \\        "homed": { "secret": { "backend": "file", "path": "/tmp/x" }, "config_dir": "/tmp/codex-homed" },
+        \\        "tmpd": { "secret": { "backend": "file", "path": "/tmp/y" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try config_mod.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    var ctx = Context.init(std.testing.allocator, parsed.value, &store);
+    defer ctx.deinit();
+    const def = config_mod.resolveProviderDefinition(parsed.value, "codex");
+    // config_dir present + config_dir_env present → store is real → guard.
+    try std.testing.expect(probeTargetsRealAccountStore(&ctx, "codex", "homed", def));
+    // No config_dir → tmpdir mode, no real store to guard.
+    try std.testing.expect(!probeTargetsRealAccountStore(&ctx, "codex", "tmpd", def));
+}
+
+test "command probe of a lock-held account store reports lock_busy without touching the store (TIN-2039)" {
+    var rt_scope = try repair_state.TestRuntimeDirScope.init(std.testing.allocator);
+    defer rt_scope.deinit(std.testing.allocator);
+    rt_scope.activate();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const store_dir = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(store_dir);
+
+    // A command probe whose command writes a marker file — proves whether
+    // the probe actually executed (it must NOT when the lock is held).
+    const marker = try std.fmt.allocPrint(std.testing.allocator, "{s}/probe-ran", .{store_dir});
+    defer std.testing.allocator.free(marker);
+
+    const json = try std.fmt.allocPrint(std.testing.allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "provider_definitions": {{
+        \\    "codex": {{
+        \\      "name": "codex", "kind": "codex", "config_dir_env": "CODEX_HOME",
+        \\      "capabilities": [
+        \\        {{ "name": "cap", "probe": {{ "transport": "command", "auth": "none", "timeout_ms": 5000, "command": ["/usr/bin/touch", "{s}"] }} }}
+        \\      ]
+        \\    }}
+        \\  }},
+        \\  "providers": {{
+        \\    "codex": {{ "kind": "codex", "config_dir_env": "CODEX_HOME", "accounts": {{ "homed": {{ "secret": {{ "backend": "file", "path": "{s}/auth.json" }}, "config_dir": "{s}" }} }} }}
+        \\  }},
+        \\  "profiles": {{}},
+        \\  "strategies": {{}}
+        \\}}
+    , .{ marker, store_dir, store_dir });
+    defer std.testing.allocator.free(json);
+
+    const parsed = try config_mod.loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+    var store = health_mod.HealthStore.init(std.testing.allocator, .{});
+    defer store.deinit();
+    var ctx = Context.init(std.testing.allocator, parsed.value, &store);
+    defer ctx.deinit();
+    ctx.provider_name = "codex";
+    ctx.account_name = "homed";
+    ctx.capability_name = "cap";
+
+    // Foreign holder on the per-account lock (the session's key).
+    const lock_path = try repair_state.lockPath(std.testing.allocator, "codex", "homed");
+    defer std.testing.allocator.free(lock_path);
+    if (std.fs.path.dirname(lock_path)) |dir| try std.fs.cwd().makePath(dir);
+    const holder = try std.fs.createFileAbsolute(lock_path, .{ .truncate = false, .mode = 0o600, .lock = .exclusive, .lock_nonblocking = true });
+
+    {
+        defer holder.close();
+        const decision = try probeCapability(&ctx);
+        _ = decision;
+        try std.testing.expect(ctx.last_probe_lock_busy);
+        try std.testing.expect(!ctx.last_probe_executed);
+        // The probe command never ran → no marker, the store was untouched.
+        try std.testing.expect(std.fs.accessAbsolute(marker, .{}) == error.FileNotFound);
+    }
 }

--- a/src/repair_state.zig
+++ b/src/repair_state.zig
@@ -748,12 +748,14 @@ fn writeTextLines(writer: anytype, lines: []const []const u8) !void {
 /// Test helper: scope lock files to a per-test tmp runtime dir via the
 /// OMUX_RUNTIME_DIR seam so unit tests never write into the user's real
 /// runtime dir (locks persist after TIN-2041, so stray writes are permanent).
-const TestRuntimeDirScope = struct {
+/// Pub so other modules' lock tests (pipeline refresh/probe) reuse it instead
+/// of polluting the real repair-locks dir (TIN-2039 review).
+pub const TestRuntimeDirScope = struct {
     tmp: std.testing.TmpDir,
     root: []const u8,
     overrides: std.process.EnvMap,
 
-    fn init(allocator: std.mem.Allocator) !TestRuntimeDirScope {
+    pub fn init(allocator: std.mem.Allocator) !TestRuntimeDirScope {
         var tmp = std.testing.tmpDir(.{});
         errdefer tmp.cleanup();
         const root = try tmp.dir.realpathAlloc(allocator, ".");
@@ -764,11 +766,11 @@ const TestRuntimeDirScope = struct {
         return .{ .tmp = tmp, .root = root, .overrides = overrides };
     }
 
-    fn activate(self: *TestRuntimeDirScope) void {
+    pub fn activate(self: *TestRuntimeDirScope) void {
         env.test_overrides = &self.overrides;
     }
 
-    fn deinit(self: *TestRuntimeDirScope, allocator: std.mem.Allocator) void {
+    pub fn deinit(self: *TestRuntimeDirScope, allocator: std.mem.Allocator) void {
         env.test_overrides = null;
         self.overrides.deinit();
         allocator.free(self.root);

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -160,6 +160,26 @@ pub fn routeReadiness(
     return info.readiness;
 }
 
+// TIN-2039: binary/path readiness WITHOUT the advisory repair-lock probe.
+// For callers that have ALREADY acquired the per-account lock (the
+// command-probe store guard), probing it again would falsely report
+// repair_in_progress for the caller's own held lock. Same as routeReadiness
+// minus that middle check.
+pub fn routeReadinessHoldingLock(
+    allocator: std.mem.Allocator,
+    cfg: config.Config,
+    route: RouteRef,
+    def: provider_schema.ProviderDefinition,
+) !types.RuntimeReadiness {
+    const provider_runtime = try providerReadiness(allocator, def, route.capability);
+    if (!provider_runtime.isReady()) return provider_runtime;
+
+    const prov = cfg.providers.map.get(route.provider) orelse return .{ .session_unavailable = "provider_config_missing" };
+    const account = prov.accounts.map.get(route.account) orelse return .{ .session_unavailable = "account_config_missing" };
+    const info = try accountInfo(allocator, prov, account, def, config.resolveProviderKind(cfg, route.provider));
+    return info.readiness;
+}
+
 pub fn accountInfo(
     allocator: std.mem.Allocator,
     prov: config.ProviderConfig,


### PR DESCRIPTION
## Summary

TIN-2039 hardens command-transport probes that run a native harness CLI inside an account's real store.

The bug class: a command probe such as `codex exec` can refresh and rewrite that account's `auth.json` while a live managed session for the same account is running in another process. Because TIN-2041 intentionally keeps repair-lock files persistent, test and e2e paths also need their own runtime dir so synthetic lock keys never land in the user's real runtime directory.

## What changed

- Command probes that target a real account store now try the same per-account repair lock used by session/refresh paths before touching the store.
- If the lock is held, the probe is skipped, reports `lock_busy`, avoids store access, and preserves the account's existing mux decision instead of poisoning health.
- HTTP-transport probes are unchanged.
- Added `routeReadinessHoldingLock` so a probe that already owns the account lock does not falsely report its own lock as `repair_in_progress`.
- Probe JSON now includes `lock_busy`.
- `scripts/e2e-local.sh` now owns an isolated `OMUX_RUNTIME_DIR`, including daemon subtests, so local/e2e runs do not write persistent synthetic locks into the user's runtime dir.

## Architecture trace

This follows the recent lock line:

- TIN-2041: lock files persist by design; release drops the flock, not the file.
- TIN-2073: refresh takes the lock/budget gate.
- TIN-2043: identity/store lock races are serialized.
- TIN-2039: command probes that enter a real account store join the same lock domain.

The implementation only locks when `config_dir` plus a provider config-dir env means the spawned CLI will actually touch the real store. It acquires before readiness probing so a held lock becomes a benign `lock_busy` skip, not a stale or poisoned health decision.

## Validation

Local debugging only:

- `bash -n scripts/e2e-local.sh`
- `nix develop --command zig build test` with before/after runtime-lock snapshot showing no new real repair-lock files

Required remote proof:

- `just remote-test tin-2039-probe-account-lock` green: https://github.com/Jesssullivan/oauth-mux/actions/runs/27480356740
- `just remote-check tin-2039-probe-account-lock` green: https://github.com/Jesssullivan/oauth-mux/actions/runs/27480452317