### PR TITLE
reauth: expose handoff env and readiness state

### DIFF
--- a/docs/spec/in-agent-reauth-handoff-contract-2026-05-14.md
+++ b/docs/spec/in-agent-reauth-handoff-contract-2026-05-14.md
@@ -139,6 +139,19 @@ engine. For browser/device OAuth, the JSON surface includes
 `fresh_browser_context_required` so agents do not reuse ambient personal,
 work, startup, or family browser profiles by accident.
 
+Managed child processes and command probes receive the same reauth coordination
+breadcrumbs as environment variables:
+
+- `OMUX_REAUTH_JOB`: stable `provider:account` correlation id.
+- `OMUX_REAUTH_LOCK_DIR`: the per-account flock directory shared with
+  refresh/session/repair.
+- `OMUX_REAUTH_UI_URL`: operator UI URL when one is provided; empty when no
+  live UI is bound.
+
+Runtime diagnostics report a pending auth handoff as `reauth_in_progress`,
+distinct from generic `repair_in_progress`, so other agents wait for the user
+handoff instead of launching duplicate login attempts.
+
 For pending daemon handoffs, agents may acknowledge visibility or clear stale
 records with explicit commands:
 

--- a/docs/spec/oauth-mux-formal-model.md
+++ b/docs/spec/oauth-mux-formal-model.md
@@ -213,6 +213,7 @@ RuntimeReadiness =
   | session_unavailable
   | sandbox_blocked
   | needs_reauth
+  | reauth_in_progress
   | repair_in_progress
 ```
 

--- a/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
+++ b/docs/spec/stay-afloat-runtime-daemon-plan-2026-04-30.md
@@ -291,6 +291,7 @@ RuntimeReadiness =
   | session_unavailable(path)
   | sandbox_blocked(operation)
   | needs_reauth(methods, reason)
+  | reauth_in_progress(account, started_at)
   | repair_in_progress(account, started_at)
 ```
 

--- a/src/adapters/codex/main.zig
+++ b/src/adapters/codex/main.zig
@@ -33,6 +33,7 @@ const broker_types = @import("../../broker/types.zig");
 const broker_loader = @import("../../broker_loader.zig");
 const cli = @import("../../cli.zig");
 const config_mod = @import("../../config.zig");
+const env_mod = @import("../../env.zig");
 const health_mod = @import("../../health.zig");
 const identity_hash = @import("../../identity_hash.zig");
 const paths = @import("../../paths.zig");
@@ -1665,6 +1666,16 @@ pub fn run(allocator: std.mem.Allocator, opts: RunOptions) !void {
     const account_only = elected.id[std.mem.indexOfScalar(u8, elected.id, ':').? + 1 ..];
     try env_map.put("OMUX_ACTIVE_ACCOUNT", account_only);
     if (launch_defaults.profile) |p| try env_map.put("OMUX_ACTIVE_PROFILE", p);
+    if (route_capability) |capability| try env_map.put("OMUX_ACTIVE_CAPABILITY", capability);
+    const reauth_job = try repair_state.reauthJobAlloc(allocator, "codex", account_only);
+    defer allocator.free(reauth_job);
+    try env_map.put("OMUX_REAUTH_JOB", reauth_job);
+    const reauth_lock_dir = try repair_state.reauthLocksDir(allocator);
+    defer allocator.free(reauth_lock_dir);
+    try env_map.put("OMUX_REAUTH_LOCK_DIR", reauth_lock_dir);
+    const reauth_ui_url = (try env_mod.get(allocator, "OMUX_REAUTH_UI_URL")) orelse try allocator.dupe(u8, "");
+    defer allocator.free(reauth_ui_url);
+    try env_map.put("OMUX_REAUTH_UI_URL", reauth_ui_url);
     try launch_timer.mark(status_writer, emit_status, "env_build");
 
     traceManagedSessionStart(allocator, elected.id, launch_defaults.profile, opts.forward_argv.len, resume_request.mode, &codex_home);

--- a/src/main.zig
+++ b/src/main.zig
@@ -3843,6 +3843,13 @@ fn repairActionFor(
             .budget = .free_local,
         },
         .needs_reauth => return reauthAction(route, def),
+        .reauth_in_progress => return .{
+            .kind = .wait_for_repair,
+            .severity = "info",
+            .message = "reauth handoff is already in progress",
+            .mediation = .wait,
+            .budget = .free_local,
+        },
         .repair_in_progress => return .{
             .kind = .wait_for_repair,
             .severity = "info",
@@ -7736,6 +7743,11 @@ fn writeRuntimeReadinessRedactedJson(writer: anytype, readiness: types.RuntimeRe
             try writer.writeAll(",\"methods\":");
             try writeStringArrayJson(writer, info.methods);
         },
+        .reauth_in_progress => |info| {
+            try writer.writeAll(",\"account\":");
+            try std.json.stringify(info.account, .{}, writer);
+            try writer.print(",\"started_at\":{d}", .{info.started_at});
+        },
         .repair_in_progress => |info| {
             try writer.writeAll(",\"account\":");
             try std.json.stringify(info.account, .{}, writer);
@@ -8611,6 +8623,11 @@ fn writeRuntimeReadinessJson(writer: anytype, readiness: types.RuntimeReadiness)
             try writeStringArrayJson(writer, info.methods);
             try writer.writeAll(",\"reason\":");
             try std.json.stringify(info.reason, .{}, writer);
+        },
+        .reauth_in_progress => |info| {
+            try writer.writeAll(",\"account\":");
+            try std.json.stringify(info.account, .{}, writer);
+            try writer.print(",\"started_at\":{d}", .{info.started_at});
         },
         .repair_in_progress => |info| {
             try writer.writeAll(",\"account\":");

--- a/src/pipeline.zig
+++ b/src/pipeline.zig
@@ -724,8 +724,18 @@ fn buildProbeEnv(
     try probe_env.addBorrowed("OMUX_ACTIVE_ACCOUNT", acct);
     try probe_env.addBorrowed("OMUX_ACTIVE_CAPABILITY", plan.capability);
     if (ctx.profile_name) |profile| try probe_env.addBorrowed("OMUX_ACTIVE_PROFILE", profile);
+    try addProbeReauthEnv(ctx, &probe_env, prov, acct);
 
     return probe_env;
+}
+
+fn addProbeReauthEnv(ctx: *Context, probe_env: *ProbeEnv, prov: []const u8, acct: []const u8) !void {
+    const job = try repair_state.reauthJobAlloc(ctx.allocator, prov, acct);
+    try probe_env.addOwned("OMUX_REAUTH_JOB", job);
+    const lock_dir = try repair_state.reauthLocksDir(ctx.allocator);
+    try probe_env.addOwned("OMUX_REAUTH_LOCK_DIR", lock_dir);
+    const ui_url = (try env.get(ctx.allocator, "OMUX_REAUTH_UI_URL")) orelse try ctx.allocator.dupe(u8, "");
+    try probe_env.addOwned("OMUX_REAUTH_UI_URL", ui_url);
 }
 
 fn attemptRefresh(ctx: *Context, rt: []const u8) PipelineError!void {
@@ -1109,6 +1119,20 @@ fn injectEnv(ctx: *Context) PipelineError!void {
     if (ctx.capability_name) |capability| {
         ctx.env_pairs.append(.{ "OMUX_ACTIVE_CAPABILITY", capability }) catch return error.OutOfMemory;
     }
+    try addReauthEnv(ctx, prov_name, acct_name);
+}
+
+fn addReauthEnv(ctx: *Context, prov_name: []const u8, acct_name: []const u8) PipelineError!void {
+    const job = repair_state.reauthJobAlloc(ctx.allocator, prov_name, acct_name) catch return error.OutOfMemory;
+    ctx.addEnvOwned("OMUX_REAUTH_JOB", job) catch return error.OutOfMemory;
+    const lock_dir = repair_state.reauthLocksDir(ctx.allocator) catch |e| switch (e) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.RuntimeNotReady,
+    };
+    ctx.addEnvOwned("OMUX_REAUTH_LOCK_DIR", lock_dir) catch return error.OutOfMemory;
+    const ui_url = (env.get(ctx.allocator, "OMUX_REAUTH_UI_URL") catch return error.OutOfMemory) orelse
+        (ctx.allocator.dupe(u8, "") catch return error.OutOfMemory);
+    ctx.addEnvOwned("OMUX_REAUTH_UI_URL", ui_url) catch return error.OutOfMemory;
 }
 
 fn providerConfigDirEnv(
@@ -1253,6 +1277,9 @@ test "runEnv uses configured provider definition" {
     try expectEnvPair(ctx.env_pairs.items, "TOY_TOKEN", "toy-at");
     try expectEnvPair(ctx.env_pairs.items, "OMUX_ACTIVE_PROVIDER", "toy");
     try expectEnvPair(ctx.env_pairs.items, "OMUX_ACTIVE_ACCOUNT", "default");
+    try expectEnvPair(ctx.env_pairs.items, "OMUX_REAUTH_JOB", "toy:default");
+    try expectEnvKey(ctx.env_pairs.items, "OMUX_REAUTH_LOCK_DIR");
+    try expectEnvPair(ctx.env_pairs.items, "OMUX_REAUTH_UI_URL", "");
 }
 
 test "refreshWritebackBackend admits only oauth-mux owned file writeback" {
@@ -1641,7 +1668,7 @@ test "runProbe executes auth none command probe without reading missing secret" 
         \\          "probe": {
         \\            "transport": "command",
         \\            "auth": "none",
-        \\            "command": ["sh", "-c", "printf '{\"loggedIn\":true}'"],
+        \\            "command": ["sh", "-c", "test \"$OMUX_REAUTH_JOB\" = \"toy:default\" && test -n \"$OMUX_REAUTH_LOCK_DIR\" && test \"$OMUX_REAUTH_UI_URL\" = \"\" && printf '{\"loggedIn\":true}'"],
         \\            "budget": "free_command"
         \\          }
         \\        }
@@ -2008,6 +2035,13 @@ fn expectEnvPair(pairs: []const [2][]const u8, key: []const u8, value: []const u
             try std.testing.expectEqualStrings(value, pair[1]);
             return;
         }
+    }
+    return error.TestUnexpectedResult;
+}
+
+fn expectEnvKey(pairs: []const [2][]const u8, key: []const u8) !void {
+    for (pairs) |pair| {
+        if (std.mem.eql(u8, pair[0], key)) return;
     }
     return error.TestUnexpectedResult;
 }

--- a/src/repair_state.zig
+++ b/src/repair_state.zig
@@ -219,11 +219,15 @@ pub fn readDaemonSnapshotAlloc(allocator: std.mem.Allocator) !?[]const u8 {
 }
 
 pub fn hasPendingHandoff(allocator: std.mem.Allocator, key: HandoffKey) !bool {
+    return (try pendingHandoffProgress(allocator, key)) != null;
+}
+
+pub fn pendingHandoffProgress(allocator: std.mem.Allocator, key: HandoffKey) !?types.RuntimeReadiness.RepairProgress {
     const path = try eventsPath(allocator);
     defer allocator.free(path);
 
     const file = std.fs.openFileAbsolute(path, .{}) catch |e| switch (e) {
-        error.FileNotFound => return false,
+        error.FileNotFound => return null,
         else => return e,
     };
     defer file.close();
@@ -231,19 +235,25 @@ pub fn hasPendingHandoff(allocator: std.mem.Allocator, key: HandoffKey) !bool {
     const bytes = try file.readToEndAlloc(allocator, 1024 * 1024);
     defer allocator.free(bytes);
 
-    var pending = false;
+    var pending_started_at: ?i64 = null;
     var it = std.mem.splitScalar(u8, bytes, '\n');
     while (it.next()) |line| {
         const trimmed = std.mem.trim(u8, line, " \t\r");
         if (trimmed.len == 0 or !eventRouteKeyMatchesHandoffKey(trimmed, key)) continue;
         if (isQueuedHandoffEvent(trimmed)) {
-            pending = true;
+            pending_started_at = eventFieldInt(trimmed, "ts") orelse 0;
         } else if (eventResolvesHandoff(trimmed)) {
-            pending = false;
+            pending_started_at = null;
         }
     }
 
-    return pending;
+    if (pending_started_at) |started_at| {
+        return .{
+            .account = key.account,
+            .started_at = started_at,
+        };
+    }
+    return null;
 }
 
 fn writeEventView(
@@ -449,6 +459,16 @@ fn eventFieldBool(line: []const u8, field: []const u8) ?bool {
     return null;
 }
 
+fn eventFieldInt(line: []const u8, field: []const u8) ?i64 {
+    var idx = eventFieldValueStart(line, field) orelse return null;
+    while (idx < line.len and line[idx] == ' ') : (idx += 1) {}
+    const start = idx;
+    if (idx < line.len and line[idx] == '-') idx += 1;
+    while (idx < line.len and std.ascii.isDigit(line[idx])) : (idx += 1) {}
+    if (idx == start or (idx == start + 1 and line[start] == '-')) return null;
+    return std.fmt.parseInt(i64, line[start..idx], 10) catch null;
+}
+
 fn eventFieldString(line: []const u8, field: []const u8) ?[]const u8 {
     var idx = eventFieldValueStart(line, field) orelse return null;
     if (std.mem.startsWith(u8, line[idx..], "null")) return null;
@@ -641,6 +661,18 @@ fn locksDir(allocator: std.mem.Allocator) ![]const u8 {
     const dir = try paths.runtimeDir(allocator);
     defer allocator.free(dir);
     return std.fs.path.join(allocator, &.{ dir, "repair-locks" });
+}
+
+// TIN-1806: reauth jobs serialize against the same per-account flock domain as
+// refresh/session/repair. Exporting this as "reauth" metadata gives child
+// processes and probes a stable place to coordinate without inventing a second
+// lock namespace that would fail to protect the credential store.
+pub fn reauthLocksDir(allocator: std.mem.Allocator) ![]const u8 {
+    return locksDir(allocator);
+}
+
+pub fn reauthJobAlloc(allocator: std.mem.Allocator, provider: []const u8, account: []const u8) ![]const u8 {
+    return std.fmt.allocPrint(allocator, "{s}:{s}", .{ provider, account });
 }
 
 pub fn lockPath(allocator: std.mem.Allocator, provider: []const u8, account: []const u8) ![]const u8 {

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const config = @import("config.zig");
+const env = @import("env.zig");
 const paths = @import("paths.zig");
 const provider_schema = @import("provider_schema.zig");
 const repair_state = @import("repair_state.zig");
@@ -153,6 +154,13 @@ pub fn routeReadiness(
 
     const prov = cfg.providers.map.get(route.provider) orelse return .{ .session_unavailable = "provider_config_missing" };
     const account = prov.accounts.map.get(route.account) orelse return .{ .session_unavailable = "account_config_missing" };
+    if (try repair_state.pendingHandoffProgress(allocator, .{
+        .provider = route.provider,
+        .account = route.account,
+        .capability = route.capability,
+    })) |progress| {
+        return .{ .reauth_in_progress = progress };
+    }
     if (try repair_state.probeRepairLock(allocator, route.provider, route.account)) |progress| {
         return .{ .repair_in_progress = progress };
     }
@@ -176,6 +184,13 @@ pub fn routeReadinessHoldingLock(
 
     const prov = cfg.providers.map.get(route.provider) orelse return .{ .session_unavailable = "provider_config_missing" };
     const account = prov.accounts.map.get(route.account) orelse return .{ .session_unavailable = "account_config_missing" };
+    if (try repair_state.pendingHandoffProgress(allocator, .{
+        .provider = route.provider,
+        .account = route.account,
+        .capability = route.capability,
+    })) |progress| {
+        return .{ .reauth_in_progress = progress };
+    }
     const info = try accountInfo(allocator, prov, account, def, config.resolveProviderKind(cfg, route.provider));
     return info.readiness;
 }
@@ -327,6 +342,7 @@ pub fn summary(readiness: types.RuntimeReadiness) []const u8 {
         .session_unavailable => "session_unavailable",
         .sandbox_blocked => "sandbox_blocked",
         .needs_reauth => "needs_reauth",
+        .reauth_in_progress => "reauth_in_progress",
         .repair_in_progress => "repair_in_progress",
     };
 }
@@ -464,6 +480,62 @@ test "routeReadiness reports missing command capability binary" {
     const readiness = try providerReadiness(std.testing.allocator, def, "status");
     switch (readiness) {
         .missing_binary => |binary| try std.testing.expectEqualStrings(missing_binary, binary),
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "routeReadiness reports pending reauth handoff distinctly" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+    var overrides = std.process.EnvMap.init(std.testing.allocator);
+    defer overrides.deinit();
+    try overrides.put("OMUX_STATE_DIR", root);
+    try overrides.put("OMUX_RUNTIME_DIR", root);
+    env.test_overrides = &overrides;
+    defer env.test_overrides = null;
+
+    const cfg_json =
+        \\{
+        \\  "version": 1,
+        \\  "providers": {
+        \\    "toy": {
+        \\      "kind": "toy",
+        \\      "accounts": {
+        \\        "default": { "secret": { "backend": "env", "variable": "OMUX_TEST_SECRET_THAT_IS_NOT_SET" } }
+        \\      }
+        \\    }
+        \\  },
+        \\  "profiles": {},
+        \\  "strategies": {}
+        \\}
+    ;
+    const parsed = try config.loadFromBytes(std.testing.allocator, cfg_json);
+    defer parsed.deinit();
+
+    try repair_state.appendEvent(std.testing.allocator, .{
+        .kind = "daemon_handoff",
+        .provider = "toy",
+        .account = "default",
+        .capability = "status",
+        .action = "reauth_start",
+        .outcome = "handoff_queued",
+        .reason = "reauth_user_mediated",
+        .interactive = true,
+        .mutating = true,
+    });
+
+    const readiness = try routeReadiness(std.testing.allocator, parsed.value, .{
+        .provider = "toy",
+        .account = "default",
+        .capability = "status",
+    }, .{ .name = "toy" });
+    switch (readiness) {
+        .reauth_in_progress => |info| {
+            try std.testing.expectEqualStrings("default", info.account);
+            try std.testing.expect(info.started_at > 0);
+        },
         else => return error.TestUnexpectedResult,
     }
 }

--- a/src/types.zig
+++ b/src/types.zig
@@ -309,6 +309,7 @@ pub const RuntimeReadiness = union(enum) {
     session_unavailable: []const u8,
     sandbox_blocked: []const u8,
     needs_reauth: ReauthInfo,
+    reauth_in_progress: RepairProgress,
     repair_in_progress: RepairProgress,
 
     pub const PathOperation = struct {


### PR DESCRIPTION
## What

Completes the next TIN-1806 slice after #423's command-owned CLI surface:

- exports `OMUX_REAUTH_JOB`, `OMUX_REAUTH_LOCK_DIR`, and `OMUX_REAUTH_UI_URL` through normal provider env injection, command probes, and managed Codex child env
- sets managed Codex `OMUX_ACTIVE_CAPABILITY` alongside provider/account/profile
- adds a distinct `RuntimeReadiness.reauth_in_progress` state for pending auth handoffs
- keeps the reauth lock directory on the existing per-account repair/session/refresh flock domain instead of inventing a second lock namespace
- updates the in-agent handoff contract and runtime-state model docs

## Truth boundary

This does not flip any provider to engine-run login execution. `OMUX_REAUTH_UI_URL` is propagated when an operator/UI sets it and is empty otherwise. Browser/device OAuth remains command-owned/user-mediated.

## Validation

Remote GloriousFlywheel validation is the proof gate. Local work so far was formatting and static diff hygiene only:

- `zig fmt src/types.zig src/runtime.zig src/main.zig src/repair_state.zig src/pipeline.zig src/adapters/codex/main.zig`
- `git diff --check`

I intentionally did not claim local build/test proof; this repo is remote-first.
