### PR TITLE
keepalive: exclude shared-identity accounts from the warm pool (TIN-2113)

### DIFF
--- a/src/keepalive/warm_runner.zig
+++ b/src/keepalive/warm_runner.zig
@@ -21,9 +21,11 @@
 const std = @import("std");
 const ws = @import("warm_scheduler.zig");
 const bind = @import("warm_binding.zig");
+const ig = @import("../identity/identity_graph.zig");
 const pipeline = @import("../pipeline.zig");
 const config_mod = @import("../config.zig");
 const health_mod = @import("../health.zig");
+const log = @import("../log.zig");
 
 /// Context the binding's `DoRefreshFn`/`ClockFn` are bound to. Borrows the config
 /// and health store for the loop's lifetime.
@@ -91,25 +93,58 @@ pub fn enumeratePool(
     errdefer arena.deinit();
     const a = arena.allocator();
 
-    var list = std.ArrayList(bind.Observed).init(a);
+    // Pass 1: every account with a readable expiry → a candidate carrying its
+    // "<provider>:<account>" key, expiry, and stable identity hash (null for a
+    // provider with no identity claim, e.g. claude — its identity lives in
+    // .claude.json, not the credential). A read failure / no-expiry skips it.
+    const Candidate = struct { key: []const u8, expires_at_ms: i64, id_hash: ?[]const u8 };
+    var candidates = std.ArrayList(Candidate).init(a);
     var prov_it = cfg.providers.map.iterator();
     while (prov_it.next()) |pe| {
         const prov = pe.key_ptr.*;
         var acct_it = pe.value_ptr.accounts.map.iterator();
         while (acct_it.next()) |ae| {
             const acct = ae.key_ptr.*;
-            // Read this account's expiry with a throwaway Context (transient
-            // allocations freed by its deinit). A read failure / no-expiry skips
-            // the account rather than poisoning the pool.
             var pctx = pipeline.Context.init(allocator, cfg, health);
             defer pctx.deinit();
             pctx.provider_name = prov;
             pctx.account_name = acct;
-            const maybe_exp = pipeline.readAccountExpiryMs(&pctx) catch null;
-            const exp = maybe_exp orelse continue;
+            const exp = (pipeline.readAccountExpiryMs(&pctx) catch null) orelse continue;
             const key = try std.fmt.allocPrint(a, "{s}:{s}", .{ prov, acct });
-            try list.append(.{ .key = key, .expires_at_ms = exp });
+            var id_hash: ?[]const u8 = null;
+            if (pipeline.readAccountIdentityHash(&pctx) catch null) |h| {
+                defer allocator.free(h); // WE own `h` (ctx.allocator); free it after duping (incl. on the dupe's OOM)
+                id_hash = try a.dupe(u8, h);
+            }
+            try candidates.append(.{ .key = key, .expires_at_ms = exp, .id_hash = id_hash });
         }
+    }
+
+    // Pass 2 (TIN-2113): two accounts with the same identity hash share ONE
+    // single-use refresh-token family — rotating either risks provider
+    // family-revocation of the other (outside the per-host lock domain). So
+    // EXCLUDE every colliding account from the warm pool. The identity graph's
+    // duplicateCollisions does the grouping; the slot's `account` is the full key
+    // so collisions report unambiguous "<provider>:<account>" names.
+    var slots = std.ArrayList(ig.AccountSlot).init(a);
+    for (candidates.items) |c| {
+        try slots.append(.{ .account = c.key, .provider = "keepalive", .capability = "keepalive", .account_id_hash = c.id_hash, .liveness = .live });
+    }
+    const collisions = try ig.duplicateCollisions(a, slots.items); // arena-owned; freed with the arena
+    var excluded = std.StringHashMap(void).init(a);
+    for (collisions) |col| {
+        for (col.accounts) |k| try excluded.put(k, {});
+    }
+
+    // Pass 3: build the pool, excluding colliding accounts (logged so the operator
+    // sees why an account is not being warmed).
+    var list = std.ArrayList(bind.Observed).init(a);
+    for (candidates.items) |c| {
+        if (excluded.contains(c.key)) {
+            log.warn("keepalive: refusing to warm {s} — shares an OAuth identity with another enrolled account (single-use refresh-token family; family-revocation risk, TIN-2113); resolve the duplicate to enable", .{c.key});
+            continue;
+        }
+        try list.append(.{ .key = c.key, .expires_at_ms = c.expires_at_ms });
     }
     return .{ .observed = try list.toOwnedSlice(), .arena = arena };
 }

--- a/src/keepalive/warm_runner_tests.zig
+++ b/src/keepalive/warm_runner_tests.zig
@@ -139,3 +139,179 @@ test "doRefresh on an un-admitted (builtin-posture) account is RefreshFailed (gr
     var wr = runner.WarmRunner{ .allocator = testing.allocator, .cfg = parsed.value, .health = &store };
     try testing.expectError(ws.RefreshError.RefreshFailed, runner.WarmRunner.doRefresh(&wr, "toy", "a"));
 }
+
+// ── TIN-2113: shared-identity exclusion ──────────────────────────────────────
+
+fn idConfig(allocator: std.mem.Allocator, path_a: []const u8, path_b: []const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "provider_definitions": {{
+        \\    "toy": {{
+        \\      "name": "toy",
+        \\      "repair": {{ "owner": "oauth_mux_refresh" }},
+        \\      "auth": {{ "token_endpoint": "http://127.0.0.1:9/token" }},
+        \\      "credential": {{
+        \\        "access_token_path": "access_token",
+        \\        "refresh_token_path": "refresh_token",
+        \\        "expires_at_path": "expires_at",
+        \\        "identity_claim_path": "account_id"
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "providers": {{
+        \\    "toy": {{
+        \\      "kind": "toy",
+        \\      "accounts": {{
+        \\        "a": {{ "secret": {{ "backend": "file", "path": "{s}" }} }},
+        \\        "b": {{ "secret": {{ "backend": "file", "path": "{s}" }} }}
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "profiles": {{}},
+        \\  "strategies": {{}}
+        \\}}
+    , .{ path_a, path_b });
+}
+
+fn writeIdCred(path: []const u8, account_id: []const u8) !void {
+    const f = try std.fs.createFileAbsolute(path, .{});
+    defer f.close();
+    var buf: [256]u8 = undefined;
+    const s = try std.fmt.bufPrint(&buf, "{{\"access_token\":\"at\",\"refresh_token\":\"rt\",\"expires_at\":9000000000,\"account_id\":\"{s}\"}}", .{account_id});
+    try f.writeAll(s);
+}
+
+fn idPoolLen(account_id_a: []const u8, account_id_b: []const u8) !usize {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+    const pa = try std.fmt.allocPrint(testing.allocator, "{s}/a.json", .{root});
+    defer testing.allocator.free(pa);
+    const pb = try std.fmt.allocPrint(testing.allocator, "{s}/b.json", .{root});
+    defer testing.allocator.free(pb);
+    try writeIdCred(pa, account_id_a);
+    try writeIdCred(pb, account_id_b);
+    const json = try idConfig(testing.allocator, pa, pb);
+    defer testing.allocator.free(json);
+    const parsed = try config_mod.loadFromBytes(testing.allocator, json);
+    defer parsed.deinit();
+    var store = health_mod.HealthStore.init(testing.allocator, .{});
+    defer store.deinit();
+    var pool = try runner.enumeratePool(testing.allocator, parsed.value, &store);
+    defer pool.deinit();
+    return pool.observed.len;
+}
+
+test "enumeratePool EXCLUDES both accounts sharing an OAuth identity (TIN-2113)" {
+    // Same account_id => one single-use RT family => both excluded from the pool.
+    try testing.expectEqual(@as(usize, 0), try idPoolLen("same-id", "same-id"));
+}
+
+test "enumeratePool KEEPS accounts with distinct identities (TIN-2113)" {
+    try testing.expectEqual(@as(usize, 2), try idPoolLen("id-a", "id-b"));
+}
+
+fn idConfig3(allocator: std.mem.Allocator, pa: []const u8, pb: []const u8, pc: []const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator,
+        \\{{
+        \\  "version": 1,
+        \\  "provider_definitions": {{
+        \\    "toy": {{
+        \\      "name": "toy",
+        \\      "repair": {{ "owner": "oauth_mux_refresh" }},
+        \\      "auth": {{ "token_endpoint": "http://127.0.0.1:9/token" }},
+        \\      "credential": {{
+        \\        "access_token_path": "access_token", "refresh_token_path": "refresh_token",
+        \\        "expires_at_path": "expires_at", "identity_claim_path": "account_id"
+        \\      }}
+        \\    }}
+        \\  }},
+        \\  "providers": {{
+        \\    "toy": {{ "kind": "toy", "accounts": {{
+        \\      "a": {{ "secret": {{ "backend": "file", "path": "{s}" }} }},
+        \\      "b": {{ "secret": {{ "backend": "file", "path": "{s}" }} }},
+        \\      "c": {{ "secret": {{ "backend": "file", "path": "{s}" }} }}
+        \\    }} }}
+        \\  }},
+        \\  "profiles": {{}}, "strategies": {{}}
+        \\}}
+    , .{ pa, pb, pc });
+}
+
+test "enumeratePool excludes a shared pair but KEEPS a distinct sibling (TIN-2113, no over-exclusion)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+    const pa = try std.fmt.allocPrint(testing.allocator, "{s}/a.json", .{root});
+    defer testing.allocator.free(pa);
+    const pb = try std.fmt.allocPrint(testing.allocator, "{s}/b.json", .{root});
+    defer testing.allocator.free(pb);
+    const pc = try std.fmt.allocPrint(testing.allocator, "{s}/c.json", .{root});
+    defer testing.allocator.free(pc);
+    try writeIdCred(pa, "dup");
+    try writeIdCred(pb, "dup"); // a,b share identity
+    try writeIdCred(pc, "solo"); // c distinct
+    const json = try idConfig3(testing.allocator, pa, pb, pc);
+    defer testing.allocator.free(json);
+    const parsed = try config_mod.loadFromBytes(testing.allocator, json);
+    defer parsed.deinit();
+    var store = health_mod.HealthStore.init(testing.allocator, .{});
+    defer store.deinit();
+    var pool = try runner.enumeratePool(testing.allocator, parsed.value, &store);
+    defer pool.deinit();
+    // Only the distinct sibling survives; the shared pair is excluded.
+    try testing.expectEqual(@as(usize, 1), pool.observed.len);
+    try testing.expectEqualStrings("toy:c", pool.observed[0].key);
+}
+
+test "enumeratePool excludes ALL members of a 3-way identity collision (TIN-2113)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+    const pa = try std.fmt.allocPrint(testing.allocator, "{s}/a.json", .{root});
+    defer testing.allocator.free(pa);
+    const pb = try std.fmt.allocPrint(testing.allocator, "{s}/b.json", .{root});
+    defer testing.allocator.free(pb);
+    const pc = try std.fmt.allocPrint(testing.allocator, "{s}/c.json", .{root});
+    defer testing.allocator.free(pc);
+    try writeIdCred(pa, "tri");
+    try writeIdCred(pb, "tri");
+    try writeIdCred(pc, "tri");
+    const json = try idConfig3(testing.allocator, pa, pb, pc);
+    defer testing.allocator.free(json);
+    const parsed = try config_mod.loadFromBytes(testing.allocator, json);
+    defer parsed.deinit();
+    var store = health_mod.HealthStore.init(testing.allocator, .{});
+    defer store.deinit();
+    var pool = try runner.enumeratePool(testing.allocator, parsed.value, &store);
+    defer pool.deinit();
+    try testing.expectEqual(@as(usize, 0), pool.observed.len);
+}
+
+test "enumeratePool does NOT exclude accounts with no identity claim (claude-style, TIN-2113)" {
+    // twoAccountConfig declares NO identity_claim_path -> both accounts key opaquely
+    // (null identity) -> no false collision -> both kept.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+    const pa = try std.fmt.allocPrint(testing.allocator, "{s}/a.json", .{root});
+    defer testing.allocator.free(pa);
+    const pb = try std.fmt.allocPrint(testing.allocator, "{s}/b.json", .{root});
+    defer testing.allocator.free(pb);
+    try writeCred(pa, "rt-a", 9_000_000_000); // no account_id field; def has no identity_claim_path
+    try writeCred(pb, "rt-b", 9_000_000_000);
+    const json = try twoAccountConfig(testing.allocator, "oauth_mux_refresh", pa, pb);
+    defer testing.allocator.free(json);
+    const parsed = try config_mod.loadFromBytes(testing.allocator, json);
+    defer parsed.deinit();
+    var store = health_mod.HealthStore.init(testing.allocator, .{});
+    defer store.deinit();
+    var pool = try runner.enumeratePool(testing.allocator, parsed.value, &store);
+    defer pool.deinit();
+    try testing.expectEqual(@as(usize, 2), pool.observed.len);
+}

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -140,6 +140,24 @@ pub fn readAccountExpiryMs(ctx: *Context) PipelineError!?i64 {
     return null;
 }
 
+/// Read one account's stable identity as `sha256_12hex(account-id claim)`, for the
+/// keepalive shared-identity guard (TIN-2113): two accounts with the same hash
+/// share one single-use refresh-token family, so the warm loop must not rotate
+/// either (provider family-revocation is outside the per-host lock domain).
+/// Returns null when the provider declares no `identity_claim_path` (claude — its
+/// identity lives in .claude.json, not the credential) or the claim is absent.
+/// Caller OWNS the returned hash. Requires `ctx.provider_name` + `ctx.account_name`.
+pub fn readAccountIdentityHash(ctx: *Context) PipelineError!?[]u8 {
+    try resolveProvider(ctx);
+    const prov = ctx.provider_name orelse return error.ProviderNotFound;
+    const def = config_mod.resolveProviderDefinition(ctx.cfg, prov);
+    const raw = try readSecretRaw(ctx);
+    defer ctx.allocator.free(raw);
+    const account_id = (provider_schema.identityClaimFromCredential(def, raw, ctx.allocator) catch null) orelse return null;
+    defer ctx.allocator.free(account_id);
+    return identity_hash.sha256_12hex(ctx.allocator, account_id) catch return error.OutOfMemory;
+}
+
 /// The retry loop: try each candidate account in priority order.
 /// On failure, record the typed failure and move to the next candidate.
 fn selectWithFallback(ctx: *Context) PipelineError!void {


### PR DESCRIPTION
## What

Closes the one hazard the grant flip (#418) exposed, found during the TIN-2057 live proof: **two enrolled accounts can share one OAuth identity / single-use refresh-token family** (e.g. `codex:max-1` and `codex:default` both hash to `38079d6a`). Rotating either risks provider-side **family revocation** of the other — outside the per-host lock domain (the TIN-2043 identity flock serializes mux-vs-mux rotation but can't stop a *provider* revoking the chain).

## Guard
The keepalive runner now reads each account's stable identity and **excludes** every account that shares it with another enrolled account from the warm pool — so the loop can **never** rotate a shared chain.

- **`pipeline.readAccountIdentityHash(ctx)`** — `sha256_12hex` of the credential's identity claim (codex `tokens.account_id`; null for claude, whose identity lives in `.claude.json`, not the credential). Models `readAccountExpiryMs`.
- **`warm_runner.enumeratePool`** — pass 1 collects `(key, expiry, id_hash)`; pass 2 runs `identity_graph.duplicateCollisions` (the TIN-1822 dedup, already on main) to build the excluded set; pass 3 builds the pool, skipping + logging every colliding account.

## Live-verified
Against the real config, `keepalive --once` now refuses to warm **both** `codex:default` and `codex:max-1` (pool **7→5**) with a clear `TIN-2113` log; the other accounts are unaffected:
```
[WRN] keepalive: refusing to warm codex:default — shares an OAuth identity … (TIN-2113) …
[WRN] keepalive: refusing to warm codex:max-1 — shares an OAuth identity … (TIN-2113) …
{"accounts":5,"ticks":1,"refreshed":0,…}
```

## Test
+2 tests (same `account_id` → both excluded; distinct → both kept). `zig build test` → **718/718**.

Closes TIN-2113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)