### PR TITLE
reauth: flip the proactive_refresh grant on the claude/codex builtins (TIN-2057)

### DIFF
--- a/src/keepalive/warm_runner.zig
+++ b/src/keepalive/warm_runner.zig
@@ -8,9 +8,11 @@
 //! SAFE-BY-GATE: `pipeline.refreshAccount` refuses any account whose
 //! `proactive_refresh` grant + operator opt-in are not both admitted (the
 //! writeback gate) BEFORE any network/store mutation, returning a typed failure.
-//! So a warm loop over builtins (which declare no grant) only records refusals;
-//! the scheduler backs each off and marks it dead, the loop drains harmlessly.
-//! Nothing is rotated until the grant flip + live proof (TIN-2054).
+//! The claude/codex providers declare the grant (TIN-2057), but admission still
+//! requires the account to opt in (`allow_proactive_refresh: true`, defaults
+//! false), so a warm loop over accounts that haven't opted in only records
+//! refusals; the scheduler backs each off and marks it dead, the loop drains
+//! harmlessly. Live-proven 2026-06-14 (TIN-2057).
 //!
 //! The actual timed wait + the CLI/daemon command that calls `bind.runLoop` are
 //! the thin, untested-by-design wrapper (a real wait blocks on the daemon stop

--- a/src/main.zig
+++ b/src/main.zig
@@ -352,8 +352,10 @@ const KeepaliveWait = struct {
 /// `oauth-mux keepalive` — run the warm-loop scheduler over every configured
 /// account: proactively refresh each at ~75% of its token lifetime so an agent
 /// never hits a dead token. SAFE: refreshAccount refuses any account whose
-/// proactive_refresh grant is not admitted (every builtin today), so this only
-/// records refusals until the grant flip. Bounded by `iterations` (default 1).
+/// proactive_refresh is not admitted — the claude/codex providers now declare the
+/// grant (TIN-2057), but admission still requires the account to set
+/// `allow_proactive_refresh: true` (defaults false), so an account that hasn't
+/// opted in only records refusals. Bounded by `iterations` (default 1).
 fn runKeepalive(allocator: std.mem.Allocator, writer: anytype, args: cli.Command.KeepaliveArgs) !void {
     const parsed = config.load(allocator) catch |e| {
         if (args.json) {

--- a/src/provider_schema.zig
+++ b/src/provider_schema.zig
@@ -784,15 +784,21 @@ pub const claude_def = ProviderDefinition{
         .required_binaries = &.{"claude"},
         .env_vars = &.{"CLAUDE_CONFIG_DIR"},
     },
-    // The refresh grant (.proactive_refresh = .oauth_refresh_token) is
-    // deliberately NOT declared yet. Serialization (TIN-2073) and
-    // field-preserving writeback (TIN-2074: merge preserves expiresAt/
-    // scopes/subscriptionType, ms-unit aware) have landed. Remaining gate
-    // before the flip: the dual-writer story (TIN-2059) — the native
-    // Claude CLI also rotates this account's refresh token, and two
-    // writers rotating one token can revoke each other.
+    // GRANT FLIPPED (TIN-2057): the provider now SUPPORTS proactive refresh.
+    // Substrate complete — serialization (TIN-2073), field-preserving writeback
+    // (TIN-2074: merge preserves expiresAt/scopes/subscriptionType, ms-unit
+    // aware), Option B proactive-rotation (TIN-2055), the per-account + identity
+    // flocks, and the canonical-keychain writeback refusal (TIN-2054/#406). Login
+    // stays upstream_cli_login, so refresh is admitted ONLY for an account that
+    // also opts in (allow_proactive_refresh: true) — no behaviour change for any
+    // account that hasn't opted in. The bare-CLI dual-writer (R3, TIN-2059) is the
+    // accepted residual: the store-invariant (never persist an RT it didn't mint)
+    // downgrades a concurrent native-CLI rotation to a wasted refresh, never
+    // corruption. Live-proven 2026-06-14 (2×Claude proactively refreshed via
+    // `oauth-mux keepalive`, scopes/subscriptionType preserved, zero collateral).
     .repair = .{
         .owner = .upstream_cli_login,
+        .proactive_refresh = .oauth_refresh_token,
     },
     .capabilities = &claude_capabilities,
     .failure_rules = &claude_failure_rules,
@@ -841,16 +847,20 @@ pub const codex_def = ProviderDefinition{
         .writable_paths = &.{"CODEX_HOME"},
         .session_paths = &.{"CODEX_HOME/auth.json"},
     },
-    // Refresh grant intentionally undeclared — same gating as claude_def.
-    // Serialization (TIN-2073), field-preserving merge (TIN-2074: preserves
-    // tokens.id_token, the codex identity source), and JWT-exp expiry
-    // derivation (TIN-2087: codex has no wall-clock expiry field) have
-    // landed. Remaining before the flip: the dual-writer story (TIN-2059)
-    // vs the native codex CLI — in particular warm-loop identity-lock
-    // participation (TIN-2043), since codex stores no expiry the merge
-    // rewrites (expiry is read from the access-token JWT, not persisted).
+    // GRANT FLIPPED (TIN-2057): the provider now SUPPORTS proactive refresh.
+    // Substrate complete — serialization (TIN-2073), field-preserving merge
+    // (TIN-2074: preserves tokens.id_token, the codex identity source), JWT-exp
+    // expiry derivation (TIN-2087), Option B proactive-rotation (TIN-2055), and —
+    // critically for codex's shared-identity shape (max-N == one Apple ID) — the
+    // warm-loop identity flock (TIN-2043), which serializes any two config
+    // accounts on one RT chain. Login stays upstream_cli_login → refresh admitted
+    // ONLY for an opted-in account. Live-proven 2026-06-14 (2×Codex proactively
+    // refreshed via `oauth-mux keepalive`, zero collateral). NOTE: two accounts
+    // that share an account_id MUST NOT both be opted in (provider family
+    // revocation is outside the lock domain) — see TIN-2113.
     .repair = .{
         .owner = .upstream_cli_login,
+        .proactive_refresh = .oauth_refresh_token,
     },
     .rate_limits = .{
         .remaining_header = "x-ratelimit-remaining-requests",
@@ -2610,4 +2620,16 @@ test "identityClaimFromCredential resolves codex tokens.account_id (TIN-2043)" {
         \\{"claudeAiOauth":{"accessToken":"at","refreshToken":"rt"}}
     ;
     try std.testing.expectEqual(@as(?[]u8, null), try identityClaimFromCredential(claude_def, claude_raw, std.testing.allocator));
+}
+
+test "claude/codex builtins declare the proactive_refresh grant but still require opt-in (TIN-2057)" {
+    // The grant flip: both providers SUPPORT proactive refresh now.
+    try std.testing.expect(claude_def.repair.proactive_refresh == .oauth_refresh_token);
+    try std.testing.expect(codex_def.repair.proactive_refresh == .oauth_refresh_token);
+    // Ownership stays upstream_cli_login, so secret.writebackPlan still admits a
+    // refresh ONLY for an account that also sets allow_proactive_refresh — the
+    // grant is provider-CAPABILITY, not auto-enable. (The admission logic itself
+    // is covered by the writebackPlan tests in secret.zig.)
+    try std.testing.expect(claude_def.repair.owner == .upstream_cli_login);
+    try std.testing.expect(codex_def.repair.owner == .upstream_cli_login);
 }


### PR DESCRIPTION
## What

The change the entire refresh-authority arc gated on: declare the builtin `claude`/`codex` providers as **supporting** proactive refresh (`.repair.proactive_refresh = .oauth_refresh_token`).

## This is capability, not auto-enable
Ownership stays `.upstream_cli_login`, so `secret.writebackPlan` admits a refresh **only** for an account that also sets `allow_proactive_refresh: true`. That field defaults **false** and no account opts in today, so this changes behaviour for **zero existing accounts** — it just lets an operator turn on `oauth-mux keepalive` per account.

## Why it's safe now (every gate the old comments listed is closed)
- serialization + under-lock revalidation (TIN-2073), field-preserving writeback (TIN-2074), **Option B** proactive-rotation (TIN-2055), JWT-exp expiry (TIN-2087), per-account + identity flocks (TIN-2043), canonical-keychain writeback refusal (TIN-2054/#406) — all landed.
- The bare-CLI dual-writer (R3, TIN-2059) is the **accepted residual**: the store-invariant (never persist an RT it didn't itself mint) downgrades a concurrent native-CLI rotation to a *wasted* refresh, never corruption.

## Live-proven (2026-06-14)
A scoped canary ran `oauth-mux keepalive` and proactively refreshed **2×Claude + 2×Codex real accounts** end-to-end (grant gate → flock → Option B revalidate → real token endpoint → field-preserving merge → atomic write). New tokens valid; Claude scopes/subscriptionType preserved; **zero collateral**. Every safety layer fired: the #406 canonical-keychain guard refused bare `~/.claude` *even under `--force`*; shared-identity accounts refused when not opted in.

## ⚠️ Caution (TIN-2113)
Two accounts sharing one `account_id` (e.g. `codex:max-1` == `codex:default`) must **not** both be opted in — provider family revocation is outside the lock domain. Tracked in TIN-2113.

## Test
+ test pinning the grant + that opt-in is still required. `zig build test` → **715/715**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)