### PR TITLE
keepalive: warm-loop binding (scheduler↔daemon glue) — pure, seam-based (TIN-1825 B.2)

### DIFF
--- a/src/keepalive/warm_binding.zig
+++ b/src/keepalive/warm_binding.zig
@@ -1,0 +1,156 @@
+//! Keepalive warm-loop BINDING — greenfield glue between the pure scheduler
+//! decision core (`warm_scheduler.zig`, B.1) and the live daemon (B.2). It is
+//! itself still pure and seam-based: the actual refresh, the clock, and the wait
+//! are INJECTED, so the binding logic — account-key round-trip, pool construction
+//! from observed credential expiry, and the tick → next-wake → wait → repeat
+//! driver — is fully unit-testable with NO I/O.
+//!
+//! The daemon wires the real seams (`pipeline.attemptRefresh`,
+//! `std.time.milliTimestamp`, a timed wait on the stop condition, config account
+//! enumeration); that thin layer is untested-by-design.
+//!
+//! NORTH STAR (never-halt, inherited from the scheduler): a dead/exhausted
+//! account never blocks the loop; the loop ends only when EVERY account is dead
+//! (nothing left to schedule) or the daemon signals stop.
+//!
+//! Self-contained: `std` + `warm_scheduler.zig` only. No `@import` of the live
+//! `src` (pipeline/secret/config) — those reach the loop exclusively through the
+//! injected `DoRefreshFn`/`WaitFn` seams.
+
+const std = @import("std");
+const ws = @import("warm_scheduler.zig");
+
+// ── Account key: a stable opaque "<provider>:<account>" the scheduler acts on ──
+
+pub const EncodeKeyError = error{ EmptyKeyComponent, NoSpaceLeft };
+
+/// Encode (provider, account) into `buf` as "<provider>:<account>". Provider keys
+/// are identifiers (no `:`); account names MAY contain `:`, which round-trips
+/// because `decodeKey` splits on the FIRST `:` only. An empty provider or account
+/// is rejected here (symmetric with `decodeKey`) so a bad key is caught at
+/// construction, not as a refusal 8 failed refreshes later.
+pub fn encodeKey(buf: []u8, provider: []const u8, account: []const u8) EncodeKeyError![]const u8 {
+    if (provider.len == 0 or account.len == 0) return error.EmptyKeyComponent;
+    return std.fmt.bufPrint(buf, "{s}:{s}", .{ provider, account });
+}
+
+pub const DecodedKey = struct {
+    provider: []const u8,
+    account: []const u8,
+};
+
+/// Split "<provider>:<account>" on the FIRST `:`. Returns null if there is no
+/// separator, an empty provider, or an empty account — so a malformed key is a
+/// refusal, never a silent mis-target.
+pub fn decodeKey(key: []const u8) ?DecodedKey {
+    const colon = std.mem.indexOfScalar(u8, key, ':') orelse return null;
+    if (colon == 0 or colon + 1 >= key.len) return null;
+    return .{ .provider = key[0..colon], .account = key[colon + 1 ..] };
+}
+
+// ── Pool construction ────────────────────────────────────────────────────────
+
+/// One account's observed credential state, as the daemon reads it from the
+/// store at tick time. `key` is borrowed and MUST outlive the built Account.
+pub const Observed = struct {
+    key: []const u8,
+    /// Absolute expiry instant (Unix ms): claude's stored `expiresAt`, or codex's
+    /// JWT-derived expiry (TIN-2087), normalized to ms by the daemon's reader.
+    expires_at_ms: i64,
+};
+
+/// Build the scheduler's mutable Account list from observed credential state at
+/// `now_ms`. The credential store does NOT persist an issue instant, so
+/// `last_refresh_ms` is seeded to `now_ms`: the scheduler then refreshes at
+/// `refresh_percent` of the OBSERVED-REMAINING lifetime (i.e. "refresh once
+/// refresh_percent of the life left at first observation has elapsed"), which is
+/// a safe, slightly-earlier trigger than 75%-of-total. Caller owns the slice.
+pub fn buildPool(allocator: std.mem.Allocator, observed: []const Observed, now_ms: i64) std.mem.Allocator.Error![]ws.Account {
+    const accounts = try allocator.alloc(ws.Account, observed.len);
+    for (observed, accounts) |o, *a| {
+        a.* = .{
+            .key = o.key,
+            .last_refresh_ms = now_ms,
+            .expires_at_ms = o.expires_at_ms,
+        };
+    }
+    return accounts;
+}
+
+// ── Refresh seam: bind the scheduler's RefreshFn to a (provider, account) op ───
+
+/// The live refresh the daemon binds to `pipeline.attemptRefresh`: perform ONE
+/// locked refresh for a decoded (provider, account) and report the new issue +
+/// expiry instants. Errors map onto the scheduler's `RefreshError`
+/// (`RefreshFailed` for a real failure, `OutOfMemory` for a transient).
+pub const DoRefreshFn = *const fn (ctx: *anyopaque, provider: []const u8, account: []const u8) ws.RefreshError!ws.RefreshResult;
+
+/// Adapter that satisfies the scheduler's opaque `RefreshFn` by decoding the
+/// account key and dispatching to an injected `DoRefreshFn`. A key that fails to
+/// decode is a `RefreshFailed` (never a wrong-account refresh).
+pub const RefreshBinding = struct {
+    do_refresh: DoRefreshFn,
+    do_refresh_ctx: *anyopaque,
+
+    /// Matches `ws.RefreshFn`. Bind via `.refresh = RefreshBinding.refresh,
+    /// .refresh_ctx = &binding` on the Scheduler.
+    pub fn refresh(ctx: *anyopaque, account_key: []const u8) ws.RefreshError!ws.RefreshResult {
+        const self: *RefreshBinding = @ptrCast(@alignCast(ctx));
+        const dk = decodeKey(account_key) orelse return ws.RefreshError.RefreshFailed;
+        return self.do_refresh(self.do_refresh_ctx, dk.provider, dk.account);
+    }
+};
+
+// ── Loop driver ──────────────────────────────────────────────────────────────
+
+/// Injected wait seam: block until the absolute instant `wake_at_ms` OR until the
+/// daemon signals stop. Returns `true` to continue the loop, `false` to stop. The
+/// daemon implements this as a real timed wait on its stop condition; tests use a
+/// fake that advances a fake clock and bounds the iteration count.
+pub const WaitFn = *const fn (ctx: *anyopaque, wake_at_ms: i64) bool;
+
+/// Per-loop outcome counters for logging / the operator UI.
+pub const LoopReport = struct {
+    ticks: u32 = 0,
+    refreshed: u32 = 0,
+    failed: u32 = 0,
+    died: u32 = 0,
+    /// True when the loop ended because every account is dead (nothing left to
+    /// schedule), as opposed to a daemon stop.
+    drained: bool = false,
+};
+
+/// Run the warm loop: tick the scheduler, accumulate the report, compute the next
+/// wake via `nextWakeMs`, wait (injected), repeat — until `wait` returns false
+/// (daemon stop) or `nextWakeMs` returns null (all accounts dead → drained).
+/// Saturating counter adds so a pathological run can never overflow-panic.
+pub fn runLoop(
+    sched: *const ws.Scheduler,
+    accounts: []ws.Account,
+    wait: WaitFn,
+    wait_ctx: *anyopaque,
+) LoopReport {
+    var report = LoopReport{};
+    while (true) {
+        const tr = sched.tick(accounts);
+        report.ticks +|= 1;
+        report.refreshed +|= tr.refreshed;
+        report.failed +|= tr.failed;
+        report.died +|= tr.died;
+        const wake = ws.nextWakeMs(accounts, sched.policy) orelse {
+            report.drained = true;
+            break;
+        };
+        // Forward-progress floor: never wait on a past/now instant. A due-now
+        // account — e.g. a token whose refreshed TTL is shorter than
+        // `min_lead_ms`, so `refreshDueAtMs` clamps the due instant up to `now` —
+        // makes `nextWakeMs` return a past/now value; a real timed wait would
+        // return from that immediately, busy-spinning the refresh seam with zero
+        // delay. Flooring to `now + backoff_base_ms` rate-limits such an account
+        // to one pass per backoff interval regardless of the injected WaitFn.
+        const now = sched.clock(sched.clock_ctx);
+        const safe_wake = if (wake <= now) now +| sched.policy.backoff_base_ms else wake;
+        if (!wait(wait_ctx, safe_wake)) break; // daemon signalled stop
+    }
+    return report;
+}

--- a/src/keepalive/warm_binding_tests.zig
+++ b/src/keepalive/warm_binding_tests.zig
@@ -1,0 +1,241 @@
+//! Unit tests for the keepalive warm-loop binding. Pure: a fake clock, fake
+//! refresh seam, and fake wait seam drive the loop deterministically with no I/O.
+//!
+//!     zig test src/keepalive/warm_binding_tests.zig
+
+const std = @import("std");
+const testing = std.testing;
+const ws = @import("warm_scheduler.zig");
+const bind = @import("warm_binding.zig");
+
+test {
+    testing.refAllDeclsRecursive(bind);
+}
+
+// ── Fakes ────────────────────────────────────────────────────────────────────
+
+const FakeEnv = struct {
+    now: i64,
+    refresh_mode: enum { ok, fail, oom } = .ok,
+    new_ttl_ms: i64 = 1_000_000,
+    refresh_calls: u32 = 0,
+    last_provider: [64]u8 = undefined,
+    last_provider_len: usize = 0,
+    last_account: [64]u8 = undefined,
+    last_account_len: usize = 0,
+    waits: u32 = 0,
+    max_waits: u32 = 1000,
+
+    fn clock(ctx: *anyopaque) i64 {
+        const self: *FakeEnv = @ptrCast(@alignCast(ctx));
+        return self.now;
+    }
+
+    fn doRefresh(ctx: *anyopaque, provider: []const u8, account: []const u8) ws.RefreshError!ws.RefreshResult {
+        const self: *FakeEnv = @ptrCast(@alignCast(ctx));
+        self.refresh_calls += 1;
+        self.last_provider_len = @min(provider.len, self.last_provider.len);
+        @memcpy(self.last_provider[0..self.last_provider_len], provider[0..self.last_provider_len]);
+        self.last_account_len = @min(account.len, self.last_account.len);
+        @memcpy(self.last_account[0..self.last_account_len], account[0..self.last_account_len]);
+        return switch (self.refresh_mode) {
+            .ok => .{ .new_last_refresh_ms = self.now, .new_expires_at_ms = self.now + self.new_ttl_ms },
+            .fail => ws.RefreshError.RefreshFailed,
+            .oom => ws.RefreshError.OutOfMemory,
+        };
+    }
+
+    /// Advances the fake clock to the scheduled wake instant, then continues until
+    /// the wait cap is hit (simulating a daemon stop).
+    fn wait(ctx: *anyopaque, wake_at_ms: i64) bool {
+        const self: *FakeEnv = @ptrCast(@alignCast(ctx));
+        self.waits += 1;
+        self.now = wake_at_ms;
+        return self.waits < self.max_waits;
+    }
+
+    /// A FAITHFUL timed wait: it only advances the clock when the wake is strictly
+    /// in the FUTURE — a real timed wait returns immediately from a past/now
+    /// deadline without sleeping. Used to detect a busy-spin (clock never advances).
+    fn faithfulWait(ctx: *anyopaque, wake_at_ms: i64) bool {
+        const self: *FakeEnv = @ptrCast(@alignCast(ctx));
+        self.waits += 1;
+        if (wake_at_ms > self.now) self.now = wake_at_ms;
+        return self.waits < self.max_waits;
+    }
+
+    fn lastProvider(self: *FakeEnv) []const u8 {
+        return self.last_provider[0..self.last_provider_len];
+    }
+    fn lastAccount(self: *FakeEnv) []const u8 {
+        return self.last_account[0..self.last_account_len];
+    }
+
+    fn scheduler(self: *FakeEnv, binding: *bind.RefreshBinding, policy: ws.Policy) ws.Scheduler {
+        return .{
+            .policy = policy,
+            .clock = FakeEnv.clock,
+            .clock_ctx = self,
+            .refresh = bind.RefreshBinding.refresh,
+            .refresh_ctx = binding,
+        };
+    }
+};
+
+const due_policy = ws.Policy{ .refresh_percent = 75, .min_lead_ms = 0 };
+
+// ── Account key codec ────────────────────────────────────────────────────────
+
+test "encodeKey/decodeKey round-trips, splitting on the first colon" {
+    var buf: [64]u8 = undefined;
+    const key = try bind.encodeKey(&buf, "codex", "max-1");
+    try testing.expectEqualStrings("codex:max-1", key);
+    const dk = bind.decodeKey(key).?;
+    try testing.expectEqualStrings("codex", dk.provider);
+    try testing.expectEqualStrings("max-1", dk.account);
+}
+
+test "decodeKey keeps an account that itself contains a colon (split-first)" {
+    const dk = bind.decodeKey("claude:org:acct").?;
+    try testing.expectEqualStrings("claude", dk.provider);
+    try testing.expectEqualStrings("org:acct", dk.account);
+}
+
+test "decodeKey refuses malformed keys (no/empty provider/empty account)" {
+    try testing.expect(bind.decodeKey("nocolon") == null);
+    try testing.expect(bind.decodeKey(":acct") == null); // empty provider
+    try testing.expect(bind.decodeKey("prov:") == null); // empty account
+    try testing.expect(bind.decodeKey("") == null);
+}
+
+test "encodeKey rejects empty components (symmetric with decodeKey)" {
+    var buf: [64]u8 = undefined;
+    try testing.expectError(error.EmptyKeyComponent, bind.encodeKey(&buf, "", "acct"));
+    try testing.expectError(error.EmptyKeyComponent, bind.encodeKey(&buf, "codex", ""));
+    try testing.expectError(error.EmptyKeyComponent, bind.encodeKey(&buf, "", ""));
+}
+
+// ── Pool construction ────────────────────────────────────────────────────────
+
+test "buildPool seeds last_refresh to now and preserves expiry per account" {
+    const a = testing.allocator;
+    const observed = [_]bind.Observed{
+        .{ .key = "claude:work", .expires_at_ms = 5_000_000 },
+        .{ .key = "codex:max-1", .expires_at_ms = 9_000_000 },
+    };
+    const pool = try bind.buildPool(a, &observed, 1_000_000);
+    defer a.free(pool);
+    try testing.expectEqual(@as(usize, 2), pool.len);
+    try testing.expectEqualStrings("claude:work", pool[0].key);
+    try testing.expectEqual(@as(i64, 1_000_000), pool[0].last_refresh_ms);
+    try testing.expectEqual(@as(i64, 5_000_000), pool[0].expires_at_ms);
+    try testing.expectEqual(@as(i64, 9_000_000), pool[1].expires_at_ms);
+    try testing.expectEqual(@as(u32, 0), pool[0].failures);
+}
+
+// ── Refresh binding ──────────────────────────────────────────────────────────
+
+test "RefreshBinding decodes the key and dispatches to (provider, account)" {
+    var env = FakeEnv{ .now = 0, .new_ttl_ms = 500 };
+    var binding = bind.RefreshBinding{ .do_refresh = FakeEnv.doRefresh, .do_refresh_ctx = &env };
+    const res = try bind.RefreshBinding.refresh(&binding, "codex:max-1");
+    try testing.expectEqual(@as(i64, 500), res.new_expires_at_ms); // now(0) + ttl(500)
+    try testing.expectEqualStrings("codex", env.lastProvider());
+    try testing.expectEqualStrings("max-1", env.lastAccount());
+}
+
+test "RefreshBinding turns an undecodable key into RefreshFailed (never a wrong-account refresh)" {
+    var env = FakeEnv{ .now = 0 };
+    var binding = bind.RefreshBinding{ .do_refresh = FakeEnv.doRefresh, .do_refresh_ctx = &env };
+    try testing.expectError(ws.RefreshError.RefreshFailed, bind.RefreshBinding.refresh(&binding, "nocolon"));
+    try testing.expectEqual(@as(u32, 0), env.refresh_calls); // never dispatched
+}
+
+// ── Loop driver ──────────────────────────────────────────────────────────────
+
+test "runLoop refreshes a due account each tick until the daemon stops" {
+    var env = FakeEnv{ .now = 1_000_000, .refresh_mode = .ok, .new_ttl_ms = 1_000_000, .max_waits = 3 };
+    var binding = bind.RefreshBinding{ .do_refresh = FakeEnv.doRefresh, .do_refresh_ctx = &env };
+    const sched = env.scheduler(&binding, due_policy);
+    var accounts = [_]ws.Account{
+        .{ .key = "claude:work", .last_refresh_ms = 0, .expires_at_ms = 1_000_000 }, // due at 750k <= now
+    };
+    const report = bind.runLoop(&sched, &accounts, FakeEnv.wait, &env);
+    // 3 ticks then the 3rd wait stops; the account was due-then-refreshed each time.
+    try testing.expectEqual(@as(u32, 3), report.ticks);
+    try testing.expectEqual(@as(u32, 3), report.refreshed);
+    try testing.expectEqual(@as(u32, 3), env.refresh_calls);
+    try testing.expect(!report.drained); // stopped by the daemon, not by draining
+    try testing.expectEqualStrings("claude", env.lastProvider());
+    try testing.expectEqualStrings("work", env.lastAccount());
+}
+
+test "runLoop drains: a persistently failing account backs off, dies, ends the loop" {
+    var env = FakeEnv{ .now = 1_000_000, .refresh_mode = .fail, .max_waits = 1000 };
+    var binding = bind.RefreshBinding{ .do_refresh = FakeEnv.doRefresh, .do_refresh_ctx = &env };
+    const policy = ws.Policy{ .refresh_percent = 75, .min_lead_ms = 0, .max_failures = 3 };
+    const sched = env.scheduler(&binding, policy);
+    var accounts = [_]ws.Account{
+        .{ .key = "x:y", .last_refresh_ms = 0, .expires_at_ms = 1_000_000 }, // due
+    };
+    const report = bind.runLoop(&sched, &accounts, FakeEnv.wait, &env);
+    try testing.expect(report.drained); // every account dead → nothing left to schedule
+    try testing.expectEqual(@as(u32, 1), report.died);
+    try testing.expectEqual(@as(u32, 2), report.failed); // failures 1,2 = failed; 3rd = died
+    try testing.expect(accounts[0].dead);
+}
+
+test "runLoop NEVER-HALT: a dead peer never blocks the live account, never drains" {
+    var env = FakeEnv{ .now = 1_000_000, .refresh_mode = .ok, .new_ttl_ms = 1_000_000, .max_waits = 2 };
+    var binding = bind.RefreshBinding{ .do_refresh = FakeEnv.doRefresh, .do_refresh_ctx = &env };
+    const sched = env.scheduler(&binding, due_policy);
+    var accounts = [_]ws.Account{
+        .{ .key = "dead:acct", .last_refresh_ms = 0, .expires_at_ms = 1000, .dead = true },
+        .{ .key = "live:acct", .last_refresh_ms = 0, .expires_at_ms = 1_000_000 }, // due
+    };
+    const report = bind.runLoop(&sched, &accounts, FakeEnv.wait, &env);
+    try testing.expect(!report.drained); // the live account keeps the loop afloat
+    try testing.expectEqual(@as(u32, 2), report.refreshed);
+    // only the live account was ever refreshed; the dead peer was skipped.
+    try testing.expectEqualStrings("live", env.lastProvider());
+    try testing.expect(!accounts[1].dead);
+}
+
+test "runLoop floors a past/now wake so a short-TTL token can't busy-spin the seam" {
+    // A refreshed token whose TTL (30s) is shorter than min_lead_ms (60s) makes
+    // refreshDueAtMs clamp the due instant up to `now`, so nextWakeMs returns a
+    // past/now value every tick. A FAITHFUL timed wait returns immediately from a
+    // past deadline WITHOUT advancing time — so without the forward-progress floor
+    // the loop would spin, refreshing with zero real delay (the fake clock would
+    // never advance). The floor pushes the wake to now+backoff_base, so the wait
+    // genuinely sleeps and time marches forward.
+    var env = FakeEnv{ .now = 1_000_000, .refresh_mode = .ok, .new_ttl_ms = 30_000, .max_waits = 5 };
+    var binding = bind.RefreshBinding{ .do_refresh = FakeEnv.doRefresh, .do_refresh_ctx = &env };
+    const policy = ws.Policy{ .refresh_percent = 75, .min_lead_ms = 60_000, .backoff_base_ms = 5_000 };
+    const sched = env.scheduler(&binding, policy);
+    var accounts = [_]ws.Account{
+        .{ .key = "claude:work", .last_refresh_ms = 0, .expires_at_ms = 1_000_000 },
+    };
+    const report = bind.runLoop(&sched, &accounts, FakeEnv.faithfulWait, &env);
+    // The wait actually slept each pass (clock advanced by ~max_waits*backoff_base).
+    // With the busy-spin bug the faithful wait would never advance → env.now stays
+    // at the start and this fails.
+    try testing.expect(env.now >= 1_000_000 + @as(i64, 5) * 5_000);
+    try testing.expectEqual(@as(u32, 5), env.waits);
+    try testing.expect(!report.drained);
+}
+
+test "runLoop: a sticky OOM is transient — never counts toward death, loop is wait-bounded" {
+    var env = FakeEnv{ .now = 1_000_000, .refresh_mode = .oom, .max_waits = 4 };
+    var binding = bind.RefreshBinding{ .do_refresh = FakeEnv.doRefresh, .do_refresh_ctx = &env };
+    const sched = env.scheduler(&binding, due_policy);
+    var accounts = [_]ws.Account{
+        .{ .key = "x:y", .last_refresh_ms = 0, .expires_at_ms = 1_000_000 },
+    };
+    const report = bind.runLoop(&sched, &accounts, FakeEnv.wait, &env);
+    // OOM never marks the account dead, so the loop only ends on the wait cap.
+    try testing.expect(!report.drained);
+    try testing.expectEqual(@as(u32, 0), report.died);
+    try testing.expect(!accounts[0].dead);
+    try testing.expectEqual(@as(u32, 0), accounts[0].failures); // OOM not charged
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -19751,6 +19751,7 @@ comptime {
     _ = @import("enroll/claude_reauth_tests.zig");
     _ = @import("enroll/web_ui_tests.zig");
     _ = @import("keepalive/warm_scheduler_tests.zig");
+    _ = @import("keepalive/warm_binding_tests.zig");
     _ = @import("identity/identity_graph_tests.zig");
     _ = @import("identity/claude_identity_tests.zig");
     _ = @import("identity/identity_lane_integration_tests.zig");


### PR DESCRIPTION
## What

The keepalive **warm-loop binding** — the glue between the pure scheduler decision core (`warm_scheduler.zig`, B.1, landed in #407) and the live daemon (B.2). This is increment 1 of the daemon binding: still **pure and seam-based** (refresh, clock, and wait all injected), so the load-bearing loop logic is fully unit-tested with **no I/O**. The next increment wires the real seams (`pipeline.attemptRefresh`, `milliTimestamp`, a timed wait, config account enumeration) — the thin untested wrapper.

This is the substantive work remaining before the `proactive_refresh` grant flip → the TIN-2057 golden metric (the cores are landed; this makes the warm loop actually *run*).

## Provides
- **`encodeKey`/`decodeKey`** — a stable `"<provider>:<account>"` key; decode splits on the **first** `:` so an account name with `:` round-trips. Both ends reject empty components (symmetric — a bad key fails at construction, not after 8 failed refreshes).
- **`buildPool`** — builds the scheduler's `[]Account` from observed credential expiry, seeding `last_refresh_ms = now` (the store persists no issue instant) → refresh fires at `refresh_percent` of observed-remaining life (safe, slightly-earlier).
- **`RefreshBinding`** — satisfies the scheduler's opaque `RefreshFn` by decoding the key and dispatching to an injected `DoRefreshFn`; an undecodable key → `RefreshFailed`, **never** a wrong-account refresh.
- **`runLoop`** — the `tick → nextWakeMs → wait → repeat` driver. Ends on a daemon stop (`wait`→false) or when every account is dead (`nextWakeMs` null → `drained`).

## Adversarial review found + fixed one BLOCKER
A refreshed token whose TTL is shorter than `min_lead_ms` makes `refreshDueAtMs` clamp the due instant up to `now`, so `nextWakeMs` returns a past/now value — and a real timed wait returns from that **immediately → a zero-delay busy-spin hammering the refresh seam**. `runLoop` now **floors the wake to `now +| backoff_base_ms`** whenever it's ≤ now, rate-limiting such an account to one pass per backoff interval regardless of the injected `WaitFn`. Fixed in the binding (which *owns* the wait) rather than killing the account in the core — a legitimately short-lived token should keep being refreshed at a bounded rate, not given up on. Also fixed an `encodeKey`/`decodeKey` empty-component asymmetry.

## Tests
**13 tests**, including the busy-spin regression (a *faithful* timed wait that only advances on a strictly-future wake; asserts the clock marches forward, not a spin), never-halt (a dead peer never blocks a live account), drain-on-death, and OOM-transient. `zig build test` → **705/705**; `zig test -OReleaseSafe` clean.

Part of TIN-1825 / TIN-2053 (the keepalive activation arc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
