### PR TITLE
Make proof entrypoints remote-first

### DIFF
--- a/.github/workflows/remote-validate.yml
+++ b/.github/workflows/remote-validate.yml
@@ -16,7 +16,10 @@ on:
           - check
           - test
           - build
+          - build-release
+          - build-small
           - e2e
+          - first-run-e2e
           - release-proof
       version:
         description: "Release version for release-proof"
@@ -118,9 +121,21 @@ jobs:
                 run_with_timeout "remote build" "${OMUX_REMOTE_BUILD_TIMEOUT:-20m}" \
                   nix develop --command zig build
                 ;;
+              build-release)
+                run_with_timeout "remote release build" "${OMUX_REMOTE_BUILD_TIMEOUT:-20m}" \
+                  nix develop --command zig build -Doptimize=ReleaseSafe
+                ;;
+              build-small)
+                run_with_timeout "remote small build" "${OMUX_REMOTE_BUILD_TIMEOUT:-20m}" \
+                  nix develop --command zig build -Doptimize=ReleaseSmall
+                ;;
               e2e)
                 run_with_timeout "remote e2e" "${OMUX_REMOTE_E2E_TIMEOUT:-20m}" \
                   nix develop --command just e2e-local
+                ;;
+              first-run-e2e)
+                run_with_timeout "remote first-run e2e" "${OMUX_REMOTE_E2E_TIMEOUT:-20m}" \
+                  nix develop --command just first-run-e2e-local
                 ;;
               release-proof)
                 run_with_timeout "remote release proof" "${OMUX_REMOTE_RELEASE_PROOF_TIMEOUT:-40m}" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,21 +68,27 @@ easier to generalize into the next harness adapter, it is probably out of scope.
 ## Build And Validation
 
 Remote-first rule: proof builds, test gates, release checks, and agent validation
-must use the GloriousFlywheel remote lanes. Do not use local `zig build`,
-`just build`, `just test`, or `just check-local` as the completion proof on a
-developer laptop.
+must use the GloriousFlywheel remote lanes. The bare proof recipes dispatch
+remote by default:
 
 ```bash
+just build          # build on the GloriousFlywheel runner
+just test           # test on the GloriousFlywheel runner
+just check          # full check on the GloriousFlywheel runner
+just e2e            # e2e on the GloriousFlywheel runner
+
 just remote-build   # build on the GloriousFlywheel runner
 just remote-test    # test on the GloriousFlywheel runner
 just remote-check   # full check on the GloriousFlywheel runner
 just remote-e2e     # e2e on the GloriousFlywheel runner
 ```
 
-Local build commands remain available only for narrow debugging of a local
-toolchain, generated binary, or installer issue. If a local build is used for
-debugging, state that it is not validation and follow with the remote lane before
-making a completion or merge claim.
+Do not use local `zig build`, `just build-local`, `just test-local`,
+`just check-local`, or `just e2e-local` as the completion proof on a developer
+laptop. Local build commands remain available only for narrow debugging of a
+local toolchain, generated binary, or installer issue. If a local build is used
+for debugging, state that it is not validation and follow with the remote lane
+before making a completion or merge claim.
 
 ## Architecture
 
@@ -132,8 +138,9 @@ just remote-check   # full validation on the GloriousFlywheel runner
 ```
 
 Tests are in-file `test` blocks (Zig convention) plus `test/fixtures/` for
-provider token format samples. Local `just test` and `just test-verbose` are
-debugging tools only; do not use them as completion proof.
+provider token format samples. `just test` is a remote proof lane. Local
+`just test-local` and `just test-verbose` are debugging tools only; do not use
+them as completion proof.
 
 ## Distribution
 

--- a/README.md
+++ b/README.md
@@ -269,16 +269,26 @@ UX:
 DX:
 
 ```bash
+just build
+just test
+just check
+just e2e
+```
+
+The explicit aliases remain available:
+
+```bash
 just remote-build
 just remote-test
 just remote-check
 just remote-e2e
 ```
 
-Use `just remote-release-proof <ref> <version>` before any registry mutation. Local
-`zig build`, `just build`, and `just check-local` are debugging tools only; they
-are not the proof path for PR, release, or dogfood readiness on low-power
-developer machines.
+Use `just release-proof <version> [ref]` or
+`just remote-release-proof <ref> <version>` before any registry mutation. Local
+`zig build`, `just build-local`, `just test-local`, `just check-local`, and
+`just e2e-local` are debugging tools only; they are not the proof path for PR,
+release, or dogfood readiness on low-power developer machines.
 
 AX:
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -131,8 +131,9 @@ just first-run-e2e
 
 When checking unreleased behavior from source, use the remote validation lanes
 first (`just remote-build`, `just remote-check`, or `just remote-e2e`). Local
-`just run -- ...`, `just build`, or `./zig-out/bin/oauth-mux` are debugging
-tools only and should not be used as readiness proof on developer laptops.
+`just run -- ...`, `just build-local`, or `./zig-out/bin/oauth-mux` are
+debugging tools only and should not be used as readiness proof on developer
+laptops.
 
 Live probes remain explicit because they can spend subscription calls:
 

--- a/docs/productionization-ledger.md
+++ b/docs/productionization-ledger.md
@@ -97,12 +97,15 @@ UX:
 
 DX:
 
+- `just build`, `just test`, `just check`, and `just e2e` dispatch remote
+  development proof gates on GloriousFlywheel.
 - `just remote-build`, `just remote-test`, `just remote-check`, and
-  `just remote-e2e` are the development proof gates.
-- `just remote-release-proof <ref> <version>` is required before any registry
+  `just remote-e2e` remain explicit aliases for the same remote lanes.
+- `just release-proof <version> [ref]` or
+  `just remote-release-proof <ref> <version>` is required before any registry
   mutation.
-- Local build/check commands are debugging tools only; do not use them as PR,
-  release, or dogfood readiness proof on developer laptops.
+- Local `*-local` build/check commands are debugging tools only; do not use them
+  as PR, release, or dogfood readiness proof on developer laptops.
 - Installed-command dogfood must use `oauth-mux version --json`,
   `which -a oauth-mux`, `which -a codex`, and `codex preflight` to prove the
   exact binary and shim path under test.

--- a/docs/release-install-lanes.md
+++ b/docs/release-install-lanes.md
@@ -178,14 +178,17 @@ UX gates:
 
 DX gates:
 
-- `just remote-check` is the default validation chain for PR and dogfood
-  readiness;
-- `just remote-build`, `just remote-test`, and `just remote-e2e` are the
-  targeted remote proof lanes;
-- `just remote-release-proof <ref> <version>` is required before any registry
+- `just check` is the default validation chain for PR and dogfood readiness; it
+  dispatches the GloriousFlywheel remote lane;
+- `just build`, `just test`, and `just e2e` are targeted remote proof lanes;
+- `just remote-build`, `just remote-test`, `just remote-check`, and
+  `just remote-e2e` remain explicit aliases for the same dispatch path;
+- `just release-proof <version> [ref]` or
+  `just remote-release-proof <ref> <version>` is required before any registry
   mutation;
-- local `just check-local`, `just release-proof <version>`, `nix build .#`, and
-  `nix flake check` are debugging tools only and do not replace remote proof.
+- local `just check-local`, `just release-proof-local <version>`, `nix build .#`,
+  and `nix flake check` are debugging tools only and do not replace remote
+  proof.
 
 AX gates:
 

--- a/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
+++ b/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
@@ -77,6 +77,24 @@ Because GitHub exposes manual dispatch workflows from the default branch, the
 remote validation workflow must land on `main` before branch/SHA validation can
 be requested through `just remote-*`.
 
+Update, 2026-06-13: the bare proof entrypoints now dispatch the same remote
+lane:
+
+- `just build` -> `just remote-build`
+- `just build-release` -> `just remote-build-release`
+- `just build-small` -> `just remote-build-small`
+- `just test` -> `just remote-test`
+- `just check` -> `just remote-check`
+- `just e2e` -> `just remote-e2e`
+- `just first-run-e2e` -> `just remote-first-run-e2e`
+- `just release-proof <version> [ref]` -> remote release proof
+
+Local execution is intentionally explicit through `build-local`, `test-local`,
+`check-local`, `e2e-local`, `first-run-e2e-local`, and
+`release-proof-local`. Just recipes that need `./zig-out/bin/oauth-mux` still
+depend on `build-local`; that is a local debug/build-artifact dependency, not a
+proof claim.
+
 This is intentionally remote-first. `just check-local`, `just e2e-local`, and
 direct Zig recipes remain available only for narrow local debugging and runner
 failure triage. They are not proof gates for PR readiness, release readiness, or

--- a/justfile
+++ b/justfile
@@ -8,18 +8,30 @@ default:
 
 # ── Build ──
 
-build:
+build REF="":
+    ./scripts/remote-validate.sh build {{REF}}
+
+build-local:
     {{zig}} build
 
-build-release:
+build-release REF="":
+    ./scripts/remote-validate.sh build-release {{REF}}
+
+build-release-local:
     {{zig}} build -Doptimize=ReleaseSafe
 
-build-small:
+build-small REF="":
+    ./scripts/remote-validate.sh build-small {{REF}}
+
+build-small-local:
     {{zig}} build -Doptimize=ReleaseSmall
 
 # ── Test ──
 
-test:
+test REF="":
+    ./scripts/remote-validate.sh test {{REF}}
+
+test-local:
     {{zig}} build test
 
 # ── Run ──
@@ -27,7 +39,7 @@ test:
 run *ARGS:
     {{zig}} build run -- {{ARGS}}
 
-version: build
+version: build-local
     ./zig-out/bin/oauth-mux version
 
 install-local-dogfood:
@@ -39,56 +51,56 @@ install-local-dogfood-shim:
 uninstall-local-dogfood:
     ./scripts/uninstall-local-dogfood.sh
 
-status: build
+status: build-local
     ./zig-out/bin/oauth-mux status --json
 
-doctor: build
+doctor: build-local
     ./zig-out/bin/oauth-mux doctor
 
-report: build
+report: build-local
     ./zig-out/bin/oauth-mux report --redacted
 
-providers: build
+providers: build-local
     ./zig-out/bin/oauth-mux providers list
 
-health: build
+health: build-local
     ./zig-out/bin/oauth-mux health
 
-probe *ARGS: build
+probe *ARGS: build-local
     ./zig-out/bin/oauth-mux probe {{ARGS}}
 
 # ── Codex Max operator helpers ──
 
 codex_max_config := "examples/codex-max.config.json"
 
-codex-max-bootstrap-dirs: build
+codex-max-bootstrap-dirs: build-local
     ./zig-out/bin/oauth-mux codex bootstrap-dirs
 
-codex-max-validate: build
+codex-max-validate: build-local
     OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux config validate
 
-codex-max-login ACCOUNT: build
+codex-max-login ACCOUNT: build-local
     ./zig-out/bin/oauth-mux codex login {{ACCOUNT}}
 
-codex-max-login-device ACCOUNT: build
+codex-max-login-device ACCOUNT: build-local
     ./zig-out/bin/oauth-mux codex login-device {{ACCOUNT}}
 
-codex-max-login-status ACCOUNT: build
+codex-max-login-status ACCOUNT: build-local
     ./zig-out/bin/oauth-mux codex login-status {{ACCOUNT}}
 
-codex-max-login-status-all: build
+codex-max-login-status-all: build-local
     ./zig-out/bin/oauth-mux codex login-status-all
 
-codex-max-onboard: build
+codex-max-onboard: build-local
     OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux codex onboard
 
-codex-max-setup: build
+codex-max-setup: build-local
     OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux setup codex
 
-codex-max-canary: build
+codex-max-canary: build-local
     OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux codex canary
 
-paid-cohort-soak-snapshot: build
+paid-cohort-soak-snapshot: build-local
     ./scripts/paid-cohort-soak-snapshot.sh
 
 codex-max-soak-snapshot: paid-cohort-soak-snapshot
@@ -102,32 +114,33 @@ dogfood-process-snapshot-json:
 codex-max-process-snapshot OUT="dist/dogfood/process":
     python3 ./scripts/dogfood-process-snapshot.py --out {{OUT}} --tag codex-max
 
-codex-max-live-qa: build
+codex-max-live-qa: build-local
     OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux codex live-qa
 
-codex-max-live-qa-confirmed: build
+codex-max-live-qa-confirmed: build-local
     OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux codex live-qa --confirm-spend
 
-codex-max-repair-plan CAPABILITY="codex-max": build
+codex-max-repair-plan CAPABILITY="codex-max": build-local
     OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux repair-plan --profile {{CAPABILITY}} --capability {{CAPABILITY}} --json
 
-codex-max-config-candidate OUTPUT="/tmp/oauth-mux-codex-max.config.json": build
+codex-max-config-candidate OUTPUT="/tmp/oauth-mux-codex-max.config.json": build-local
     ./zig-out/bin/oauth-mux codex config-candidate --output {{OUTPUT}}
 
-codex-max-config-merge CANDIDATE="/tmp/oauth-mux-codex-max.config.json": build
+codex-max-config-merge CANDIDATE="/tmp/oauth-mux-codex-max.config.json": build-local
     ./zig-out/bin/oauth-mux codex config-merge --candidate {{CANDIDATE}}
 
-codex-max-probe ACCOUNT CAPABILITY="codex-mini": build
+codex-max-probe ACCOUNT CAPABILITY="codex-mini": build-local
     OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux probe --provider codex --account {{ACCOUNT}} --capability {{CAPABILITY}} --json
 
-codex-max-probe-all CAPABILITY="codex-mini": build
+codex-max-probe-all CAPABILITY="codex-mini": build-local
     OMUX_CONFIG=$PWD/{{codex_max_config}} ./zig-out/bin/oauth-mux codex probe-all --capability {{CAPABILITY}} --json
 
 # ── Cross-compilation ──
 
-release: release-all
+release VERSION=release_version REF="":
+    OMUX_REMOTE_RELEASE_VERSION={{VERSION}} ./scripts/remote-validate.sh release-proof {{REF}}
 
-release-all:
+release-all-local:
     {{zig}} build release
     @echo "all release builds complete"
 
@@ -152,8 +165,8 @@ homebrew-qa VERSION=release_version:
 npm-deprecate-plan VERSION="0.1.1":
     OMUX_NPM_DEPRECATE_PLAN_ONLY=1 nix develop --command ./scripts/npm-ci-deprecate.sh {{VERSION}}
 
-release-proof VERSION=release_version:
-    nix develop --command just release-proof-local {{VERSION}}
+release-proof VERSION=release_version REF="":
+    OMUX_REMOTE_RELEASE_VERSION={{VERSION}} ./scripts/remote-validate.sh release-proof {{REF}}
 
 release-proof-local VERSION=release_version:
     ./scripts/release-local.sh {{VERSION}}
@@ -191,22 +204,22 @@ home-manager-smoke:
 
 # ── Validation ──
 
-check:
-    nix develop --command just check-local
+check REF="":
+    ./scripts/remote-validate.sh check {{REF}}
 
 check-local:
     ./scripts/check-local.sh
     @echo "all checks passed"
 
-e2e:
-    nix develop --command just e2e-local
+e2e REF="":
+    ./scripts/remote-validate.sh e2e {{REF}}
 
 e2e-local:
     zig build
     ./scripts/e2e-local.sh
 
-first-run-e2e:
-    nix develop --command just first-run-e2e-local
+first-run-e2e REF="":
+    ./scripts/remote-validate.sh first-run-e2e {{REF}}
 
 first-run-e2e-local:
     zig build
@@ -229,8 +242,17 @@ remote-test REF="":
 remote-build REF="":
     ./scripts/remote-validate.sh build {{REF}}
 
+remote-build-release REF="":
+    ./scripts/remote-validate.sh build-release {{REF}}
+
+remote-build-small REF="":
+    ./scripts/remote-validate.sh build-small {{REF}}
+
 remote-e2e REF="":
     ./scripts/remote-validate.sh e2e {{REF}}
+
+remote-first-run-e2e REF="":
+    ./scripts/remote-validate.sh first-run-e2e {{REF}}
 
 remote-release-proof REF="" VERSION=release_version:
     OMUX_REMOTE_RELEASE_VERSION={{VERSION}} ./scripts/remote-validate.sh release-proof {{REF}}
@@ -347,53 +369,53 @@ github-tracker-comment ISSUE BODY_FILE:
 
 # ── Config ──
 
-init: build
+init: build-local
     ./zig-out/bin/oauth-mux init
 
-config-path: build
+config-path: build-local
     ./zig-out/bin/oauth-mux config path
 
-config-validate: build
+config-validate: build-local
     ./zig-out/bin/oauth-mux config validate
 
 # ── Daemon ──
 
-daemon-run: build
+daemon-run: build-local
     ./zig-out/bin/oauth-mux daemon run
 
-daemon-start: build
+daemon-start: build-local
     ./zig-out/bin/oauth-mux daemon start
 
-daemon-stop: build
+daemon-stop: build-local
     ./zig-out/bin/oauth-mux daemon stop
 
-daemon-status: build
+daemon-status: build-local
     ./zig-out/bin/oauth-mux daemon status --json
 
-daemon-events: build
+daemon-events: build-local
     ./zig-out/bin/oauth-mux daemon events --json
 
-daemon-tick PROFILE="codex-max" CAPABILITY="codex-max": build
+daemon-tick PROFILE="codex-max" CAPABILITY="codex-max": build-local
     ./zig-out/bin/oauth-mux daemon tick --once --profile {{PROFILE}} --capability {{CAPABILITY}} --json
 
-daemon-loop PROFILE="codex-max" CAPABILITY="codex-max" ITERATIONS="2" INTERVAL_MS="0": build
+daemon-loop PROFILE="codex-max" CAPABILITY="codex-max" ITERATIONS="2" INTERVAL_MS="0": build-local
     ./zig-out/bin/oauth-mux daemon tick --loop --iterations {{ITERATIONS}} --interval-ms {{INTERVAL_MS}} --profile {{PROFILE}} --capability {{CAPABILITY}} --json
 
-daemon-loop-host PROFILE="codex-max" CAPABILITY="codex-max" INTERVAL_MS="60000": build
+daemon-loop-host PROFILE="codex-max" CAPABILITY="codex-max" INTERVAL_MS="60000": build-local
     ./zig-out/bin/oauth-mux daemon loop --profile {{PROFILE}} --capability {{CAPABILITY}} --interval-ms {{INTERVAL_MS}}
 
-daemon-loop-smoke PROFILE="codex-max" CAPABILITY="codex-max" ITERATIONS="3" INTERVAL_MS="500": build
+daemon-loop-smoke PROFILE="codex-max" CAPABILITY="codex-max" ITERATIONS="3" INTERVAL_MS="500": build-local
     ./zig-out/bin/oauth-mux daemon loop --profile {{PROFILE}} --capability {{CAPABILITY}} --iterations {{ITERATIONS}} --interval-ms {{INTERVAL_MS}}
 
 # ── Shell integration ──
 
-completions-fish: build
+completions-fish: build-local
     ./zig-out/bin/oauth-mux completions fish
 
-completions-zsh: build
+completions-zsh: build-local
     ./zig-out/bin/oauth-mux completions zsh
 
-completions-bash: build
+completions-bash: build-local
     ./zig-out/bin/oauth-mux completions bash
 
 # ── Utilities ──
@@ -401,12 +423,12 @@ completions-bash: build
 clean:
     rm -rf zig-out .zig-cache
 
-size: build-release
+size: build-release-local
     @ls -lh zig-out/bin/oauth-mux
 
 # ── E2E smoke test ──
 
-smoke: build
+smoke: build-local
     #!/usr/bin/env bash
     set -euo pipefail
     echo "=== version ==="

--- a/scripts/codex-max-canary.sh
+++ b/scripts/codex-max-canary.sh
@@ -14,7 +14,7 @@ bin="${OMUX_BIN:-$repo_root/zig-out/bin/oauth-mux}"
 
 if [ ! -x "$bin" ]; then
   printf 'oauth-mux binary not found at %s\n' "$bin" >&2
-  printf 'run: just build\n' >&2
+  printf 'run: just build-local\n' >&2
   exit 1
 fi
 

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -8,7 +8,7 @@ bin="${OMUX_BIN:-$repo_root/zig-out/bin/oauth-mux}"
 
 if [ ! -x "$bin" ]; then
   printf 'missing oauth-mux binary: %s\n' "$bin" >&2
-  printf 'run `zig build` or `just e2e` first\n' >&2
+  printf 'run `zig build` or `just build-local` first\n' >&2
   exit 1
 fi
 

--- a/scripts/first-run-e2e.sh
+++ b/scripts/first-run-e2e.sh
@@ -8,7 +8,7 @@ bin="${OMUX_BIN:-$repo_root/zig-out/bin/oauth-mux}"
 
 if [ ! -x "$bin" ]; then
   printf 'missing oauth-mux binary: %s\n' "$bin" >&2
-  printf 'run `zig build` or `just first-run-e2e` first\n' >&2
+  printf 'run `zig build` or `just build-local` first\n' >&2
   exit 1
 fi
 

--- a/scripts/live-provider-qa.sh
+++ b/scripts/live-provider-qa.sh
@@ -23,7 +23,7 @@ fi
 bin="${OMUX_BIN:-$repo_root/zig-out/bin/oauth-mux}"
 if [ ! -x "$bin" ]; then
   printf 'oauth-mux binary not found at %s\n' "$bin" >&2
-  printf 'run: just build\n' >&2
+  printf 'run: just build-local\n' >&2
   exit 1
 fi
 

--- a/scripts/onboard-codex-max.sh
+++ b/scripts/onboard-codex-max.sh
@@ -12,7 +12,7 @@ bin="${OMUX_BIN:-$repo_root/zig-out/bin/oauth-mux}"
 
 if [ ! -x "$bin" ]; then
   printf 'oauth-mux binary not found at %s\n' "$bin" >&2
-  printf 'run: just build\n' >&2
+  printf 'run: just build-local\n' >&2
   exit 1
 fi
 

--- a/scripts/paid-cohort-soak-snapshot.sh
+++ b/scripts/paid-cohort-soak-snapshot.sh
@@ -17,7 +17,7 @@ config_path="${OMUX_CONFIG:-}"
 
 if [ ! -x "$bin" ]; then
   printf 'oauth-mux binary not found at %s\n' "$bin" >&2
-  printf 'run: just build\n' >&2
+  printf 'run: just build-local\n' >&2
   exit 1
 fi
 

--- a/scripts/remote-validate.sh
+++ b/scripts/remote-validate.sh
@@ -9,7 +9,10 @@ Targets:
   check          Run just check-local on the GloriousFlywheel runner.
   test           Run zig build test on the GloriousFlywheel runner.
   build          Run zig build on the GloriousFlywheel runner.
+  build-release  Run zig build -Doptimize=ReleaseSafe on the GloriousFlywheel runner.
+  build-small    Run zig build -Doptimize=ReleaseSmall on the GloriousFlywheel runner.
   e2e            Run just e2e-local on the GloriousFlywheel runner.
+  first-run-e2e  Run just first-run-e2e-local on the GloriousFlywheel runner.
   release-proof  Run just release-proof-local on the GloriousFlywheel runner.
 
 The workflow file must already exist on the repository default branch. After
@@ -67,7 +70,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 case "$target" in
-  check|test|build|e2e|release-proof)
+  check|test|build|build-release|build-small|e2e|first-run-e2e|release-proof)
     ;;
   *)
     echo "remote-validate: unsupported target: $target" >&2

--- a/scripts/smoke-broker-claude.sh
+++ b/scripts/smoke-broker-claude.sh
@@ -16,7 +16,7 @@ BIN="$ROOT/zig-out/bin/oauth-mux"
 
 if [[ ! -x "$BIN" ]]; then
     echo "smoke-broker-claude: oauth-mux binary not built at $BIN" >&2
-    echo "  run: just build" >&2
+    echo "  run: just build-local" >&2
     exit 64
 fi
 

--- a/scripts/smoke-broker.sh
+++ b/scripts/smoke-broker.sh
@@ -30,7 +30,7 @@ BIN="$ROOT/zig-out/bin/oauth-mux"
 
 if [[ ! -x "$BIN" ]]; then
     echo "smoke-broker: oauth-mux binary not built at $BIN" >&2
-    echo "  run: just build" >&2
+    echo "  run: just build-local" >&2
     exit 64
 fi
 

--- a/scripts/smoke-codex-401-propagation.sh
+++ b/scripts/smoke-codex-401-propagation.sh
@@ -11,7 +11,7 @@ BIN="$ROOT/zig-out/bin/oauth-mux"
 
 if [[ ! -x "$BIN" ]]; then
     echo "smoke-codex-401-propagation: oauth-mux binary not built at $BIN" >&2
-    echo "  run: just build" >&2
+    echo "  run: just build-local" >&2
     exit 64
 fi
 

--- a/scripts/smoke-codex-acceptance.sh
+++ b/scripts/smoke-codex-acceptance.sh
@@ -43,7 +43,7 @@ BIN="$ROOT/zig-out/bin/oauth-mux"
 
 if [[ ! -x "$BIN" ]]; then
     echo "smoke-codex-acceptance: oauth-mux binary not built at $BIN" >&2
-    echo "  run: just build" >&2
+    echo "  run: just build-local" >&2
     exit 64
 fi
 

--- a/scripts/smoke-codex-all-exhausted.sh
+++ b/scripts/smoke-codex-all-exhausted.sh
@@ -10,7 +10,7 @@ BIN="$ROOT/zig-out/bin/oauth-mux"
 
 if [[ ! -x "$BIN" ]]; then
     echo "smoke-codex-all-exhausted: oauth-mux binary not built at $BIN" >&2
-    echo "  run: just build" >&2
+    echo "  run: just build-local" >&2
     exit 64
 fi
 

--- a/scripts/smoke-codex-cassette-all-exhausted.sh
+++ b/scripts/smoke-codex-cassette-all-exhausted.sh
@@ -13,7 +13,7 @@ BIN="$ROOT/zig-out/bin/oauth-mux"
 
 if [[ ! -x "$BIN" ]]; then
     echo "smoke-codex-cassette-all-exhausted: oauth-mux binary not built at $BIN" >&2
-    echo "  run: just build" >&2
+    echo "  run: just build-local" >&2
     exit 64
 fi
 

--- a/scripts/smoke-codex-child-refresh.sh
+++ b/scripts/smoke-codex-child-refresh.sh
@@ -11,7 +11,7 @@ BIN="$ROOT/zig-out/bin/oauth-mux"
 
 if [[ ! -x "$BIN" ]]; then
     echo "smoke-codex-child-refresh: oauth-mux binary not built at $BIN" >&2
-    echo "  run: just build" >&2
+    echo "  run: just build-local" >&2
     exit 64
 fi
 

--- a/scripts/smoke-codex-cli-ux.sh
+++ b/scripts/smoke-codex-cli-ux.sh
@@ -30,7 +30,7 @@ BIN="$ROOT/zig-out/bin/oauth-mux"
 
 if [[ ! -x "$BIN" ]]; then
     echo "smoke-codex-cli-ux: oauth-mux binary not built at $BIN" >&2
-    echo "  run: just build" >&2
+    echo "  run: just build-local" >&2
     exit 64
 fi
 

--- a/scripts/smoke-codex-concurrent-sessions.sh
+++ b/scripts/smoke-codex-concurrent-sessions.sh
@@ -24,7 +24,7 @@ BIN="$ROOT/zig-out/bin/oauth-mux"
 
 if [[ ! -x "$BIN" ]]; then
     echo "smoke-codex-concurrent-sessions: oauth-mux binary not built at $BIN" >&2
-    echo "  run: just build" >&2
+    echo "  run: just build-local" >&2
     exit 64
 fi
 

--- a/scripts/smoke-codex-provider-degraded.sh
+++ b/scripts/smoke-codex-provider-degraded.sh
@@ -16,7 +16,7 @@ BIN="$ROOT/zig-out/bin/oauth-mux"
 
 if [[ ! -x "$BIN" ]]; then
     echo "smoke-codex-provider-degraded: oauth-mux binary not built at $BIN" >&2
-    echo "  run: just build" >&2
+    echo "  run: just build-local" >&2
     exit 64
 fi
 

--- a/scripts/smoke-codex-tier-insufficient.sh
+++ b/scripts/smoke-codex-tier-insufficient.sh
@@ -10,7 +10,7 @@ BIN="$ROOT/zig-out/bin/oauth-mux"
 
 if [[ ! -x "$BIN" ]]; then
     echo "smoke-codex-tier-insufficient: oauth-mux binary not built at $BIN" >&2
-    echo "  run: just build" >&2
+    echo "  run: just build-local" >&2
     exit 64
 fi
 

--- a/scripts/smoke-trace.sh
+++ b/scripts/smoke-trace.sh
@@ -9,7 +9,7 @@ BIN="$ROOT/zig-out/bin/oauth-mux"
 
 if [[ ! -x "$BIN" ]]; then
     echo "smoke-trace: oauth-mux binary not built at $BIN" >&2
-    echo "  run: just build" >&2
+    echo "  run: just build-local" >&2
     exit 64
 fi
 


### PR DESCRIPTION
## Summary

- Make bare proof recipes (`just build`, `just test`, `just check`, `just e2e`, `just release-proof`) dispatch the GloriousFlywheel remote validation workflow.
- Keep local execution explicit through `*-local` recipes for debugging and recipes that need `./zig-out/bin/oauth-mux`.
- Add remote targets for release/small builds and first-run e2e.
- Update docs and local-binary script hints so operators are not told to run remote proof when they need a local binary.

## Validation

- `bash -n` on touched shell scripts.
- `just --summary` and `just --dry-run` for representative remote/local recipes.
- `git diff --check`.
- Remote proof dispatched: `Remote Validate / check` run 27485054536 on `remote-first-just-entrypoints`.
