### PR TITLE
identity: unpark the identity lane into the build + tests (TIN-1822, TIN-2053)

### DIFF
--- a/src/identity/claude_identity.zig
+++ b/src/identity/claude_identity.zig
@@ -1,0 +1,177 @@
+//! Claude (Claude Code) stable-identity labeler — greenfield, the producer half of
+//! TIN-1822. It turns a Claude account profile (the `oauthAccount` block of
+//! `<CLAUDE_CONFIG_DIR>/.claude.json`, or `~/.claude.json`) into a stable,
+//! non-secret `ClaudeIdentity` whose `account_id_hash` feeds the identity graph
+//! (`identity_graph.zig`, its `IdentityKey.hash`).
+//!
+//! Canonical key: `oauthAccount.accountUuid` (server-issued, durable per-account
+//! UUID; stable across re-logins, distinct across accounts). NOT `userID` (a
+//! 64-char per-INSTALL anonymous hash that collides across accounts in one config
+//! dir and fragments one account across installs) and NOT `organizationUuid` (a
+//! many-accounts-to-one billing/rate-limit pool — context-dependent, never the
+//! per-account key, never composited into it). This mirrors Codex exactly:
+//! Codex hashes `chatgpt_account_id`, Claude hashes `accountUuid`, both via the
+//! same `sha256_12hex` (first 6 bytes of SHA-256 → 12 lowercase hex).
+//!
+//! Fail-safe: any empty/malformed input, absent `oauthAccount`, or absent
+//! `accountUuid` yields `present=false` with `account_id_hash=null` — so the graph
+//! keys the slot as an OPAQUE per-(provider,account) identity (the honest
+//! representation of "authenticated-but-unprofiled"), instead of coalescing all
+//! profile-less Claude accounts under one hashed-empty-string key.
+//!
+//! Redaction (enforced structurally): the struct holds NO raw UUID, email, or
+//! token — only `sha256_12hex` hashes, a masked email hint (`j***@domain`), and an
+//! `org_display` that is flagged identifying and must be gated to operator-only,
+//! non-agent surfaces.
+//!
+//! OWNERSHIP / LIFETIME: a `ClaudeIdentity` OWNS its slices and frees them in
+//! `deinit`. The identity graph's `AccountSlot` BORROWS `account_id_hash`, so a
+//! `ClaudeIdentity` MUST outlive any `AccountSlot` that borrows it — do not
+//! `deinit` it until graph analysis is done (or `dupe` the hash into the slot's
+//! arena). `stable_label`/`org_id_hash`/`org_display` are producer-local
+//! diagnostics — only `account_id_hash` (and a masked `email_hint`) ever crosses
+//! into the graph.
+//!
+//! Self-contained: `std` only, NO `@import` of existing `src` (the `sha256_12hex`,
+//! `maskEmail`, `nonEmpty` helpers are re-derived locally to match the Codex ones
+//! byte-for-byte). Pure (no I/O — the caller reads the file and passes the bytes).
+//! `std.testing.allocator`-clean. Zig 0.14.1.
+
+const std = @import("std");
+
+pub const account_id_source_label: []const u8 = "oauthAccount.accountUuid";
+
+/// Parse result. `present` is true only when a usable `accountUuid` was found.
+/// `reason` is a static string literal (never owned). All `?[]const u8` payloads
+/// are allocator-OWNED when non-null and freed by `deinit`.
+pub const ClaudeIdentity = struct {
+    present: bool = false,
+    /// One of: "input_empty", "json_invalid", "oauth_account_missing",
+    /// "account_uuid_missing", "identity_present". Static literal.
+    reason: []const u8 = "input_empty",
+    /// Static provenance for the canonical id when present, else null.
+    account_id_source: ?[]const u8 = null,
+    /// sha256_12hex(accountUuid). THIS is what the identity graph consumes as
+    /// `IdentityKey.hash`. OWNED. null when no stable identity (graph keys opaque).
+    account_id_hash: ?[]const u8 = null,
+    /// sha256_12hex(organizationUuid): a SEPARATE hashed grouping dimension, NOT a
+    /// graph input. OWNED. null when org absent/empty (never a hash of "").
+    org_id_hash: ?[]const u8 = null,
+    /// Hashed, non-secret composite label for logs/UX: `claude:<org12|noorg>:<acct12>`.
+    /// Producer-local diagnostic, not a graph input. OWNED. null iff no identity.
+    stable_label: ?[]const u8 = null,
+    /// Masked email "j***@domain" — never the raw local part. OWNED. null when absent.
+    email_hint: ?[]const u8 = null,
+    /// organizationName — IDENTIFYING human display for OPERATOR-ONLY surfaces;
+    /// must NOT be emitted on agent/MCP surfaces. OWNED. null when absent.
+    org_display: ?[]const u8 = null,
+
+    /// Frees every owned slice. Safe on the zero/unknown value (all nulls).
+    pub fn deinit(self: ClaudeIdentity, allocator: std.mem.Allocator) void {
+        if (self.account_id_hash) |v| allocator.free(v);
+        if (self.org_id_hash) |v| allocator.free(v);
+        if (self.stable_label) |v| allocator.free(v);
+        if (self.email_hint) |v| allocator.free(v);
+        if (self.org_display) |v| allocator.free(v);
+    }
+};
+
+// ── Local helpers (re-derived to match the Codex ones; no @import of src) ─────
+
+/// Lowercase hex of the first 6 bytes of SHA-256 → 12 chars. Matches the repo's
+/// `shortSha256HexAlloc` (golden: sha256_12hex("acct-test") == "660d25a9d7ee").
+fn sha256_12hex(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
+    var digest: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(value, &digest, .{});
+    const hex = "0123456789abcdef";
+    const out = try allocator.alloc(u8, 12);
+    for (digest[0..6], 0..) |b, i| {
+        out[i * 2] = hex[b >> 4];
+        out[i * 2 + 1] = hex[b & 0x0f];
+    }
+    return out;
+}
+
+fn nonEmpty(s: ?[]const u8) ?[]const u8 {
+    if (s) |v| {
+        if (v.len > 0) return v;
+    }
+    return null;
+}
+
+/// "jess@sulliwood.org" → "j***@sulliwood.org". Returns null for a non-email
+/// (no '@', or empty local part) so a malformed value never produces a hint.
+fn maskEmail(allocator: std.mem.Allocator, email: []const u8) !?[]u8 {
+    const at = std.mem.indexOfScalar(u8, email, '@') orelse return null;
+    if (at == 0) return null; // empty local part
+    const domain = email[at..]; // includes '@'
+    // Keep a single-char hint for an ASCII local part (`j***@domain`). For a
+    // non-ASCII first byte, `{c}` would emit one partial UTF-8 byte — invalid
+    // encoding that mojibakes or fails re-encode on a JSON/MCP surface — so mask
+    // the whole local part instead (also the more conservative redaction).
+    if (std.ascii.isAscii(email[0])) {
+        return try std.fmt.allocPrint(allocator, "{c}***{s}", .{ email[0], domain });
+    }
+    return try std.fmt.allocPrint(allocator, "***{s}", .{domain});
+}
+
+fn buildStableLabel(allocator: std.mem.Allocator, acct12: []const u8, org12: ?[]const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator, "claude:{s}:{s}", .{ org12 orelse "noorg", acct12 });
+}
+
+// ── Parser ───────────────────────────────────────────────────────────────────
+
+const OAuthAccount = struct {
+    accountUuid: ?[]const u8 = null,
+    organizationUuid: ?[]const u8 = null,
+    organizationName: ?[]const u8 = null,
+    emailAddress: ?[]const u8 = null,
+};
+
+const RootJson = struct {
+    oauthAccount: ?OAuthAccount = null,
+};
+
+/// Parse a Claude account profile JSON (the contents of `.claude.json`) into a
+/// stable identity. Pure + fail-safe: never crashes; an unusable input returns a
+/// `present=false` value with `account_id_hash=null`.
+pub fn parseClaudeIdentity(allocator: std.mem.Allocator, raw: []const u8) !ClaudeIdentity {
+    const trimmed = std.mem.trim(u8, raw, " \t\r\n");
+    if (trimmed.len == 0) return .{ .present = false, .reason = "input_empty" };
+
+    const parsed = std.json.parseFromSlice(RootJson, allocator, raw, .{
+        .ignore_unknown_fields = true,
+    }) catch |e| switch (e) {
+        // A transient allocator failure must not masquerade as malformed input
+        // (never-halt callers retry OOM, but treat json_invalid as terminal).
+        error.OutOfMemory => return e,
+        else => return .{ .present = false, .reason = "json_invalid" },
+    };
+    defer parsed.deinit();
+
+    const oauth = parsed.value.oauthAccount orelse
+        return .{ .present = false, .reason = "oauth_account_missing" };
+    const acct_uuid = nonEmpty(oauth.accountUuid) orelse
+        return .{ .present = false, .reason = "account_uuid_missing" };
+
+    var result = ClaudeIdentity{
+        .present = true,
+        .reason = "identity_present",
+        .account_id_source = account_id_source_label,
+    };
+    errdefer result.deinit(allocator);
+
+    result.account_id_hash = try sha256_12hex(allocator, acct_uuid);
+    if (nonEmpty(oauth.organizationUuid)) |org_uuid| {
+        result.org_id_hash = try sha256_12hex(allocator, org_uuid);
+    }
+    if (nonEmpty(oauth.organizationName)) |org_name| {
+        result.org_display = try allocator.dupe(u8, org_name);
+    }
+    if (nonEmpty(oauth.emailAddress)) |email| {
+        result.email_hint = try maskEmail(allocator, email);
+    }
+    result.stable_label = try buildStableLabel(allocator, result.account_id_hash.?, result.org_id_hash);
+
+    return result;
+}

--- a/src/identity/claude_identity_tests.zig
+++ b/src/identity/claude_identity_tests.zig
@@ -1,0 +1,213 @@
+//! Unit tests for the Claude stable-identity labeler. Pure: synthetic profiles
+//! inline (no real PII, no fixtures), no I/O.
+//!
+//!     zig test src/identity/claude_identity_tests.zig
+
+const std = @import("std");
+const testing = std.testing;
+const ci = @import("claude_identity.zig");
+
+test {
+    std.testing.refAllDeclsRecursive(ci);
+}
+
+// sha256_12hex of the empty string — must NEVER be emitted as any identity hash
+// (emitting it would coalesce all profile-less / no-org accounts into one).
+const empty_hash = "e3b0c44298fc";
+
+// A synthetic full profile. All UUIDs/email are fake — this file lives under
+// src/ (not scanned) and carries no real PII or tokens.
+const full_profile =
+    \\{
+    \\  "userID": "0000000000000000000000000000000000000000000000000000000000000000",
+    \\  "oauthAccount": {
+    \\    "accountUuid": "11111111-2222-3333-4444-555555555555",
+    \\    "organizationUuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    \\    "organizationName": "Acme Robotics",
+    \\    "emailAddress": "jess@example.com",
+    \\    "billingType": "subscription"
+    \\  }
+    \\}
+;
+
+// ── Happy path ──────────────────────────────────────────────────────────────
+
+test "parse a full profile: present, hashed identity, masked email, org display" {
+    const a = testing.allocator;
+    const id = try ci.parseClaudeIdentity(a, full_profile);
+    defer id.deinit(a);
+
+    try testing.expect(id.present);
+    try testing.expectEqualStrings("identity_present", id.reason);
+    try testing.expectEqualStrings("oauthAccount.accountUuid", id.account_id_source.?);
+
+    try testing.expectEqual(@as(usize, 12), id.account_id_hash.?.len);
+    try testing.expectEqual(@as(usize, 12), id.org_id_hash.?.len);
+    // stable label = claude:<org12>:<acct12>
+    var buf: [64]u8 = undefined;
+    const want = try std.fmt.bufPrint(&buf, "claude:{s}:{s}", .{ id.org_id_hash.?, id.account_id_hash.? });
+    try testing.expectEqualStrings(want, id.stable_label.?);
+    // masked email, raw local part gone
+    try testing.expectEqualStrings("j***@example.com", id.email_hint.?);
+    try testing.expectEqualStrings("Acme Robotics", id.org_display.?);
+}
+
+test "golden vector: sha256_12hex matches the Codex shortSha256HexAlloc" {
+    // Codex golden (main.zig:791): sha256_12hex("acct-test") == "660d25a9d7ee".
+    // Feed accountUuid="acct-test" and assert the produced hash matches.
+    const a = testing.allocator;
+    const id = try ci.parseClaudeIdentity(a,
+        \\{"oauthAccount":{"accountUuid":"acct-test"}}
+    );
+    defer id.deinit(a);
+    try testing.expectEqualStrings("660d25a9d7ee", id.account_id_hash.?);
+}
+
+// ── Redaction ───────────────────────────────────────────────────────────────
+
+test "redaction: no raw uuid or email local-part in label/hint" {
+    const a = testing.allocator;
+    const id = try ci.parseClaudeIdentity(a, full_profile);
+    defer id.deinit(a);
+
+    // raw account/org UUID segments never appear in the label
+    try testing.expect(std.mem.indexOf(u8, id.stable_label.?, "11111111") == null);
+    try testing.expect(std.mem.indexOf(u8, id.stable_label.?, "aaaaaaaa") == null);
+    // raw email local part never appears in the hint
+    try testing.expect(std.mem.indexOf(u8, id.email_hint.?, "jess") == null);
+}
+
+test "redaction: a non-ASCII email local part is masked whole and stays valid UTF-8" {
+    const a = testing.allocator;
+    // "école@example.com" — é is the 2-byte UTF-8 sequence \xc3\xa9. A `{c}` hint
+    // would emit only the lead byte \xc3 → invalid UTF-8; the whole local must be
+    // masked instead.
+    const id = try ci.parseClaudeIdentity(a,
+        "{\"oauthAccount\":{\"accountUuid\":\"u-1\",\"emailAddress\":\"\xc3\xa9cole@example.com\"}}");
+    defer id.deinit(a);
+    try testing.expect(id.present);
+    try testing.expectEqualStrings("***@example.com", id.email_hint.?);
+    try testing.expect(std.unicode.utf8ValidateSlice(id.email_hint.?)); // never invalid UTF-8
+    try testing.expect(std.mem.indexOf(u8, id.email_hint.?, "cole") == null); // local not leaked
+}
+
+// ── Stability + uniqueness ──────────────────────────────────────────────────
+
+test "stability: same profile yields an identical hash + label" {
+    const a = testing.allocator;
+    const id1 = try ci.parseClaudeIdentity(a, full_profile);
+    defer id1.deinit(a);
+    const id2 = try ci.parseClaudeIdentity(a, full_profile);
+    defer id2.deinit(a);
+    try testing.expectEqualStrings(id1.account_id_hash.?, id2.account_id_hash.?);
+    try testing.expectEqualStrings(id1.stable_label.?, id2.stable_label.?);
+}
+
+test "uniqueness: distinct accountUuids yield distinct hashes" {
+    const a = testing.allocator;
+    const id1 = try ci.parseClaudeIdentity(a,
+        \\{"oauthAccount":{"accountUuid":"account-one"}}
+    );
+    defer id1.deinit(a);
+    const id2 = try ci.parseClaudeIdentity(a,
+        \\{"oauthAccount":{"accountUuid":"account-two"}}
+    );
+    defer id2.deinit(a);
+    try testing.expect(!std.mem.eql(u8, id1.account_id_hash.?, id2.account_id_hash.?));
+}
+
+// ── No-org (personal) ───────────────────────────────────────────────────────
+
+test "no-org account: org_id_hash is null (NOT a hash of empty), label uses noorg" {
+    const a = testing.allocator;
+    const id = try ci.parseClaudeIdentity(a,
+        \\{"oauthAccount":{"accountUuid":"solo-account","emailAddress":"a@b.com"}}
+    );
+    defer id.deinit(a);
+    try testing.expect(id.present);
+    try testing.expect(id.org_id_hash == null); // never sha256_12hex("")
+    try testing.expect(id.org_display == null);
+    var buf: [48]u8 = undefined;
+    const want = try std.fmt.bufPrint(&buf, "claude:noorg:{s}", .{id.account_id_hash.?});
+    try testing.expectEqualStrings(want, id.stable_label.?);
+}
+
+// ── The empty-string-hash coalescing guard (verify correction #5) ───────────
+
+test "no identity hash is ever the hash of the empty string" {
+    const a = testing.allocator;
+    // a profile with an empty-string org and a real account
+    const id = try ci.parseClaudeIdentity(a,
+        \\{"oauthAccount":{"accountUuid":"x","organizationUuid":"","organizationName":""}}
+    );
+    defer id.deinit(a);
+    try testing.expect(id.account_id_hash == null or !std.mem.eql(u8, id.account_id_hash.?, empty_hash));
+    try testing.expect(id.org_id_hash == null); // empty org => null, never empty_hash
+    try testing.expect(id.org_display == null); // empty name => null
+}
+
+// ── Fail-safe branches (never crash; present=false; hash=null) ──────────────
+
+test "fail-safe: empty input => input_empty, unknown identity" {
+    const a = testing.allocator;
+    for ([_][]const u8{ "", "   \n\t " }) |raw| {
+        const id = try ci.parseClaudeIdentity(a, raw);
+        defer id.deinit(a);
+        try testing.expect(!id.present);
+        try testing.expectEqualStrings("input_empty", id.reason);
+        try testing.expect(id.account_id_hash == null);
+    }
+}
+
+test "fail-safe: malformed JSON => json_invalid" {
+    const a = testing.allocator;
+    const id = try ci.parseClaudeIdentity(a, "{ not json");
+    defer id.deinit(a);
+    try testing.expect(!id.present);
+    try testing.expectEqualStrings("json_invalid", id.reason);
+    try testing.expect(id.account_id_hash == null);
+}
+
+test "fail-safe: JSON null literal never crashes, returns unknown (reason pinned)" {
+    const a = testing.allocator;
+    const id = try ci.parseClaudeIdentity(a, "null");
+    defer id.deinit(a);
+    try testing.expect(!id.present);
+    try testing.expect(id.account_id_hash == null);
+    // Pin the classification so a std.json version bump can't silently change it.
+    // (json `null` into a struct-typed parse is a parse error in 0.14.1 => json_invalid.)
+    try testing.expectEqualStrings("json_invalid", id.reason);
+}
+
+test "fail-safe: no oauthAccount => oauth_account_missing" {
+    const a = testing.allocator;
+    const id = try ci.parseClaudeIdentity(a,
+        \\{"userID":"abc","projects":{}}
+    );
+    defer id.deinit(a);
+    try testing.expect(!id.present);
+    try testing.expectEqualStrings("oauth_account_missing", id.reason);
+    try testing.expect(id.account_id_hash == null);
+}
+
+test "fail-safe: oauthAccount without accountUuid => account_uuid_missing" {
+    const a = testing.allocator;
+    const id = try ci.parseClaudeIdentity(a,
+        \\{"oauthAccount":{"organizationUuid":"o","emailAddress":"a@b.com"}}
+    );
+    defer id.deinit(a);
+    try testing.expect(!id.present);
+    try testing.expectEqualStrings("account_uuid_missing", id.reason);
+    try testing.expect(id.account_id_hash == null);
+}
+
+test "fail-safe: empty accountUuid string => account_uuid_missing (not empty hash)" {
+    const a = testing.allocator;
+    const id = try ci.parseClaudeIdentity(a,
+        \\{"oauthAccount":{"accountUuid":""}}
+    );
+    defer id.deinit(a);
+    try testing.expect(!id.present);
+    try testing.expectEqualStrings("account_uuid_missing", id.reason);
+    try testing.expect(id.account_id_hash == null);
+}

--- a/src/identity/identity_graph.zig
+++ b/src/identity/identity_graph.zig
@@ -1,0 +1,363 @@
+//! Identity graph — greenfield, provider-agnostic read-only ANALYSIS over the
+//! account inventory (TIN-1822 / A.6). It answers the questions the mux needs to
+//! keep its never-halt promise honest:
+//!
+//!   * Which config slots are actually the SAME underlying account? (group by
+//!     `account_id_hash` = sha256_12hex of the provider's account-id claim).
+//!   * What is the TRUE redundancy depth for a capability — counting DISTINCT
+//!     LIVE identities, not slots — so a duplicate slot is never mistaken for
+//!     real failover (the max-2==max-1 trap).
+//!   * Is a capability still afloat? (>=1 distinct live identity remains.)
+//!   * Is retiring a slot safe, per capability? Is re-authing a dead slot a
+//!     STRICT-LOSS operation (it shares an identity with a live sibling, so a
+//!     re-login would revoke the live one)?
+//!
+//! NORTH STAR (never-halt): one dead / duplicate / rate-limited / quota-exhausted
+//! account must NEVER halt the mux. `afloat` is defined over the SET of distinct
+//! live identities, so a non-live slot contributes 0 and can never remove a member
+//! another live slot put there. The ONLY false case is every distinct identity
+//! down. This module makes that depth visible; it is the analysis the keepalive
+//! escalation and the operator diagnostics consume.
+//!
+//! SCOPE / NO-CLOBBER: this is pure analysis. Route SELECTION lives in
+//! `src/pipeline.zig` (`selectWithFallback` + the health-store `muxDecisionFor`)
+//! and is NOT touched or reimplemented here. The graph only reads account records
+//! the caller fills from `accounts list` evidence and returns verdicts.
+//!
+//! Self-contained: `std` only, NO `@import` of existing `src`; pure data functions
+//! (no I/O, no seams). Liveness classes mirror the repo's `CredentialLiveness`
+//! (`types.zig`): `.live.{available,rate_limited,quota_exhausted,cooldown}`,
+//! `.degraded:*`, `.dead:*`. Allocation-explicit; `std.testing.allocator`-clean.
+
+const std = @import("std");
+
+// ── Liveness (mirrors types.zig CredentialLiveness summary classes) ──────────
+
+/// The liveness of one (account, capability) route. Only `.live` (i.e. the repo's
+/// `.live.available`) counts toward redundancy depth / afloat. `rate_limited`,
+/// `quota_exhausted`, `cooldown` are the repo's other `.live.*` arms — the account
+/// is alive but transiently unusable (recoverable; wait, don't escalate).
+/// `degraded` is a `.degraded:*` reason (tier/scope/schema — needs intervention,
+/// not auto-recovering, but not dead). `dead` is a `.dead:*` reason (needs reauth).
+pub const Liveness = enum {
+    live,
+    rate_limited,
+    quota_exhausted,
+    cooldown,
+    degraded,
+    dead,
+    unknown,
+
+    /// Counts toward redundancy depth / afloat — usable right now.
+    pub fn countsAfloat(self: Liveness) bool {
+        return self == .live;
+    }
+
+    /// Alive but transiently unusable — will return on its own; do not escalate.
+    pub fn isRecoverable(self: Liveness) bool {
+        return self == .rate_limited or self == .quota_exhausted or self == .cooldown;
+    }
+
+    pub fn isDead(self: Liveness) bool {
+        return self == .dead;
+    }
+};
+
+// ── Identity key (verify fix #1: null hash => per-slot-unique opaque key) ─────
+
+/// The real underlying identity of a slot. A non-null `account_id_hash` groups
+/// slots that are the SAME account. A null hash (identity unknown — e.g. a codex
+/// account whose auth.json is unavailable) is keyed by the per-slot-unique
+/// (provider, account) tuple, so two UNKNOWN identities are NEVER coalesced into
+/// one, and one real account's capability rows (same provider+account) DO group.
+pub const IdentityKey = union(enum) {
+    hash: []const u8,
+    opaque_slot: struct { provider: []const u8, account: []const u8 },
+
+    pub fn eql(a: IdentityKey, b: IdentityKey) bool {
+        return switch (a) {
+            .hash => |ah| switch (b) {
+                .hash => |bh| std.mem.eql(u8, ah, bh),
+                .opaque_slot => false,
+            },
+            .opaque_slot => |ao| switch (b) {
+                .hash => false,
+                .opaque_slot => |bo| std.mem.eql(u8, ao.provider, bo.provider) and
+                    std.mem.eql(u8, ao.account, bo.account),
+            },
+        };
+    }
+};
+
+// ── Account slot (one (account, capability) route) ───────────────────────────
+
+/// One route row, as the caller flattens it from `accounts list` (an account with
+/// N capabilities → N slots). All slices are borrowed; the input must outlive any
+/// returned analysis (collisions/strict-loss/retire results borrow these strings).
+pub const AccountSlot = struct {
+    /// Config slot name, e.g. "max-2". The caller guarantees (provider, account)
+    /// is unique per real slot (asserted in debug for the unknown-identity case).
+    account: []const u8,
+    provider: []const u8, // "codex" / "claude" / …
+    capability: []const u8, // "codex-max" / "codex-mini" / "auth-status" / …
+    /// sha256_12hex of the provider account-id claim; null = identity unknown.
+    account_id_hash: ?[]const u8 = null,
+    email_hint: ?[]const u8 = null,
+    liveness: Liveness,
+    /// false when the identity cannot be re-authed (e.g. AAS phone-OTP lockout,
+    /// openai/codex#25737) — surfaced on strict-loss/collision for escalation.
+    reauthable: bool = true,
+
+    pub fn identityKey(self: AccountSlot) IdentityKey {
+        if (self.account_id_hash) |h| return .{ .hash = h };
+        return .{ .opaque_slot = .{ .provider = self.provider, .account = self.account } };
+    }
+};
+
+fn matchesPC(s: AccountSlot, provider: []const u8, capability: []const u8) bool {
+    return std.mem.eql(u8, s.provider, provider) and std.mem.eql(u8, s.capability, capability);
+}
+
+// ── Core redundancy math (allocation-free) ───────────────────────────────────
+
+/// Count DISTINCT live identities for (provider, capability), optionally excluding
+/// one account (for retire-safety). First-occurrence dedup by `IdentityKey`.
+fn countDistinctLive(
+    slots: []const AccountSlot,
+    provider: []const u8,
+    capability: []const u8,
+    exclude_account: ?[]const u8,
+) usize {
+    var count: usize = 0;
+    for (slots, 0..) |s, i| {
+        if (!matchesPC(s, provider, capability)) continue;
+        if (!s.liveness.countsAfloat()) continue;
+        if (exclude_account) |ex| {
+            if (std.mem.eql(u8, s.account, ex)) continue;
+        }
+        var dup = false;
+        var j: usize = 0;
+        while (j < i) : (j += 1) {
+            const t = slots[j];
+            if (!matchesPC(t, provider, capability)) continue;
+            if (!t.liveness.countsAfloat()) continue;
+            if (exclude_account) |ex| {
+                if (std.mem.eql(u8, t.account, ex)) continue;
+            }
+            if (s.identityKey().eql(t.identityKey())) {
+                dup = true;
+                break;
+            }
+        }
+        if (!dup) count += 1;
+    }
+    return count;
+}
+
+/// The TRUE redundancy depth: how many distinct live identities serve this
+/// (provider, capability). Duplicate slots of one identity count once.
+pub fn distinctLiveIdentities(slots: []const AccountSlot, provider: []const u8, capability: []const u8) usize {
+    return countDistinctLive(slots, provider, capability, null);
+}
+
+/// The never-halt predicate: a capability is afloat iff >=1 distinct live identity
+/// remains. A dead/duplicate/rate-limited/quota slot can never flip this false on
+/// its own.
+pub fn isAfloat(slots: []const AccountSlot, provider: []const u8, capability: []const u8) bool {
+    return distinctLiveIdentities(slots, provider, capability) >= 1;
+}
+
+/// What the keepalive should do for a (provider, capability) — separates "wait"
+/// (recoverable) from "escalate" (needs reauth/probe), so a transient blip is
+/// never escalated as a death and a real death is never silently waited on.
+pub const Disposition = enum {
+    afloat, // >=1 live identity — usable now
+    recoverable_only, // 0 live, >=1 recoverable (rate/quota/cooldown) — WAIT
+    needs_intervention, // 0 live, 0 recoverable, >=1 dead/degraded/unknown — ESCALATE
+    empty, // no slots for this (provider, capability)
+};
+
+pub fn disposition(slots: []const AccountSlot, provider: []const u8, capability: []const u8) Disposition {
+    var any = false;
+    var any_recoverable = false;
+    for (slots) |s| {
+        if (!matchesPC(s, provider, capability)) continue;
+        any = true;
+        if (s.liveness.countsAfloat()) return .afloat;
+        if (s.liveness.isRecoverable()) any_recoverable = true;
+    }
+    if (!any) return .empty;
+    return if (any_recoverable) .recoverable_only else .needs_intervention;
+}
+
+// ── Duplicate-enrollment collisions ──────────────────────────────────────────
+
+/// An identity enrolled into >=2 distinct config slots — i.e. apparent redundancy
+/// that is not real. `accounts` are the distinct slot names (borrowed). Free with
+/// `freeCollisions`.
+pub const Collision = struct {
+    identity: IdentityKey,
+    accounts: [][]const u8,
+    has_live_slot: bool, // at least one slot of this identity is live somewhere
+    any_unreauthable: bool, // at least one slot of this identity is un-reauthable
+};
+
+pub fn duplicateCollisions(allocator: std.mem.Allocator, slots: []const AccountSlot) ![]Collision {
+    var list = std.ArrayList(Collision).init(allocator);
+    errdefer {
+        for (list.items) |c| allocator.free(c.accounts);
+        list.deinit();
+    }
+
+    for (slots, 0..) |s, i| {
+        // process each identity once (at its first-occurrence slot)
+        var first = true;
+        var j: usize = 0;
+        while (j < i) : (j += 1) {
+            if (s.identityKey().eql(slots[j].identityKey())) {
+                first = false;
+                break;
+            }
+        }
+        if (!first) continue;
+
+        const key = s.identityKey();
+        var accts = std.ArrayList([]const u8).init(allocator);
+        errdefer accts.deinit();
+        var has_live = false;
+        var any_unreauth = false;
+        for (slots) |t| {
+            if (!key.eql(t.identityKey())) continue;
+            if (t.liveness.countsAfloat()) has_live = true;
+            if (!t.reauthable) any_unreauth = true;
+            var dup = false;
+            for (accts.items) |a| {
+                if (std.mem.eql(u8, a, t.account)) {
+                    dup = true;
+                    break;
+                }
+            }
+            if (!dup) try accts.append(t.account);
+        }
+
+        if (accts.items.len >= 2) {
+            try list.append(.{
+                .identity = key,
+                .accounts = try accts.toOwnedSlice(),
+                .has_live_slot = has_live,
+                .any_unreauthable = any_unreauth,
+            });
+        } else {
+            accts.deinit();
+        }
+    }
+
+    return list.toOwnedSlice();
+}
+
+pub fn freeCollisions(allocator: std.mem.Allocator, collisions: []Collision) void {
+    for (collisions) |c| allocator.free(c.accounts);
+    allocator.free(collisions);
+}
+
+// ── Strict-loss-to-reauth (verify fix #2: per-capability) ────────────────────
+
+/// A non-live slot whose identity is ALSO live (for the same capability) via a
+/// sibling slot — so re-authing it would revoke the live sibling's tokens. One
+/// entry per (slot, capability). Advisory only — pure metadata, never mutates.
+pub const StrictLossSlot = struct {
+    account: []const u8,
+    provider: []const u8,
+    capability: []const u8,
+    live_sibling: []const u8, // the slot whose tokens a reauth would revoke
+    identity_unreauthable: bool, // the shared identity also can't be re-authed (#25737)
+};
+
+pub fn strictLossSlots(allocator: std.mem.Allocator, slots: []const AccountSlot) ![]StrictLossSlot {
+    var list = std.ArrayList(StrictLossSlot).init(allocator);
+    errdefer list.deinit();
+
+    for (slots, 0..) |s, i| {
+        if (s.liveness.countsAfloat()) continue; // strict-loss applies to NON-live slots
+        for (slots, 0..) |t, j| {
+            if (i == j) continue;
+            if (!matchesPC(t, s.provider, s.capability)) continue;
+            if (!t.liveness.countsAfloat()) continue;
+            if (!s.identityKey().eql(t.identityKey())) continue;
+            try list.append(.{
+                .account = s.account,
+                .provider = s.provider,
+                .capability = s.capability,
+                .live_sibling = t.account,
+                .identity_unreauthable = !s.reauthable or !t.reauthable,
+            });
+            break; // one live sibling is enough
+        }
+    }
+
+    return list.toOwnedSlice();
+}
+
+// ── Retire-safety (verify fix #3: per-capability delta) ──────────────────────
+
+pub const CapabilityDelta = struct {
+    capability: []const u8,
+    distinct_live_before: usize,
+    distinct_live_after: usize,
+    flips_afloat: bool, // before >= 1 and after == 0
+};
+
+/// The per-capability effect of removing (provider, account) from the inventory.
+/// `overall_safe` is true iff no capability is flipped from afloat to not-afloat.
+/// Free with `freeRetireSafety`.
+pub const RetireSafety = struct {
+    overall_safe: bool,
+    per_capability: []CapabilityDelta,
+};
+
+pub fn wouldRetireReduceRedundancy(
+    allocator: std.mem.Allocator,
+    slots: []const AccountSlot,
+    retire_provider: []const u8,
+    retire_account: []const u8,
+) !RetireSafety {
+    var list = std.ArrayList(CapabilityDelta).init(allocator);
+    errdefer list.deinit();
+    var overall_safe = true;
+
+    for (slots, 0..) |s, i| {
+        if (!std.mem.eql(u8, s.provider, retire_provider)) continue;
+        if (!std.mem.eql(u8, s.account, retire_account)) continue;
+        // each capability of the retire account once
+        var seen = false;
+        var j: usize = 0;
+        while (j < i) : (j += 1) {
+            const t = slots[j];
+            if (std.mem.eql(u8, t.provider, retire_provider) and
+                std.mem.eql(u8, t.account, retire_account) and
+                std.mem.eql(u8, t.capability, s.capability))
+            {
+                seen = true;
+                break;
+            }
+        }
+        if (seen) continue;
+
+        const before = countDistinctLive(slots, retire_provider, s.capability, null);
+        const after = countDistinctLive(slots, retire_provider, s.capability, retire_account);
+        const flips = before >= 1 and after == 0;
+        if (flips) overall_safe = false;
+        try list.append(.{
+            .capability = s.capability,
+            .distinct_live_before = before,
+            .distinct_live_after = after,
+            .flips_afloat = flips,
+        });
+    }
+
+    return .{ .overall_safe = overall_safe, .per_capability = try list.toOwnedSlice() };
+}
+
+pub fn freeRetireSafety(allocator: std.mem.Allocator, rs: RetireSafety) void {
+    allocator.free(rs.per_capability);
+}

--- a/src/identity/identity_graph_tests.zig
+++ b/src/identity/identity_graph_tests.zig
@@ -1,0 +1,242 @@
+//! Unit tests for the identity graph. Pure: in-memory account inventories, no I/O.
+//! Proves the six never-halt invariants + the real ground-truth inventory.
+//!
+//!     zig test src/identity/identity_graph_tests.zig
+
+const std = @import("std");
+const testing = std.testing;
+const ig = @import("identity_graph.zig");
+
+test {
+    std.testing.refAllDeclsRecursive(ig);
+}
+
+const Slot = ig.AccountSlot;
+
+// ── The real inventory (oauth-mux accounts list, 2026-06-01) as the ground truth ──
+// max-1 == max-2 (same hash 38079d6acec6, the AAS-locked sulliwood.org account);
+// max-3 (columbari.us) is distinct; claude personal is keychain (null hash).
+const real_inventory = [_]Slot{
+    .{ .account = "max-1", .provider = "codex", .capability = "codex-max", .account_id_hash = "38079d6acec6", .liveness = .live, .reauthable = false },
+    .{ .account = "max-1", .provider = "codex", .capability = "codex-mini", .account_id_hash = "38079d6acec6", .liveness = .live, .reauthable = false },
+    .{ .account = "max-2", .provider = "codex", .capability = "codex-max", .account_id_hash = "38079d6acec6", .liveness = .dead, .reauthable = false },
+    .{ .account = "max-2", .provider = "codex", .capability = "codex-mini", .account_id_hash = "38079d6acec6", .liveness = .dead, .reauthable = false },
+    .{ .account = "max-3", .provider = "codex", .capability = "codex-max", .account_id_hash = "c0dfbc44912c", .liveness = .degraded, .reauthable = true },
+    .{ .account = "max-3", .provider = "codex", .capability = "codex-mini", .account_id_hash = "c0dfbc44912c", .liveness = .live, .reauthable = true },
+    .{ .account = "personal", .provider = "claude", .capability = "auth-status", .account_id_hash = null, .liveness = .live, .reauthable = true },
+};
+
+// ── IdentityKey ──────────────────────────────────────────────────────────────
+
+test "IdentityKey: hash equality, opaque tuple equality, hash != opaque" {
+    const h1 = ig.IdentityKey{ .hash = "abc" };
+    const h1b = ig.IdentityKey{ .hash = "abc" };
+    const h2 = ig.IdentityKey{ .hash = "xyz" };
+    try testing.expect(h1.eql(h1b));
+    try testing.expect(!h1.eql(h2));
+
+    const o1 = ig.IdentityKey{ .opaque_slot = .{ .provider = "codex", .account = "default" } };
+    const o1b = ig.IdentityKey{ .opaque_slot = .{ .provider = "codex", .account = "default" } };
+    const o2 = ig.IdentityKey{ .opaque_slot = .{ .provider = "gemini", .account = "default" } };
+    try testing.expect(o1.eql(o1b));
+    try testing.expect(!o1.eql(o2)); // different provider, same name => distinct
+    try testing.expect(!h1.eql(o1)); // a hash key never equals an opaque key
+}
+
+// ── Core redundancy math + INV-IDENTITIES-NOT-SLOTS + INV-PER-CAPABILITY ──────
+
+test "distinctLiveIdentities counts identities not slots, per capability (real inventory)" {
+    const inv = &real_inventory;
+    // codex-max: only max-1 is live (max-2 dead, max-3 degraded) => 1
+    try testing.expectEqual(@as(usize, 1), ig.distinctLiveIdentities(inv, "codex", "codex-max"));
+    // codex-mini: max-1 + max-3 live (max-2 dead) => 2 distinct identities
+    try testing.expectEqual(@as(usize, 2), ig.distinctLiveIdentities(inv, "codex", "codex-mini"));
+    // claude auth-status: 1
+    try testing.expectEqual(@as(usize, 1), ig.distinctLiveIdentities(inv, "claude", "auth-status"));
+}
+
+test "INV-IDENTITIES-NOT-SLOTS: two live slots of the SAME identity count as 1" {
+    const slots = [_]Slot{
+        .{ .account = "max-1", .provider = "codex", .capability = "codex-max", .account_id_hash = "dup", .liveness = .live },
+        .{ .account = "max-2", .provider = "codex", .capability = "codex-max", .account_id_hash = "dup", .liveness = .live },
+    };
+    try testing.expectEqual(@as(usize, 1), ig.distinctLiveIdentities(&slots, "codex", "codex-max"));
+}
+
+test "isAfloat true on the real inventory for served capabilities" {
+    const inv = &real_inventory;
+    try testing.expect(ig.isAfloat(inv, "codex", "codex-max"));
+    try testing.expect(ig.isAfloat(inv, "codex", "codex-mini"));
+    try testing.expect(ig.isAfloat(inv, "claude", "auth-status"));
+}
+
+// ── INV-AFLOAT-MONOTONE-UNDER-NONLIVE ────────────────────────────────────────
+
+test "INV-AFLOAT-MONOTONE: non-live slots never flip a live capability to not-afloat" {
+    // one live identity, surrounded by dead/rate-limited/quota/degraded of OTHER identities
+    const slots = [_]Slot{
+        .{ .account = "live", .provider = "codex", .capability = "codex-max", .account_id_hash = "A", .liveness = .live },
+        .{ .account = "d1", .provider = "codex", .capability = "codex-max", .account_id_hash = "B", .liveness = .dead },
+        .{ .account = "r1", .provider = "codex", .capability = "codex-max", .account_id_hash = "C", .liveness = .rate_limited },
+        .{ .account = "q1", .provider = "codex", .capability = "codex-max", .account_id_hash = "D", .liveness = .quota_exhausted },
+        .{ .account = "g1", .provider = "codex", .capability = "codex-max", .account_id_hash = "E", .liveness = .degraded },
+    };
+    try testing.expect(ig.isAfloat(&slots, "codex", "codex-max"));
+    try testing.expectEqual(@as(usize, 1), ig.distinctLiveIdentities(&slots, "codex", "codex-max"));
+    try testing.expectEqual(ig.Disposition.afloat, ig.disposition(&slots, "codex", "codex-max"));
+}
+
+// ── Disposition: wait vs escalate (never-halt nuance) ────────────────────────
+
+test "disposition: recoverable_only => WAIT, never escalate a transient blip" {
+    const slots = [_]Slot{
+        .{ .account = "a", .provider = "codex", .capability = "codex-max", .account_id_hash = "A", .liveness = .rate_limited },
+        .{ .account = "b", .provider = "codex", .capability = "codex-max", .account_id_hash = "B", .liveness = .quota_exhausted },
+    };
+    try testing.expect(!ig.isAfloat(&slots, "codex", "codex-max"));
+    try testing.expectEqual(ig.Disposition.recoverable_only, ig.disposition(&slots, "codex", "codex-max"));
+}
+
+test "disposition: all dead => needs_intervention (the only escalate case)" {
+    const slots = [_]Slot{
+        .{ .account = "a", .provider = "codex", .capability = "codex-max", .account_id_hash = "A", .liveness = .dead },
+        .{ .account = "b", .provider = "codex", .capability = "codex-max", .account_id_hash = "B", .liveness = .degraded },
+    };
+    try testing.expect(!ig.isAfloat(&slots, "codex", "codex-max"));
+    try testing.expectEqual(ig.Disposition.needs_intervention, ig.disposition(&slots, "codex", "codex-max"));
+}
+
+test "disposition: empty for an unknown capability" {
+    const inv = &real_inventory;
+    try testing.expectEqual(ig.Disposition.empty, ig.disposition(inv, "codex", "no-such-capability"));
+}
+
+// ── INV-CROSS-PROVIDER-ISOLATION ─────────────────────────────────────────────
+
+test "INV-CROSS-PROVIDER: total codex outage leaves claude afloat" {
+    const slots = [_]Slot{
+        .{ .account = "max-1", .provider = "codex", .capability = "codex-max", .account_id_hash = "A", .liveness = .dead },
+        .{ .account = "max-3", .provider = "codex", .capability = "codex-max", .account_id_hash = "B", .liveness = .dead },
+        .{ .account = "personal", .provider = "claude", .capability = "auth-status", .account_id_hash = null, .liveness = .live },
+    };
+    try testing.expect(!ig.isAfloat(&slots, "codex", "codex-max"));
+    try testing.expect(ig.isAfloat(&slots, "claude", "auth-status")); // unaffected
+}
+
+// ── Duplicate collisions (the max-2==max-1 auto-detector) ────────────────────
+
+test "duplicateCollisions flags max-1/max-2 as the same identity, with no false positives" {
+    const a = testing.allocator;
+    const inv = &real_inventory;
+    const cols = try ig.duplicateCollisions(a, inv);
+    defer ig.freeCollisions(a, cols);
+
+    try testing.expectEqual(@as(usize, 1), cols.len); // only the sulliwood duplicate
+    const c = cols[0];
+    try testing.expect(c.identity.eql(.{ .hash = "38079d6acec6" }));
+    try testing.expectEqual(@as(usize, 2), c.accounts.len); // max-1, max-2
+    try testing.expect(c.has_live_slot); // max-1 is live
+    try testing.expect(c.any_unreauthable); // AAS-locked (#25737)
+}
+
+test "duplicateCollisions: two distinct unknown identities are NOT coalesced (null-key safety)" {
+    const a = testing.allocator;
+    // two different accounts, both null hash, same provider — must NOT collide
+    const slots = [_]Slot{
+        .{ .account = "default", .provider = "codex", .capability = "codex-mini", .account_id_hash = null, .liveness = .live },
+        .{ .account = "other", .provider = "codex", .capability = "codex-mini", .account_id_hash = null, .liveness = .live },
+    };
+    const cols = try ig.duplicateCollisions(a, &slots);
+    defer ig.freeCollisions(a, cols);
+    try testing.expectEqual(@as(usize, 0), cols.len);
+    // and they count as 2 distinct live identities, not coalesced to 1
+    try testing.expectEqual(@as(usize, 2), ig.distinctLiveIdentities(&slots, "codex", "codex-mini"));
+}
+
+test "an unknown account's capability rows DO group as one identity" {
+    const slots = [_]Slot{
+        .{ .account = "default", .provider = "codex", .capability = "codex-max", .account_id_hash = null, .liveness = .live },
+        .{ .account = "default", .provider = "codex", .capability = "codex-mini", .account_id_hash = null, .liveness = .live },
+    };
+    // same (provider, account) => same opaque identity; one live identity per capability
+    try testing.expectEqual(@as(usize, 1), ig.distinctLiveIdentities(&slots, "codex", "codex-max"));
+    try testing.expectEqual(@as(usize, 1), ig.distinctLiveIdentities(&slots, "codex", "codex-mini"));
+}
+
+// ── INV-STRICT-LOSS (per-capability, verify fix #2) ──────────────────────────
+
+test "strictLossSlots: max-2 is strict-loss for BOTH capabilities; max-3 for none" {
+    const a = testing.allocator;
+    const inv = &real_inventory;
+    const sl = try ig.strictLossSlots(a, inv);
+    defer a.free(sl);
+
+    try testing.expectEqual(@as(usize, 2), sl.len); // max-2 codex-max + max-2 codex-mini
+    for (sl) |entry| {
+        try testing.expectEqualStrings("max-2", entry.account);
+        try testing.expectEqualStrings("max-1", entry.live_sibling); // reauth would revoke the live max-1
+        try testing.expect(entry.identity_unreauthable); // shared identity is AAS-locked
+    }
+    // max-3's degraded codex-max has no live same-identity sibling => not strict-loss
+    for (sl) |entry| try testing.expect(!std.mem.eql(u8, entry.account, "max-3"));
+}
+
+// ── INV-RETIRE (per-capability delta, verify fix #3) ─────────────────────────
+
+test "retire max-2 is SAFE on every capability (dead duplicate of live max-1)" {
+    const a = testing.allocator;
+    const inv = &real_inventory;
+    const rs = try ig.wouldRetireReduceRedundancy(a, inv, "codex", "max-2");
+    defer ig.freeRetireSafety(a, rs);
+
+    try testing.expect(rs.overall_safe);
+    try testing.expectEqual(@as(usize, 2), rs.per_capability.len);
+    for (rs.per_capability) |d| {
+        try testing.expect(!d.flips_afloat);
+        try testing.expectEqual(d.distinct_live_before, d.distinct_live_after); // unchanged
+    }
+}
+
+test "retire max-1 is UNSAFE for codex-max but codex-mini visibly survives (per-capability)" {
+    const a = testing.allocator;
+    const inv = &real_inventory;
+    const rs = try ig.wouldRetireReduceRedundancy(a, inv, "codex", "max-1");
+    defer ig.freeRetireSafety(a, rs);
+
+    try testing.expect(!rs.overall_safe);
+    var saw_max = false;
+    var saw_mini = false;
+    for (rs.per_capability) |d| {
+        if (std.mem.eql(u8, d.capability, "codex-max")) {
+            saw_max = true;
+            try testing.expectEqual(@as(usize, 1), d.distinct_live_before);
+            try testing.expectEqual(@as(usize, 0), d.distinct_live_after);
+            try testing.expect(d.flips_afloat); // would halt codex-max
+        } else if (std.mem.eql(u8, d.capability, "codex-mini")) {
+            saw_mini = true;
+            try testing.expectEqual(@as(usize, 2), d.distinct_live_before);
+            try testing.expectEqual(@as(usize, 1), d.distinct_live_after);
+            try testing.expect(!d.flips_afloat); // codex-mini survives — visible to the operator
+        }
+    }
+    try testing.expect(saw_max and saw_mini);
+}
+
+// ── Allocator hygiene on empty inputs ────────────────────────────────────────
+
+test "empty inventory: no collisions, no strict-loss, safe retire" {
+    const a = testing.allocator;
+    const slots = [_]Slot{};
+    const cols = try ig.duplicateCollisions(a, &slots);
+    defer ig.freeCollisions(a, cols);
+    try testing.expectEqual(@as(usize, 0), cols.len);
+
+    const sl = try ig.strictLossSlots(a, &slots);
+    defer a.free(sl);
+    try testing.expectEqual(@as(usize, 0), sl.len);
+
+    const rs = try ig.wouldRetireReduceRedundancy(a, &slots, "codex", "nope");
+    defer ig.freeRetireSafety(a, rs);
+    try testing.expect(rs.overall_safe);
+    try testing.expectEqual(@as(usize, 0), rs.per_capability.len);
+}

--- a/src/identity/identity_lane_integration_tests.zig
+++ b/src/identity/identity_lane_integration_tests.zig
@@ -1,0 +1,89 @@
+//! Integration: the Claude identity PRODUCER (`claude_identity.zig`) feeds the
+//! identity-graph CONSUMER (`identity_graph.zig`) — the producer→graph seam the
+//! two separately-parked greenfield modules never exercised together. Proves the
+//! `account_id_hash` the labeler emits is exactly what the graph groups on, so:
+//!   * two config slots backed by the SAME Claude account count as ONE distinct
+//!     live identity (the max-2 == max-1 trap the golden metric must not fall for);
+//!   * two DISTINCT accounts count as two (real failover depth);
+//!   * an unprofiled slot (no accountUuid → null hash) keys OPAQUELY and is never
+//!     coalesced with another unprofiled account (honest never-halt accounting).
+//!
+//! Borrowing discipline (per claude_identity.zig's ownership note): the graph's
+//! AccountSlot BORROWS the producer's hash, so each ClaudeIdentity outlives the
+//! slots that reference it (deinit deferred to end of test).
+
+const std = @import("std");
+const testing = std.testing;
+const ci = @import("claude_identity.zig");
+const ig = @import("identity_graph.zig");
+
+test {
+    testing.refAllDeclsRecursive(@This());
+}
+
+test "producer→graph: two slots on the SAME Claude account = ONE distinct live identity" {
+    const a = testing.allocator;
+    // One real account (accountUuid) fronted by two config slots (e.g. max-1/max-2).
+    const id = try ci.parseClaudeIdentity(a,
+        "{\"oauthAccount\":{\"accountUuid\":\"acct-shared\",\"organizationUuid\":\"org-1\"}}");
+    defer id.deinit(a);
+    try testing.expect(id.present);
+    const hash = id.account_id_hash.?;
+
+    const slots = [_]ig.AccountSlot{
+        .{ .account = "claude-a", .provider = "claude", .capability = "claude-max", .account_id_hash = hash, .liveness = .live },
+        .{ .account = "claude-b", .provider = "claude", .capability = "claude-max", .account_id_hash = hash, .liveness = .live },
+    };
+    // Two live SLOTS, but ONE distinct live IDENTITY — the duplicate is not failover.
+    try testing.expectEqual(@as(usize, 1), ig.distinctLiveIdentities(&slots, "claude", "claude-max"));
+    try testing.expect(ig.isAfloat(&slots, "claude", "claude-max"));
+}
+
+test "producer→graph: two DISTINCT Claude accounts = TWO distinct live identities" {
+    const a = testing.allocator;
+    const id1 = try ci.parseClaudeIdentity(a, "{\"oauthAccount\":{\"accountUuid\":\"acct-1\"}}");
+    defer id1.deinit(a);
+    const id2 = try ci.parseClaudeIdentity(a, "{\"oauthAccount\":{\"accountUuid\":\"acct-2\"}}");
+    defer id2.deinit(a);
+    try testing.expect(!std.mem.eql(u8, id1.account_id_hash.?, id2.account_id_hash.?));
+
+    const slots = [_]ig.AccountSlot{
+        .{ .account = "claude-a", .provider = "claude", .capability = "claude-max", .account_id_hash = id1.account_id_hash.?, .liveness = .live },
+        .{ .account = "claude-b", .provider = "claude", .capability = "claude-max", .account_id_hash = id2.account_id_hash.?, .liveness = .live },
+    };
+    try testing.expectEqual(@as(usize, 2), ig.distinctLiveIdentities(&slots, "claude", "claude-max"));
+}
+
+test "producer→graph: two unprofiled accounts key opaquely and are never coalesced" {
+    const a = testing.allocator;
+    // No accountUuid → present=false, null hash (the honest "authenticated but
+    // unprofiled" state). The graph must key each opaquely by (provider, account).
+    const id = try ci.parseClaudeIdentity(a, "{\"oauthAccount\":{}}");
+    defer id.deinit(a);
+    try testing.expect(!id.present);
+    try testing.expect(id.account_id_hash == null);
+
+    const slots = [_]ig.AccountSlot{
+        .{ .account = "claude-x", .provider = "claude", .capability = "claude-max", .account_id_hash = null, .liveness = .live },
+        .{ .account = "claude-y", .provider = "claude", .capability = "claude-max", .account_id_hash = null, .liveness = .live },
+    };
+    // Two distinct unprofiled accounts → two distinct opaque identities, NOT one
+    // coalesced hashed-empty-string identity.
+    try testing.expectEqual(@as(usize, 2), ig.distinctLiveIdentities(&slots, "claude", "claude-max"));
+}
+
+test "producer→graph: a duplicate slot does not fake failover when its twin is the only live one" {
+    const a = testing.allocator;
+    // Same account behind two slots; the second is dead. Distinct LIVE depth = 1,
+    // and re-authing the dead twin would be strict-loss (shares the live identity).
+    const id = try ci.parseClaudeIdentity(a, "{\"oauthAccount\":{\"accountUuid\":\"acct-shared\"}}");
+    defer id.deinit(a);
+    const hash = id.account_id_hash.?;
+    const slots = [_]ig.AccountSlot{
+        .{ .account = "claude-a", .provider = "claude", .capability = "claude-max", .account_id_hash = hash, .liveness = .live },
+        .{ .account = "claude-b", .provider = "claude", .capability = "claude-max", .account_id_hash = hash, .liveness = .dead },
+    };
+    // Still afloat on the one live slot; depth is 1 (the dead twin adds nothing).
+    try testing.expectEqual(@as(usize, 1), ig.distinctLiveIdentities(&slots, "claude", "claude-max"));
+    try testing.expect(ig.isAfloat(&slots, "claude", "claude-max"));
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -19748,4 +19748,7 @@ comptime {
     _ = @import("repair_state.zig");
     _ = @import("enroll/tests.zig");
     _ = @import("enroll/callback_server_tests.zig");
+    _ = @import("identity/identity_graph_tests.zig");
+    _ = @import("identity/claude_identity_tests.zig");
+    _ = @import("identity/identity_lane_integration_tests.zig");
 }


### PR DESCRIPTION
## What

The identity **producer** (`claude_identity.zig` — labels a Claude account profile to a stable, non-secret `account_id_hash`) and **consumer** (`identity_graph.zig` — counts *distinct live identities*, not slots, for afloat / retire-safety / strict-loss) shipped as new files under `src/identity/` (originally #360 and #359) but were wired into **neither** `main.zig`'s test aggregator **nor** `build.zig` — so their **31 tests never ran** under `zig build test` (vacuous CI, TIN-2053).

This PR wires all three test modules into the aggregator: suite **544 → 581**. Both cores are pure std-only (no `@import` of existing `src`), so no substrate drift.

## Why it matters

This lane is the basis of the golden metric's denominator — *count distinct live identities, not slots*. It's what stops a duplicate config slot (max-2 ≡ max-1) from being mistaken for real failover.

## Adversarial review — load-bearing claims verified under live testing
- **sha256_12hex byte-for-byte match** with on-main `src/identity_hash.zig` (the "mirrors Codex exactly" claim) — confirmed across empty / binary / golden (`"acct-test" → "660d25a9d7ee"`) inputs. No identity-coalescing divergence.
- **distinct-identity counting** dedups by `IdentityKey`; two slots sharing a hash count once, a non-live slot never adds to / removes from the live set, `.hash` can never collide with `.opaque_slot`.
- **fail-safe / never-halt**: malformed / absent-`accountUuid` input → `present=false`, `hash=null`, keyed opaquely by `(provider, account)` — no empty-string coalescing.
- **ownership / lifetime**: per-index `FailingAllocator` scan → zero leaks on every error path; `ClaudeIdentity` owns, `AccountSlot` borrows.

## Two non-blocking review findings, fixed
1. **`maskEmail` emitted invalid UTF-8** for a non-ASCII email local part (`{c}` cut a multibyte codepoint mid-sequence → mojibake / re-encode error on a JSON/MCP surface). Now masks the whole local part for a non-ASCII lead byte; ASCII keeps the `j***@domain` hint. + regression test asserting `utf8ValidateSlice`.
2. **JSON-parse OOM misclassified as `json_invalid`** → now propagated, so a never-halt caller retries the transient instead of treating it as terminal bad-data.

## Integration tests the parked modules never had
Producer→graph end-to-end: same-account-two-slots = **1** distinct live identity, two distinct accounts = **2**, two unprofiled accounts key opaquely (not coalesced), a dead duplicate twin adds **no** false failover depth.

## Test
`zig build test` → **581/581**; `zig test -OReleaseSafe` on both identity test modules clean (exercises the UTF-8 fix + allocation paths).

Supersedes #359 and #360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)