### PR TITLE
keepalive: unpark the operator status-UI server + harden (TIN-1827, TIN-2053)

### DIFF
--- a/src/keepalive/ui_server.zig
+++ b/src/keepalive/ui_server.zig
@@ -1,0 +1,296 @@
+//! Keepalive operator status UI — greenfield (TIN-1827 / ide-keepalive epic).
+//!
+//! A `127.0.0.1`-only status board that makes the warm-loop scheduler (B.1,
+//! `warm_scheduler.zig`) observable: per account, its masked label, health
+//! state, last-refresh instant, and next-refresh ETA. No actions, no spend, no
+//! secrets — a read-only window onto the keepalive pool.
+//!
+//! Same proven shape as the reauth web UI (#347) + callback server (#349):
+//!   * a PURE `routeRequest(method, target, host, seam) -> Response` core that
+//!     touches no socket — fully unit-testable with `std.testing.allocator`;
+//!   * a thin, untested-by-design listener wrapper.
+//!
+//! Security / privacy, by construction:
+//!   * Anti-DNS-rebinding: pool-bearing routes require the Host header to be
+//!     EXACTLY 127.0.0.1/localhost (optional :port); suffix bypass → 403.
+//!   * Structural redaction: the view type `AccountStatus` has NO token / no raw
+//!     account_id field, so no credential can reach the rendered output — the
+//!     seam supplies only an already-masked, non-identifying `label`. Rendered
+//!     values are HTML/JSON-escaped.
+//!
+//! Self-contained: `std` only, no `@import` of existing `src`. Feeding real
+//! scheduler state into the pool seam + wiring the listener into the daemon are
+//! coordinated follow-ups (shared files).
+
+const std = @import("std");
+
+/// Sentinel "never due" instant (matches `warm_scheduler.never`): a dead account.
+pub const never: i64 = std.math.maxInt(i64);
+
+/// Health of one account in the keepalive pool (display vocabulary).
+pub const HealthState = enum {
+    warm, // token fresh, not yet due
+    refreshing, // a refresh is in flight
+    backoff, // last refresh failed, waiting to retry
+    expired, // past expiry, needs refresh now
+    dead, // gave up (failure budget) — skipped, awaiting re-login
+    unknown,
+
+    pub fn name(self: HealthState) []const u8 {
+        return switch (self) {
+            .warm => "warm",
+            .refreshing => "refreshing",
+            .backoff => "backoff",
+            .expired => "expired",
+            .dead => "dead",
+            .unknown => "unknown",
+        };
+    }
+};
+
+/// A single, redaction-safe pool row. NOTE: deliberately no token / account_id
+/// field — the seam masks identity into `label` before it ever reaches here.
+pub const AccountStatus = struct {
+    label: []const u8, // already-masked, non-identifying (e.g. "claude · max · ****@work")
+    state: HealthState,
+    last_refresh_ms: i64,
+    next_due_ms: i64, // effective due instant, or `never` for dead
+    failures: u32,
+};
+
+/// Read-only snapshot seam onto the keepalive pool. `list` returns rows borrowed
+/// from the seam's storage (valid for the duration of the request).
+pub const PoolSeam = struct {
+    ctx: *anyopaque,
+    list: *const fn (ctx: *anyopaque) []const AccountStatus,
+    now: *const fn (ctx: *anyopaque) i64,
+};
+
+/// An HTTP response. `body` is always allocator-owned (static bodies are duped)
+/// so `freeResponse` is uniform.
+pub const Response = struct {
+    status: u16,
+    content_type: []const u8,
+    body: []const u8,
+};
+
+pub fn freeResponse(allocator: std.mem.Allocator, r: Response) void {
+    allocator.free(r.body);
+}
+
+// ── Pure router ────────────────────────────────────────────────────────────
+
+/// Route one request. Pure: no socket, no clock of its own (the seam provides
+/// `now`). Returns an allocator-owned Response.
+pub fn routeRequest(
+    allocator: std.mem.Allocator,
+    method: []const u8,
+    target: []const u8,
+    host_header: []const u8,
+    seam: PoolSeam,
+) !Response {
+    const path = splitPath(target);
+
+    // Liveness needs no data and no host gate.
+    if (std.mem.eql(u8, path, "/healthz")) return staticResponse(allocator, 200, "text/plain", "ok");
+
+    // Everything else is pool-bearing: enforce loopback Host first.
+    if (!isLoopbackHost(host_header)) return staticResponse(allocator, 403, "text/plain", "forbidden");
+    if (!std.mem.eql(u8, method, "GET")) return staticResponse(allocator, 405, "text/plain", "method not allowed");
+
+    if (std.mem.eql(u8, path, "/")) {
+        const rows = seam.list(seam.ctx);
+        const body = try renderStatusHtml(allocator, rows, seam.now(seam.ctx));
+        return .{ .status = 200, .content_type = "text/html; charset=utf-8", .body = body };
+    }
+    if (std.mem.eql(u8, path, "/status") or std.mem.eql(u8, path, "/api/pool")) {
+        const rows = seam.list(seam.ctx);
+        const body = try renderStatusJson(allocator, rows, seam.now(seam.ctx));
+        return .{ .status = 200, .content_type = "application/json", .body = body };
+    }
+    return staticResponse(allocator, 404, "text/plain", "not found");
+}
+
+fn staticResponse(allocator: std.mem.Allocator, status: u16, ct: []const u8, body: []const u8) !Response {
+    return .{ .status = status, .content_type = ct, .body = try allocator.dupe(u8, body) };
+}
+
+/// Path portion of a request target (drops any query string).
+pub fn splitPath(target: []const u8) []const u8 {
+    return if (std.mem.indexOfScalar(u8, target, '?')) |q| target[0..q] else target;
+}
+
+/// Exact loopback Host (optional :port). Defeats the suffix bypass
+/// (127.0.0.1.evil.com) that `startsWith` would allow.
+pub fn isLoopbackHost(host_header: []const u8) bool {
+    if (host_header.len == 0) return false;
+    const host = if (std.mem.indexOfScalar(u8, host_header, ':')) |c| host_header[0..c] else host_header;
+    return std.mem.eql(u8, host, "127.0.0.1") or std.mem.eql(u8, host, "localhost");
+}
+
+// ── Renderers ──────────────────────────────────────────────────────────────
+
+/// JSON array of pool rows. Allow-listed keys only: label, state, lastRefreshMs,
+/// nextDueMs, etaMs, failures. No token/account_id can appear (no such field).
+pub fn renderStatusJson(allocator: std.mem.Allocator, rows: []const AccountStatus, now_ms: i64) ![]u8 {
+    var out = std.ArrayList(u8).init(allocator);
+    errdefer out.deinit();
+    const w = out.writer();
+    try w.writeByte('[');
+    for (rows, 0..) |row, i| {
+        if (i != 0) try w.writeByte(',');
+        try w.writeAll("{\"label\":\"");
+        try writeJsonEscaped(w, row.label);
+        try w.print("\",\"state\":\"{s}\",\"lastRefreshMs\":{d},", .{ row.state.name(), row.last_refresh_ms });
+        if (row.next_due_ms == never) {
+            try w.writeAll("\"nextDueMs\":null,\"etaMs\":null,");
+        } else {
+            const eta: i64 = if (row.next_due_ms > now_ms) row.next_due_ms -| now_ms else 0;
+            try w.print("\"nextDueMs\":{d},\"etaMs\":{d},", .{ row.next_due_ms, eta });
+        }
+        try w.print("\"failures\":{d}}}", .{row.failures});
+    }
+    try w.writeByte(']');
+    return out.toOwnedSlice();
+}
+
+/// Human status board (self-refreshing every 2s, no JS build).
+pub fn renderStatusHtml(allocator: std.mem.Allocator, rows: []const AccountStatus, now_ms: i64) ![]u8 {
+    var out = std.ArrayList(u8).init(allocator);
+    errdefer out.deinit();
+    const w = out.writer();
+    try w.writeAll(
+        "<!doctype html><html><head><meta charset=\"utf-8\">" ++
+        "<meta http-equiv=\"refresh\" content=\"2\">" ++
+        "<title>oauth-mux keepalive</title>" ++
+        "<style>body{font:14px system-ui;margin:2rem}table{border-collapse:collapse}" ++
+        "th,td{border:1px solid #ccc;padding:.3rem .6rem;text-align:left}" ++
+        ".dead{color:#b00}.backoff,.expired{color:#b60}.warm{color:#070}</style>" ++
+        "</head><body><h1>Keepalive pool</h1><table>" ++
+        "<tr><th>account</th><th>state</th><th>last refresh (ms)</th><th>next refresh ETA</th><th>failures</th></tr>",
+    );
+    for (rows) |row| {
+        try w.print("<tr><td>", .{});
+        try writeHtmlEscaped(w, row.label);
+        try w.print("</td><td class=\"{s}\">{s}</td><td>{d}</td><td>", .{ row.state.name(), row.state.name(), row.last_refresh_ms });
+        if (row.next_due_ms == never) {
+            try w.writeAll("—");
+        } else {
+            const eta: i64 = if (row.next_due_ms > now_ms) row.next_due_ms -| now_ms else 0;
+            try w.print("{d} ms", .{eta});
+        }
+        try w.print("</td><td>{d}</td></tr>", .{row.failures});
+    }
+    try w.writeAll("</table></body></html>");
+    return out.toOwnedSlice();
+}
+
+fn writeJsonEscaped(w: anytype, s: []const u8) !void {
+    for (s) |c| {
+        switch (c) {
+            '"' => try w.writeAll("\\\""),
+            '\\' => try w.writeAll("\\\\"),
+            '\n' => try w.writeAll("\\n"),
+            '\r' => try w.writeAll("\\r"),
+            '\t' => try w.writeAll("\\t"),
+            else => if (c < 0x20) try w.print("\\u{x:0>4}", .{c}) else try w.writeByte(c),
+        }
+    }
+}
+
+fn writeHtmlEscaped(w: anytype, s: []const u8) !void {
+    for (s) |c| {
+        switch (c) {
+            '&' => try w.writeAll("&amp;"),
+            '<' => try w.writeAll("&lt;"),
+            '>' => try w.writeAll("&gt;"),
+            '"' => try w.writeAll("&quot;"),
+            '\'' => try w.writeAll("&#39;"),
+            else => try w.writeByte(c),
+        }
+    }
+}
+
+// ── Listener wrapper (thin, untested by design) ────────────────────────────
+//
+// The only code that touches a real socket. Mirrors the repo's loopback idiom
+// (wire_proxy.zig: parseIp → listen(.reuse_address) → accept → conn.stream) and
+// delegates every decision to the pure router. Serves a long-lived status loop.
+
+pub const UiListener = struct {
+    allocator: std.mem.Allocator,
+    seam: PoolSeam,
+
+    /// Bind 127.0.0.1:0 and return the assigned port (for the daemon to advertise).
+    pub fn bind(self: *const UiListener) !std.net.Server {
+        _ = self;
+        const loopback = try std.net.Address.parseIp("127.0.0.1", 0);
+        return loopback.listen(.{ .reuse_address = true });
+    }
+
+    /// Handle exactly one accepted connection (untested by design).
+    pub fn serveConn(self: *const UiListener, conn: std.net.Server.Connection) void {
+        defer conn.stream.close();
+        var buf: [8 * 1024]u8 = undefined;
+        const n = conn.stream.read(&buf) catch return;
+        const raw = buf[0..n];
+        const line = parseRequestLine(raw) orelse return;
+        const host = parseHostHeader(raw) orelse "";
+        const resp = routeRequest(self.allocator, line.method, line.target, host, self.seam) catch return;
+        defer freeResponse(self.allocator, resp);
+        writeResponse(conn.stream, resp) catch {};
+    }
+
+    /// Serve forever (until `should_stop` flips). Untested by design.
+    pub fn serve(self: *const UiListener, server: *std.net.Server, should_stop: *const std.atomic.Value(bool)) void {
+        while (!should_stop.load(.acquire)) {
+            const conn = server.accept() catch continue;
+            self.serveConn(conn);
+        }
+    }
+};
+
+const RequestLine = struct { method: []const u8, target: []const u8 };
+
+pub fn parseRequestLine(raw: []const u8) ?RequestLine {
+    const eol = std.mem.indexOfScalar(u8, raw, '\r') orelse raw.len;
+    var parts = std.mem.splitScalar(u8, raw[0..eol], ' ');
+    const method = parts.next() orelse return null;
+    const target = parts.next() orelse return null;
+    if (method.len == 0 or target.len == 0) return null;
+    return .{ .method = method, .target = target };
+}
+
+pub fn parseHostHeader(raw: []const u8) ?[]const u8 {
+    var lines = std.mem.splitSequence(u8, raw, "\r\n");
+    _ = lines.next();
+    while (lines.next()) |line| {
+        if (line.len == 0) break;
+        const colon = std.mem.indexOfScalar(u8, line, ':') orelse continue;
+        if (std.ascii.eqlIgnoreCase(line[0..colon], "Host")) {
+            return std.mem.trim(u8, line[colon + 1 ..], " \t");
+        }
+    }
+    return null;
+}
+
+fn writeResponse(stream: std.net.Stream, resp: Response) !void {
+    var hdr: [256]u8 = undefined;
+    const head = try std.fmt.bufPrint(
+        &hdr,
+        "HTTP/1.1 {d} {s}\r\nContent-Type: {s}\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n",
+        .{ resp.status, statusText(resp.status), resp.content_type, resp.body.len },
+    );
+    try stream.writeAll(head);
+    try stream.writeAll(resp.body);
+}
+
+fn statusText(status: u16) []const u8 {
+    return switch (status) {
+        200 => "OK",
+        403 => "Forbidden",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        else => "OK",
+    };
+}

--- a/src/keepalive/ui_server_tests.zig
+++ b/src/keepalive/ui_server_tests.zig
@@ -1,0 +1,177 @@
+//! Unit tests for the keepalive status UI (pure router + renderers). No socket.
+//!
+//!     zig test src/keepalive/ui_server_tests.zig
+
+const std = @import("std");
+const ui = @import("ui_server.zig");
+
+test {
+    std.testing.refAllDeclsRecursive(ui);
+}
+
+const rows = [_]ui.AccountStatus{
+    .{ .label = "claude · max · ****@work", .state = .warm, .last_refresh_ms = 1000, .next_due_ms = 2000, .failures = 0 },
+    .{ .label = "codex:max-1", .state = .backoff, .last_refresh_ms = 500, .next_due_ms = 1500, .failures = 2 },
+    .{ .label = "codex:max-2", .state = .dead, .last_refresh_ms = 0, .next_due_ms = ui.never, .failures = 8 },
+};
+
+const FakePool = struct {
+    rows: []const ui.AccountStatus = &rows,
+    now_ms: i64 = 1000,
+
+    fn listFn(ctx: *anyopaque) []const ui.AccountStatus {
+        const self: *FakePool = @ptrCast(@alignCast(ctx));
+        return self.rows;
+    }
+    fn nowFn(ctx: *anyopaque) i64 {
+        const self: *FakePool = @ptrCast(@alignCast(ctx));
+        return self.now_ms;
+    }
+    fn seam(self: *FakePool) ui.PoolSeam {
+        return .{ .ctx = self, .list = listFn, .now = nowFn };
+    }
+};
+
+fn contains(haystack: []const u8, needle: []const u8) bool {
+    return std.mem.indexOf(u8, haystack, needle) != null;
+}
+
+fn route(method: []const u8, target: []const u8, host: []const u8) !ui.Response {
+    var pool = FakePool{};
+    return ui.routeRequest(std.testing.allocator, method, target, host, pool.seam());
+}
+
+// ── Routing + security ─────────────────────────────────────────────────────
+
+test "GET /healthz is 200 ok without a host gate" {
+    const r = try route("GET", "/healthz", "");
+    defer ui.freeResponse(std.testing.allocator, r);
+    try std.testing.expectEqual(@as(u16, 200), r.status);
+    try std.testing.expectEqualStrings("ok", r.body);
+}
+
+test "GET / on loopback renders the HTML board" {
+    const r = try route("GET", "/", "127.0.0.1:7777");
+    defer ui.freeResponse(std.testing.allocator, r);
+    try std.testing.expectEqual(@as(u16, 200), r.status);
+    try std.testing.expectEqualStrings("text/html; charset=utf-8", r.content_type);
+    try std.testing.expect(contains(r.body, "Keepalive pool"));
+    try std.testing.expect(contains(r.body, "codex:max-1"));
+    try std.testing.expect(contains(r.body, "warm"));
+}
+
+test "GET /status on loopback returns JSON" {
+    const r = try route("GET", "/status", "localhost");
+    defer ui.freeResponse(std.testing.allocator, r);
+    try std.testing.expectEqual(@as(u16, 200), r.status);
+    try std.testing.expectEqualStrings("application/json", r.content_type);
+    try std.testing.expect(contains(r.body, "\"label\":\"claude · max · ****@work\""));
+    try std.testing.expect(contains(r.body, "\"state\":\"backoff\""));
+}
+
+test "GET /status ignores the query string (splitPath)" {
+    const r = try route("GET", "/status?foo=bar", "127.0.0.1");
+    defer ui.freeResponse(std.testing.allocator, r);
+    try std.testing.expectEqual(@as(u16, 200), r.status);
+}
+
+test "DNS-rebind suffix host -> 403" {
+    const r = try route("GET", "/", "127.0.0.1.evil.com");
+    defer ui.freeResponse(std.testing.allocator, r);
+    try std.testing.expectEqual(@as(u16, 403), r.status);
+}
+
+test "missing host -> 403 on a pool route" {
+    const r = try route("GET", "/status", "");
+    defer ui.freeResponse(std.testing.allocator, r);
+    try std.testing.expectEqual(@as(u16, 403), r.status);
+}
+
+test "non-GET -> 405" {
+    const r = try route("POST", "/", "127.0.0.1");
+    defer ui.freeResponse(std.testing.allocator, r);
+    try std.testing.expectEqual(@as(u16, 405), r.status);
+}
+
+test "unknown path -> 404" {
+    const r = try route("GET", "/nope", "127.0.0.1");
+    defer ui.freeResponse(std.testing.allocator, r);
+    try std.testing.expectEqual(@as(u16, 404), r.status);
+}
+
+// ── Rendering correctness ──────────────────────────────────────────────────
+
+test "JSON: a warm account reports etaMs = next_due - now" {
+    const r = try route("GET", "/status", "127.0.0.1");
+    defer ui.freeResponse(std.testing.allocator, r);
+    // warm row: next_due 2000, now 1000 -> eta 1000
+    try std.testing.expect(contains(r.body, "\"etaMs\":1000"));
+}
+
+test "JSON: a dead account reports null nextDueMs + etaMs" {
+    const r = try route("GET", "/status", "127.0.0.1");
+    defer ui.freeResponse(std.testing.allocator, r);
+    try std.testing.expect(contains(r.body, "\"state\":\"dead\",\"lastRefreshMs\":0,\"nextDueMs\":null,\"etaMs\":null,\"failures\":8"));
+}
+
+test "HTML escapes a hostile label" {
+    var pool = FakePool{ .rows = &[_]ui.AccountStatus{
+        .{ .label = "<script>alert(1)</script>", .state = .warm, .last_refresh_ms = 0, .next_due_ms = 1, .failures = 0 },
+    } };
+    const r = try ui.routeRequest(std.testing.allocator, "GET", "/", "127.0.0.1", pool.seam());
+    defer ui.freeResponse(std.testing.allocator, r);
+    try std.testing.expect(contains(r.body, "&lt;script&gt;"));
+    try std.testing.expect(!contains(r.body, "<script>alert"));
+}
+
+test "JSON escapes a quote in a label" {
+    var pool = FakePool{ .rows = &[_]ui.AccountStatus{
+        .{ .label = "a\"b", .state = .warm, .last_refresh_ms = 0, .next_due_ms = 1, .failures = 0 },
+    } };
+    const r = try ui.routeRequest(std.testing.allocator, "GET", "/status", "127.0.0.1", pool.seam());
+    defer ui.freeResponse(std.testing.allocator, r);
+    try std.testing.expect(contains(r.body, "\"label\":\"a\\\"b\""));
+}
+
+// ── Redaction allow-list ───────────────────────────────────────────────────
+
+test "JSON exposes only allow-listed keys (no token/secret leakage possible)" {
+    const r = try route("GET", "/status", "127.0.0.1");
+    defer ui.freeResponse(std.testing.allocator, r);
+    for ([_][]const u8{ "label", "state", "lastRefreshMs", "nextDueMs", "etaMs", "failures" }) |k| {
+        try std.testing.expect(contains(r.body, k));
+    }
+    for ([_][]const u8{ "token", "access", "refresh", "secret", "sk-ant", "auth.json" }) |bad| {
+        try std.testing.expect(!contains(r.body, bad));
+    }
+}
+
+// ── Host predicate ─────────────────────────────────────────────────────────
+
+test "isLoopbackHost: accepts loopback, rejects suffix/foreign/empty" {
+    try std.testing.expect(ui.isLoopbackHost("127.0.0.1"));
+    try std.testing.expect(ui.isLoopbackHost("127.0.0.1:8080"));
+    try std.testing.expect(ui.isLoopbackHost("localhost"));
+    try std.testing.expect(!ui.isLoopbackHost("127.0.0.1.evil.com"));
+    try std.testing.expect(!ui.isLoopbackHost("example.com"));
+    try std.testing.expect(!ui.isLoopbackHost(""));
+}
+
+test "render: a near-maxInt next_due with a negative clock never overflow-panics (etaMs saturates)" {
+    // next_due near the `never` sentinel but NOT equal to it (slips past the
+    // `== never` guard), with a negative clock — the ETA subtraction would
+    // overflow-panic without saturating arithmetic. Both render paths must
+    // complete (this test traps on regression).
+    var pool = FakePool{
+        .rows = &[_]ui.AccountStatus{
+            .{ .label = "x", .state = .warm, .last_refresh_ms = 0, .next_due_ms = ui.never - 1, .failures = 0 },
+        },
+        .now_ms = std.math.minInt(i64),
+    };
+    const j = try ui.routeRequest(std.testing.allocator, "GET", "/status", "127.0.0.1", pool.seam());
+    defer ui.freeResponse(std.testing.allocator, j);
+    try std.testing.expectEqual(@as(u16, 200), j.status);
+    const h = try ui.routeRequest(std.testing.allocator, "GET", "/", "127.0.0.1", pool.seam());
+    defer ui.freeResponse(std.testing.allocator, h);
+    try std.testing.expectEqual(@as(u16, 200), h.status);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -19752,4 +19752,5 @@ comptime {
     _ = @import("identity/claude_identity_tests.zig");
     _ = @import("identity/identity_lane_integration_tests.zig");
     _ = @import("keepalive/warm_scheduler_tests.zig");
+    _ = @import("keepalive/ui_server_tests.zig");
 }


### PR DESCRIPTION
## What

The 127.0.0.1-only, read-only keepalive operator status board (originally #356) — a pure `routeRequest(method, target, host, seam) -> Response` core (no socket) — shipped as new files under `src/keepalive/` but was wired into **neither** `main.zig`'s aggregator **nor** `build.zig`, so its **15 tests never ran** (vacuous CI, TIN-2053). Wired in.

## Adversarial review — both security claims survived attack

- **Anti-DNS-rebinding**: `isLoopbackHost` exact-matches the host **name** (split on first `:`). All 31 probed bypasses are correctly 403'd — `127.0.0.1.evil.com`, `evil127.0.0.1`, `localhost.evil.com`, trailing-dot, leading/trailing space, `[::1]`, decimal-IP `2130706433`, etc. The `startsWith` suffix trap the module comments about is genuinely defended.
- **Structural redaction + escaping**: `AccountStatus` carries no token/account_id (structurally unleakable). HTML path escapes `&<>"'`; JSON path escapes `"`/`\`/controls and is served as `application/json` (so unescaped `<`,`>` is safe, not HTML-sniffable). No XSS, no response-splitting (a CRLF in a label is escaped before the body and never reaches a header).
- Leak-free under `checkAllAllocationFailures`; routing (method confusion, path traversal, trailing-slash, query-strip) all clean.

## One should-fix, fixed
The ETA subtraction `next_due_ms - now_ms` (JSON + HTML render) was **non-saturating**. The saturating `warm_scheduler` can hand the UI a `next_due_ms` near `maxInt` (close to the `never` sentinel but **not equal** to it, so it slips past the `== never` guard); combined with a negative clock that subtraction would **overflow-panic the daemon thread**. Both sites now use `-|` (saturating). + regression test (near-`maxInt` next_due + `minInt` clock renders without trapping on both paths).

## Tests
`zig build test` → **659/659**; `zig test -OReleaseSafe` clean (exercises the overflow path).

Supersedes #356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
