### PR TITLE
build: add bounded Zig Bazel REAPI candidate skeleton

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,5 @@
+.zig-cache
+zig-out
+dist
+captures
+memory

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,18 @@
+# oauth-mux Bazel configuration.
+#
+# Endpoint authority is runtime-only. Do not put remote_cache,
+# remote_executor, credentials, or auth headers in checked-in rc files.
+
+common --noenable_bzlmod
+common --color=yes
+common --curses=yes
+
+build --jobs=auto
+build --show_timestamps
+test --test_output=errors
+test --test_summary=detailed
+
+# GloriousFlywheel behavior is endpoint-free. The wrapper supplies cache and
+# executor endpoints as validated command-line flags.
+try-import %workspace%/.bazelrc.flywheel
+try-import %workspace%/user.bazelrc

--- a/.bazelrc.flywheel
+++ b/.bazelrc.flywheel
@@ -1,0 +1,19 @@
+# Endpoint-free GloriousFlywheel behavior for oauth-mux's TIN-2105 candidate.
+#
+# Runtime authority lives in scripts/gloriousflywheel-bazel.sh:
+# BAZEL_REMOTE_CACHE, BAZEL_REMOTE_EXECUTOR, auth headers, and upload policy
+# are validated there and passed as explicit Bazel flags.
+
+common:flywheel --remote_upload_local_results=false
+common:flywheel --remote_timeout=60
+common:flywheel --remote_download_minimal
+
+common:flywheel-executor --config=flywheel
+common:flywheel-executor --remote_local_fallback=false
+common:flywheel-executor --spawn_strategy=remote
+common:flywheel-executor --jobs=200
+
+# Candidate-only filter. Do not switch this to `flywheel-eligible` until the
+# target class is proved and promoted in GloriousFlywheel.
+common:flywheel-executor --build_tag_filters=gloriousflywheel-rbe-candidate
+common:flywheel-executor --test_tag_filters=gloriousflywheel-rbe-candidate

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ Thumbs.db
 
 # Bazel (future)
 bazel-*
+MODULE.bazel.lock
 
 # Distribution artifacts
 dist/build/

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,46 @@
+"""
+Bounded Bazel surface for TIN-2105.
+
+These labels are candidates for an `oauth-mux-zig-build-test` REAPI target
+class. They deliberately use only candidate tags; GloriousFlywheel eligibility
+must wait for a forced proof artifact with nonzero remote processes, worker
+image provenance, executor/cache attachment, and no local fallback.
+"""
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "zig_inputs",
+    srcs = [
+        "build.zig",
+        "build.zig.zon",
+    ] + glob(["src/**/*.zig"]),
+)
+
+genrule(
+    name = "zig_build",
+    srcs = [
+        ":zig_inputs",
+        "scripts/bazel/zig-build-action.sh",
+    ],
+    outs = ["zig_build.marker"],
+    cmd = "$(location scripts/bazel/zig-build-action.sh) build $@",
+    tags = [
+        "gloriousflywheel-rbe-candidate",
+        "target-class=oauth-mux-zig-build-test",
+    ],
+)
+
+genrule(
+    name = "zig_build_test",
+    srcs = [
+        ":zig_inputs",
+        "scripts/bazel/zig-build-action.sh",
+    ],
+    outs = ["zig_build_test.marker"],
+    cmd = "$(location scripts/bazel/zig-build-action.sh) test $@",
+    tags = [
+        "gloriousflywheel-rbe-candidate",
+        "target-class=oauth-mux-zig-build-test",
+    ],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,13 @@
+"""
+oauth-mux Bazel module.
+
+This graph is intentionally tiny: TIN-2105 uses it only to prove a bounded
+Zig build/test REAPI target class. The existing Just/Nix remote lanes remain
+the repository's validation authority until a forced GloriousFlywheel proof
+artifact promotes the target class.
+"""
+
+module(
+    name = "oauth_mux",
+    version = "0.1.13",
+)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,0 +1,1 @@
+# oauth-mux's first Bazel/REAPI candidate is intentionally dependency-free.

--- a/justfile
+++ b/justfile
@@ -257,6 +257,17 @@ remote-first-run-e2e REF="":
 remote-release-proof REF="" VERSION=release_version:
     OMUX_REMOTE_RELEASE_VERSION={{VERSION}} ./scripts/remote-validate.sh release-proof {{REF}}
 
+# ── Bazel / REAPI candidate (TIN-2105, not proof authority yet) ──
+
+flywheel-zig-info *ARGS:
+    ./scripts/gloriousflywheel-bazel.sh info {{ARGS}}
+
+flywheel-zig-build *ARGS:
+    ./scripts/gloriousflywheel-bazel.sh build //:zig_build {{ARGS}}
+
+flywheel-zig-test *ARGS:
+    ./scripts/gloriousflywheel-bazel.sh test //:zig_build_test {{ARGS}}
+
 # ── Broker MCP smoke (provider-neutral regression catch-net) ──
 
 smoke-broker:

--- a/scripts/bazel/zig-build-action.sh
+++ b/scripts/bazel/zig-build-action.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Bounded Zig action used by Bazel candidate labels.
+
+set -euo pipefail
+
+mode="${1:-}"
+marker="${2:-}"
+
+if [[ -n "${TEST_SRCDIR:-}" && -n "${TEST_WORKSPACE:-}" && -d "${TEST_SRCDIR}/${TEST_WORKSPACE}" ]]; then
+  cd "${TEST_SRCDIR}/${TEST_WORKSPACE}"
+fi
+
+case "${mode}" in
+build | test) ;;
+*)
+  echo "usage: zig-build-action.sh build [marker] | test" >&2
+  exit 2
+  ;;
+esac
+
+if [[ -n "${TEST_TMPDIR:-}" ]]; then
+  scratch="${TEST_TMPDIR}"
+else
+  scratch="$(mktemp -d "${TMPDIR:-/tmp}/oauth-mux-bazel-zig.XXXXXX")"
+  trap 'rm -rf "${scratch}"' EXIT HUP INT TERM
+fi
+mkdir -p "${scratch}/home" "${scratch}/xdg-cache" "${scratch}/xdg-config" \
+  "${scratch}/zig-global-cache" "${scratch}/zig-local-cache" "${scratch}/zig-prefix"
+
+export HOME="${scratch}/home"
+export XDG_CACHE_HOME="${scratch}/xdg-cache"
+export XDG_CONFIG_HOME="${scratch}/xdg-config"
+export ZIG_GLOBAL_CACHE_DIR="${scratch}/zig-global-cache"
+export ZIG_LOCAL_CACHE_DIR="${scratch}/zig-local-cache"
+
+zig_bin="${ZIG_BIN:-zig}"
+
+case "${mode}" in
+build)
+  "${zig_bin}" build --prefix "${scratch}/zig-prefix"
+  ;;
+test)
+  "${zig_bin}" build test
+  ;;
+esac
+
+if [[ -n "${marker}" ]]; then
+  printf 'ok\n' >"${marker}"
+fi

--- a/scripts/check-local.sh
+++ b/scripts/check-local.sh
@@ -25,6 +25,7 @@ done
 ./scripts/stay-afloat-wrapper-doc-smoke.sh
 ./scripts/smoke-trace.sh
 ./scripts/smoke-remote-validate-contract.sh
+./scripts/smoke-bazel-remote-contract.sh
 ./scripts/smoke-dogfood-process-snapshot.sh
 ./scripts/smoke-broker.sh
 ./scripts/smoke-broker-claude.sh

--- a/scripts/gloriousflywheel-bazel.sh
+++ b/scripts/gloriousflywheel-bazel.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# Spoke-side Bazel wrapper for oauth-mux's bounded GloriousFlywheel REAPI work.
+#
+# Endpoint values come from the environment and are passed as explicit Bazel
+# flags. Checked-in .bazelrc files are not cache/executor authority.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+flywheel_env="${repo_root}/.env.flywheel.local"
+if [[ -f "${flywheel_env}" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "${flywheel_env}"
+  set +a
+fi
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/gloriousflywheel-bazel.sh <command> [args...]
+
+Commands:
+  info   Validate cache attachment, then run bazel info
+  build  Run a GloriousFlywheel-backed Bazel build
+  test   Build a GloriousFlywheel-backed target that runs `zig build test`
+
+Required environment:
+  BAZEL_REMOTE_CACHE        grpc://, grpcs://, http://, or https:// endpoint
+  GF_BAZEL_SUBSTRATE_MODE   shared-cache-backed or executor-backed
+
+Executor-backed mode also requires:
+  BAZEL_REMOTE_EXECUTOR     grpc://, grpcs://, http://, or https:// endpoint
+
+Optional environment:
+  BAZEL_BIN                         Bazel executable, defaults to bazelisk
+  GF_BAZEL_REMOTE_UPLOAD            true only for trusted cache-writing jobs
+  GF_BAZEL_FORCE_EXECUTION          true adds --remote_accept_cached=false
+  GF_BAZEL_REMOTE_EXECUTION_PLATFORM
+                                    defaults to gloriousflywheel-rbe-linux-x86_64
+  BAZEL_REMOTE_EXECUTOR_CACHE       executor-readable CAS/cache endpoint
+  BAZEL_CREDENTIAL_HELPER           Bazel credential helper, one per line
+  BAZEL_REMOTE_HEADER               remote header as name=value, one per line
+  BAZEL_REMOTE_CACHE_HEADER         cache-only header as name=value, one per line
+  BAZEL_REMOTE_EXEC_HEADER          executor-only header as name=value, one per line
+  BAZEL_REMOTE_MAX_CONNECTIONS      cap remote gRPC connections
+  GF_BAZEL_JOBS                     Bazel jobs override
+  BAZEL_OUTPUT_USER_ROOT            isolated Bazel output user root
+  BAZEL_OUTPUT_BASE                 isolated Bazel output base
+  BAZEL_REPOSITORY_CACHE            Bazel repository cache directory
+  BAZEL_DISTDIR                     colon-separated Bazel distdir paths
+EOF
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 2
+fi
+
+command="$1"
+shift
+
+case "${command}" in
+info | build | test) ;;
+-h | --help)
+  usage
+  exit 0
+  ;;
+*)
+  echo "ERROR: unsupported Bazel command for GloriousFlywheel wrapper: ${command}" >&2
+  usage
+  exit 2
+  ;;
+esac
+
+bazel_bin="${BAZEL_BIN:-bazelisk}"
+remote_cache="${BAZEL_REMOTE_CACHE:-}"
+remote_executor="${BAZEL_REMOTE_EXECUTOR:-}"
+remote_executor_cache="${BAZEL_REMOTE_EXECUTOR_CACHE:-}"
+mode="${GF_BAZEL_SUBSTRATE_MODE:-}"
+upload="${GF_BAZEL_REMOTE_UPLOAD:-false}"
+force_execution="${GF_BAZEL_FORCE_EXECUTION:-false}"
+remote_execution_platform="${GF_BAZEL_REMOTE_EXECUTION_PLATFORM:-gloriousflywheel-rbe-linux-x86_64}"
+remote_max_connections="${BAZEL_REMOTE_MAX_CONNECTIONS:-}"
+jobs="${GF_BAZEL_JOBS:-}"
+
+startup_args=()
+external_fetch_args=()
+executor_args=()
+auth_args=()
+cache_auth_args=()
+exec_auth_args=()
+
+validate_runtime_value() {
+  local flag_name="$1"
+  local value="$2"
+
+  if [[ ${value} == *'${'* ]] || [[ ${value} == *'}'* ]]; then
+    echo "ERROR: ${flag_name} contains a literal shell placeholder, not a real value." >&2
+    exit 1
+  fi
+}
+
+validate_endpoint() {
+  local name="$1"
+  local value="$2"
+
+  validate_runtime_value "${name}" "${value}"
+  if [[ ${value} =~ (attic-cache-dev|fuzzy-dev|attic\.dev-cluster|attic\.tinyland) ]]; then
+    echo "ERROR: ${name} points at a stale GloriousFlywheel endpoint." >&2
+    exit 1
+  fi
+  if [[ ! ${value} =~ ^(grpc|grpcs|http|https):// ]]; then
+    echo "ERROR: ${name} must start with grpc://, grpcs://, http://, or https://." >&2
+    exit 1
+  fi
+}
+
+if [[ -n ${BAZEL_OUTPUT_USER_ROOT:-} ]]; then
+  startup_args+=(--output_user_root="${BAZEL_OUTPUT_USER_ROOT}")
+fi
+
+if [[ -n ${BAZEL_OUTPUT_BASE:-} ]]; then
+  startup_args+=(--output_base="${BAZEL_OUTPUT_BASE}")
+fi
+
+if [[ -n ${BAZEL_REPOSITORY_CACHE:-} ]]; then
+  external_fetch_args+=(--repository_cache="${BAZEL_REPOSITORY_CACHE}")
+fi
+
+while IFS= read -r credential_helper; do
+  if [[ -n ${credential_helper} ]]; then
+    validate_runtime_value "BAZEL_CREDENTIAL_HELPER" "${credential_helper}"
+    auth_args+=(--credential_helper="${credential_helper}")
+  fi
+done <<<"${BAZEL_CREDENTIAL_HELPER:-}"
+
+while IFS= read -r remote_header; do
+  if [[ -n ${remote_header} ]]; then
+    validate_runtime_value "BAZEL_REMOTE_HEADER" "${remote_header}"
+    auth_args+=(--remote_header="${remote_header}")
+  fi
+done <<<"${BAZEL_REMOTE_HEADER:-}"
+
+while IFS= read -r remote_cache_header; do
+  if [[ -n ${remote_cache_header} ]]; then
+    validate_runtime_value "BAZEL_REMOTE_CACHE_HEADER" "${remote_cache_header}"
+    cache_auth_args+=(--remote_cache_header="${remote_cache_header}")
+  fi
+done <<<"${BAZEL_REMOTE_CACHE_HEADER:-}"
+
+while IFS= read -r remote_exec_header; do
+  if [[ -n ${remote_exec_header} ]]; then
+    validate_runtime_value "BAZEL_REMOTE_EXEC_HEADER" "${remote_exec_header}"
+    exec_auth_args+=(--remote_exec_header="${remote_exec_header}")
+  fi
+done <<<"${BAZEL_REMOTE_EXEC_HEADER:-}"
+
+if [[ -n ${BAZEL_DISTDIR:-} ]]; then
+  IFS=: read -r -a bazel_distdirs <<<"${BAZEL_DISTDIR}"
+  for bazel_distdir in "${bazel_distdirs[@]}"; do
+    if [[ -n ${bazel_distdir} ]]; then
+      external_fetch_args+=(--distdir="${bazel_distdir}")
+    fi
+  done
+fi
+
+if [[ -z ${remote_cache} ]]; then
+  echo "ERROR: BAZEL_REMOTE_CACHE is required for GloriousFlywheel-backed Bazel work." >&2
+  exit 1
+fi
+validate_endpoint "BAZEL_REMOTE_CACHE" "${remote_cache}"
+
+case "${mode}" in
+shared-cache-backed)
+  if [[ -n ${remote_executor} ]]; then
+    echo "ERROR: BAZEL_REMOTE_EXECUTOR is set but GF_BAZEL_SUBSTRATE_MODE is shared-cache-backed." >&2
+    exit 1
+  fi
+  bazel_config="flywheel"
+  ;;
+executor-backed)
+  if [[ -z ${remote_executor} ]]; then
+    echo "ERROR: executor-backed mode requires BAZEL_REMOTE_EXECUTOR." >&2
+    exit 1
+  fi
+  validate_endpoint "BAZEL_REMOTE_EXECUTOR" "${remote_executor}"
+  if [[ -n ${remote_executor_cache} ]]; then
+    validate_endpoint "BAZEL_REMOTE_EXECUTOR_CACHE" "${remote_executor_cache}"
+  fi
+  bazel_config="flywheel-executor"
+  remote_cache="${remote_executor_cache:-${remote_executor}}"
+  executor_args+=(
+    --remote_executor="${remote_executor}"
+    --remote_local_fallback=false
+    --spawn_strategy=remote
+    --remote_default_exec_properties="gf.platform=${remote_execution_platform}"
+  )
+  if [[ -n ${remote_max_connections} ]]; then
+    executor_args+=(--remote_max_connections="${remote_max_connections}")
+  fi
+  if [[ -n ${jobs} ]]; then
+    executor_args+=(--jobs="${jobs}")
+  fi
+  ;;
+*)
+  echo "ERROR: GF_BAZEL_SUBSTRATE_MODE must be shared-cache-backed or executor-backed." >&2
+  exit 1
+  ;;
+esac
+
+case "${upload}" in
+true | 1 | yes)
+  upload_args=(--remote_upload_local_results=true)
+  ;;
+false | 0 | no | "")
+  upload_args=(--remote_upload_local_results=false)
+  ;;
+*)
+  echo "ERROR: GF_BAZEL_REMOTE_UPLOAD must be true or false." >&2
+  exit 1
+  ;;
+esac
+
+case "${force_execution}" in
+true | 1 | yes)
+  force_args=(--remote_accept_cached=false)
+  ;;
+false | 0 | no | "")
+  force_args=()
+  ;;
+*)
+  echo "ERROR: GF_BAZEL_FORCE_EXECUTION must be true or false." >&2
+  exit 1
+  ;;
+esac
+
+if ! command -v "${bazel_bin}" >/dev/null 2>&1; then
+  echo "ERROR: ${bazel_bin} is not on PATH; enter direnv or nix develop first." >&2
+  exit 127
+fi
+
+bazel_action="${command}"
+if [[ ${command} == "test" ]]; then
+  bazel_action="build"
+fi
+
+case "${command}" in
+info)
+  bazel_args=(
+    info
+    --remote_cache="${remote_cache}"
+    ${upload_args[@]+"${upload_args[@]}"}
+    ${auth_args[@]+"${auth_args[@]}"}
+    ${cache_auth_args[@]+"${cache_auth_args[@]}"}
+  )
+  ;;
+build | test)
+  bazel_args=(
+    "${bazel_action}"
+    --config="${bazel_config}"
+    --remote_cache="${remote_cache}"
+    ${upload_args[@]+"${upload_args[@]}"}
+    ${force_args[@]+"${force_args[@]}"}
+    ${auth_args[@]+"${auth_args[@]}"}
+    ${cache_auth_args[@]+"${cache_auth_args[@]}"}
+    ${exec_auth_args[@]+"${exec_auth_args[@]}"}
+    ${executor_args[@]+"${executor_args[@]}"}
+    ${external_fetch_args[@]+"${external_fetch_args[@]}"}
+  )
+  ;;
+esac
+
+exec_args=("${bazel_bin}")
+if [[ ${#startup_args[@]} -gt 0 ]]; then
+  exec_args+=(${startup_args[@]+"${startup_args[@]}"})
+fi
+exec_args+=("${bazel_args[@]}" "$@")
+
+cd "${repo_root}"
+exec "${exec_args[@]}"

--- a/scripts/smoke-bazel-remote-contract.sh
+++ b/scripts/smoke-bazel-remote-contract.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env sh
+# Textual guard for the bounded Bazel/GloriousFlywheel REAPI candidate.
+
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WRAPPER="$ROOT/scripts/gloriousflywheel-bazel.sh"
+ACTION="$ROOT/scripts/bazel/zig-build-action.sh"
+BAZELRC="$ROOT/.bazelrc"
+FLYWHEEL_RC="$ROOT/.bazelrc.flywheel"
+BUILD_FILE="$ROOT/BUILD.bazel"
+BAZELIGNORE="$ROOT/.bazelignore"
+
+fail() {
+  echo "smoke-bazel-remote-contract: $*" >&2
+  exit 1
+}
+
+bash -n "$WRAPPER"
+bash -n "$ACTION"
+
+for rc in "$BAZELRC" "$FLYWHEEL_RC"; do
+  [ -f "$rc" ] || fail "missing $(basename "$rc")"
+  if grep -E -- '--remote_(cache|executor)=(grpc|grpcs|http|https)://' "$rc" >/dev/null; then
+    fail "$(basename "$rc") must not contain concrete remote endpoints"
+  fi
+  if grep -E 'attic-cache-dev|fuzzy-dev|attic\.dev-cluster|attic\.tinyland' "$rc" >/dev/null; then
+    fail "$(basename "$rc") must not contain stale GloriousFlywheel endpoints"
+  fi
+done
+
+grep -F -- '--noenable_bzlmod' "$BAZELRC" >/dev/null ||
+  fail "dependency-free candidate graph must not opt into checked-in Bzlmod deps"
+
+grep -F 'BAZEL_REMOTE_CACHE' "$WRAPPER" >/dev/null ||
+  fail "wrapper must read BAZEL_REMOTE_CACHE"
+grep -F 'BAZEL_REMOTE_EXECUTOR' "$WRAPPER" >/dev/null ||
+  fail "wrapper must read BAZEL_REMOTE_EXECUTOR"
+grep -F 'BAZEL_CREDENTIAL_HELPER' "$WRAPPER" >/dev/null ||
+  fail "wrapper must pass credential helpers from env"
+grep -F 'BAZEL_REMOTE_HEADER' "$WRAPPER" >/dev/null ||
+  fail "wrapper must pass common remote headers from env"
+grep -F 'BAZEL_REMOTE_CACHE_HEADER' "$WRAPPER" >/dev/null ||
+  fail "wrapper must pass cache-specific remote headers from env"
+grep -F 'BAZEL_REMOTE_EXEC_HEADER' "$WRAPPER" >/dev/null ||
+  fail "wrapper must pass executor-specific remote headers from env"
+grep -F -- '--remote_local_fallback=false' "$WRAPPER" >/dev/null ||
+  fail "executor-backed wrapper must disable local fallback"
+grep -F -- '--spawn_strategy=remote' "$WRAPPER" >/dev/null ||
+  fail "executor-backed wrapper must force remote spawn strategy"
+grep -F -- '--remote_accept_cached=false' "$WRAPPER" >/dev/null ||
+  fail "wrapper must expose a forced-execution proof mode"
+
+grep -F 'name = "zig_build"' "$BUILD_FILE" >/dev/null ||
+  fail "BUILD.bazel must define //:zig_build"
+grep -F 'name = "zig_build_test"' "$BUILD_FILE" >/dev/null ||
+  fail "BUILD.bazel must define //:zig_build_test"
+grep -F 'gloriousflywheel-rbe-candidate' "$BUILD_FILE" >/dev/null ||
+  fail "candidate labels must carry the candidate tag"
+if grep -F 'flywheel-eligible' "$BUILD_FILE" >/dev/null; then
+  fail "candidate labels must not claim flywheel eligibility before proof"
+fi
+
+grep -F 'ZIG_GLOBAL_CACHE_DIR' "$ACTION" >/dev/null ||
+  fail "zig action must isolate global Zig cache"
+grep -F 'ZIG_LOCAL_CACHE_DIR' "$ACTION" >/dev/null ||
+  fail "zig action must isolate local Zig cache"
+grep -F 'XDG_CONFIG_HOME' "$ACTION" >/dev/null ||
+  fail "zig action must isolate config home"
+
+grep -Fx '.zig-cache' "$BAZELIGNORE" >/dev/null ||
+  fail ".bazelignore must exclude Zig cache output"
+grep -Fx 'zig-out' "$BAZELIGNORE" >/dev/null ||
+  fail ".bazelignore must exclude Zig install output"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/omux-bazel-smoke.XXXXXX")"
+trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
+fake_bazel="$tmp_dir/bazelisk"
+cat >"$fake_bazel" <<'EOF'
+#!/usr/bin/env sh
+printf '%s\n' "$@"
+EOF
+chmod +x "$fake_bazel"
+
+wrapper_plan="$(
+  BAZEL_BIN="$fake_bazel" \
+  BAZEL_REMOTE_CACHE=grpc://cache.example \
+  BAZEL_REMOTE_EXECUTOR=grpc://executor.example \
+  GF_BAZEL_SUBSTRATE_MODE=executor-backed \
+  GF_BAZEL_FORCE_EXECUTION=true \
+  BAZEL_CREDENTIAL_HELPER=/bin/true \
+  BAZEL_REMOTE_HEADER='x-common=true' \
+  BAZEL_REMOTE_CACHE_HEADER='x-cache=true' \
+  BAZEL_REMOTE_EXEC_HEADER='x-exec=true' \
+  "$WRAPPER" test //:zig_build_test
+)"
+printf '%s\n' "$wrapper_plan" | grep -Fx 'build' >/dev/null ||
+  fail "wrapper test verb must execute a Bazel build action"
+printf '%s\n' "$wrapper_plan" | grep -Fx -- '--config=flywheel-executor' >/dev/null ||
+  fail "executor-backed wrapper must select flywheel-executor config"
+printf '%s\n' "$wrapper_plan" | grep -Fx -- '--remote_accept_cached=false' >/dev/null ||
+  fail "forced proof mode must bypass remote cache hits"
+printf '%s\n' "$wrapper_plan" | grep -Fx -- '--remote_local_fallback=false' >/dev/null ||
+  fail "executor-backed dry run must disable local fallback"
+printf '%s\n' "$wrapper_plan" | grep -Fx -- '--remote_header=x-common=true' >/dev/null ||
+  fail "wrapper dry run must pass common remote header"
+printf '%s\n' "$wrapper_plan" | grep -Fx -- '--remote_cache_header=x-cache=true' >/dev/null ||
+  fail "wrapper dry run must pass cache remote header"
+printf '%s\n' "$wrapper_plan" | grep -Fx -- '--remote_exec_header=x-exec=true' >/dev/null ||
+  fail "wrapper dry run must pass executor remote header"
+
+if BAZEL_BIN="$fake_bazel" \
+  BAZEL_REMOTE_CACHE=grpc://attic-cache-dev.example \
+  GF_BAZEL_SUBSTRATE_MODE=shared-cache-backed \
+  "$WRAPPER" info >/dev/null 2>&1; then
+  fail "wrapper must reject stale GloriousFlywheel endpoints"
+fi
+
+echo "smoke-bazel-remote-contract: ok"


### PR DESCRIPTION
## Summary

Adds the first bounded Bazel/GloriousFlywheel REAPI candidate surface for oauth-mux:

- `//:zig_build` runs `zig build` through a Bazel action.
- `//:zig_build_test` runs `zig build test` through a Bazel build action.
- `scripts/gloriousflywheel-bazel.sh` supplies runtime-only cache/executor endpoints, credential helpers, headers, forced-execution mode, and executor mode with local fallback disabled.
- `just flywheel-zig-info`, `just flywheel-zig-build`, and `just flywheel-zig-test` expose the candidate lane without promoting it to validation authority.
- `scripts/smoke-bazel-remote-contract.sh` guards endpoint-free rc files, candidate-only tags, stale endpoint rejection, remote header plumbing, forced execution, and Zig cache/config isolation.

## Truth boundary

This PR does **not** claim that oauth-mux has proved countable Bazel REAPI execution yet. It adds the skeleton and proof plumbing only. The existing GloriousFlywheel Just/Nix remote lanes remain the validation authority until a forced proof artifact records the exact target, exact command, executor/cache attachment, worker provenance, no local fallback, and `remote_processes > 0`.

## Validation

Local debugging only, not completion proof:

- `bash -n scripts/gloriousflywheel-bazel.sh scripts/bazel/zig-build-action.sh scripts/smoke-bazel-remote-contract.sh`
- `./scripts/smoke-bazel-remote-contract.sh`
- `bazelisk query //...`
- `bazelisk build --nobuild //:zig_build //:zig_build_test`
- `git diff --check`

Hosted PR checks are the proof lane for this change.

Refs TIN-2105.