### PR TITLE
Correlate remote validation dispatch by request id

### DIFF
--- a/.github/workflows/remote-validate.yml
+++ b/.github/workflows/remote-validate.yml
@@ -1,4 +1,5 @@
 name: Remote Validate
+run-name: Remote Validate ${{ inputs.request_id || github.run_id }} ${{ inputs.target || 'e2e' }}
 
 on:
   schedule:
@@ -25,6 +26,11 @@ on:
         description: "Release version for release-proof"
         required: false
         default: "0.1.13"
+        type: string
+      request_id:
+        description: "Unique caller request id for dispatch/run correlation"
+        required: false
+        default: ""
         type: string
 
 permissions:
@@ -74,6 +80,7 @@ jobs:
         uses: ./.gloriousflywheel/.github/actions/nix-job
         env:
           ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN || '' }}
+          OMUX_REMOTE_REQUEST_ID: ${{ inputs.request_id || github.run_id }}
           OMUX_REMOTE_TARGET: ${{ inputs.target || 'e2e' }}
           OMUX_REMOTE_RELEASE_VERSION: ${{ inputs.version }}
         with:

--- a/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
+++ b/docs/spec/gloriousflywheel-substrate-integration-2026-04-26.md
@@ -109,6 +109,15 @@ The remote workflow fails rather than silently falling back when the
 GloriousFlywheel action token is absent. A skipped or fallback local run is not
 remote validation.
 
+Update, 2026-06-13: remote validation dispatches include a caller-generated
+`request_id`, and the workflow run-name includes that id. `scripts/remote-validate.sh`
+uses the id to find the exact `workflow_dispatch` run instead of watching the
+latest run on the branch, which is racy when several agents or tabs dispatch the
+same workflow close together. As with the original remote workflow bootstrap,
+this request-id path is available only after the workflow input has landed on
+the repository default branch; before then, branch-local edits are validated by
+PR CI rather than by manually dispatching the not-yet-landed input shape.
+
 ## What This Proves
 
 When `GF_ACTIONS_TOKEN` and the Attic settings are present, this proves that

--- a/scripts/check-local.sh
+++ b/scripts/check-local.sh
@@ -11,6 +11,7 @@ bash -n ./scripts/uninstall-local-dogfood.sh
 bash -n ./scripts/release-local.sh
 bash -n ./scripts/release-smoke.sh
 bash -n ./scripts/release-handoff.sh
+bash -n ./scripts/remote-validate.sh
 python3 -m py_compile ./scripts/dogfood-process-snapshot.py
 sh -n ./dist/codex-shim.sh
 sh -n ./dist/install.sh
@@ -23,6 +24,7 @@ done
 ./scripts/first-run-e2e.sh
 ./scripts/stay-afloat-wrapper-doc-smoke.sh
 ./scripts/smoke-trace.sh
+./scripts/smoke-remote-validate-contract.sh
 ./scripts/smoke-dogfood-process-snapshot.sh
 ./scripts/smoke-broker.sh
 ./scripts/smoke-broker-claude.sh

--- a/scripts/remote-validate.sh
+++ b/scripts/remote-validate.sh
@@ -33,6 +33,7 @@ shift || true
 watch=1
 ref=""
 version="${OMUX_REMOTE_RELEASE_VERSION:-}"
+request_id="${OMUX_REMOTE_REQUEST_ID:-}"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -99,31 +100,48 @@ fi
 repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
 workflow="remote-validate.yml"
 
-echo "remote-validate: dispatching ${target} on ${repo}@${ref}"
+if [ -z "$request_id" ]; then
+  repo_slug="$(printf '%s' "$repo" | sed 's#[/[:space:]]#-#g' | tr -c 'A-Za-z0-9_.:-' '-')"
+  target_slug="$(printf '%s' "$target" | tr -c 'A-Za-z0-9_.:-' '-')"
+  nonce="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+  request_id="omux-remote-${repo_slug}-${target_slug}-${nonce}"
+fi
+request_id="$(printf '%s' "$request_id" | tr -c 'A-Za-z0-9_.:-' '-')"
+request_id="${request_id:0:200}"
+dispatch_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-args=(workflow run "$workflow" --repo "$repo" --ref "$ref" -f "target=$target")
+echo "remote-validate: dispatching ${target} on ${repo}@${ref} (request_id=${request_id})"
+
+args=(workflow run "$workflow" --repo "$repo" --ref "$ref" -f "target=$target" -f "request_id=$request_id")
 if [ -n "$version" ]; then
   args+=(-f "version=$version")
 fi
 gh "${args[@]}"
 
 if [ "$watch" != "1" ]; then
-  echo "remote-validate: dispatched; watch with: gh run list --repo ${repo} --workflow ${workflow}"
+  echo "remote-validate: dispatched request_id=${request_id}"
+  echo "remote-validate: watch with: gh run list --repo ${repo} --workflow ${workflow}"
   exit 0
 fi
 
-echo "remote-validate: locating latest workflow_dispatch run"
-run_id="$(gh run list \
-  --repo "$repo" \
-  --workflow "$workflow" \
-  --branch "$ref" \
-  --event workflow_dispatch \
-  --json databaseId,status,createdAt \
-  --jq 'sort_by(.createdAt) | reverse | .[0].databaseId // empty' \
-  --limit 10)"
+echo "remote-validate: locating workflow_dispatch run for request_id=${request_id}"
+run_id=""
+for _ in $(seq 1 60); do
+  run_id="$(gh run list \
+    --repo "$repo" \
+    --workflow "$workflow" \
+    --event workflow_dispatch \
+    --json databaseId,createdAt,displayTitle \
+    --jq "[.[] | select(.createdAt >= \"${dispatch_time}\") | select((.displayTitle // \"\") | contains(\"${request_id}\"))] | sort_by(.createdAt, .databaseId) | first | .databaseId // empty" \
+    --limit 50)" || run_id=""
+  if [ -n "$run_id" ]; then
+    break
+  fi
+  sleep 5
+done
 
 if [ -z "$run_id" ]; then
-  echo "remote-validate: dispatched, but GitHub has not exposed the run yet" >&2
+  echo "remote-validate: dispatched request_id=${request_id}, but GitHub has not exposed the matching run yet" >&2
   echo "remote-validate: check: gh run list --repo ${repo} --workflow ${workflow}" >&2
   exit 1
 fi

--- a/scripts/smoke-remote-validate-contract.sh
+++ b/scripts/smoke-remote-validate-contract.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env sh
+# Textual guard for the remote validation dispatch contract.
+
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT/scripts/remote-validate.sh"
+WORKFLOW="$ROOT/.github/workflows/remote-validate.yml"
+
+fail() {
+  echo "smoke-remote-validate-contract: $*" >&2
+  exit 1
+}
+
+bash -n "$SCRIPT"
+
+grep -F 'request_id:' "$WORKFLOW" >/dev/null ||
+  fail "remote-validate workflow must expose a request_id input"
+grep -F 'inputs.request_id' "$WORKFLOW" >/dev/null ||
+  fail "remote-validate run-name must include inputs.request_id"
+grep -F 'OMUX_REMOTE_REQUEST_ID' "$WORKFLOW" >/dev/null ||
+  fail "remote-validate workflow must pass request id into the job environment"
+
+grep -F 'request_id=' "$SCRIPT" >/dev/null ||
+  fail "remote-validate script must generate or accept a request_id"
+grep -F -- '-f "request_id=$request_id"' "$SCRIPT" >/dev/null ||
+  fail "remote-validate script must dispatch request_id to the workflow"
+grep -F 'contains(\"${request_id}\")' "$SCRIPT" >/dev/null ||
+  fail "remote-validate script must discover runs by request id"
+
+if grep -F 'locating latest workflow_dispatch run' "$SCRIPT" >/dev/null; then
+  fail "remote-validate script must not discover the latest workflow_dispatch run"
+fi
+
+echo "smoke-remote-validate-contract: ok"


### PR DESCRIPTION
## Summary
- add a request_id input and run-name to the Remote Validate workflow
- make scripts/remote-validate.sh discover the exact workflow_dispatch run by request_id instead of the latest run
- add a cheap smoke guard for the remote validation dispatch contract
- document the default-branch bootstrap caveat for the new input shape

## Validation
- bash -n scripts/remote-validate.sh scripts/smoke-remote-validate-contract.sh scripts/check-local.sh
- ./scripts/smoke-remote-validate-contract.sh
- git diff --check

Remote proof is the PR CI lane; local script checks above are not completion proof.