### PR TITLE
reauth: add command-owned approval CLI surface

### DIFF
--- a/docs/spec/in-agent-reauth-handoff-contract-2026-05-14.md
+++ b/docs/spec/in-agent-reauth-handoff-contract-2026-05-14.md
@@ -61,6 +61,7 @@ oauth-mux route explain --profile <profile> --capability <capability> --json
 oauth-mux repair-plan --profile <profile> --capability <capability> --json
 oauth-mux stay-afloat --once --profile <profile> --capability <capability> --json
 oauth-mux stay-afloat handoffs --json
+oauth-mux reauth drain --json
 oauth-mux codex preflight --profile codex-max --capability codex-max --json
 ```
 
@@ -120,6 +121,23 @@ refresh rather than assuming success:
 ```bash
 oauth-mux stay-afloat refresh --profile <profile> --capability <capability> --json
 ```
+
+The reauth approval surface is command-owned until a provider is explicitly
+flipped to engine-run:
+
+```bash
+oauth-mux reauth start --provider <provider> --account <account> --json
+oauth-mux reauth wait --provider <provider> --account <account> --json
+oauth-mux reauth drain --json
+oauth-mux reauth run <provider>:<account> --json
+```
+
+`reauth start` records the handoff under the per-account repair lock and prints
+the redacted next action; `reauth run` refuses with
+`engine_run_available:false` until an approved provider flow is wired to the
+engine. For browser/device OAuth, the JSON surface includes
+`fresh_browser_context_required` so agents do not reuse ambient personal,
+work, startup, or family browser profiles by accident.
 
 For pending daemon handoffs, agents may acknowledge visibility or clear stale
 records with explicit commands:

--- a/docs/spec/reauth-orchestrator-designation-2026-06-12.md
+++ b/docs/spec/reauth-orchestrator-designation-2026-06-12.md
@@ -77,6 +77,14 @@ side of those deltas and wires the module into the main test root. #422 adds
 the first production flow-composition runner for `device_code`, but approval
 still cannot invoke engine-run flows.
 
+Approval-surface implementation note (2026-06-14): TIN-1806 now has the first
+CLI surface shape: `oauth-mux reauth start|wait|drain|run`. `start` queues a
+redacted user-mediated handoff under the per-account repair lock, `wait`
+observes pending/resolved state, `drain` lists pending handoffs, and `run`
+refuses with `engine_run_available:false` until a provider is explicitly
+flipped to engine-run. This is intentionally command-owned only; it does not
+silently invoke browser, device, vendor CLI, or credential-write flows.
+
 ### Binding map (corrected to the real seams)
 
 Mediator seams (`orchestrator.zig`): `clock`, `read_evidence`, `refresh`,

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -26,6 +26,7 @@ pub const Command = union(enum) {
     stay_afloat: DaemonTickArgs,
     stay_afloat_handoff: HandoffArgs,
     keepalive: KeepaliveArgs,
+    reauth: ReauthArgs,
     config_validate,
     config_path,
     init: InitArgs,
@@ -320,6 +321,24 @@ pub const Command = union(enum) {
         json: bool = false,
     };
 
+    pub const ReauthAction = enum {
+        start,
+        wait,
+        drain,
+        run,
+    };
+
+    pub const ReauthArgs = struct {
+        action: ReauthAction = .start,
+        profile: ?[]const u8 = null,
+        provider: ?[]const u8 = null,
+        account: ?[]const u8 = null,
+        capability: ?[]const u8 = null,
+        correlation_id: ?[]const u8 = null,
+        timeout_ms: u64 = 0,
+        json: bool = false,
+    };
+
     pub const HandoffAction = enum {
         ack,
         clear,
@@ -361,6 +380,7 @@ pub fn parse(args: []const []const u8) Command {
     if (eql(cmd, "route")) return parseRoute(rest);
     if (eql(cmd, "stay-afloat")) return parseStayAfloat(rest);
     if (eql(cmd, "keepalive")) return parseKeepalive(rest);
+    if (eql(cmd, "reauth")) return parseReauth(rest);
     if (eql(cmd, "config")) return parseConfig(rest);
     if (eql(cmd, "init")) return parseInit(rest);
     if (eql(cmd, "setup")) return parseSetup(rest);
@@ -950,6 +970,54 @@ fn parseKeepalive(args: []const []const u8) Command {
     return .{ .keepalive = result };
 }
 
+fn parseReauth(args: []const []const u8) Command {
+    var result = Command.ReauthArgs{};
+    var i: usize = 0;
+    if (args.len > 0) {
+        if (eql(args[0], "start")) {
+            result.action = .start;
+            i = 1;
+        } else if (eql(args[0], "wait")) {
+            result.action = .wait;
+            i = 1;
+        } else if (eql(args[0], "drain")) {
+            result.action = .drain;
+            i = 1;
+        } else if (eql(args[0], "run")) {
+            result.action = .run;
+            i = 1;
+            if (i < args.len and !std.mem.startsWith(u8, args[i], "-")) {
+                result.correlation_id = args[i];
+                i += 1;
+            }
+        }
+    }
+    while (i < args.len) : (i += 1) {
+        if (eql(args[i], "--profile") or eql(args[i], "-p")) {
+            i += 1;
+            if (i < args.len) result.profile = args[i];
+        } else if (eql(args[i], "--provider")) {
+            i += 1;
+            if (i < args.len) result.provider = args[i];
+        } else if (eql(args[i], "--account")) {
+            i += 1;
+            if (i < args.len) result.account = args[i];
+        } else if (eql(args[i], "--capability")) {
+            i += 1;
+            if (i < args.len) result.capability = args[i];
+        } else if (eql(args[i], "--correlation-id")) {
+            i += 1;
+            if (i < args.len) result.correlation_id = args[i];
+        } else if (eql(args[i], "--timeout-ms")) {
+            i += 1;
+            if (i < args.len) result.timeout_ms = std.fmt.parseInt(u64, args[i], 10) catch result.timeout_ms;
+        } else if (eql(args[i], "--json")) {
+            result.json = true;
+        }
+    }
+    return .{ .reauth = result };
+}
+
 fn parseStayAfloatObserve(args: []const []const u8) Command {
     var result = Command.ObserveArgs{};
     var i: usize = 0;
@@ -1353,6 +1421,14 @@ pub fn printUsage(writer: anytype) !void {
         \\      Show pending user-mediated stay-afloat handoffs; --all includes history.
         \\  stay-afloat handoff ack|clear --provider <name> --account <name> [--profile <name>] [--capability <name>] [--json]
         \\      Acknowledge or clear a pending user-mediated handoff.
+        \\  reauth start --provider <name> --account <name> [--profile <name>] [--capability <name>] [--json]
+        \\      Queue/report a redacted user-mediated reauth handoff; refuses if the per-account lock is busy.
+        \\  reauth wait --provider <name> --account <name> [--profile <name>] [--capability <name>] [--timeout-ms <ms>] [--json]
+        \\      Report whether a user-mediated reauth handoff is still pending.
+        \\  reauth drain [--json]
+        \\      List pending reauth/stay-afloat handoffs; does not run login flows.
+        \\  reauth run <correlation-id> [--json]
+        \\      Approval-surface placeholder for engine-run flows; refuses until a provider is explicitly flipped.
         \\
         \\  config validate    Validate the configuration file.
         \\  config path        Print the config file path.
@@ -2397,6 +2473,50 @@ test "parse stay-afloat handoff clear" {
     }
 }
 
+test "parse reauth start" {
+    const args = [_][]const u8{ "reauth", "start", "--profile", "codex-max", "--provider", "codex", "--account", "max-1", "--capability", "codex-max", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .reauth => |reauth| {
+            try std.testing.expectEqual(Command.ReauthAction.start, reauth.action);
+            try std.testing.expectEqualStrings("codex-max", reauth.profile.?);
+            try std.testing.expectEqualStrings("codex", reauth.provider.?);
+            try std.testing.expectEqualStrings("max-1", reauth.account.?);
+            try std.testing.expectEqualStrings("codex-max", reauth.capability.?);
+            try std.testing.expect(reauth.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse reauth wait timeout" {
+    const args = [_][]const u8{ "reauth", "wait", "--provider", "codex", "--account", "max-1", "--timeout-ms", "250", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .reauth => |reauth| {
+            try std.testing.expectEqual(Command.ReauthAction.wait, reauth.action);
+            try std.testing.expectEqualStrings("codex", reauth.provider.?);
+            try std.testing.expectEqualStrings("max-1", reauth.account.?);
+            try std.testing.expectEqual(@as(u64, 250), reauth.timeout_ms);
+            try std.testing.expect(reauth.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
+test "parse reauth run correlation id" {
+    const args = [_][]const u8{ "reauth", "run", "codex:max-1", "--json" };
+    const cmd = parse(&args);
+    switch (cmd) {
+        .reauth => |reauth| {
+            try std.testing.expectEqual(Command.ReauthAction.run, reauth.action);
+            try std.testing.expectEqualStrings("codex:max-1", reauth.correlation_id.?);
+            try std.testing.expect(reauth.json);
+        },
+        else => return error.Unexpected,
+    }
+}
+
 test "parse daemon tick bounded loop" {
     const args = [_][]const u8{ "daemon", "tick", "--loop", "--execute", "--iterations", "3", "--interval-ms", "250", "--profile", "codex-max", "--capability", "codex-max", "--json" };
     const cmd = parse(&args);
@@ -2558,6 +2678,7 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n __fish_use_subcommand -a repair -d 'Run admitted repair actions'
             \\complete -c oauth-mux -n __fish_use_subcommand -a route -d 'Select or explain routes'
             \\complete -c oauth-mux -n __fish_use_subcommand -a stay-afloat -d 'Run stay-afloat planner'
+            \\complete -c oauth-mux -n __fish_use_subcommand -a reauth -d 'User-mediated reauth handoffs'
             \\complete -c oauth-mux -n __fish_use_subcommand -a config -d 'Config operations'
             \\complete -c oauth-mux -n __fish_use_subcommand -a init -d 'Generate config'
             \\complete -c oauth-mux -n __fish_use_subcommand -a setup -d 'First-run setup'
@@ -2566,10 +2687,10 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n __fish_use_subcommand -a mcp -d 'Run broker MCP server'
             \\complete -c oauth-mux -n __fish_use_subcommand -a version -d 'Print version'
             \\complete -c oauth-mux -n __fish_use_subcommand -a completions -d 'Generate completions'
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route stay-afloat' -l profile -s p -d 'Profile name' -r
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route stay-afloat' -l provider -d 'Provider name' -r
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec probe route stay-afloat' -l account -d 'Account name' -r
-            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route stay-afloat' -l capability -d 'Route capability' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route stay-afloat reauth' -l profile -s p -d 'Profile name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route stay-afloat reauth' -l provider -d 'Provider name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec probe route stay-afloat reauth' -l account -d 'Account name' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from exec env probe route stay-afloat reauth' -l capability -d 'Route capability' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from probe' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -a runtime -d 'Runtime readiness checks'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from doctor' -l json -d 'JSON output'
@@ -2612,6 +2733,10 @@ pub fn printCompletions(writer: anytype, shell_name: []const u8) !void {
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l json -d 'JSON output'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -a 'next launch observe handoffs handoff refresh' -d 'Stay-afloat subcommand'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from handoff' -a 'ack clear' -d 'Handoff action'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from reauth' -a 'start wait drain run' -d 'Reauth subcommand'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from reauth' -l json -d 'JSON output'
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from reauth' -l timeout-ms -d 'Bounded wait timeout' -r
+            \\complete -c oauth-mux -n '__fish_seen_subcommand_from reauth' -l correlation-id -d 'Reauth handoff correlation id' -r
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l once -d 'Run one stay-afloat tick'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l loop -d 'Run bounded foreground stay-afloat ticks'
             \\complete -c oauth-mux -n '__fish_seen_subcommand_from stay-afloat' -l execute -d 'Execute one admitted non-interactive action'

--- a/src/main.zig
+++ b/src/main.zig
@@ -278,6 +278,13 @@ pub fn main() !void {
             };
         },
 
+        .reauth => |reauth_args| {
+            runReauth(allocator, stdout, reauth_args) catch |e| {
+                log.err("reauth: {s}", .{@errorName(e)});
+                std.process.exit(exitCodeFromPipelineError(e));
+            };
+        },
+
         .completions => |comp_args| {
             try cli.printCompletions(stdout, comp_args.shell);
         },
@@ -5417,6 +5424,266 @@ fn runStayAfloatHandoff(
     try writer.print("  handoff_resolved: {s}\n", .{if (args.action == .clear and event_recorded and !pending_after) "true" else "false"});
     try writer.print("  event_recorded: {s}\n", .{if (event_recorded) "true" else "false"});
     try writer.print("  reason: {s}\n", .{reason});
+}
+
+fn runReauth(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    args: cli.Command.ReauthArgs,
+) !void {
+    switch (args.action) {
+        .start => try runReauthStart(allocator, writer, args),
+        .wait => try runReauthWait(allocator, writer, args),
+        .drain => try runReauthDrain(allocator, writer, args),
+        .run => try runReauthRun(allocator, writer, args),
+    }
+}
+
+fn runReauthStart(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    args: cli.Command.ReauthArgs,
+) !void {
+    const provider_name = args.provider orelse return error.ConfigValidationError;
+    const account = args.account orelse return error.ConfigValidationError;
+    const key = repair_state.HandoffKey{
+        .profile = args.profile,
+        .provider = provider_name,
+        .account = account,
+        .capability = args.capability,
+    };
+
+    var lock = repair_state.acquireRepairLock(allocator, provider_name, account) catch |e| switch (e) {
+        error.RepairInProgress => {
+            try writeReauthStartResult(writer, allocator, args, false, false, true, false, "repair_lock_busy");
+            return;
+        },
+        else => return e,
+    };
+    defer lock.release();
+
+    const pending_before = try repair_state.hasPendingHandoff(allocator, key);
+    if (!pending_before) {
+        const command = try reauthCommandOwnedCommandAlloc(allocator, provider_name, account);
+        defer allocator.free(command);
+        try repair_state.appendEvent(allocator, .{
+            .kind = "daemon_handoff",
+            .profile = args.profile,
+            .provider = provider_name,
+            .account = account,
+            .capability = args.capability,
+            .action = "reauth_start",
+            .command = command,
+            .engine_run_available = false,
+            .execution = "command_owned",
+            .agent_safe = false,
+            .spends_provider_calls = false,
+            .budget = "1 interactive login",
+            .repair_owner = "upstream_cli_login",
+            .fresh_browser_context_required = reauthNeedsFreshBrowserContext(provider_name),
+            .browser_context = "fresh_incognito_or_isolated_profile",
+            .outcome = "handoff_queued",
+            .reason = "reauth_user_mediated",
+            .ok = false,
+            .executed = false,
+            .interactive = true,
+            .mutating = true,
+        });
+    }
+
+    try writeReauthStartResult(writer, allocator, args, true, !pending_before, false, true, if (pending_before) "handoff_already_pending" else "handoff_queued");
+}
+
+fn runReauthWait(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    args: cli.Command.ReauthArgs,
+) !void {
+    const provider_name = args.provider orelse return error.ConfigValidationError;
+    const account = args.account orelse return error.ConfigValidationError;
+    const key = repair_state.HandoffKey{
+        .profile = args.profile,
+        .provider = provider_name,
+        .account = account,
+        .capability = args.capability,
+    };
+
+    var pending = try repair_state.hasPendingHandoff(allocator, key);
+    const start_ms = std.time.milliTimestamp();
+    while (pending and args.timeout_ms > 0) {
+        const elapsed: u64 = @intCast(@max(0, std.time.milliTimestamp() - start_ms));
+        if (elapsed >= args.timeout_ms) break;
+        const remaining = args.timeout_ms - elapsed;
+        const sleep_ms: u64 = @min(@as(u64, 100), remaining);
+        std.time.sleep(sleep_ms * @as(u64, std.time.ns_per_ms));
+        pending = try repair_state.hasPendingHandoff(allocator, key);
+    }
+
+    try writeReauthWaitResult(writer, args, pending, if (pending) "handoff_pending" else "handoff_resolved");
+}
+
+fn runReauthDrain(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    args: cli.Command.ReauthArgs,
+) !void {
+    _ = args.provider; // Parsed for CLI compatibility; provider filtering is a later queue refinement.
+    try repair_state.writeHandoffs(allocator, writer, args.json, 50, false);
+}
+
+fn runReauthRun(
+    allocator: std.mem.Allocator,
+    writer: anytype,
+    args: cli.Command.ReauthArgs,
+) !void {
+    const correlation_id = args.correlation_id orelse return error.ConfigValidationError;
+    const split = std.mem.indexOfScalar(u8, correlation_id, ':');
+    const provider_name = if (split) |idx| blk: {
+        const value = correlation_id[0..idx];
+        if (value.len == 0) return error.ConfigValidationError;
+        break :blk value;
+    } else args.provider orelse return error.ConfigValidationError;
+    const account = if (split) |idx| blk: {
+        const value = correlation_id[idx + 1 ..];
+        if (value.len == 0) return error.ConfigValidationError;
+        break :blk value;
+    } else args.account orelse correlation_id;
+    if (account.len == 0) return error.ConfigValidationError;
+    const command = try reauthCommandOwnedCommandAlloc(allocator, provider_name, account);
+    defer allocator.free(command);
+
+    if (args.json) {
+        try writer.writeAll("{\"ok\":false,\"action\":\"run\",\"correlation_id\":");
+        try std.json.stringify(correlation_id, .{}, writer);
+        try writer.writeAll(",\"provider\":");
+        try std.json.stringify(provider_name, .{}, writer);
+        try writer.writeAll(",\"account\":");
+        try std.json.stringify(account, .{}, writer);
+        try writer.writeAll(",\"engine_run_available\":false,\"execution\":\"command_owned\",\"fresh_browser_context_required\":");
+        try writer.writeAll(if (reauthNeedsFreshBrowserContext(provider_name)) "true" else "false");
+        try writer.writeAll(",\"next_action\":");
+        try std.json.stringify(command, .{}, writer);
+        try writer.writeAll(",\"reason\":\"no_provider_flipped_to_engine_run\"}\n");
+        return;
+    }
+
+    try writer.writeAll("oauth-mux reauth run\n\n");
+    try writer.print("  correlation_id: {s}\n", .{correlation_id});
+    try writer.writeAll("  engine_run_available: false\n");
+    try writer.writeAll("  execution: command_owned\n");
+    try writer.print("  fresh_browser_context_required: {s}\n", .{if (reauthNeedsFreshBrowserContext(provider_name)) "true" else "false"});
+    try writer.print("  next_action: {s}\n", .{command});
+    try writer.writeAll("  reason: no_provider_flipped_to_engine_run\n");
+}
+
+fn writeReauthStartResult(
+    writer: anytype,
+    allocator: std.mem.Allocator,
+    args: cli.Command.ReauthArgs,
+    ok: bool,
+    queued: bool,
+    lock_busy: bool,
+    pending: bool,
+    reason: []const u8,
+) !void {
+    const provider_name = args.provider orelse "";
+    const account = args.account orelse "";
+    const correlation_id = try std.fmt.allocPrint(allocator, "{s}:{s}", .{ provider_name, account });
+    defer allocator.free(correlation_id);
+    const command = try reauthCommandOwnedCommandAlloc(allocator, provider_name, account);
+    defer allocator.free(command);
+
+    if (args.json) {
+        try writer.writeAll("{\"ok\":");
+        try writer.writeAll(if (ok) "true" else "false");
+        try writer.writeAll(",\"action\":\"start\",\"profile\":");
+        try writeOptionalJsonString(writer, args.profile);
+        try writer.writeAll(",\"provider\":");
+        try std.json.stringify(provider_name, .{}, writer);
+        try writer.writeAll(",\"account\":");
+        try std.json.stringify(account, .{}, writer);
+        try writer.writeAll(",\"capability\":");
+        try writeOptionalJsonString(writer, args.capability);
+        try writer.writeAll(",\"correlation_id\":");
+        try std.json.stringify(correlation_id, .{}, writer);
+        try writer.writeAll(",\"handoff_queued\":");
+        try writer.writeAll(if (queued) "true" else "false");
+        try writer.writeAll(",\"handoff_pending\":");
+        try writer.writeAll(if (pending) "true" else "false");
+        try writer.writeAll(",\"lock_busy\":");
+        try writer.writeAll(if (lock_busy) "true" else "false");
+        try writer.writeAll(",\"engine_run_available\":false,\"execution\":\"command_owned\",\"agent_safe\":false,\"interactive\":true,\"mutating\":true,\"spends_provider_calls\":false,\"budget\":\"1 interactive login\",\"repair_owner\":\"upstream_cli_login\",\"fresh_browser_context_required\":");
+        try writer.writeAll(if (reauthNeedsFreshBrowserContext(provider_name)) "true" else "false");
+        try writer.writeAll(",\"browser_context\":\"fresh_incognito_or_isolated_profile\",\"next_action\":");
+        try std.json.stringify(command, .{}, writer);
+        try writer.writeAll(",\"reason\":");
+        try std.json.stringify(reason, .{}, writer);
+        try writer.writeAll("}\n");
+        return;
+    }
+
+    try writer.writeAll("oauth-mux reauth start\n\n");
+    try writer.print("  ok: {s}\n", .{if (ok) "true" else "false"});
+    try writer.print("  provider: {s}\n", .{provider_name});
+    try writer.print("  account: {s}\n", .{account});
+    if (args.profile) |profile| try writer.print("  profile: {s}\n", .{profile});
+    if (args.capability) |capability| try writer.print("  capability: {s}\n", .{capability});
+    try writer.print("  correlation_id: {s}\n", .{correlation_id});
+    try writer.print("  handoff_queued: {s}\n", .{if (queued) "true" else "false"});
+    try writer.print("  handoff_pending: {s}\n", .{if (pending) "true" else "false"});
+    try writer.print("  lock_busy: {s}\n", .{if (lock_busy) "true" else "false"});
+    try writer.writeAll("  execution: command_owned\n");
+    try writer.print("  fresh_browser_context_required: {s}\n", .{if (reauthNeedsFreshBrowserContext(provider_name)) "true" else "false"});
+    try writer.writeAll("  browser_context: fresh_incognito_or_isolated_profile\n");
+    try writer.print("  next_action: {s}\n", .{command});
+    try writer.print("  reason: {s}\n", .{reason});
+}
+
+fn writeReauthWaitResult(
+    writer: anytype,
+    args: cli.Command.ReauthArgs,
+    pending: bool,
+    reason: []const u8,
+) !void {
+    const provider_name = args.provider orelse "";
+    const account = args.account orelse "";
+
+    if (args.json) {
+        try writer.writeAll("{\"ok\":true,\"action\":\"wait\",\"profile\":");
+        try writeOptionalJsonString(writer, args.profile);
+        try writer.writeAll(",\"provider\":");
+        try std.json.stringify(provider_name, .{}, writer);
+        try writer.writeAll(",\"account\":");
+        try std.json.stringify(account, .{}, writer);
+        try writer.writeAll(",\"capability\":");
+        try writeOptionalJsonString(writer, args.capability);
+        try writer.writeAll(",\"handoff_pending\":");
+        try writer.writeAll(if (pending) "true" else "false");
+        try writer.writeAll(",\"reason\":");
+        try std.json.stringify(reason, .{}, writer);
+        try writer.writeAll("}\n");
+        return;
+    }
+
+    try writer.writeAll("oauth-mux reauth wait\n\n");
+    try writer.print("  provider: {s}\n", .{provider_name});
+    try writer.print("  account: {s}\n", .{account});
+    try writer.print("  handoff_pending: {s}\n", .{if (pending) "true" else "false"});
+    try writer.print("  reason: {s}\n", .{reason});
+}
+
+fn reauthCommandOwnedCommandAlloc(allocator: std.mem.Allocator, provider_name: []const u8, account: []const u8) ![]const u8 {
+    if (std.mem.eql(u8, provider_name, "codex")) {
+        return try std.fmt.allocPrint(allocator, "oauth-mux codex login-device {s}", .{account});
+    }
+    if (std.mem.eql(u8, provider_name, "claude")) {
+        return try std.fmt.allocPrint(allocator, "oauth-mux enroll plan claude --account {s} --json", .{account});
+    }
+    return try std.fmt.allocPrint(allocator, "oauth-mux enroll plan {s} --account {s} --json", .{ provider_name, account });
+}
+
+fn reauthNeedsFreshBrowserContext(provider_name: []const u8) bool {
+    return std.mem.eql(u8, provider_name, "codex");
 }
 
 fn daemonTickMessage(args: cli.Command.DaemonTickArgs) []const u8 {

--- a/src/repair_state.zig
+++ b/src/repair_state.zig
@@ -13,6 +13,14 @@ pub const RepairEvent = struct {
     capability: ?[]const u8 = null,
     action: ?[]const u8 = null,
     command: ?[]const u8 = null,
+    engine_run_available: ?bool = null,
+    execution: ?[]const u8 = null,
+    agent_safe: ?bool = null,
+    spends_provider_calls: ?bool = null,
+    budget: ?[]const u8 = null,
+    repair_owner: ?[]const u8 = null,
+    fresh_browser_context_required: ?bool = null,
+    browser_context: ?[]const u8 = null,
     writeback_capability: ?[]const u8 = null,
     automatic_refresh_admitted: ?bool = null,
     outcome: []const u8,
@@ -719,6 +727,22 @@ fn writeEventJson(writer: anytype, event: RepairEvent) !void {
     if (event.action) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"command\":");
     if (event.command) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"engine_run_available\":");
+    if (event.engine_run_available) |value| try writer.writeAll(if (value) "true" else "false") else try writer.writeAll("null");
+    try writer.writeAll(",\"execution\":");
+    if (event.execution) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"agent_safe\":");
+    if (event.agent_safe) |value| try writer.writeAll(if (value) "true" else "false") else try writer.writeAll("null");
+    try writer.writeAll(",\"spends_provider_calls\":");
+    if (event.spends_provider_calls) |value| try writer.writeAll(if (value) "true" else "false") else try writer.writeAll("null");
+    try writer.writeAll(",\"budget\":");
+    if (event.budget) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"repair_owner\":");
+    if (event.repair_owner) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
+    try writer.writeAll(",\"fresh_browser_context_required\":");
+    if (event.fresh_browser_context_required) |value| try writer.writeAll(if (value) "true" else "false") else try writer.writeAll("null");
+    try writer.writeAll(",\"browser_context\":");
+    if (event.browser_context) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"writeback_capability\":");
     if (event.writeback_capability) |value| try std.json.stringify(value, .{}, writer) else try writer.writeAll("null");
     try writer.writeAll(",\"automatic_refresh_admitted\":");
@@ -987,6 +1011,38 @@ test "refresh event json carries redacted writeback evidence" {
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"outcome\":\"persisted\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "access_token") == null);
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "refresh_token") == null);
+}
+
+test "handoff event json carries redacted consent metadata" {
+    var buf = std.ArrayList(u8).init(std.testing.allocator);
+    defer buf.deinit();
+
+    try writeEventJson(buf.writer(), .{
+        .ts = 44,
+        .kind = "daemon_handoff",
+        .provider = "codex",
+        .account = "max-1",
+        .action = "reauth_start",
+        .command = "oauth-mux codex login-device max-1",
+        .engine_run_available = false,
+        .execution = "command_owned",
+        .agent_safe = false,
+        .spends_provider_calls = false,
+        .budget = "1 interactive login",
+        .repair_owner = "upstream_cli_login",
+        .fresh_browser_context_required = true,
+        .browser_context = "fresh_incognito_or_isolated_profile",
+        .outcome = "handoff_queued",
+        .reason = "reauth_user_mediated",
+        .interactive = true,
+        .mutating = true,
+    });
+
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"kind\":\"daemon_handoff\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"engine_run_available\":false") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"execution\":\"command_owned\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"fresh_browser_context_required\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"browser_context\":\"fresh_incognito_or_isolated_profile\"") != null);
 }
 
 test "sanitized lock file names do not preserve path separators" {


### PR DESCRIPTION
## What changed

- Adds `oauth-mux reauth start|wait|drain|run` as the first TIN-1806 approval surface.
- `reauth start` records a redacted user-mediated handoff under the per-account repair lock.
- `reauth wait` reports pending/resolved state with a bounded optional timeout.
- `reauth drain` lists pending handoffs without running login flows.
- `reauth run` refuses with `engine_run_available:false` until a provider is explicitly flipped to engine-run.
- Extends repair-event records with optional consent metadata, including fresh browser context requirements for Codex/device OAuth.
- Updates the reauth orchestrator and in-agent handoff specs to describe the command-owned boundary.

## Why

This makes the approval surface real without changing credential authority. It keeps browser/device/vendor login user-mediated, while giving agents a stable redacted surface for queueing, waiting, and reporting handoffs.

## Validation

Debug only on this laptop, not completion proof:

- `zig fmt src/cli.zig src/main.zig src/repair_state.zig`
- `nix develop --command zig build test`
- `git diff --check`
- `nix develop --command zig build`
- temporary-runtime smoke for `reauth start`, `wait`, `drain`, and `run`

Hosted remote checks are the merge gate.

## Truth boundary

No provider is flipped to engine-run in this PR. Codex and Claude remain command-owned/user-mediated for auth execution.
