### PR TITLE
build: add Zig REAPI proof dispatch lane

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,6 +12,12 @@ build --show_timestamps
 test --test_output=errors
 test --test_summary=detailed
 
+# GloriousFlywheel's cross-repo proof workflow invokes consumer workspaces with
+# --config=ci-cached. Keep this endpoint-free and candidate-scoped; the proof
+# workflow supplies --remote_cache, --remote_executor, forced execution, and
+# worker provenance as explicit runtime flags.
+build:ci-cached --config=flywheel-executor
+
 # GloriousFlywheel behavior is endpoint-free. The wrapper supplies cache and
 # executor endpoints as validated command-line flags.
 try-import %workspace%/.bazelrc.flywheel

--- a/docs/spec/oauth-mux-zig-reapi-target-class-plan-2026-06-14.md
+++ b/docs/spec/oauth-mux-zig-reapi-target-class-plan-2026-06-14.md
@@ -155,6 +155,34 @@ TIN-2105 is complete only when a forced GloriousFlywheel proof artifact cites:
 Only after that proof should GloriousFlywheel target-class eligibility mention
 `oauth-mux-zig-build-test`.
 
+## Spoke Proof Dispatch
+
+`oauth-mux` now has spoke-side helpers for the next proof gate:
+
+```bash
+just flywheel-zig-proof-dispatch --image-digest sha256:<gf-reapi-cell-digest>
+just flywheel-zig-proof-verify <run-id> --image-digest sha256:<gf-reapi-cell-digest>
+```
+
+The dispatch helper calls GloriousFlywheel's `gf-reapi-cell-proof.yml` with:
+
+- `consumer_repository=Jesssullivan/oauth-mux`
+- `workspace_path=consumer-workspace`
+- `target=//:zig_build_test`
+- `bazel_command=build`
+- `force_execution=true`
+- `apply=true` for the Linux proof endpoint
+
+The verifier helper delegates to GloriousFlywheel's
+`download-gf-reapi-proof-artifact.sh` and requires forced execution,
+`gloriousflywheel-rbe-linux-x86_64`, the expected target, and the expected
+worker image digest when supplied.
+
+These scripts are convenience wrappers only. The proof authority remains the
+GloriousFlywheel artifact verifier and `proof-result.json`. Dispatching a
+workflow, seeing a cache hit, or passing oauth-mux's normal hosted CI still
+does not count as REAPI eligibility.
+
 ## Risk Controls
 
 - Do not replace current Just/Nix remote proof lanes before the target class is

--- a/justfile
+++ b/justfile
@@ -268,6 +268,12 @@ flywheel-zig-build *ARGS:
 flywheel-zig-test *ARGS:
     ./scripts/gloriousflywheel-bazel.sh test //:zig_build_test {{ARGS}}
 
+flywheel-zig-proof-dispatch *ARGS:
+    ./scripts/dispatch-zig-reapi-proof.sh {{ARGS}}
+
+flywheel-zig-proof-verify RUN_ID *ARGS:
+    ./scripts/verify-zig-reapi-proof.sh --run-id {{RUN_ID}} {{ARGS}}
+
 # ── Broker MCP smoke (provider-neutral regression catch-net) ──
 
 smoke-broker:

--- a/scripts/dispatch-zig-reapi-proof.sh
+++ b/scripts/dispatch-zig-reapi-proof.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# Dispatch oauth-mux's bounded Zig target to GloriousFlywheel's explicit REAPI
+# proof workflow. This script does not run Bazel locally and does not itself
+# prove RBE; the GF proof artifact/verifier remains the authority.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/dispatch-zig-reapi-proof.sh --image-digest sha256:<64 hex> [options]
+
+Options:
+  --workflow-repo OWNER/REPO          GF workflow repo (default: tinyland-inc/GloriousFlywheel)
+  --workflow-ref REF                  GF workflow ref (default: main)
+  --request-id ID                     Correlation id; default tin2105-oauth-mux-zig-<time>-<sha>
+  --image-digest DIGEST               Published gf-reapi-cell image digest; may use GF_REAPI_CELL_DIGEST
+  --target TARGET                     Bazel target to prove (default: //:zig_build_test)
+  --bazel-command build|test          Bazel command (default: build)
+  --platform PLATFORM                 GF platform (default: gloriousflywheel-rbe-linux-x86_64)
+  --remote-executor ENDPOINT          Optional explicit grpc(s):// executor
+  --consumer-repository OWNER/REPO    Consumer repo (default: Jesssullivan/oauth-mux)
+  --consumer-ref REF                  Consumer ref; default current branch or HEAD sha
+  --consumer-checkout-authority AUTH  github-app, owner-scoped-secret, repo-scoped-deploy-key
+  --require-consumer-app-token        Require GF GitHub App checkout auth
+  --skip-apply                        Do not scale/apply the Linux gf-reapi-cell proof endpoint
+  --scale-to-zero-after-proof         Ask GF to scale the endpoint down after proof
+  --no-force-execution                Allow cache-hit-only runs; not acceptable for TIN-2105 proof
+  --dry-run                           Print the gh workflow command only
+  -h, --help                          Show this help
+
+Countable TIN-2105 proof still requires the GF artifact verifier to pass with
+force_execution=true, remote_processes > 0, worker image digest, and no local
+fallback.
+EOF
+}
+
+current_ref() {
+  local branch
+  branch="$(git -C "${repo_root}" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  if [[ -n ${branch} && ${branch} != "HEAD" ]]; then
+    printf '%s\n' "${branch}"
+    return
+  fi
+  git -C "${repo_root}" rev-parse HEAD
+}
+
+workflow_repo="${GF_REAPI_WORKFLOW_REPO:-tinyland-inc/GloriousFlywheel}"
+workflow_ref="${GF_REAPI_WORKFLOW_REF:-main}"
+request_id=""
+image_digest="${GF_REAPI_CELL_DIGEST:-}"
+target="//:zig_build_test"
+bazel_command="build"
+platform="${GF_BAZEL_REMOTE_EXECUTION_PLATFORM:-gloriousflywheel-rbe-linux-x86_64}"
+remote_executor="${BAZEL_REMOTE_EXECUTOR:-}"
+consumer_repository="${GF_REAPI_CONSUMER_REPOSITORY:-Jesssullivan/oauth-mux}"
+consumer_ref="${GF_REAPI_CONSUMER_REF:-}"
+consumer_checkout_authority="${GF_REAPI_CONSUMER_CHECKOUT_AUTHORITY:-github-app}"
+require_consumer_app_token="false"
+apply="true"
+scale_to_zero_after_proof="false"
+force_execution="true"
+dry_run="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --workflow-repo)
+    workflow_repo="${2:?missing value for --workflow-repo}"
+    shift 2
+    ;;
+  --workflow-ref)
+    workflow_ref="${2:?missing value for --workflow-ref}"
+    shift 2
+    ;;
+  --request-id)
+    request_id="${2:?missing value for --request-id}"
+    shift 2
+    ;;
+  --image-digest)
+    image_digest="${2:?missing value for --image-digest}"
+    shift 2
+    ;;
+  --target)
+    target="${2:?missing value for --target}"
+    shift 2
+    ;;
+  --bazel-command)
+    bazel_command="${2:?missing value for --bazel-command}"
+    shift 2
+    ;;
+  --platform)
+    platform="${2:?missing value for --platform}"
+    shift 2
+    ;;
+  --remote-executor)
+    remote_executor="${2:?missing value for --remote-executor}"
+    shift 2
+    ;;
+  --consumer-repository)
+    consumer_repository="${2:?missing value for --consumer-repository}"
+    shift 2
+    ;;
+  --consumer-ref)
+    consumer_ref="${2:?missing value for --consumer-ref}"
+    shift 2
+    ;;
+  --consumer-checkout-authority)
+    consumer_checkout_authority="${2:?missing value for --consumer-checkout-authority}"
+    shift 2
+    ;;
+  --require-consumer-app-token)
+    require_consumer_app_token="true"
+    shift
+    ;;
+  --skip-apply)
+    apply="false"
+    shift
+    ;;
+  --scale-to-zero-after-proof)
+    scale_to_zero_after_proof="true"
+    shift
+    ;;
+  --no-force-execution)
+    force_execution="false"
+    shift
+    ;;
+  --dry-run)
+    dry_run="true"
+    shift
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "ERROR: unknown argument: $1" >&2
+    usage
+    exit 2
+    ;;
+  esac
+done
+
+if [[ -z ${consumer_ref} ]]; then
+  consumer_ref="$(current_ref)"
+fi
+
+if [[ -z ${request_id} ]]; then
+  request_id="tin2105-oauth-mux-zig-$(date -u +%Y%m%dT%H%M%SZ)-$(git -C "${repo_root}" rev-parse --short HEAD)"
+fi
+
+if [[ ! ${workflow_repo} =~ ^[^/]+/[^/]+$ ]]; then
+  echo "ERROR: --workflow-repo must be OWNER/REPO" >&2
+  exit 2
+fi
+
+if [[ ! ${consumer_repository} =~ ^[^/]+/[^/]+$ ]]; then
+  echo "ERROR: --consumer-repository must be OWNER/REPO" >&2
+  exit 2
+fi
+
+if [[ -z ${workflow_ref} || -z ${consumer_ref} ]]; then
+  echo "ERROR: workflow and consumer refs must be non-empty" >&2
+  exit 2
+fi
+
+if [[ ! ${request_id} =~ ^[A-Za-z0-9._:-]+$ ]]; then
+  echo "ERROR: --request-id may contain only letters, numbers, dot, underscore, colon, or dash" >&2
+  exit 2
+fi
+
+if [[ ! ${image_digest} =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  echo "ERROR: --image-digest or GF_REAPI_CELL_DIGEST must be sha256:<64 lowercase hex chars>" >&2
+  exit 2
+fi
+
+if [[ ! ${target} =~ ^// ]]; then
+  echo "ERROR: --target must be a Bazel label beginning with //" >&2
+  exit 2
+fi
+
+case "${bazel_command}" in
+build | test) ;;
+*)
+  echo "ERROR: --bazel-command must be build or test" >&2
+  exit 2
+  ;;
+esac
+
+case "${platform}" in
+gloriousflywheel-rbe-linux-x86_64 | gloriousflywheel-rbe-darwin-aarch64) ;;
+*)
+  echo "ERROR: --platform must be gloriousflywheel-rbe-linux-x86_64 or gloriousflywheel-rbe-darwin-aarch64" >&2
+  exit 2
+  ;;
+esac
+
+case "${consumer_checkout_authority}" in
+github-app | owner-scoped-secret | repo-scoped-deploy-key) ;;
+*)
+  echo "ERROR: --consumer-checkout-authority must be github-app, owner-scoped-secret, or repo-scoped-deploy-key" >&2
+  exit 2
+  ;;
+esac
+
+if [[ -n ${remote_executor} && ! ${remote_executor} =~ ^(grpc|grpcs):// ]]; then
+  echo "ERROR: --remote-executor must start with grpc:// or grpcs://" >&2
+  exit 2
+fi
+
+linux_executor="grpc://gf-reapi-cell.gf-rbe.svc.cluster.local:8980"
+if [[ ${platform} == "gloriousflywheel-rbe-darwin-aarch64" ]]; then
+  if [[ -z ${remote_executor} ]]; then
+    echo "ERROR: Darwin platform requires --remote-executor" >&2
+    exit 2
+  fi
+  if [[ ${remote_executor} == "${linux_executor}" ]]; then
+    echo "ERROR: Darwin platform cannot use the Linux gf-reapi-cell executor" >&2
+    exit 2
+  fi
+  if [[ ${apply} == "true" ]]; then
+    echo "ERROR: Darwin platform requires --skip-apply" >&2
+    exit 2
+  fi
+fi
+
+case "${apply}" in true | false) ;;
+*) echo "ERROR: apply must be true or false" >&2; exit 2 ;;
+esac
+case "${scale_to_zero_after_proof}" in true | false) ;;
+*) echo "ERROR: scale_to_zero_after_proof must be true or false" >&2; exit 2 ;;
+esac
+case "${force_execution}" in true | false) ;;
+*) echo "ERROR: force_execution must be true or false" >&2; exit 2 ;;
+esac
+
+cmd=(
+  gh workflow run gf-reapi-cell-proof.yml
+  --repo "${workflow_repo}"
+  --ref "${workflow_ref}"
+  -f "request_id=${request_id}"
+  -f "image_digest=${image_digest}"
+  -f "target=${target}"
+  -f "bazel_command=${bazel_command}"
+  -f "platform=${platform}"
+  -f "remote_executor=${remote_executor}"
+  -f "workspace_path=consumer-workspace"
+  -f "consumer_repository=${consumer_repository}"
+  -f "consumer_ref=${consumer_ref}"
+  -f "require_consumer_app_token=${require_consumer_app_token}"
+  -f "consumer_checkout_authority=${consumer_checkout_authority}"
+  -f "was110_public_handoff=false"
+  -f "tinyland_schemas_private_handoff=false"
+  -f "apply=${apply}"
+  -f "scale_to_zero_after_proof=${scale_to_zero_after_proof}"
+  -f "force_execution=${force_execution}"
+)
+
+if [[ ${dry_run} == "true" ]]; then
+  printf '%q ' "${cmd[@]}"
+  printf '\n'
+  exit 0
+fi
+
+if [[ ${force_execution} != "true" ]]; then
+  echo "WARN: --no-force-execution runs are not countable TIN-2105 proof." >&2
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh is required to dispatch GF REAPI Cell Proof" >&2
+  exit 127
+fi
+
+printf 'Dispatching GF REAPI proof request_id=%s consumer_ref=%s target=%s\n' \
+  "${request_id}" "${consumer_ref}" "${target}" >&2
+printf 'After dispatch, find the run with:\n' >&2
+printf '  gh run list --repo %q --workflow gf-reapi-cell-proof.yml --json databaseId,displayTitle,status,conclusion,url --jq %q\n' \
+  "${workflow_repo}" ".[] | select(.displayTitle | contains(\"${request_id}\"))" >&2
+
+exec "${cmd[@]}"

--- a/scripts/smoke-bazel-remote-contract.sh
+++ b/scripts/smoke-bazel-remote-contract.sh
@@ -6,10 +6,13 @@ set -eu
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 WRAPPER="$ROOT/scripts/gloriousflywheel-bazel.sh"
 ACTION="$ROOT/scripts/bazel/zig-build-action.sh"
+DISPATCH="$ROOT/scripts/dispatch-zig-reapi-proof.sh"
+VERIFY="$ROOT/scripts/verify-zig-reapi-proof.sh"
 BAZELRC="$ROOT/.bazelrc"
 FLYWHEEL_RC="$ROOT/.bazelrc.flywheel"
 BUILD_FILE="$ROOT/BUILD.bazel"
 BAZELIGNORE="$ROOT/.bazelignore"
+JUSTFILE="$ROOT/justfile"
 
 fail() {
   echo "smoke-bazel-remote-contract: $*" >&2
@@ -18,6 +21,8 @@ fail() {
 
 bash -n "$WRAPPER"
 bash -n "$ACTION"
+bash -n "$DISPATCH"
+bash -n "$VERIFY"
 
 for rc in "$BAZELRC" "$FLYWHEEL_RC"; do
   [ -f "$rc" ] || fail "missing $(basename "$rc")"
@@ -31,6 +36,8 @@ done
 
 grep -F -- '--noenable_bzlmod' "$BAZELRC" >/dev/null ||
   fail "dependency-free candidate graph must not opt into checked-in Bzlmod deps"
+grep -F 'build:ci-cached --config=flywheel-executor' "$BAZELRC" >/dev/null ||
+  fail "GF proof workflow invokes --config=ci-cached; it must map to the candidate executor config"
 
 grep -F 'BAZEL_REMOTE_CACHE' "$WRAPPER" >/dev/null ||
   fail "wrapper must read BAZEL_REMOTE_CACHE"
@@ -51,6 +58,26 @@ grep -F -- '--spawn_strategy=remote' "$WRAPPER" >/dev/null ||
 grep -F -- '--remote_accept_cached=false' "$WRAPPER" >/dev/null ||
   fail "wrapper must expose a forced-execution proof mode"
 
+grep -F 'gh workflow run gf-reapi-cell-proof.yml' "$DISPATCH" >/dev/null ||
+  fail "Zig proof dispatcher must delegate to GF REAPI Cell Proof"
+grep -F 'workspace_path=consumer-workspace' "$DISPATCH" >/dev/null ||
+  fail "Zig proof dispatcher must use the GF consumer workspace checkout"
+grep -F 'consumer_repository=${consumer_repository}' "$DISPATCH" >/dev/null ||
+  fail "Zig proof dispatcher must pass consumer repository"
+grep -F 'force_execution=${force_execution}' "$DISPATCH" >/dev/null ||
+  fail "Zig proof dispatcher must pass forced execution"
+grep -F 'apply=${apply}' "$DISPATCH" >/dev/null ||
+  fail "Zig proof dispatcher must pass apply/skip-apply explicitly"
+grep -F 'does not itself' "$DISPATCH" >/dev/null ||
+  fail "Zig proof dispatcher must not claim proof authority"
+
+grep -F 'download-gf-reapi-proof-artifact.sh' "$VERIFY" >/dev/null ||
+  fail "Zig proof verifier must delegate artifact validation to GF"
+grep -F -- '--require-force-execution' "$VERIFY" >/dev/null ||
+  fail "Zig proof verifier must require countable forced execution"
+grep -F 'GF_REAPI_TOOLS_DIR' "$VERIFY" >/dev/null ||
+  fail "Zig proof verifier must allow an explicit GF tools checkout"
+
 grep -F 'name = "zig_build"' "$BUILD_FILE" >/dev/null ||
   fail "BUILD.bazel must define //:zig_build"
 grep -F 'name = "zig_build_test"' "$BUILD_FILE" >/dev/null ||
@@ -60,6 +87,11 @@ grep -F 'gloriousflywheel-rbe-candidate' "$BUILD_FILE" >/dev/null ||
 if grep -F 'flywheel-eligible' "$BUILD_FILE" >/dev/null; then
   fail "candidate labels must not claim flywheel eligibility before proof"
 fi
+
+grep -F 'flywheel-zig-proof-dispatch' "$JUSTFILE" >/dev/null ||
+  fail "Justfile must expose the Zig REAPI proof dispatcher"
+grep -F 'flywheel-zig-proof-verify' "$JUSTFILE" >/dev/null ||
+  fail "Justfile must expose the Zig REAPI proof verifier"
 
 grep -F 'ZIG_GLOBAL_CACHE_DIR' "$ACTION" >/dev/null ||
   fail "zig action must isolate global Zig cache"
@@ -115,5 +147,61 @@ if BAZEL_BIN="$fake_bazel" \
   "$WRAPPER" info >/dev/null 2>&1; then
   fail "wrapper must reject stale GloriousFlywheel endpoints"
 fi
+
+digest="sha256:1111111111111111111111111111111111111111111111111111111111111111"
+dispatch_plan="$(
+  GF_REAPI_CONSUMER_REF=test-branch \
+  "$DISPATCH" --image-digest "$digest" --request-id tin2105-static --dry-run
+)"
+printf '%s\n' "$dispatch_plan" | grep -F 'gh workflow run gf-reapi-cell-proof.yml' >/dev/null ||
+  fail "dispatch dry run must call GF proof workflow"
+printf '%s\n' "$dispatch_plan" | grep -F -- '--repo tinyland-inc/GloriousFlywheel' >/dev/null ||
+  fail "dispatch dry run must target the GF workflow repo"
+printf '%s\n' "$dispatch_plan" | grep -F 'request_id=tin2105-static' >/dev/null ||
+  fail "dispatch dry run must pass request id"
+printf '%s\n' "$dispatch_plan" | grep -F "image_digest=$digest" >/dev/null ||
+  fail "dispatch dry run must pass image digest"
+printf '%s\n' "$dispatch_plan" | grep -F 'target=//:zig_build_test' >/dev/null ||
+  fail "dispatch dry run must pass the Zig candidate target"
+printf '%s\n' "$dispatch_plan" | grep -F 'bazel_command=build' >/dev/null ||
+  fail "dispatch dry run must use Bazel build for the genrule-backed test target"
+printf '%s\n' "$dispatch_plan" | grep -F 'consumer_repository=Jesssullivan/oauth-mux' >/dev/null ||
+  fail "dispatch dry run must pass oauth-mux as consumer repository"
+printf '%s\n' "$dispatch_plan" | grep -F 'consumer_ref=test-branch' >/dev/null ||
+  fail "dispatch dry run must pass consumer ref"
+printf '%s\n' "$dispatch_plan" | grep -F 'workspace_path=consumer-workspace' >/dev/null ||
+  fail "dispatch dry run must pass consumer workspace path"
+printf '%s\n' "$dispatch_plan" | grep -F 'apply=true' >/dev/null ||
+  fail "dispatch dry run must apply the Linux proof endpoint by default"
+printf '%s\n' "$dispatch_plan" | grep -F 'force_execution=true' >/dev/null ||
+  fail "dispatch dry run must force execution by default"
+
+if "$DISPATCH" --image-digest sha256:bad --dry-run >/dev/null 2>&1; then
+  fail "dispatch must reject malformed image digests"
+fi
+
+fake_gf="$tmp_dir/gf"
+mkdir -p "$fake_gf/scripts"
+cat >"$fake_gf/scripts/download-gf-reapi-proof-artifact.sh" <<'EOF'
+#!/usr/bin/env sh
+printf '%s\n' "$@"
+EOF
+chmod +x "$fake_gf/scripts/download-gf-reapi-proof-artifact.sh"
+verify_plan="$(
+  GF_REAPI_TOOLS_DIR="$fake_gf" \
+  "$VERIFY" --run-id 123456 --image-digest "$digest"
+)"
+printf '%s\n' "$verify_plan" | grep -Fx -- '--repo' >/dev/null ||
+  fail "verify dry fake must pass repo flag"
+printf '%s\n' "$verify_plan" | grep -Fx 'tinyland-inc/GloriousFlywheel' >/dev/null ||
+  fail "verify dry fake must pass GF workflow repo"
+printf '%s\n' "$verify_plan" | grep -Fx -- '--target' >/dev/null ||
+  fail "verify dry fake must pass target flag"
+printf '%s\n' "$verify_plan" | grep -Fx '//:zig_build_test' >/dev/null ||
+  fail "verify dry fake must require the Zig candidate target"
+printf '%s\n' "$verify_plan" | grep -Fx -- '--require-force-execution' >/dev/null ||
+  fail "verify dry fake must require forced execution"
+printf '%s\n' "$verify_plan" | grep -Fx -- '--require-image-digest' >/dev/null ||
+  fail "verify dry fake must pass image digest requirement when supplied"
 
 echo "smoke-bazel-remote-contract: ok"

--- a/scripts/verify-zig-reapi-proof.sh
+++ b/scripts/verify-zig-reapi-proof.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Download and verify the GloriousFlywheel proof artifact for oauth-mux's Zig
+# REAPI candidate. Verification is delegated to GloriousFlywheel tooling.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/verify-zig-reapi-proof.sh --run-id RUN_ID [options]
+
+Options:
+  --gf-tools-dir DIR        GloriousFlywheel checkout (default: ../GloriousFlywheel)
+  --workflow-repo OWNER/REPO
+                            GF workflow repo (default: tinyland-inc/GloriousFlywheel)
+  --run-id RUN_ID           GF REAPI Cell Proof run id
+  --output-dir DIR          Artifact download directory
+  --image-digest DIGEST     Require exact gf-reapi-cell digest; may use GF_REAPI_CELL_DIGEST
+  --target TARGET           Required target (default: //:zig_build_test)
+  --bazel-command build|test
+                            Required Bazel command (default: build)
+  --platform PLATFORM       Required platform (default: gloriousflywheel-rbe-linux-x86_64)
+  -h, --help                Show this help
+
+This script does not create evidence. It only downloads the GF artifact and
+requires force_execution=true plus countable remote execution.
+EOF
+}
+
+gf_tools_dir="${GF_REAPI_TOOLS_DIR:-${repo_root}/../GloriousFlywheel}"
+workflow_repo="${GF_REAPI_WORKFLOW_REPO:-tinyland-inc/GloriousFlywheel}"
+run_id=""
+output_dir=""
+image_digest="${GF_REAPI_CELL_DIGEST:-}"
+target="//:zig_build_test"
+bazel_command="build"
+platform="${GF_BAZEL_REMOTE_EXECUTION_PLATFORM:-gloriousflywheel-rbe-linux-x86_64}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --gf-tools-dir)
+    gf_tools_dir="${2:?missing value for --gf-tools-dir}"
+    shift 2
+    ;;
+  --workflow-repo)
+    workflow_repo="${2:?missing value for --workflow-repo}"
+    shift 2
+    ;;
+  --run-id)
+    run_id="${2:?missing value for --run-id}"
+    shift 2
+    ;;
+  --output-dir)
+    output_dir="${2:?missing value for --output-dir}"
+    shift 2
+    ;;
+  --image-digest)
+    image_digest="${2:?missing value for --image-digest}"
+    shift 2
+    ;;
+  --target)
+    target="${2:?missing value for --target}"
+    shift 2
+    ;;
+  --bazel-command)
+    bazel_command="${2:?missing value for --bazel-command}"
+    shift 2
+    ;;
+  --platform)
+    platform="${2:?missing value for --platform}"
+    shift 2
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "ERROR: unknown argument: $1" >&2
+    usage
+    exit 2
+    ;;
+  esac
+done
+
+if [[ ! ${workflow_repo} =~ ^[^/]+/[^/]+$ ]]; then
+  echo "ERROR: --workflow-repo must be OWNER/REPO" >&2
+  exit 2
+fi
+
+if [[ ! ${run_id} =~ ^[0-9]+$ ]]; then
+  echo "ERROR: --run-id is required and must be numeric" >&2
+  exit 2
+fi
+
+if [[ ! ${target} =~ ^// ]]; then
+  echo "ERROR: --target must be a Bazel label beginning with //" >&2
+  exit 2
+fi
+
+case "${bazel_command}" in
+build | test) ;;
+*)
+  echo "ERROR: --bazel-command must be build or test" >&2
+  exit 2
+  ;;
+esac
+
+case "${platform}" in
+gloriousflywheel-rbe-linux-x86_64 | gloriousflywheel-rbe-darwin-aarch64) ;;
+*)
+  echo "ERROR: --platform must be gloriousflywheel-rbe-linux-x86_64 or gloriousflywheel-rbe-darwin-aarch64" >&2
+  exit 2
+  ;;
+esac
+
+if [[ -n ${image_digest} && ! ${image_digest} =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  echo "ERROR: --image-digest or GF_REAPI_CELL_DIGEST must be sha256:<64 lowercase hex chars>" >&2
+  exit 2
+fi
+
+download_script="${gf_tools_dir}/scripts/download-gf-reapi-proof-artifact.sh"
+if [[ ! -x ${download_script} ]]; then
+  echo "ERROR: GloriousFlywheel verifier is required at ${download_script}" >&2
+  echo "       set GF_REAPI_TOOLS_DIR to a GloriousFlywheel checkout" >&2
+  exit 2
+fi
+
+args=(
+  --repo "${workflow_repo}"
+  --run-id "${run_id}"
+  --target "${target}"
+  --require-bazel-command "${bazel_command}"
+  --require-force-execution
+  --require-platform "${platform}"
+)
+
+if [[ -n ${output_dir} ]]; then
+  args+=(--output-dir "${output_dir}")
+fi
+
+if [[ -n ${image_digest} ]]; then
+  args+=(--require-image-digest "${image_digest}")
+fi
+
+exec bash "${download_script}" "${args[@]}"


### PR DESCRIPTION
## Summary

Adds the next TIN-2105 spoke-side lane for proving the bounded Zig Bazel target through GloriousFlywheel's explicit REAPI proof workflow.

- Adds `scripts/dispatch-zig-reapi-proof.sh` to dispatch `gf-reapi-cell-proof.yml` for `Jesssullivan/oauth-mux`, `consumer-workspace`, `//:zig_build_test`, `bazel_command=build`, and `force_execution=true`.
- Adds `scripts/verify-zig-reapi-proof.sh` to delegate artifact download/verification to GloriousFlywheel's proof verifier.
- Adds endpoint-free `ci-cached` config mapping for the GF consumer proof wrapper.
- Adds Just entrypoints and extends the static Bazel/REAPI contract smoke.
- Updates the TIN-2105 plan with the dispatch/verify handoff and the non-proof boundary.

## Truth boundary

This does not prove Zig REAPI execution and does not close TIN-2105. It only gives oauth-mux a correct spoke-side way to request and verify the forced GF proof. Countable proof still requires the GF artifact verifier to pass with `remote_processes > 0`, forced execution, worker image provenance, and no local fallback.

## Debug checks run locally, not proof

- `bash -n scripts/dispatch-zig-reapi-proof.sh scripts/verify-zig-reapi-proof.sh scripts/smoke-bazel-remote-contract.sh`
- `./scripts/smoke-bazel-remote-contract.sh`
- `git diff --check`
- `just --summary` parse check

Hosted remote CI remains the merge gate.
