### PR TITLE
keepalive: `oauth-mux keepalive` command — run the warm loop end-to-end (TIN-1825 B.2)

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -25,6 +25,7 @@ pub const Command = union(enum) {
     stay_afloat_observe: ObserveArgs,
     stay_afloat: DaemonTickArgs,
     stay_afloat_handoff: HandoffArgs,
+    keepalive: KeepaliveArgs,
     config_validate,
     config_path,
     init: InitArgs,
@@ -309,6 +310,16 @@ pub const Command = union(enum) {
         json: bool = false,
     };
 
+    /// `oauth-mux keepalive` — run the warm-loop scheduler over the configured
+    /// accounts. Bounded by `iterations` (default 1 = a single tick) so it always
+    /// terminates; `interval_ms` caps the per-tick sleep. Refuses to rotate any
+    /// account whose proactive_refresh grant is not admitted (safe over builtins).
+    pub const KeepaliveArgs = struct {
+        iterations: u32 = 1,
+        interval_ms: u64 = 60_000,
+        json: bool = false,
+    };
+
     pub const HandoffAction = enum {
         ack,
         clear,
@@ -349,6 +360,7 @@ pub fn parse(args: []const []const u8) Command {
     if (eql(cmd, "repair-plan")) return parseRepairPlan(rest);
     if (eql(cmd, "route")) return parseRoute(rest);
     if (eql(cmd, "stay-afloat")) return parseStayAfloat(rest);
+    if (eql(cmd, "keepalive")) return parseKeepalive(rest);
     if (eql(cmd, "config")) return parseConfig(rest);
     if (eql(cmd, "init")) return parseInit(rest);
     if (eql(cmd, "setup")) return parseSetup(rest);
@@ -917,6 +929,25 @@ fn parseStayAfloat(args: []const []const u8) Command {
         return .{ .stay_afloat = tick };
     }
     return .{ .stay_afloat = parseDaemonTickArgs(args) };
+}
+
+fn parseKeepalive(args: []const []const u8) Command {
+    var result = Command.KeepaliveArgs{};
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        if (eql(args[i], "--json")) {
+            result.json = true;
+        } else if (eql(args[i], "--once")) {
+            result.iterations = 1;
+        } else if (eql(args[i], "--iterations")) {
+            i += 1;
+            if (i < args.len) result.iterations = std.fmt.parseInt(u32, args[i], 10) catch result.iterations;
+        } else if (eql(args[i], "--interval-ms")) {
+            i += 1;
+            if (i < args.len) result.interval_ms = std.fmt.parseInt(u64, args[i], 10) catch result.interval_ms;
+        }
+    }
+    return .{ .keepalive = result };
 }
 
 fn parseStayAfloatObserve(args: []const []const u8) Command {
@@ -1541,6 +1572,25 @@ test "parse status json" {
     const cmd = parse(&args);
     switch (cmd) {
         .status => |status| try std.testing.expect(status.json),
+        else => return error.Unexpected,
+    }
+}
+
+test "parse keepalive defaults and flags" {
+    switch (parse(&[_][]const u8{"keepalive"})) {
+        .keepalive => |k| {
+            try std.testing.expectEqual(@as(u32, 1), k.iterations);
+            try std.testing.expectEqual(@as(u64, 60_000), k.interval_ms);
+            try std.testing.expect(!k.json);
+        },
+        else => return error.Unexpected,
+    }
+    switch (parse(&[_][]const u8{ "keepalive", "--iterations", "5", "--interval-ms", "1000", "--json" })) {
+        .keepalive => |k| {
+            try std.testing.expectEqual(@as(u32, 5), k.iterations);
+            try std.testing.expectEqual(@as(u64, 1000), k.interval_ms);
+            try std.testing.expect(k.json);
+        },
         else => return error.Unexpected,
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,6 +9,9 @@ const types = @import("types.zig");
 const pipeline = @import("pipeline.zig");
 const health_mod = @import("health.zig");
 const provider = @import("provider.zig");
+const warm_scheduler = @import("keepalive/warm_scheduler.zig");
+const warm_binding = @import("keepalive/warm_binding.zig");
+const warm_runner = @import("keepalive/warm_runner.zig");
 const provider_schema = @import("provider_schema.zig");
 const daemon = @import("daemon.zig");
 const repair_state = @import("repair_state.zig");
@@ -268,6 +271,13 @@ pub fn main() !void {
             };
         },
 
+        .keepalive => |ka_args| {
+            runKeepalive(allocator, stdout, ka_args) catch |e| {
+                log.err("keepalive: {s}", .{@errorName(e)});
+                std.process.exit(types.ExitCode.general_error.int());
+            };
+        },
+
         .completions => |comp_args| {
             try cli.printCompletions(stdout, comp_args.shell);
         },
@@ -312,6 +322,82 @@ pub fn main() !void {
                 std.process.exit(exitCodeFromPipelineError(e));
             };
         },
+    }
+}
+
+/// Bounded real-sleep wait for the foreground keepalive loop: terminates after
+/// `remaining` more waits (so the loop runs a fixed number of ticks), and caps
+/// each sleep at `cap_ms` so a far-future due instant still re-ticks periodically.
+/// runLoop floors a past/now wake before calling this, so there is no busy-spin.
+const KeepaliveWait = struct {
+    remaining: u32,
+    cap_ms: u64,
+    fn wait(ctx: *anyopaque, wake_at_ms: i64) bool {
+        const self: *KeepaliveWait = @ptrCast(@alignCast(ctx));
+        if (self.remaining == 0) return false;
+        self.remaining -= 1;
+        const now = std.time.milliTimestamp();
+        if (wake_at_ms > now) {
+            const delta: u64 = @intCast(wake_at_ms - now);
+            // Clamp to a sane max (24h) so an absurd operator --interval-ms can't
+            // overflow the u64 ns multiply, and the loop never sleeps past a day.
+            const max_ms: u64 = 24 * 60 * 60 * 1000;
+            const sleep_ms = @min(@min(delta, self.cap_ms), max_ms);
+            std.time.sleep(sleep_ms * std.time.ns_per_ms);
+        }
+        return true;
+    }
+};
+
+/// `oauth-mux keepalive` — run the warm-loop scheduler over every configured
+/// account: proactively refresh each at ~75% of its token lifetime so an agent
+/// never hits a dead token. SAFE: refreshAccount refuses any account whose
+/// proactive_refresh grant is not admitted (every builtin today), so this only
+/// records refusals until the grant flip. Bounded by `iterations` (default 1).
+fn runKeepalive(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.KeepaliveArgs) !void {
+    const parsed = config.load(allocator) catch |e| {
+        if (args.json) {
+            try writer.writeAll("{\"error\":\"config not found\"}\n");
+        } else {
+            log.err("keepalive: config load: {s}", .{@errorName(e)});
+        }
+        return e;
+    };
+    defer parsed.deinit();
+    const cfg = parsed.value;
+
+    var health = health_mod.HealthStore.load(allocator, .{});
+    defer health.deinit();
+
+    // Build the warm pool from live config + credential expiry.
+    var pool = try warm_runner.enumeratePool(allocator, cfg, &health);
+    defer pool.deinit();
+    const accounts = try warm_binding.buildPool(allocator, pool.observed, std.time.milliTimestamp());
+    defer allocator.free(accounts); // freed BEFORE pool.deinit (accounts borrow pool keys)
+
+    // Bind the scheduler to the live refresh path (proactive; refuses ungranted).
+    var wr = warm_runner.WarmRunner{ .allocator = allocator, .cfg = cfg, .health = &health };
+    var binding = warm_binding.RefreshBinding{ .do_refresh = warm_runner.WarmRunner.doRefresh, .do_refresh_ctx = &wr };
+    const sched = warm_scheduler.Scheduler{
+        .clock = warm_runner.WarmRunner.clock,
+        .clock_ctx = &wr,
+        .refresh = warm_binding.RefreshBinding.refresh,
+        .refresh_ctx = &binding,
+    };
+
+    var wait_ctx = KeepaliveWait{ .remaining = args.iterations -| 1, .cap_ms = args.interval_ms };
+    const report = warm_binding.runLoop(&sched, accounts, KeepaliveWait.wait, &wait_ctx);
+
+    if (args.json) {
+        try writer.print(
+            "{{\"accounts\":{d},\"ticks\":{d},\"refreshed\":{d},\"failed\":{d},\"died\":{d},\"drained\":{}}}\n",
+            .{ accounts.len, report.ticks, report.refreshed, report.failed, report.died, report.drained },
+        );
+    } else {
+        try writer.print(
+            "keepalive: {d} account(s); {d} tick(s) — refreshed={d} failed={d} died={d} drained={}\n",
+            .{ accounts.len, report.ticks, report.refreshed, report.failed, report.died, report.drained },
+        );
     }
 }
 


### PR DESCRIPTION
## What

The thin foreground wrapper that **completes the daemon binding** — making the keepalive warm loop user-invokable end-to-end:

`enumeratePool` (live config + credential expiry) → `buildPool` → `Scheduler` bound to `WarmRunner` (clock = wall clock, refresh = `pipeline.refreshAccount` via `RefreshBinding`) → `warm_binding.runLoop` with a **bounded real-sleep `WaitFn`** (terminates after `iterations` ticks; caps each sleep at `interval_ms`; `runLoop` floors past-wakes so no busy-spin). Reports refreshed / failed / died / drained (text or `--json`).

## Safe-by-gate — verified end-to-end
`refreshAccount` refuses any account whose `proactive_refresh` grant is not admitted (every builtin today) **before** any network/store mutation. Ran the real binary over a *due, un-granted* toy account:

```
$ oauth-mux keepalive --once --json
[WRN] token: refresh writeback not admitted for toy:warm: provider_repair_owned_by_upstream_cli
{"accounts":1,"ticks":1,"refreshed":0,"failed":1,"died":0,"drained":false}
```

— the credential file was **unmodified** (no network call, no rotation). The binding works *and* the safety gate holds: nothing rotates until the grant flip.

## CLI
`keepalive [--once] [--iterations N] [--interval-ms MS] [--json]` (`KeepaliveArgs`, `parseKeepalive`) + parse test.

## Test
`zig build test` → **714/714**. The loop/glue/scheduler are unit-tested (warm_binding/warm_runner/warm_scheduler); this wrapper is verified by the live run above + the parse test.

## Still gated (NOT in this PR)
The `proactive_refresh` grant flip + a live concurrent-proof run (2×Claude + 2×Codex) remain the final step (TIN-2054 / TIN-2057). Today the loop is a safe no-op over builtins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)