### PR TITLE
reauth: flow-composition train car — production RunFlowFn (device_code arm)

### DIFF
--- a/docs/spec/reauth-orchestrator-designation-2026-06-12.md
+++ b/docs/spec/reauth-orchestrator-designation-2026-06-12.md
@@ -41,38 +41,41 @@ executes — and the consent boundary sits exactly between them.**
 
 ### Current state vs target (honesty section)
 
-The review established that **today, approval does not reach the engine**:
+The review established that **approval still does not reach the engine**:
 the mediator's emitted `next_action` for `auth_revoked` points at
 vendor-CLI paths (`oauth-mux codex login-device <slot>`, which shells the
 vendor's own `codex login --device-auth`; `env CLAUDE_CONFIG_DIR=… claude
-/login`), and no production `RunFlowFn` implementation exists for **any**
-engine flow — `reauth.zig` / `device_code.zig` / `browser_launch.zig` /
-`callback_server.zig` are mutually unconnected std-only modules wired only
-into the test root. `command_owned` and `pat_paste` are enum variants with
-no mechanics.
+/login`). As of the flow-composition car, a production `RunFlowFn` exists for
+the `device_code` arm, and `device_code.zig` / `browser_launch.zig` are wired
+into the main test root. That does **not** mean any provider has flipped to
+engine-run yet: no approval verb or UI action invokes the engine, loopback
+still lacks a live `awaitCallback` seam, and `command_owned` / `pat_paste`
+remain non-engine-run by design.
 
 That is acceptable and intended: **vendor-CLI delegation remains a valid
 execution path forever** (it is the contract-pinned path for Claude — see
 Contract note). The engine becomes the executor for flows as they gain
 production bindings, via a named workstream:
 
-**NEW TRAIN CAR — "flow composition" (insert into TIN-2053 before #347/#354
+**TRAIN CAR — "flow composition" (inserted into TIN-2053 before #347/#354
 wiring):**
-- Production `RunFlowFn` impls composing `device_code.zig` (RFC 8628),
-  `callback_server.zig` (loopback PKCE), and `browser_launch.zig` — these
-  modules each own their own seam bundles; the composition layer binds them.
-- `HandoffRecord` gains a correlation id so approval verbs can name what they
-  approve.
-- `MediationKind` gains `command_owned` / `pat_paste` variants and
-  `consentFor` stops hardcoding `.device_login` for every provider.
-- The mediator's `next_action` strings become flow-aware: vendor-CLI command
-  for command-owned providers, `oauth-mux reauth run <handoff-id>` for
-  engine-run flows.
+- Done in #422: production `RunFlowFn` composition for `device_code.zig` (RFC
+  8628), plus main-test-root wiring for `device_code.zig` and
+  `browser_launch.zig`.
+- Still pending: `callback_server.zig` loopback PKCE composition needs a live
+  `awaitCallback` seam, and `browser_launch.zig` is not yet consumed by a live
+  runner.
+- Done in #378: `HandoffRecord` has a correlation id so approval verbs can name
+  what they approve.
+- Done in #378: `MediationKind` gained `command_owned` / `pat_paste` variants
+  and `consentFor` stopped hardcoding `.device_login` for every provider.
+- Still pending: approval verbs / UI wiring that invoke `oauth-mux reauth run
+  <handoff-id>` for engine-run flows.
 
 Graduation implementation note (2026-06-14): #378 now implements the mediator
-side of those deltas and wires the module into the main test root. Flow
-composition is still the next train car before approval can invoke engine-run
-flows.
+side of those deltas and wires the module into the main test root. #422 adds
+the first production flow-composition runner for `device_code`, but approval
+still cannot invoke engine-run flows.
 
 ### Binding map (corrected to the real seams)
 
@@ -91,7 +94,7 @@ Engine seams (`reauth.zig`): `run_flow`, `confirm_identity`, `write_store`,
 
 | Engine seam | Binds to |
 | --- | --- |
-| `run_flow` | the flow-composition layer (new train car): device_code / callback_server / command-owned mechanics, each with its own seam bundle |
+| `run_flow` | the flow-composition layer: `device_code` is composed; loopback / browser launch execution remain pending; command-owned remains vendor delegation |
 | `confirm_identity` | identity-hash compare (`identity_hash.zig`; clone-gate semantics from #344) |
 | `write_store` | atomic `writeFileReplace` 0600; invoked only under the externally-held account lock (see Locks) |
 | `process_spawn` | OS process spawn (browser/vendor-CLI); `browser_launch.zig` has its own seam bundle consumed by `run_flow` impls, not bound here directly |

--- a/src/enroll/browser_launch.zig
+++ b/src/enroll/browser_launch.zig
@@ -40,9 +40,8 @@ pub const BrowserLaunchError = error{
 /// Result of a launch, so callers/tests can introspect what happened.
 pub const LaunchResult = struct {
     tier: BrowserTier,
-    /// For Tier 2: the ephemeral profile dir that was created (and then deleted).
-    /// Null for Tier 1. Borrowed view into engine-owned memory; valid until the
-    /// LaunchResult is dropped (the dir itself is already deleted by launch()).
+    /// Reserved for future lifecycle reporting. Today `launch()` deletes the
+    /// ephemeral profile before returning and reports null for both tiers.
     ephemeral_dir: ?[]const u8 = null,
 };
 

--- a/src/enroll/device_code.zig
+++ b/src/enroll/device_code.zig
@@ -239,7 +239,8 @@ pub const DeviceCodeFlow = struct {
                 error.HttpFailed => return error.HttpFailed,
                 error.InvalidResponse => return error.InvalidResponse,
             };
-            // From here the token response is owned by us; free on every exit.
+            // From here (on a successful poll) the token response is owned by us;
+            // free on every exit. The error `continue`s above never reach here.
             defer self.freeTokenResp(token_resp);
 
             // 4. Extract identity for the confirm gate.
@@ -260,16 +261,27 @@ pub const DeviceCodeFlow = struct {
             else
                 null;
 
-            return FlowResult{
-                .access_token = self.allocator.dupe(u8, token_resp.access_token) catch {
+            // Allocate to locals with explicit cleanup so a later dupe failure
+            // never leaks an earlier one. (Building these inline in the struct
+            // literal leaked `access_token` when the `refresh_token` dupe OOM'd.)
+            const access_owned = self.allocator.dupe(u8, token_resp.access_token) catch {
+                self.allocator.free(identity.email);
+                self.allocator.free(identity.account_id);
+                return error.OutOfMemory;
+            };
+            const refresh_owned: ?[]const u8 = if (token_resp.refresh_token) |rt|
+                (self.allocator.dupe(u8, rt) catch {
+                    self.allocator.free(access_owned);
                     self.allocator.free(identity.email);
                     self.allocator.free(identity.account_id);
                     return error.OutOfMemory;
-                },
-                .refresh_token = if (token_resp.refresh_token) |rt|
-                    (self.allocator.dupe(u8, rt) catch return error.OutOfMemory)
-                else
-                    null,
+                })
+            else
+                null;
+
+            return FlowResult{
+                .access_token = access_owned,
+                .refresh_token = refresh_owned,
                 .expires_at = expires_at,
                 .email = identity.email,
                 .account_id = identity.account_id,
@@ -317,11 +329,21 @@ const Harness = struct {
         _: []const u8,
     ) error{ HttpFailed, InvalidResponse, OutOfMemory }!DeviceAuthResponse {
         _ = ctx;
+        // OOM-safe: free earlier dupes if a later one fails (so checkAllAllocationFailures
+        // exercises run()'s leak-safety, not a leak in this fake).
+        const dc = try allocator.dupe(u8, "DEVICE_CODE_SECRET_OK_TO_HOLD");
+        errdefer allocator.free(dc);
+        const uc = try allocator.dupe(u8, "WXYZ-7788");
+        errdefer allocator.free(uc);
+        const vu = try allocator.dupe(u8, "https://auth.example.com/device");
+        errdefer allocator.free(vu);
+        const vuc = try allocator.dupe(u8, "https://auth.example.com/device?user_code=WXYZ-7788");
+        errdefer allocator.free(vuc);
         return .{
-            .device_code = try allocator.dupe(u8, "DEVICE_CODE_SECRET_OK_TO_HOLD"),
-            .user_code = try allocator.dupe(u8, "WXYZ-7788"),
-            .verification_uri = try allocator.dupe(u8, "https://auth.example.com/device"),
-            .verification_uri_complete = try allocator.dupe(u8, "https://auth.example.com/device?user_code=WXYZ-7788"),
+            .device_code = dc,
+            .user_code = uc,
+            .verification_uri = vu,
+            .verification_uri_complete = vuc,
             .expires_in = 600,
             .interval = 5,
         };
@@ -353,13 +375,25 @@ const Harness = struct {
             .pending => error.AuthorizationPending,
             .slow_down => error.SlowDown,
             .denied => error.AuthorizationDenied,
-            .success => .{
-                .access_token = try allocator.dupe(u8, "ACCESS_secret"),
-                .token_type = try allocator.dupe(u8, "Bearer"),
-                .expires_in = 3600,
-                .refresh_token = try allocator.dupe(u8, "REFRESH_secret"),
-                .scope = try allocator.dupe(u8, "openid email"),
-                .id_token = try allocator.dupe(u8, "header.payload.sig"),
+            .success => blk: {
+                const at = try allocator.dupe(u8, "ACCESS_secret");
+                errdefer allocator.free(at);
+                const tt = try allocator.dupe(u8, "Bearer");
+                errdefer allocator.free(tt);
+                const rt = try allocator.dupe(u8, "REFRESH_secret");
+                errdefer allocator.free(rt);
+                const sc = try allocator.dupe(u8, "openid email");
+                errdefer allocator.free(sc);
+                const it = try allocator.dupe(u8, "header.payload.sig");
+                errdefer allocator.free(it); // redundant today (last alloc), kept for insert-safety
+                break :blk .{
+                    .access_token = at,
+                    .token_type = tt,
+                    .expires_in = 3600,
+                    .refresh_token = rt,
+                    .scope = sc,
+                    .id_token = it,
+                };
             },
         };
     }
@@ -371,10 +405,10 @@ const Harness = struct {
         _: []const u8,
     ) error{ InvalidToken, OutOfMemory }!IdentityInfo {
         _ = ctx;
-        return .{
-            .email = try allocator.dupe(u8, "dev@example.com"),
-            .account_id = try allocator.dupe(u8, "acct_dev_42"),
-        };
+        const em = try allocator.dupe(u8, "dev@example.com");
+        errdefer allocator.free(em);
+        const aid = try allocator.dupe(u8, "acct_dev_42");
+        return .{ .email = em, .account_id = aid };
     }
 
     fn display(
@@ -426,6 +460,23 @@ fn freeResult(allocator: std.mem.Allocator, r: FlowResult) void {
     if (r.refresh_token) |rt| allocator.free(rt);
     allocator.free(r.email);
     allocator.free(r.account_id);
+}
+
+/// Drive the flow to success under the given allocator and free the result. Used
+/// by the OOM-safety check below: every allocation in `run()` (including the
+/// FlowResult access/refresh dupes) propagates OutOfMemory and must not leak.
+fn runHappyToCompletion(allocator: std.mem.Allocator) !void {
+    var h = Harness{ .poll_script = &.{.success} };
+    const flow = DeviceCodeFlow.init(allocator, h.seams(), "https://x/device", "https://x/token", "cid", "openid");
+    const r = try flow.run();
+    freeResult(allocator, r);
+}
+
+test "device_code: run() is OOM-safe at every allocation point (regression: FlowResult dupe must not leak access_token)" {
+    // checkAllAllocationFailures re-runs the flow failing at each allocation index
+    // in turn, asserting OutOfMemory is returned AND nothing leaks. Before the fix,
+    // failing on the refresh_token dupe leaked the already-duped access_token.
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, runHappyToCompletion, .{});
 }
 
 test "device_code: authorization_pending x2 then success yields token + identity" {

--- a/src/enroll/device_code.zig
+++ b/src/enroll/device_code.zig
@@ -253,8 +253,8 @@ pub const DeviceCodeFlow = struct {
                 error.OutOfMemory => return error.OutOfMemory,
                 error.InvalidToken => return error.IdentityExtractFailed,
             };
-            // identity.email / identity.account_id are owned; on any failure below
-            // we must free them. There is no failure below, so they pass through.
+            // identity.email / identity.account_id are owned; token dupes below may
+            // still fail, so those failure branches must free identity explicitly.
 
             const expires_at: ?i64 = if (token_resp.expires_in) |e|
                 self.seams.clock(self.seams.clock_ctx) + e

--- a/src/enroll/flow_composition.zig
+++ b/src/enroll/flow_composition.zig
@@ -1,0 +1,292 @@
+//! flow_composition.zig — the production `RunFlowFn` for the reauth engine
+//! (flow-composition train car; successor to the #378 orchestrator graduation,
+//! TIN-2048/TIN-2064).
+//!
+//! It is the seam-binding glue between the engine (`reauth.zig`) and the flow
+//! sub-modules. The engine's `begin()` calls ONE `RunFlowFn`; in production this
+//! module's `runFlow` IS that function. It dispatches on the engine's `Flow`
+//! enum and drives the matching sub-module THROUGH that module's own injected
+//! seam bundle — so the composition itself stays PURE: it opens no socket, makes
+//! no HTTP call, holds no real clock. Tests bind deterministic fakes, exactly
+//! like `device_code.zig` / `orchestrator.zig` / the warm loop.
+//!
+//! Mediation-not-control (in-agent-reauth-handoff contract): `runFlow` only ever
+//! executes INSIDE the engine's `begin()`, which runs only after operator
+//! approval. There is no other caller and no bypass. `command_owned` and
+//! `pat_paste` are NOT engine-run (vendor-CLI delegation / manual paste) and are
+//! refused BEFORE the flow config is unpacked or any seam is touched — no
+//! browser, no process spawn, no network. `redirect_loopback` composition needs
+//! a LIVE loopback socket to obtain the parsed callback (the callback_server
+//! pure core only handles an already-parsed request); that live `awaitCallback`
+//! seam is the next sub-car, so loopback is refused here too. The device_code
+//! flow composes end-to-end through pure seams and is fully wired.
+//!
+//! Secrets: `runFlow` moves the sub-module's owned token slices straight into the
+//! engine's `FlowOutcome` and returns them; it logs nothing token-bearing. The
+//! engine frees them on reject/store-failure or returns them on success.
+
+const std = @import("std");
+const engine = @import("reauth.zig");
+const device_code = @import("device_code.zig");
+
+const log = std.log.scoped(.flow_composition);
+
+/// The opaque `flow_ctx` the engine passes to `runFlow` points at this. It
+/// carries the per-flow bindings (provider endpoints + the sub-module's own seam
+/// bundle). A binding is `null` when that flow is not configured for the account.
+pub const FlowConfig = struct {
+    /// device_code (RFC 8628) binding. Required when `Flow.device_code` is run.
+    device: ?DeviceCodeBinding = null,
+    // loopback: ?LoopbackBinding — next sub-car (needs a live awaitCallback seam).
+};
+
+/// Everything the device-code arm needs: the provider endpoints/client and the
+/// device_code sub-module's own injected seam bundle (authorize / poll / extract
+/// / display / clock / sleep — every one fake-able, so this stays pure).
+pub const DeviceCodeBinding = struct {
+    device_auth_url: []const u8,
+    token_url: []const u8,
+    client_id: []const u8,
+    scope: []const u8,
+    seams: device_code.DeviceCodeSeams,
+};
+
+/// Production `engine.RunFlowFn`. Bind into `engine.Seams.run_flow` with a
+/// `*const FlowConfig` as `flow_ctx`. Exhaustive over `engine.Flow` — every
+/// variant is handled, so a new `Flow` member is a compile error here (the
+/// dispatcher can never silently drop a flow).
+pub fn runFlow(
+    allocator: std.mem.Allocator,
+    flow: engine.Flow,
+    flow_ctx: *anyopaque,
+) error{ FlowFailed, OutOfMemory }!engine.FlowOutcome {
+    // Refuse the non-engine-run flows BEFORE unpacking the config or touching any
+    // seam: no spawn, no browser, no network can occur on these paths.
+    switch (flow) {
+        .command_owned, .pat_paste => {
+            log.debug("flow '{s}' is not engine-run (vendor-CLI delegation / manual paste); refusing", .{@tagName(flow)});
+            return error.FlowFailed;
+        },
+        .redirect_loopback => {
+            log.debug("redirect_loopback composition needs a live awaitCallback seam (next sub-car); refusing", .{});
+            return error.FlowFailed;
+        },
+        .device_code => {},
+    }
+
+    const cfg: *const FlowConfig = @ptrCast(@alignCast(flow_ctx));
+    const binding = cfg.device orelse {
+        log.warn("device_code flow selected but no device binding is configured", .{});
+        return error.FlowFailed;
+    };
+
+    const dcf = device_code.DeviceCodeFlow.init(
+        allocator,
+        binding.seams,
+        binding.device_auth_url,
+        binding.token_url,
+        binding.client_id,
+        binding.scope,
+    );
+    const result = dcf.run() catch |e| switch (e) {
+        // Host pressure, not the account's fault — surface as-is so the engine
+        // can retry rather than charge a flow failure.
+        error.OutOfMemory => return error.OutOfMemory,
+        // Every other DeviceCodeError (AuthorizationDenied / Timeout / HttpFailed
+        // / InvalidResponse / InvalidToken / ...) is a flow failure.
+        else => return error.FlowFailed,
+    };
+
+    // device_code.FlowResult is field-identical to engine.FlowOutcome; ownership
+    // of every owned slice transfers straight through to the engine.
+    return .{
+        .access_token = result.access_token,
+        .refresh_token = result.refresh_token,
+        .expires_at = result.expires_at,
+        .email = result.email,
+        .account_id = result.account_id,
+    };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests — deterministic fakes; std.testing.allocator leak-checked. No network,
+// no socket, no real clock. A `*FlowConfig` is the engine's opaque flow_ctx.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+/// A spy bound to all six device_code seams that records if ANY is invoked, so
+/// the "refused before any seam" claim is ENFORCED, not just documented:
+/// command_owned / pat_paste / loopback must return FlowFailed with zero seam
+/// calls. (Its fn bodies never run in those tests; they only need to type-check
+/// against the exact seam signatures.)
+const NoSeamSpy = struct {
+    touched: bool = false,
+
+    fn deviceAuthorize(_: std.mem.Allocator, ctx: *anyopaque, _: []const u8, _: []const u8, _: []const u8) error{ HttpFailed, InvalidResponse, OutOfMemory }!device_code.DeviceAuthResponse {
+        const self: *NoSeamSpy = @ptrCast(@alignCast(ctx));
+        self.touched = true;
+        return error.HttpFailed;
+    }
+    fn pollToken(_: std.mem.Allocator, ctx: *anyopaque, _: []const u8, _: []const u8, _: []const u8) error{ HttpFailed, InvalidResponse, OutOfMemory, AuthorizationPending, SlowDown, AuthorizationDenied }!device_code.TokenExchangeResponse {
+        const self: *NoSeamSpy = @ptrCast(@alignCast(ctx));
+        self.touched = true;
+        return error.HttpFailed;
+    }
+    fn extractIdentity(_: std.mem.Allocator, ctx: *anyopaque, _: ?[]const u8, _: []const u8) error{ InvalidToken, OutOfMemory }!device_code.IdentityInfo {
+        const self: *NoSeamSpy = @ptrCast(@alignCast(ctx));
+        self.touched = true;
+        return error.InvalidToken;
+    }
+    fn display(_: std.mem.Allocator, ctx: *anyopaque, _: []const u8, _: []const u8, _: ?[]const u8) error{OutOfMemory}!void {
+        const self: *NoSeamSpy = @ptrCast(@alignCast(ctx));
+        self.touched = true;
+    }
+    fn clock(ctx: *anyopaque) i64 {
+        const self: *NoSeamSpy = @ptrCast(@alignCast(ctx));
+        self.touched = true;
+        return 0;
+    }
+    fn sleep(ctx: *anyopaque, _: i64) void {
+        const self: *NoSeamSpy = @ptrCast(@alignCast(ctx));
+        self.touched = true;
+    }
+
+    fn seams(self: *NoSeamSpy) device_code.DeviceCodeSeams {
+        return .{
+            .device_authorize = deviceAuthorize,
+            .poll_token = pollToken,
+            .extract_identity = extractIdentity,
+            .display_instructions = display,
+            .clock = clock,
+            .sleep = sleep,
+            .device_authorize_ctx = self,
+            .poll_token_ctx = self,
+            .extract_identity_ctx = self,
+            .display_instructions_ctx = self,
+            .clock_ctx = self,
+            .sleep_ctx = self,
+        };
+    }
+};
+
+fn deviceConfig(spy: *NoSeamSpy) FlowConfig {
+    return .{ .device = .{
+        .device_auth_url = "https://example.invalid/device",
+        .token_url = "https://example.invalid/token",
+        .client_id = "cid",
+        .scope = "openid",
+        .seams = spy.seams(),
+    } };
+}
+
+test "command_owned is refused before any seam is touched (no spawn/browser/network)" {
+    var spy = NoSeamSpy{};
+    var cfg = deviceConfig(&spy);
+    try testing.expectError(error.FlowFailed, runFlow(testing.allocator, .command_owned, &cfg));
+    try testing.expect(!spy.touched); // structurally: refused before unpacking cfg
+}
+
+test "pat_paste is refused before any seam is touched" {
+    var spy = NoSeamSpy{};
+    var cfg = deviceConfig(&spy);
+    try testing.expectError(error.FlowFailed, runFlow(testing.allocator, .pat_paste, &cfg));
+    try testing.expect(!spy.touched);
+}
+
+test "redirect_loopback is refused (composition is the next sub-car), no seam touched" {
+    var spy = NoSeamSpy{};
+    var cfg = deviceConfig(&spy);
+    try testing.expectError(error.FlowFailed, runFlow(testing.allocator, .redirect_loopback, &cfg));
+    try testing.expect(!spy.touched);
+}
+
+test "device_code with no binding configured returns FlowFailed" {
+    var cfg = FlowConfig{}; // device = null
+    try testing.expectError(error.FlowFailed, runFlow(testing.allocator, .device_code, &cfg));
+}
+
+// ── A scripted device_code fake that drives run() to SUCCESS, so the device_code
+//    arm is exercised end-to-end through the composition (authorize → display →
+//    poll(success) → extract identity → FlowResult → FlowOutcome). Every returned
+//    slice is allocator-owned so the leak checker proves the ownership transfer.
+const HappyDevice = struct {
+    alloc: std.mem.Allocator,
+    fn dup(self: *HappyDevice, s: []const u8) []const u8 {
+        return self.alloc.dupe(u8, s) catch unreachable;
+    }
+    fn deviceAuthorize(_: std.mem.Allocator, ctx: *anyopaque, _: []const u8, _: []const u8, _: []const u8) error{ HttpFailed, InvalidResponse, OutOfMemory }!device_code.DeviceAuthResponse {
+        const self: *HappyDevice = @ptrCast(@alignCast(ctx));
+        return .{
+            .device_code = self.dup("DEV-CODE"),
+            .user_code = self.dup("WXYZ-1234"),
+            .verification_uri = self.dup("https://example.invalid/activate"),
+            .verification_uri_complete = null,
+            .expires_in = 1800,
+            .interval = 5,
+        };
+    }
+    fn pollToken(_: std.mem.Allocator, ctx: *anyopaque, _: []const u8, _: []const u8, _: []const u8) error{ HttpFailed, InvalidResponse, OutOfMemory, AuthorizationPending, SlowDown, AuthorizationDenied }!device_code.TokenExchangeResponse {
+        const self: *HappyDevice = @ptrCast(@alignCast(ctx));
+        return .{
+            .access_token = self.dup("ACCESS-TOK"),
+            .token_type = self.dup("Bearer"),
+            .expires_in = 3600,
+            .refresh_token = self.dup("REFRESH-TOK"),
+            .scope = null,
+            .id_token = self.dup("ID.JWT.TOK"),
+        };
+    }
+    fn extractIdentity(_: std.mem.Allocator, ctx: *anyopaque, _: ?[]const u8, _: []const u8) error{ InvalidToken, OutOfMemory }!device_code.IdentityInfo {
+        const self: *HappyDevice = @ptrCast(@alignCast(ctx));
+        return .{ .email = self.dup("alice@example.com"), .account_id = self.dup("acct-123") };
+    }
+    fn display(_: std.mem.Allocator, _: *anyopaque, _: []const u8, _: []const u8, _: ?[]const u8) error{OutOfMemory}!void {}
+    fn clock(_: *anyopaque) i64 {
+        return 1_000_000;
+    }
+    fn sleep(_: *anyopaque, _: i64) void {}
+
+    fn seams(self: *HappyDevice) device_code.DeviceCodeSeams {
+        return .{
+            .device_authorize = deviceAuthorize,
+            .poll_token = pollToken,
+            .extract_identity = extractIdentity,
+            .display_instructions = display,
+            .clock = clock,
+            .sleep = sleep,
+            .device_authorize_ctx = self,
+            .poll_token_ctx = self,
+            .extract_identity_ctx = self,
+            .display_instructions_ctx = self,
+            .clock_ctx = self,
+            .sleep_ctx = self,
+        };
+    }
+};
+
+test "device_code happy path composes end-to-end into a filled FlowOutcome" {
+    var dev = HappyDevice{ .alloc = testing.allocator };
+    var cfg = FlowConfig{ .device = .{
+        .device_auth_url = "https://example.invalid/device",
+        .token_url = "https://example.invalid/token",
+        .client_id = "cid",
+        .scope = "openid",
+        .seams = dev.seams(),
+    } };
+
+    const outcome = try runFlow(testing.allocator, .device_code, &cfg);
+    defer {
+        testing.allocator.free(outcome.access_token);
+        if (outcome.refresh_token) |rt| testing.allocator.free(rt);
+        testing.allocator.free(outcome.email);
+        testing.allocator.free(outcome.account_id);
+    }
+
+    // Required fields are present (composition-correctness: no field left null).
+    try testing.expectEqualStrings("ACCESS-TOK", outcome.access_token);
+    try testing.expectEqualStrings("REFRESH-TOK", outcome.refresh_token.?);
+    try testing.expectEqualStrings("alice@example.com", outcome.email);
+    try testing.expectEqualStrings("acct-123", outcome.account_id);
+    try testing.expectEqual(@as(?i64, 1_000_000 + 3600), outcome.expires_at);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -19837,6 +19837,8 @@ comptime {
     _ = @import("reauth/orchestrator.zig"); // graduated from draft (TIN-2048/TIN-2064): tests now run in CI
     _ = @import("enroll/tests.zig");
     _ = @import("enroll/callback_server_tests.zig");
+    _ = @import("enroll/device_code.zig"); // unparked (flow-composition car): RFC 8628 device flow, tests now run in CI
+    _ = @import("enroll/browser_launch.zig"); // unparked (flow-composition car): cookieless launcher, tests now run in CI
     _ = @import("enroll/claude_reauth_tests.zig");
     _ = @import("enroll/web_ui_tests.zig");
     _ = @import("keepalive/warm_scheduler_tests.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -19839,6 +19839,7 @@ comptime {
     _ = @import("enroll/callback_server_tests.zig");
     _ = @import("enroll/device_code.zig"); // unparked (flow-composition car): RFC 8628 device flow, tests now run in CI
     _ = @import("enroll/browser_launch.zig"); // unparked (flow-composition car): cookieless launcher, tests now run in CI
+    _ = @import("enroll/flow_composition.zig"); // flow-composition car: production RunFlowFn (device_code composed)
     _ = @import("enroll/claude_reauth_tests.zig");
     _ = @import("enroll/web_ui_tests.zig");
     _ = @import("keepalive/warm_scheduler_tests.zig");

--- a/src/reauth/orchestrator.zig
+++ b/src/reauth/orchestrator.zig
@@ -150,10 +150,10 @@ pub const MediationKind = enum {
 pub const FlowExecution = enum { command_owned, engine_run };
 
 /// Which execution path a provider's re-login flow takes. Both current providers
-/// are command-owned (the engine has no production `RunFlowFn` yet — see the
-/// designation spec's "current state vs target"). Flipping a provider to
-/// `engine_run` is a one-line change gated on the flow-composition car + the
-/// Claude contract amendment.
+/// are command-owned today. A production `RunFlowFn` now exists for the
+/// device-code arm, but no approval surface invokes engine-run flows yet; flipping
+/// a provider to `engine_run` is gated on that approval wiring and, for Claude,
+/// the contract amendment.
 pub fn flowExecutionFor(provider: []const u8) FlowExecution {
     _ = provider; // codex (login-device) + claude (claude /login) are both command-owned today
     return .command_owned;


### PR DESCRIPTION
## What

The **flow-composition train car** — the designated next reauth step after the #378 orchestrator graduation (designation spec `reauth-orchestrator-designation-2026-06-12.md`, step 2). It gives the engine its first production `RunFlowFn` so an approved flow can actually be *executed*, not only mediated.

Two cars:

### 1. Unpark the parked flow modules
`device_code.zig` (RFC 8628) and `browser_launch.zig` were on disk since Jun 12 but **never wired into the build** — their tests compiled to nothing (the vacuous-CI trap). Wired both into the test root; **proven non-vacuous** (injected failing assertions into both modules' tests, confirmed the suite caught them, reverted).

### 2. `flow_composition.zig` — production `RunFlowFn`
A **pure** dispatcher that binds the engine's `Flow` enum to the right sub-module's own injected seam bundle:
- **`device_code`** → composes `device_code.zig` end-to-end through pure seams (authorize → display → poll → extract identity), converting `FlowResult` → `FlowOutcome`. Fully wired + fake-tested.
- **`redirect_loopback`** → deferred: needs a live `awaitCallback` seam (the callback_server pure core only handles an already-parsed request). Refused for now — the next sub-car.
- **`command_owned` / `pat_paste`** → **NOT engine-run** (vendor-CLI delegation / manual paste). Refused with `error.FlowFailed` **before** the config is unpacked or any seam is touched — enforced by a `NoSeamSpy` test asserting zero seam calls.

No live OAuth/socket/HTTP: every sub-module seam stays injected, so the whole composition is deterministic-fake-testable like `orchestrator.zig` / the warm loop. Mediation-not-control preserved: `runFlow` only runs inside the engine's `begin()` (post-approval) and adds no login/spawn/network of its own. The `Flow` switch is exhaustive (a new variant is a compile error here).

### Bug fixed (found by the design review)
`device_code.zig` leaked the duped `access_token` if the `refresh_token` dupe OOM'd during `FlowResult` construction. Fixed with explicit cleanup; hardened the test fakes to be OOM-safe; added a `checkAllAllocationFailures` regression test that exhaustively proves `run()` leaks nothing at any allocation-failure point.

### Review follow-up on this PR
Pre-landing review found two stale truth surfaces after the flow-composition implementation:
- `docs/spec/reauth-orchestrator-designation-2026-06-12.md` still said no production `RunFlowFn` existed and approval-current-state text implied the flow modules were only disconnected pieces.
- `src/reauth/orchestrator.zig` and a `device_code.zig` ownership comment still carried the same old framing.

Those are now corrected on the branch: #422 adds a device-code `RunFlowFn`, but no provider is flipped to engine-run and no approval verb/UI invokes it yet.

## Proof gate

Remote GitHub/GloriousFlywheel checks are the merge proof. Local debug runs are not used as completion proof for this repo.

## Out of scope (next cars)
Live HTTP/identity seam impls; the `redirect_loopback` `awaitCallback` seam; approval-surface wiring (TIN-1806 verbs / #347 web UI); the Claude contract amendment.

Linear: TIN-2053 successor (flow composition).
