### PR TITLE
keepalive: warm-loop runner glue — bind pool/scheduler to the live pipeline (TIN-1825 B.2)

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -401,6 +401,15 @@ fn validateProviderConfig(cfg: Config, provider_name: []const u8, prov: Provider
         ok.* = false;
     }
 
+    // A provider name must not contain ':': the keepalive warm-loop encodes an
+    // account key as "<provider>:<account>" and decodes by splitting on the FIRST
+    // ':' (so account names may contain ':' but provider names may not). A colon
+    // here would mis-target the decoded (provider, account) — refuse it at load.
+    if (std.mem.indexOfScalar(u8, provider_name, ':') != null) {
+        try writer.print("config error: provider name '{s}' must not contain ':'\n", .{provider_name});
+        ok.* = false;
+    }
+
     if (prov.kind.len == 0) {
         try writer.print("config error: providers.{s}.kind must not be empty\n", .{provider_name});
         ok.* = false;
@@ -1026,6 +1035,31 @@ test "validate rejects unknown provider kind without definition" {
     defer out.deinit();
     try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
     try std.testing.expect(std.mem.indexOf(u8, out.items, "has no built-in or provider_definitions entry") != null);
+}
+
+test "validate rejects a provider name containing ':' (warm-loop key codec contract)" {
+    const json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "a:b": {
+        \\      "kind": "codex",
+        \\      "accounts": {
+        \\        "default": { "secret": { "backend": "env", "variable": "X" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try loadFromBytes(std.testing.allocator, json);
+    defer parsed.deinit();
+
+    var out = std.ArrayList(u8).init(std.testing.allocator);
+    defer out.deinit();
+    try std.testing.expectError(error.ConfigValidationError, validate(parsed.value, out.writer()));
+    try std.testing.expect(std.mem.indexOf(u8, out.items, "must not contain ':'") != null);
 }
 
 test "validate rejects unknown profile account" {

--- a/src/keepalive/warm_runner.zig
+++ b/src/keepalive/warm_runner.zig
@@ -1,0 +1,113 @@
+//! Keepalive warm-loop RUNNER — the live glue (B.2) that binds the pure binding
+//! (`warm_binding.zig`) to the real system: it builds the scheduler's account
+//! pool from live config + credential expiry, and satisfies the binding's
+//! injected `DoRefreshFn`/`ClockFn` from `pipeline.refreshAccount` and the wall
+//! clock. Unlike `warm_binding`/`warm_scheduler` (pure), this layer DOES import
+//! `src` — it is the seam-binding glue, not the decision core.
+//!
+//! SAFE-BY-GATE: `pipeline.refreshAccount` refuses any account whose
+//! `proactive_refresh` grant + operator opt-in are not both admitted (the
+//! writeback gate) BEFORE any network/store mutation, returning a typed failure.
+//! So a warm loop over builtins (which declare no grant) only records refusals;
+//! the scheduler backs each off and marks it dead, the loop drains harmlessly.
+//! Nothing is rotated until the grant flip + live proof (TIN-2054).
+//!
+//! The actual timed wait + the CLI/daemon command that calls `bind.runLoop` are
+//! the thin, untested-by-design wrapper (a real wait blocks on the daemon stop
+//! condition); this file's pool-build + refresh adapter are unit-tested.
+
+const std = @import("std");
+const ws = @import("warm_scheduler.zig");
+const bind = @import("warm_binding.zig");
+const pipeline = @import("../pipeline.zig");
+const config_mod = @import("../config.zig");
+const health_mod = @import("../health.zig");
+
+/// Context the binding's `DoRefreshFn`/`ClockFn` are bound to. Borrows the config
+/// and health store for the loop's lifetime.
+pub const WarmRunner = struct {
+    allocator: std.mem.Allocator,
+    cfg: config_mod.Config,
+    health: *health_mod.HealthStore,
+
+    /// `ws.ClockFn`: real wall clock in Unix ms.
+    pub fn clock(ctx: *anyopaque) i64 {
+        _ = ctx;
+        return std.time.milliTimestamp();
+    }
+
+    /// `bind.DoRefreshFn`: proactively refresh one (provider, account) via
+    /// `pipeline.refreshAccount`, building a fresh Context per call (deinit'd
+    /// each call — no cross-tick state leak). Maps the pipeline outcome onto the
+    /// scheduler's `RefreshError`: `OutOfMemory` → transient (host pressure, not
+    /// the account's fault, not charged toward death); any other failure
+    /// (incl. the grant-gate refusal and a network/endpoint failure) →
+    /// `RefreshFailed`. On success the new expiry comes from the POST-rotation
+    /// `ctx.token` (seconds → ms, saturating), so the scheduler re-arms honestly.
+    pub fn doRefresh(ctx: *anyopaque, provider: []const u8, account: []const u8) ws.RefreshError!ws.RefreshResult {
+        const self: *WarmRunner = @ptrCast(@alignCast(ctx));
+        var pctx = pipeline.Context.init(self.allocator, self.cfg, self.health);
+        defer pctx.deinit();
+        pctx.provider_name = provider;
+        pctx.account_name = account;
+        pipeline.refreshAccount(&pctx) catch |e| return switch (e) {
+            error.OutOfMemory => ws.RefreshError.OutOfMemory,
+            else => ws.RefreshError.RefreshFailed,
+        };
+        const tok = pctx.token orelse return ws.RefreshError.RefreshFailed;
+        const exp_s = tok.expires_at orelse return ws.RefreshError.RefreshFailed;
+        return .{
+            .new_last_refresh_ms = std.time.milliTimestamp(),
+            .new_expires_at_ms = exp_s *| std.time.ms_per_s,
+        };
+    }
+};
+
+/// The warm pool built from live config: the scheduler's `Observed` rows plus an
+/// arena owning the "<provider>:<account>" key strings the rows (and the built
+/// Accounts) borrow. `deinit` frees everything; it must outlive any
+/// `warm_binding.buildPool` / scheduler run over `observed`.
+pub const Pool = struct {
+    observed: []const bind.Observed,
+    arena: std.heap.ArenaAllocator,
+
+    pub fn deinit(self: *Pool) void {
+        self.arena.deinit();
+    }
+};
+
+/// Enumerate every configured (provider, account) with a READABLE expiry into a
+/// warm pool. Accounts whose credential is unreadable or carries no expiry are
+/// skipped (logged) — a dead/unprofiled account never blocks the loop. Keys are
+/// "<provider>:<account>", arena-owned. Caller frees via `Pool.deinit`.
+pub fn enumeratePool(
+    allocator: std.mem.Allocator,
+    cfg: config_mod.Config,
+    health: *health_mod.HealthStore,
+) std.mem.Allocator.Error!Pool {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    errdefer arena.deinit();
+    const a = arena.allocator();
+
+    var list = std.ArrayList(bind.Observed).init(a);
+    var prov_it = cfg.providers.map.iterator();
+    while (prov_it.next()) |pe| {
+        const prov = pe.key_ptr.*;
+        var acct_it = pe.value_ptr.accounts.map.iterator();
+        while (acct_it.next()) |ae| {
+            const acct = ae.key_ptr.*;
+            // Read this account's expiry with a throwaway Context (transient
+            // allocations freed by its deinit). A read failure / no-expiry skips
+            // the account rather than poisoning the pool.
+            var pctx = pipeline.Context.init(allocator, cfg, health);
+            defer pctx.deinit();
+            pctx.provider_name = prov;
+            pctx.account_name = acct;
+            const maybe_exp = pipeline.readAccountExpiryMs(&pctx) catch null;
+            const exp = maybe_exp orelse continue;
+            const key = try std.fmt.allocPrint(a, "{s}:{s}", .{ prov, acct });
+            try list.append(.{ .key = key, .expires_at_ms = exp });
+        }
+    }
+    return .{ .observed = try list.toOwnedSlice(), .arena = arena };
+}

--- a/src/keepalive/warm_runner_tests.zig
+++ b/src/keepalive/warm_runner_tests.zig
@@ -1,0 +1,141 @@
+//! Unit tests for the keepalive warm-loop runner glue. Exercises the pool
+//! enumeration and the DoRefreshFn→pipeline mapping against the toy provider
+//! over a file-backed credential store; the timed-wait + CLI command are the
+//! untested-by-design wrapper.
+
+const std = @import("std");
+const testing = std.testing;
+const ws = @import("warm_scheduler.zig");
+const runner = @import("warm_runner.zig");
+const pipeline = @import("../pipeline.zig");
+const config_mod = @import("../config.zig");
+const health_mod = @import("../health.zig");
+const repair_state = @import("../repair_state.zig");
+
+test {
+    testing.refAllDeclsRecursive(runner);
+}
+
+// Two toy accounts ("a","b"); the credential file path is templated per account.
+fn twoAccountConfig(allocator: std.mem.Allocator, owner: []const u8, path_a: []const u8, path_b: []const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "provider_definitions": {{
+        \\    "toy": {{
+        \\      "name": "toy",
+        \\      "repair": {{ "owner": "{s}" }},
+        \\      "auth": {{ "token_endpoint": "http://127.0.0.1:9/token" }},
+        \\      "credential": {{
+        \\        "access_token_path": "access_token",
+        \\        "refresh_token_path": "refresh_token",
+        \\        "expires_at_path": "expires_at"
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "providers": {{
+        \\    "toy": {{
+        \\      "kind": "toy",
+        \\      "accounts": {{
+        \\        "a": {{ "secret": {{ "backend": "file", "path": "{s}" }} }},
+        \\        "b": {{ "secret": {{ "backend": "file", "path": "{s}" }} }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{}},
+        \\  "strategies": {{}}
+        \\}}
+    , .{ owner, path_a, path_b });
+}
+
+fn writeCred(path: []const u8, rt: []const u8, exp_s: i64) !void {
+    const f = try std.fs.createFileAbsolute(path, .{});
+    defer f.close();
+    var buf: [256]u8 = undefined;
+    const s = try std.fmt.bufPrint(&buf, "{{\"access_token\":\"at\",\"refresh_token\":\"{s}\",\"expires_at\":{d}}}", .{ rt, exp_s });
+    try f.writeAll(s);
+}
+
+test "enumeratePool includes accounts with a readable expiry, skips unreadable, keys+ms correct" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+    const path_a = try std.fmt.allocPrint(testing.allocator, "{s}/a.json", .{root});
+    defer testing.allocator.free(path_a);
+    const path_b = try std.fmt.allocPrint(testing.allocator, "{s}/b.json", .{root});
+    defer testing.allocator.free(path_b);
+
+    // Account "a" has a credential (expiry 9_000_000_000 s); "b"'s file is absent.
+    try writeCred(path_a, "rt-a", 9_000_000_000);
+
+    const json = try twoAccountConfig(testing.allocator, "oauth_mux_refresh", path_a, path_b);
+    defer testing.allocator.free(json);
+    const parsed = try config_mod.loadFromBytes(testing.allocator, json);
+    defer parsed.deinit();
+    var store = health_mod.HealthStore.init(testing.allocator, .{});
+    defer store.deinit();
+
+    var pool = try runner.enumeratePool(testing.allocator, parsed.value, &store);
+    defer pool.deinit();
+
+    // Only "a" is readable → exactly one row, keyed "toy:a", expiry in ms.
+    try testing.expectEqual(@as(usize, 1), pool.observed.len);
+    try testing.expectEqualStrings("toy:a", pool.observed[0].key);
+    try testing.expectEqual(@as(i64, 9_000_000_000 * std.time.ms_per_s), pool.observed[0].expires_at_ms);
+}
+
+test "doRefresh maps a failed proactive refresh to RefreshFailed (admitted account, dead endpoint)" {
+    var rt_scope = try repair_state.TestRuntimeDirScope.init(testing.allocator);
+    defer rt_scope.deinit(testing.allocator);
+    rt_scope.activate();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+    const path_a = try std.fmt.allocPrint(testing.allocator, "{s}/a.json", .{root});
+    defer testing.allocator.free(path_a);
+    const path_b = try std.fmt.allocPrint(testing.allocator, "{s}/b.json", .{root});
+    defer testing.allocator.free(path_b);
+    try writeCred(path_a, "rt-a", 9_000_000_000); // still-valid → proactive rotate attempt
+
+    const json = try twoAccountConfig(testing.allocator, "oauth_mux_refresh", path_a, path_b);
+    defer testing.allocator.free(json);
+    const parsed = try config_mod.loadFromBytes(testing.allocator, json);
+    defer parsed.deinit();
+    var store = health_mod.HealthStore.init(testing.allocator, .{});
+    defer store.deinit();
+
+    var wr = runner.WarmRunner{ .allocator = testing.allocator, .cfg = parsed.value, .health = &store };
+    // The proactive rotation proceeds past the adopt (same RT) and hits the dead
+    // endpoint → the pipeline returns a typed failure → mapped to RefreshFailed.
+    try testing.expectError(ws.RefreshError.RefreshFailed, runner.WarmRunner.doRefresh(&wr, "toy", "a"));
+}
+
+test "doRefresh on an un-admitted (builtin-posture) account is RefreshFailed (grant-gate refusal)" {
+    var rt_scope = try repair_state.TestRuntimeDirScope.init(testing.allocator);
+    defer rt_scope.deinit(testing.allocator);
+    rt_scope.activate();
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+    const path_a = try std.fmt.allocPrint(testing.allocator, "{s}/a.json", .{root});
+    defer testing.allocator.free(path_a);
+    const path_b = try std.fmt.allocPrint(testing.allocator, "{s}/b.json", .{root});
+    defer testing.allocator.free(path_b);
+    try writeCred(path_a, "rt-a", 9_000_000_000);
+
+    // upstream_cli_login owner + no opt-in = builtin posture → grant gate refuses.
+    const json = try twoAccountConfig(testing.allocator, "upstream_cli_login", path_a, path_b);
+    defer testing.allocator.free(json);
+    const parsed = try config_mod.loadFromBytes(testing.allocator, json);
+    defer parsed.deinit();
+    var store = health_mod.HealthStore.init(testing.allocator, .{});
+    defer store.deinit();
+
+    var wr = runner.WarmRunner{ .allocator = testing.allocator, .cfg = parsed.value, .health = &store };
+    try testing.expectError(ws.RefreshError.RefreshFailed, runner.WarmRunner.doRefresh(&wr, "toy", "a"));
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -19752,6 +19752,7 @@ comptime {
     _ = @import("enroll/web_ui_tests.zig");
     _ = @import("keepalive/warm_scheduler_tests.zig");
     _ = @import("keepalive/warm_binding_tests.zig");
+    _ = @import("keepalive/warm_runner_tests.zig");
     _ = @import("identity/identity_graph_tests.zig");
     _ = @import("identity/claude_identity_tests.zig");
     _ = @import("identity/identity_lane_integration_tests.zig");


### PR DESCRIPTION
## What

The live seam-binding layer (B.2 increment 2b-glue) between the pure binding (`warm_binding.zig`) and the real system. Unlike `warm_binding`/`warm_scheduler` (pure), this imports `src` — it is the glue, not the decision core.

- **`WarmRunner.clock`** — real wall clock (ms) for the scheduler `ClockFn`.
- **`WarmRunner.doRefresh`** — the binding's `DoRefreshFn`: builds a fresh `pipeline.Context` per (provider,account) (deinit'd each call — no cross-tick leak), calls `pipeline.refreshAccount`, and maps the outcome onto the scheduler's `RefreshError` (`OutOfMemory`→transient, else→`RefreshFailed`). On success the new expiry is the **post-rotation** `ctx.token.expires_at` (sec → ms, saturating), so the scheduler re-arms honestly.
- **`enumeratePool`** — every configured (provider,account) with a **readable** expiry → the scheduler's `Observed` rows (arena-owned `"<provider>:<account>"` keys matching `decodeKey`); unreadable/expiry-less accounts are skipped, never blocking the loop.

## Safe-by-gate
`refreshAccount` refuses any un-admitted (builtin-posture) account at the writeback gate **before** any network/store mutation, so a warm loop over builtins only records refusals and drains harmlessly — nothing rotates until the `proactive_refresh` flip + live proof (TIN-2054).

## Adversarial review — SHIP, no blocker
Verified the per-tick Context lifecycle is **leak/double-free clean on every path** (grant refusal / network failure / success-with-new-token), and the error mapping is correct for never-halt (only host-pressure OOM is transient; a builtin grant refusal correctly drains to dead → skipped). One should-fix it found, **fixed**: provider names containing `:` could break the `<provider>:<account>` key round-trip — now **rejected at config load** (the documented contract is now enforced) + test.

## Tests (+4)
enumeratePool includes-readable / skips-unreadable / keys+ms correct; doRefresh maps a failed proactive refresh (admitted, dead endpoint) → `RefreshFailed`; doRefresh on a builtin-posture account → `RefreshFailed` (grant-gate refusal); config rejects a `:`-bearing provider name. `zig build test` → **714/714**.

Follow-up (noted by the review, covered by the live-proof leg): a `doRefresh` **success-path** test needs a stub token endpoint. The timed-wait `WaitFn` + the `keepalive` CLI command that calls `warm_binding.runLoop` are the thin untested-by-design wrapper — the immediate next increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)